### PR TITLE
Fix 'circleci' build in upgrading to '.Net 6.0.200'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ jobs:
             ls -lart /tmp/cmake-3.21.3-linux-x86_64
             cd /tmp/cmake-3.21.3-linux-x86_64/ && sudo rsync -au . /usr/local
             ls -lart /usr/local/bin
+            echo "Infos about NuGet.config"
+            ls -lart /home/circleci/.nuget/NuGet
+            cat /home/circleci/.nuget/NuGet/NuGet.config
 
       - run:
           name: "Print tools versions"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,12 @@ jobs:
             ls -lart /tmp/cmake-3.21.3-linux-x86_64
             cd /tmp/cmake-3.21.3-linux-x86_64/ && sudo rsync -au . /usr/local
             ls -lart /usr/local/bin
-            echo "Infos about NuGet.config"
+            echo "Generate NuGet.config"
+            mkdir -p /home/circleci/.nuget/NuGet
+            cd /home/circleci/.nuget/NuGet && dotnet new nugetconfig
             ls -lart /home/circleci/.nuget/NuGet
+            cd /home/circleci/.nuget/NuGet && mv nuget.config NuGet.config
+            echo "Print NuGet.config"
             cat /home/circleci/.nuget/NuGet/NuGet.config
 
       - run:


### PR DESCRIPTION
The last ubuntu image in 'circleci' ships with '.Net 6.0.200'.
This version of the SDK sends an error if the 'NuGet.config' file in home repository is empty.
To prevent this error, we generate a default 'NuGet.config' file with the command `dotnet new nugetconfig`.