### PR TITLE
CI : Update IFPEN CI

### DIFF
--- a/.github/workflows/ifpen_el7_foss-2018b.yml
+++ b/.github/workflows/ifpen_el7_foss-2018b.yml
@@ -36,7 +36,7 @@ env:
   CM_BUILD_OPTS: "-j2"
   CM_BUILD_TYPE: Release
   # CTest
-  CT_OPTS: "--timeout 300"
+  CT_OPTS: "--timeout 300 --output-on-failure"
 
 jobs:
   arccon-install:

--- a/.github/workflows/ifpen_el7_gimkl-2018b.yml
+++ b/.github/workflows/ifpen_el7_gimkl-2018b.yml
@@ -36,7 +36,7 @@ env:
   CM_BUILD_OPTS: "-j2"
   CM_BUILD_TYPE: Release
   # CTest
-  CT_OPTS: "--timeout 300"
+  CT_OPTS: "--timeout 300 --output-on-failure"
 
 jobs:
   arccon-install:

--- a/.github/workflows/ifpen_el8_foss-2018b.yml
+++ b/.github/workflows/ifpen_el8_foss-2018b.yml
@@ -36,7 +36,7 @@ env:
   CM_BUILD_OPTS: "-j2"
   CM_BUILD_TYPE: Release
   # CTest
-  CT_OPTS: "--timeout 300"
+  CT_OPTS: "--timeout 300 --output-on-failure"
 
 jobs:
   arccon-install:

--- a/.github/workflows/ifpen_el8_gimkl-2018b.yml
+++ b/.github/workflows/ifpen_el8_gimkl-2018b.yml
@@ -36,7 +36,7 @@ env:
   CM_BUILD_OPTS: "-j2"
   CM_BUILD_TYPE: Release
   # CTest
-  CT_OPTS: "--timeout 300"
+  CT_OPTS: "--timeout 300 --output-on-failure"
 
 jobs:
   arccon-install:


### PR DESCRIPTION
- Add '--output-on-failure' ctest option
- Use parallel build
- Update ctest command
- Remove 'source /env.sh', environment is preconfigured in docker images