### PR TITLE
OneTBB: Fix currentTaskThreadIndex != 0 when T=1

### DIFF
--- a/arcane/src/arcane/parallel/thread/OneTBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/OneTBBTaskImplementation.cc
@@ -193,7 +193,7 @@ class OneTBBTaskImplementation
 
   Int32 currentTaskThreadIndex() const final
   {
-    return _currentTaskTreadIndex();
+    return (nbAllowedThread() <= 1 ) ? 0 : _currentTaskTreadIndex();
   }
 
   Int32 currentTaskIndex() const final;


### PR DESCRIPTION
Valid for all TBB version