### PR TITLE
Fix missing Arccon loads for in house find_package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,12 @@ trim_trailing_whitespace = true
 charset = utf-8
 insert_final_newline = true
 
+[{CMakeLists.txt,*.cmake}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+charset = utf-8
+insert_final_newline = true
+
 [*.md]
 charset = utf-8

--- a/arccon/build-system/Modules/FindGlib.cmake
+++ b/arccon/build-system/Modules/FindGlib.cmake
@@ -5,7 +5,8 @@
 # Glib_INCLUDE_DIRS, where to find headers,
 # Glib_LIBRARIES, the libraries to link against to use glib.
 # Glib_FOUND, If false, do not try to use glib.
- 
+
+include(${CMAKE_CURRENT_LIST_DIR}/../commands/commands.cmake)
 arccon_return_if_package_found(Glib)
 
 find_package(PkgConfig)

--- a/arccon/build-system/Modules/FindLibXml2.cmake
+++ b/arccon/build-system/Modules/FindLibXml2.cmake
@@ -7,12 +7,13 @@
 # LIBICONV_FOUND, If false, do not try to use LIBICONV.
 
 # Note: pour CMake, il faut faire un find_package(LibXml2)
-# mais les variables associées sont préfixées par LIBXML2
+# mais les variables associÃ©es sont prÃ©fixÃ©es par LIBXML2
 # au lieu de 'LibXml2'.
+include(${CMAKE_CURRENT_LIST_DIR}/../commands/commands.cmake)
 
 arccon_return_if_package_found(LibXml2)
 
-# Supprime temporairement CMAKE_MODULE_PATH pour éviter une récursion
+# Supprime temporairement CMAKE_MODULE_PATH pour Ã©viter une rÃ©cursion
 # infinie.
 
 set(_SAVED_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})

--- a/arccon/build-system/Modules/FindMTL4.cmake
+++ b/arccon/build-system/Modules/FindMTL4.cmake
@@ -1,3 +1,4 @@
+include(${CMAKE_CURRENT_LIST_DIR}/../commands/commands.cmake)
 arccon_return_if_package_found(MTL4)
 
 find_path(MTL4_INCLUDE_DIRS boost/numeric/mtl/mtl.hpp)

--- a/arccon/build-system/Modules/FindOtf2.cmake
+++ b/arccon/build-system/Modules/FindOtf2.cmake
@@ -1,2 +1,3 @@
 # Find the OTF2 includes and library
+include(${CMAKE_CURRENT_LIST_DIR}/../commands/commands.cmake)
 arccon_find_legacy_package(NAME Otf2 LIBRARIES otf2 HEADERS otf2/otf2.h)

--- a/arccon/build-system/Modules/FindPETSc.cmake
+++ b/arccon/build-system/Modules/FindPETSc.cmake
@@ -1,3 +1,4 @@
+include(${CMAKE_CURRENT_LIST_DIR}/../commands/commands.cmake)
 arccon_return_if_package_found(PETSc)
 
 find_path(PETSC_INCLUDE_DIRS petsc.h)

--- a/arccon/build-system/Modules/FindTBB.cmake
+++ b/arccon/build-system/Modules/FindTBB.cmake
@@ -6,6 +6,7 @@
 # TBB_LIBRARIES, the libraries to link against to use TBB.
 # TBB_FOUND, If false, do not try to use TBB.
 
+include(${CMAKE_CURRENT_LIST_DIR}/../commands/commands.cmake)
 arccon_return_if_package_found(TBB)
 
 # A partir des versions OneTBB (2020+), il existe un fichier de configuration


### PR DESCRIPTION
This allows find_package defined in Arccon to be used even without having to load Arccon.