### PR TITLE
Use '.Net 6' for circle-ci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
             sudo dpkg -i packages-microsoft-prod.deb
             sudo apt-get update
-            sudo apt-get install -y apt-transport-https dotnet-sdk-5.0
+            sudo apt-get install -y apt-transport-https dotnet-sdk-6.0
             wget https://github.com/Kitware/CMake/releases/download/v3.21.3/cmake-3.21.3-Linux-x86_64.tar.gz
             cp cmake-3.21.3-Linux-x86_64.tar.gz /tmp
             cd /tmp && tar xf cmake-3.21.3-Linux-x86_64.tar.gz


### PR DESCRIPTION
The last version was '.NetCore 5'.
