### PR TITLE
Fix floating point exception when using libxml2 version 2.9.10+

### DIFF
--- a/arcane/src/arcane/DomLibXml2V2.cc
+++ b/arcane/src/arcane/DomLibXml2V2.cc
@@ -2486,8 +2486,13 @@ ownerElement() const
 void DOMImplementation::
 initialize()
 {
-  // On peut appeler ::xmlInitParser() mais ce n'est pas nécessaire
-  // donc on ne le fait pas.
+  // Appelle explicitement xmlInitParser(). Cela n'est en théorie pas
+  // indispensable mais cette méthode peut générer des exceptions flottante
+  // car à un momement il y a un appel explicite à une division par zéro pour
+  // générer un Nan (dans xmlXPathInit()). Comme DOMImplementation::initialize()
+  // est appelé avant d'activer les exception flottantes il faut faire
+  // explicitement l'appel à l'initialisation du parseur ici.
+  ::xmlInitParser();
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
In release 2.9.10, 2.9.11 and 2.9.12 of `libmxl2`, there is an explicit division by zero during initialization of the parser (to try to get the value of Nan).

We explicitly initialize the XML parser before calling Arcane initialization.
