### PR TITLE
Deprecate implicit conversion from 'ItemEnumerator' to 'ItemEnumeratorT'.

### DIFF
--- a/arcane/ceapart/src/arcane/cea/BasicRayMeshIntersection.cc
+++ b/arcane/ceapart/src/arcane/cea/BasicRayMeshIntersection.cc
@@ -670,7 +670,7 @@ compute(IItemFamily* ray_family,
   Real3UniqueArray local_positions(nb_local_ray);
   Real3UniqueArray local_directions(nb_local_ray);
 
-  ENUMERATE_ITEM(iitem,ray_family->allItems()){
+  ENUMERATE_PARTICLE(iitem,ray_family->allItems()){
     Integer index = iitem.index();
     //local_ids[index] = iitem.localId();
     //unique_ids[index] = (*iitem).uniqueId();
@@ -786,7 +786,7 @@ compute(IItemFamily* ray_family,
     Int32UniqueArray orig_faces(nb_local_ray);
     Int32UniqueArray user_values(nb_local_ray);
 
-    ENUMERATE_ITEM(iitem,ray_family->allItems()){
+    ENUMERATE_PARTICLE(iitem,ray_family->allItems()){
       Integer index = iitem.index();
       orig_faces[index] = rays_orig_face[iitem];
       user_values[index] = rays_user_value[iitem];
@@ -799,7 +799,7 @@ compute(IItemFamily* ray_family,
     compute(local_positions,local_directions,orig_faces,user_values,out_intersections,out_distances,out_faces);
 
     // Recopie en sortie les valeurs dans les variables correspondantes.
-    ENUMERATE_ITEM(iitem,ray_family->allItems()){
+    ENUMERATE_PARTICLE(iitem,ray_family->allItems()){
       Integer index = iitem.index();
       intersections[iitem] = out_intersections[index];
       distances[iitem] = out_distances[index];
@@ -814,7 +814,7 @@ compute(IItemFamily* ray_family,
     RealUniqueArray local_distances(nb_new_ray);
     local_directions.resize(nb_new_ray);
     local_positions.resize(nb_new_ray);
-    ENUMERATE_ITEM(iitem,ray_family->allItems()){
+    ENUMERATE_PARTICLE(iitem,ray_family->allItems()){
       Integer index = iitem.index();
       local_distances[index] = distances[iitem];
       local_directions[index] = rays_direction[iitem];

--- a/arcane/src/arcane/EnumeratorTraceWrapper.h
+++ b/arcane/src/arcane/EnumeratorTraceWrapper.h
@@ -86,11 +86,11 @@ class EnumeratorTraceWrapper
 
 #if defined(ARCANE_TRACE_ENUMERATOR)
 #define A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) \
-  ::Arcane::EnumeratorTraceWrapper< ::Arcane::_EnumeratorClassName, ::Arcane::IItemEnumeratorTracer >
+  ::Arcane::EnumeratorTraceWrapper< _EnumeratorClassName, ::Arcane::IItemEnumeratorTracer >
 #define A_TRACE_ENUMERATOR_WHERE   ,A_FUNCINFO
 #else
 #define A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) \
-  ::Arcane::_EnumeratorClassName
+  _EnumeratorClassName
 #define A_TRACE_ENUMERATOR_WHERE
 #endif
 

--- a/arcane/src/arcane/ItemEnumerator.h
+++ b/arcane/src/arcane/ItemEnumerator.h
@@ -214,19 +214,19 @@ enumerator() const
 /*---------------------------------------------------------------------------*/
 
 #define A_ENUMERATE_ITEM(_EnumeratorClassName,iname,view)               \
-  for( A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) iname(_EnumeratorClassName::fromItemEnumerator((view).enumerator()) A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
+  for( A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) iname(_EnumeratorClassName :: fromItemEnumerator((view).enumerator()) A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 //! Enumérateur générique d'un groupe d'entité
-#define ENUMERATE_(type,name,group) A_ENUMERATE_ITEM(ItemEnumeratorT< type >,name,group)
+#define ENUMERATE_(type,name,group) A_ENUMERATE_ITEM(::Arcane::ItemEnumeratorT< type >,name,group)
 
 //! Enumérateur générique d'un groupe d'entité
-#define ENUMERATE_GENERIC(type,name,group) A_ENUMERATE_ITEM(ItemEnumeratorT< type >,name,group)
+#define ENUMERATE_GENERIC(type,name,group) A_ENUMERATE_ITEM(::Arcane::ItemEnumeratorT< type >,name,group)
 
 //! Enumérateur générique d'un groupe de noeuds
-#define ENUMERATE_ITEM(name,group) A_ENUMERATE_ITEM(ItemEnumerator,name,group)
+#define ENUMERATE_ITEM(name,group) A_ENUMERATE_ITEM(::Arcane::ItemEnumerator,name,group)
 
 #define ENUMERATE_ITEMWITHNODES(name,group) ENUMERATE_(::Arcane::ItemWithNodes,name,group)
 

--- a/arcane/src/arcane/ItemEnumerator.h
+++ b/arcane/src/arcane/ItemEnumerator.h
@@ -56,12 +56,12 @@ class ItemEnumerator
  public:
 
   ItemEnumerator()
-  : m_items(0), m_local_ids(0), m_index(0), m_count(0), m_group_impl(0) {}
-  ItemEnumerator(const ItemInternalPtr* items,const Int32* local_ids,Integer n, const ItemGroupImpl * agroup = 0)
+  : m_items(nullptr), m_local_ids(nullptr), m_index(0), m_count(0), m_group_impl(nullptr) {}
+  ItemEnumerator(const ItemInternalPtr* items,const Int32* local_ids,Integer n, const ItemGroupImpl * agroup = nullptr)
   : m_items(items), m_local_ids(local_ids), m_index(0), m_count(n), m_group_impl(agroup) {}
-  ItemEnumerator(const ItemInternalArrayView& items,const Int32ConstArrayView& local_ids, const ItemGroupImpl * agroup = 0)
+  ItemEnumerator(const ItemInternalArrayView& items,const Int32ConstArrayView& local_ids, const ItemGroupImpl * agroup = nullptr)
   : m_items(items.data()), m_local_ids(local_ids.data()), m_index(0), m_count(local_ids.size()), m_group_impl(agroup) {}
-  ItemEnumerator(const ItemInternalVectorView& view, const ItemGroupImpl * agroup = 0)
+  ItemEnumerator(const ItemInternalVectorView& view, const ItemGroupImpl * agroup = nullptr)
   : m_items(view.items().data()), m_local_ids(view.localIds().data()),
     m_index(0), m_count(view.size()), m_group_impl(agroup) {}
   ItemEnumerator(const ItemEnumerator& rhs)
@@ -69,7 +69,7 @@ class ItemEnumerator
     m_index(rhs.m_index), m_count(rhs.m_count), m_group_impl(rhs.m_group_impl) {}
   ItemEnumerator(const ItemInternalEnumerator& rhs)
   : m_items(rhs.m_items), m_local_ids(rhs.m_local_ids),
-    m_index(rhs.m_index), m_count(rhs.m_count), m_group_impl(0) {}
+    m_index(rhs.m_index), m_count(rhs.m_count), m_group_impl(nullptr) {}
 
  public:
 
@@ -113,6 +113,11 @@ class ItemEnumerator
     return ItemLocalId(m_local_ids[m_index]);
   }
 
+  static ItemEnumerator fromItemEnumerator(const ItemEnumerator& rhs)
+  {
+    return ItemEnumerator(rhs);
+  }
+
  protected:
 
   const ItemInternalPtr* m_items;
@@ -139,12 +144,18 @@ class ItemEnumeratorT
 
   ItemEnumeratorT() {}
   ItemEnumeratorT(const ItemInternalPtr* items,const Int32* local_ids,Integer n, const ItemGroupImpl * agroup = 0)
-    : ItemEnumerator(items,local_ids,n,agroup) {}
+  : ItemEnumerator(items,local_ids,n,agroup) {}
+  ItemEnumeratorT(const ItemVectorViewT<ItemType>& rhs)
+  : ItemEnumerator(rhs) {}
+
+ public:
+
+  [[deprecated("Y2021: Use strongly typed enumerator (Node, Face, Cell, ...) instead of generic (Item) enumerator")]]
   ItemEnumeratorT(const ItemInternalEnumerator& rhs)
   : ItemEnumerator(rhs) {}
+
+  [[deprecated("Y2021: Use strongly typed enumerator (Node, Face, Cell, ...) instead of generic (Item) enumerator")]]
   ItemEnumeratorT(const ItemEnumerator& rhs)
-  : ItemEnumerator(rhs) {}
-  ItemEnumeratorT(const ItemVectorViewT<ItemType>& rhs)
   : ItemEnumerator(rhs) {}
 
  public:
@@ -164,6 +175,17 @@ class ItemEnumeratorT
   {
     return LocalIdType(m_local_ids[m_index]);
   }
+
+  static ItemEnumeratorT<ItemType> fromItemEnumerator(const ItemEnumerator& rhs)
+  {
+    return ItemEnumeratorT<ItemType>(rhs,true);
+  }
+
+  private:
+
+  //! Constructeur seulement utilisé par fromItemEnumerator()
+  ItemEnumeratorT(const ItemEnumerator& rhs,bool)
+  : ItemEnumerator(rhs) {}
 };
 
 /*---------------------------------------------------------------------------*/
@@ -192,7 +214,7 @@ enumerator() const
 /*---------------------------------------------------------------------------*/
 
 #define A_ENUMERATE_ITEM(_EnumeratorClassName,iname,view)               \
-  for( A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) iname((view).enumerator() A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
+  for( A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) iname(_EnumeratorClassName::fromItemEnumerator((view).enumerator()) A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemGroup.h
+++ b/arcane/src/arcane/ItemGroup.h
@@ -422,7 +422,7 @@ class ItemGroupT
 
   ItemEnumeratorT<T> enumerator() const
   {
-    return ItemGroup::enumerator();
+    return ItemEnumeratorT<T>::fromItemEnumerator(ItemGroup::enumerator());
   }
   
  protected:

--- a/arcane/src/arcane/std/DumpWEnsight7.cc
+++ b/arcane/src/arcane/std/DumpWEnsight7.cc
@@ -1429,7 +1429,7 @@ beginWrite()
     if (mesh->parentMesh()) {
       SharedVariableNodeReal3 nodes_coords(mesh->sharedNodesCoordinates());
       coords_backup.resize(mesh->nodeFamily()->maxLocalId());
-      ENUMERATE_ITEM (i_item, all_nodes) {
+      ENUMERATE_NODE (i_item, all_nodes) {
         coords_backup[i_item.localId()] = nodes_coords[i_item];
       }
       coords_array = coords_backup.view();

--- a/arcane/src/arcane/tests/ExchangeItemsUnitTest.cc
+++ b/arcane/src/arcane/tests/ExchangeItemsUnitTest.cc
@@ -228,7 +228,7 @@ _computeGhostPPVariable()
     {
       const Integer rank = ranks[i];
       FaceVectorView ghost_items(mesh()->faceFamily()->itemsInternal(), face_synchronizer->sharedItems(i));
-      ENUMERATE_NODE(iface, ghost_items)
+      ENUMERATE_FACE(iface, ghost_items)
         {
           m_face_ghostpp[iface][rank] = 2; // ou bien mettre un identifiant du propriétaire
         }

--- a/arcane/src/arcane/tests/anyitem/AnyItemTester.cc
+++ b/arcane/src/arcane/tests/anyitem/AnyItemTester.cc
@@ -198,10 +198,10 @@ _test1()
   value = 0;
   {
     Arcane::Timer::Sentry t(&m_timer);
-    ENUMERATE_ITEM(iitem, allFaces()) {
+    ENUMERATE_FACE(iitem, allFaces()) {
       value += m_face_variable[iitem];
     }
-    ENUMERATE_ITEM(iitem, allCells()) {
+    ENUMERATE_CELL(iitem, allCells()) {
       value += m_cell_variable[iitem];
     }
   }


### PR DESCRIPTION
This will prevent potential bugs. With this implicit conversion, it is possible to index a cell variable with a node enumerator for example.