### PR TITLE
TBB: Fix currentTaskThreadIndex() != 0 when T=1

### DIFF
--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -416,7 +416,7 @@ class TBBTaskImplementation
 
   Int32 currentTaskThreadIndex() const final
   {
-    return (nbAllowedThread() == 1 ) ? 0 : _currentTaskTreadIndex();
+    return (nbAllowedThread() <= 1 ) ? 0 : _currentTaskTreadIndex();
   }
 
   Int32 currentTaskIndex() const final;

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -416,7 +416,7 @@ class TBBTaskImplementation
 
   Int32 currentTaskThreadIndex() const final
   {
-    return _currentTaskTreadIndex();
+    return (nbAllowedThread() == 1 ) ? 0 : _currentTaskTreadIndex();
   }
 
   Int32 currentTaskIndex() const final;


### PR DESCRIPTION
both commits could be squashed (ok with gitlab, don't know how with github GUI)