### PR TITLE
Improve ROCm/HIP support

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -811,12 +811,14 @@ if(DEFINED ARCANE_ACCELERATOR_MODE)
   if (ARCANE_ACCELERATOR_MODE STREQUAL "CUDANVCC" )
     set (ARCANE_WANT_CUDA TRUE)
   elseif (ARCANE_ACCELERATOR_MODE STREQUAL "ROCMHIP" )
+    set (ARCANE_WANT_HIP TRUE)
     # TODO: vérifier qu'on utilise bien 'hipcc'
   else()
     message(FATAL_ERROR "Unsupported ARCANE_ACCELERATOR_MODE '${ARCANE_ACCELERATOR_MODE}'."
       "Valid values are 'CUDANVCC' or 'ROCMHIP'")
   endif()
   set (ARCANE_ACCELERATOR_MODE ${ARCANE_ACCELERATOR_MODE} CACHE STRING "Accelerator Mode" FORCE)
+  set (ARCANE_HAS_ACCELERATOR TRUE)
 endif()
 
 # ----------------------------------------------------------------------------

--- a/arcane/cmake/ArcaneConfig.cmake.in
+++ b/arcane/cmake/ArcaneConfig.cmake.in
@@ -50,6 +50,7 @@ set(ARCANE_HAS_CUDA "@ARCANE_WANT_CUDA@" CACHE BOOL "Is Arcane compiled with CUD
 set(ARCANE_HAS_HIP "@ARCANE_WANT_HIP@" CACHE BOOL "Is Arcane compiled with HIP support?" FORCE)
 set(ARCANE_CUDA_COMPILER_HINT "@CMAKE_CUDA_COMPILER@")
 set(ARCANE_HIP_COMPILER_HINT "@CMAKE_HIP_COMPILER@")
+set(ARCANE_HIP_DIR_HINT "@Hip_DIR@")
 set(ARCANE_DEFAULT_HIP_ARCHITECTURES "@CMAKE_HIP_ARCHITECTURES@" CACHE STRING "Default GPU architectures?" FORCE)
 
 macro(arcane_internal_enable_cuda)
@@ -93,7 +94,22 @@ macro(arcane_internal_enable_hip)
       set(CMAKE_HIP_ARCHITECTURES ${ARCANE_DEFAULT_HIP_ARCHITECTURES} CACHE STRING "Default architectures" FORCE)
     endif()
 
-    find_package(Hip REQUIRED)
+    # Il faut ajouter dans CMAKE_MODULE_PATH le chemin ou se trouve ROCM.
+    # On suppose que Hip_ROOT a été positionné lors du configure de Arcane et qu'il
+    # est dans ${ROCM_ROOT}/hip/lib/cmake/hip.
+    set(_SAVED_CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
+    if (ARCANE_HIP_DIR_HINT)
+      # NOTE: Cette commande 'cmake_path' n'existe qu'à partir de CMake 3.20
+      cmake_path(GET ARCANE_HIP_DIR_HINT PARENT_PATH _path_result1)
+      cmake_path(GET _path_result1 PARENT_PATH _path_result2)
+      cmake_path(GET _path_result2 PARENT_PATH _path_result)
+      if (_path_result)
+        list(APPEND CMAKE_PREFIX_PATH "${_path_result}")
+      endif()
+      message(STATUS "Computed CMAKE_PREFIX_PATH for Hip : ${CMAKE_PREFIX_PATH}")
+    endif()
+    find_package(Hip REQUIRED "${ARCANE_HIP_DIR_HINT}")
+    set(CMAKE_PREFIX_PATH ${_SAVED_CMAKE_PREFIX_PATH})
   else()
     message(FATAL_ERROR "Can not enable HIP because Arcane is not compiled with HIP support")
   endif()

--- a/arcane/cmake/ArcaneConfig.cmake.in
+++ b/arcane/cmake/ArcaneConfig.cmake.in
@@ -39,14 +39,18 @@ endif()
 set(ARCANE_AXL2CC "${AXLSTAR_AXL2CC}")
 
 # ----------------------------------------------------------------------------
-# Support pour CUDA.
+# Support pour les accélérateurs.
 #
-# La variable 'ARCANE_HAS_CUDA' est définie si Arcane a été compilée avec
-# CUDA. Dans ce cas, il est possible d'utiliser la macro 'arcane_enable_cuda'
-# pour rechercher les différents composants nécessaires.
+# La variable 'ARCANE_HAS_ACCELERATOR' est définie si Arcane a été compilée avec
+# le support des accélérateurs. Dans ce cas, il est possible d'utiliser la macro
+# 'arcane_enable_cuda' ou 'arcane_enable_rocmhip' pour rechercher les différents composants nécessaires.
 
+set(ARCANE_HAS_ACCELERATOR "@ARCANE_HAS_ACCELERATOR@" CACHE BOOL "Is Arcane compiled with Accelerator support?" FORCE)
 set(ARCANE_HAS_CUDA "@ARCANE_WANT_CUDA@" CACHE BOOL "Is Arcane compiled with CUDA support?" FORCE)
+set(ARCANE_HAS_HIP "@ARCANE_WANT_HIP@" CACHE BOOL "Is Arcane compiled with HIP support?" FORCE)
 set(ARCANE_CUDA_COMPILER_HINT "@CMAKE_CUDA_COMPILER@")
+set(ARCANE_HIP_COMPILER_HINT "@CMAKE_HIP_COMPILER@")
+set(ARCANE_DEFAULT_HIP_ARCHITECTURES "@CMAKE_HIP_ARCHITECTURES@" CACHE STRING "Default GPU architectures?" FORCE)
 
 macro(arcane_internal_enable_cuda)
   if (ARCANE_HAS_CUDA)
@@ -71,11 +75,38 @@ macro(arcane_internal_enable_cuda)
   endif()
 endmacro()
 
+macro(arcane_internal_enable_hip)
+  if (ARCANE_HAS_HIP)
+    # La commande 'enable_language(HIP)' a besoin que la variable
+    # d'environnement 'HIPCXX' ou la variable cmake 'CMAKE_HIP_COMPILER'
+    # soit définie. Si ce n'est pas le cas, utilise le chemin du compilateur
+    # utilisé pour compiler Arcane.
+    if(NOT DEFINED ENV{HIPCXX} AND NOT CMAKE_HIP_COMPILER)
+      set(CMAKE_HIP_COMPILER "${ARCANE_HIP_COMPILER_HINT}")
+    endif()
+    message(STATUS "ArcaneHIP: CMAKE_HIP_COMPILER = ${CMAKE_HIP_COMPILER}")
+
+    # Il faut au moins la version 3.21 de CMake pour HIP
+    cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+    enable_language(HIP)
+    if (NOT CMAKE_HIP_ARCHITECTURES)
+      set(CMAKE_HIP_ARCHITECTURES ${ARCANE_DEFAULT_HIP_ARCHITECTURES} CACHE STRING "Default architectures" FORCE)
+    endif()
+
+    find_package(Hip REQUIRED)
+  else()
+    message(FATAL_ERROR "Can not enable HIP because Arcane is not compiled with HIP support")
+  endif()
+endmacro()
+
 # Macro pour activer le support des accélérateurs.
 # A utiliser avant les autres commandes 'arcane_accelerator_...'
 macro(arcane_accelerator_enable)
   if (ARCANE_HAS_CUDA)
     arcane_internal_enable_cuda()
+  endif()
+  if (ARCANE_HAS_HIP)
+    arcane_internal_enable_hip()
   endif()
 endmacro()
 
@@ -86,6 +117,12 @@ function(arcane_accelerator_add_source_files)
     foreach(_x ${ARGN})
       message(STATUS "Add CUDA language to file '${_x}'")
       set_source_files_properties(${_x} PROPERTIES LANGUAGE CUDA)
+    endforeach()
+  endif()
+  if (ARCANE_HAS_HIP)
+    foreach(_x ${ARGN})
+      message(STATUS "Add HIP language to file '${_x}'")
+      set_source_files_properties(${_x} PROPERTIES LANGUAGE HIP)
     endforeach()
   endif()
 endfunction()
@@ -100,6 +137,10 @@ function(arcane_accelerator_add_to_target target_name)
   if (ARCANE_HAS_CUDA)
     target_link_libraries(${target_name} PUBLIC arcane_accelerator_cuda_runtime)
     set_property(TARGET ${target_name} PROPERTY CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
+  endif()
+  if (ARCANE_HAS_HIP)
+    target_link_libraries(${target_name} PUBLIC arcane_accelerator_hip_runtime)
+    set_property(TARGET ${target_name} PROPERTY HIP_ARCHITECTURES ${CMAKE_HIP_ARCHITECTURES})
   endif()
 endfunction()
 

--- a/arcane/samples_build/samples/hydro_accelerator/SimpleHydroAcceleratorService.cc
+++ b/arcane/samples_build/samples/hydro_accelerator/SimpleHydroAcceleratorService.cc
@@ -134,21 +134,20 @@ class SimpleHydroAcceleratorService
 
  public:
 
-  void hydroBuild();
-  void hydroStartInit();
-  void hydroInit();
-  void hydroContinueInit() {}
-  void hydroExit();
+  void hydroBuild() override;
+  void hydroStartInit() override;
+  void hydroInit() override;
+  void hydroExit() override;
 
-  void computeForces();
-  void computeVelocity();
-  void computeViscosityWork();
-  void applyBoundaryCondition();
-  void moveNodes();
-  void computeGeometricValues();
-  void updateDensity();
-  void applyEquationOfState();
-  void computeDeltaT();
+  void computeForces() override;
+  void computeVelocity() override;
+  void computeViscosityWork() override;
+  void applyBoundaryCondition() override;
+  void moveNodes() override;
+  void computeGeometricValues() override;
+  void updateDensity() override;
+  void applyEquationOfState() override;
+  void computeDeltaT() override;
 
   void setModule(SimpleHydro::SimpleHydroModuleBase* module) override
   {
@@ -160,7 +159,7 @@ class SimpleHydroAcceleratorService
   void computeGeometricValues2();
 
   void cellScalarPseudoViscosity();
-  ARCCORE_HOST_DEVICE inline void computeCQs(Real3 node_coord[8],Real3 face_coord[6],Span<Real3> cqs);
+  ARCCORE_HOST_DEVICE static inline void computeCQs(Real3 node_coord[8],Real3 face_coord[6],Span<Real3> cqs);
 
  private:
   VariableCellInt64 m_cell_unique_id; //!< Unique ID associé à la maille
@@ -799,7 +798,7 @@ computeDeltaT()
  *
  * La méthode utilisée est celle du découpage en quatre triangles.
  */
-inline void SimpleHydroAcceleratorService::
+ARCCORE_HOST_DEVICE inline void SimpleHydroAcceleratorService::
 computeCQs(Real3 node_coord[8],Real3 face_coord[6],Span<Real3> cqs)
 {
   const Real3 c0 = face_coord[0];

--- a/arcane/src/arcane/accelerator/RunCommandEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandEnumerate.h
@@ -91,7 +91,7 @@ _applyItems(RunCommand& command,ItemVectorViewT<ItemType> items,Lambda func)
 #else
     ARCANE_FATAL("Requesting HIP kernel execution but the kernel is not compiled with HIP compiler");
 #endif
-
+    break;
   case eExecutionPolicy::Sequential:
     {
       launch_info.beginExecute();

--- a/arcane/src/arcane/accelerator/RunCommandEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandEnumerate.h
@@ -82,7 +82,7 @@ _applyItems(RunCommand& command,ItemVectorViewT<ItemType> items,Lambda func)
 #if defined(__HIP__)
     {
       launch_info.beginExecute();
-      Span<const Int32> local_ids = items.localIds();
+      SmallSpan<const Int32> local_ids = items.localIds();
       auto [b,t] = launch_info.computeThreadBlockInfo(vsize);
       hipStream_t* s = reinterpret_cast<hipStream_t*>(launch_info._internalStreamImpl());
       auto& loop_func = impl::doIndirectCUDALambda<ItemType,Lambda>;

--- a/arcane/src/arcane/accelerator/RunCommandLoop.h
+++ b/arcane/src/arcane/accelerator/RunCommandLoop.h
@@ -69,6 +69,7 @@ _applyGenericLoop(RunCommand& command,LoopBoundType<N> bounds,const Lambda& func
 #else
     ARCANE_FATAL("Requesting HIP kernel execution but the kernel is not compiled with HIP compiler");
 #endif
+    break;
   case eExecutionPolicy::Sequential:
     launch_info.beginExecute();
     arcaneSequentialFor(bounds,func);

--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -38,10 +38,7 @@ void arcaneCheckCudaErrors(const TraceInfo& ti,cudaError_t e)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Allocateur spécifique pour 'Cuda'.
- *
- * Cet allocateur utilise 'cudaMallocManaged' au lieu de 'malloc'
- * pour les allocations.
+ * \brief Classe de base d'un allocateur spécifique pour 'Cuda'.
  */
 class CudaMemoryAllocatorBase
 : public Arccore::AlignedMemoryAllocator
@@ -86,11 +83,11 @@ class UnifiedMemoryCudaMemoryAllocator
 {
  protected:
 
-  virtual cudaError_t _allocate(void** ptr, size_t new_size) override
+  cudaError_t _allocate(void** ptr, size_t new_size) override
   {
     return ::cudaMallocManaged(ptr, new_size, cudaMemAttachGlobal);
   }
-  virtual cudaError_t _deallocate(void* ptr) override
+  cudaError_t _deallocate(void* ptr) override
   {
     return ::cudaFree(ptr);
   }
@@ -104,11 +101,11 @@ class HostPinnedCudaMemoryAllocator
 {
  protected:
 
-  virtual cudaError_t _allocate(void** ptr, size_t new_size) override
+  cudaError_t _allocate(void** ptr, size_t new_size) override
   {
     return ::cudaMallocHost(ptr, new_size);
   }
-  virtual cudaError_t _deallocate(void* ptr) override
+  cudaError_t _deallocate(void* ptr) override
   {
     return ::cudaFreeHost(ptr);
   }
@@ -122,11 +119,11 @@ class DeviceCudaMemoryAllocator
 {
  protected:
 
-  virtual cudaError_t _allocate(void** ptr, size_t new_size) override
+  cudaError_t _allocate(void** ptr, size_t new_size) override
   {
     return ::cudaMalloc(ptr, new_size);
   }
-  virtual cudaError_t _deallocate(void* ptr) override
+  cudaError_t _deallocate(void* ptr) override
   {
     return ::cudaFree(ptr);
   }

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -187,10 +187,10 @@ class CudaMemoryCopier
   void copy(Span<const std::byte> from, [[maybe_unused]] eMemoryRessource from_mem,
             Span<std::byte> to, [[maybe_unused]] eMemoryRessource to_mem) override
   {
-    // 'cudaMemcpyDefault' CUDA sait automatiquement ce qu'il faut faire en tenant
+    // 'cudaMemcpyDefault' sait automatiquement ce qu'il faut faire en tenant
     // uniquement compte de la valeur des pointeurs. Il faudrait voir si
     // utiliser \a from_mem et \a to_mem peut améliorer les performances.
-    cudaMemcpy(to.data(), from.data(), from.size(), cudaMemcpyDefault);
+    ARCANE_CHECK_CUDA(cudaMemcpy(to.data(), from.data(), from.size(), cudaMemcpyDefault));
   }
 };
 

--- a/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
+++ b/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
@@ -98,11 +98,11 @@ class HostPinnedHipMemoryAllocator
 {
  protected:
 
-  virtual hipError_t _allocate(void** ptr, size_t new_size) override
+  hipError_t _allocate(void** ptr, size_t new_size) override
   {
     return ::hipHostMalloc(ptr, new_size);
   }
-  virtual hipError_t _deallocate(void* ptr) override
+  hipError_t _deallocate(void* ptr) override
   {
     return ::hipHostFree(ptr);
   }
@@ -116,11 +116,11 @@ class DeviceHipMemoryAllocator
 {
  protected:
 
-  virtual hipError_t _allocate(void** ptr, size_t new_size) override
+  hipError_t _allocate(void** ptr, size_t new_size) override
   {
     return ::hipMalloc(ptr, new_size);
   }
-  virtual hipError_t _deallocate(void* ptr) override
+  hipError_t _deallocate(void* ptr) override
   {
     return ::hipFree(ptr);
   }

--- a/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
+++ b/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
@@ -38,22 +38,19 @@ void arcaneCheckHipErrors(const TraceInfo& ti,hipError_t e)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Allocateur spécifique pour 'Hip'.
- *
- * Cet allocateur utilise 'hipMallocManaged' au lieu de 'malloc'
- * pour les allocations.
+ * \brief Classe de base d'un allocateur spécifique pour 'Hip'.
  */
-class HipMemoryAllocator
+class HipMemoryAllocatorBase
 : public Arccore::AlignedMemoryAllocator
 {
  public:
-  HipMemoryAllocator() : AlignedMemoryAllocator(128){}
+  HipMemoryAllocatorBase() : AlignedMemoryAllocator(128){}
 
   bool hasRealloc() const override { return false; }
   void* allocate(size_t new_size) override
   {
     void* out = nullptr;
-    ARCANE_CHECK_HIP(::hipMallocManaged(&out,new_size,hipMemAttachGlobal));
+    ARCANE_CHECK_HIP(_allocate(&out,new_size));
     Int64 a = reinterpret_cast<Int64>(out);
     if ((a % 128)!=0)
       ARCANE_FATAL("Bad alignment for HIP allocator: offset={0}",(a % 128));
@@ -66,14 +63,78 @@ class HipMemoryAllocator
   }
   void deallocate(void* ptr) override
   {
-    ARCANE_CHECK_HIP(::hipFree(ptr));
+    ARCANE_CHECK_HIP(_deallocate(ptr));
+  }
+
+ protected:
+
+  virtual hipError_t _allocate(void** ptr, size_t new_size) = 0;
+  virtual hipError_t _deallocate(void* ptr) = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class UnifiedMemoryHipMemoryAllocator
+: public HipMemoryAllocatorBase
+{
+ protected:
+
+  hipError_t _allocate(void** ptr, size_t new_size) override
+  {
+    return ::hipMallocManaged(ptr, new_size, hipMemAttachGlobal);
+  }
+  hipError_t _deallocate(void* ptr) override
+  {
+    return ::hipFree(ptr);
   }
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-HipMemoryAllocator default_hip_memory_allocator;
+class HostPinnedHipMemoryAllocator
+: public HipMemoryAllocatorBase
+{
+ protected:
+
+  virtual hipError_t _allocate(void** ptr, size_t new_size) override
+  {
+    return ::hipHostMalloc(ptr, new_size);
+  }
+  virtual hipError_t _deallocate(void* ptr) override
+  {
+    return ::hipHostFree(ptr);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class DeviceHipMemoryAllocator
+: public HipMemoryAllocatorBase
+{
+ protected:
+
+  virtual hipError_t _allocate(void** ptr, size_t new_size) override
+  {
+    return ::hipMalloc(ptr, new_size);
+  }
+  virtual hipError_t _deallocate(void* ptr) override
+  {
+    return ::hipFree(ptr);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace
+{
+  UnifiedMemoryHipMemoryAllocator unified_memory_hip_memory_allocator;
+  HostPinnedHipMemoryAllocator host_pinned_hip_memory_allocator;
+  DeviceHipMemoryAllocator device_hip_memory_allocator;
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -81,7 +142,25 @@ HipMemoryAllocator default_hip_memory_allocator;
 Arccore::IMemoryAllocator*
 getHipMemoryAllocator()
 {
-  return &default_hip_memory_allocator;
+  return &unified_memory_hip_memory_allocator;
+}
+
+Arccore::IMemoryAllocator*
+getHipDeviceMemoryAllocator()
+{
+  return &device_hip_memory_allocator;
+}
+
+Arccore::IMemoryAllocator*
+getHipUnifiedMemoryAllocator()
+{
+  return &unified_memory_hip_memory_allocator;
+}
+
+Arccore::IMemoryAllocator*
+getHipHostPinnedMemoryAllocator()
+{
+  return &host_pinned_hip_memory_allocator;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/hip/HipAccelerator.h
+++ b/arcane/src/arcane/accelerator/hip/HipAccelerator.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CudaAccelerator.h                                           (C) 2000-2021 */
+/* CudaAccelerator.h                                           (C) 2000-2022 */
 /*                                                                           */
 /* Backend 'HIP' pour les accélérateurs.                                     */
 /*---------------------------------------------------------------------------*/
@@ -51,6 +51,15 @@ arcaneCheckHipErrors(const TraceInfo& ti,hipError_t e);
 
 extern "C++" ARCANE_HIP_EXPORT Arccore::IMemoryAllocator*
 getHipMemoryAllocator();
+
+extern "C++" ARCANE_HIP_EXPORT Arccore::IMemoryAllocator*
+getHipDeviceMemoryAllocator();
+
+extern "C++" ARCANE_HIP_EXPORT Arccore::IMemoryAllocator*
+getHipUnifiedMemoryAllocator();
+
+extern "C++" ARCANE_HIP_EXPORT Arccore::IMemoryAllocator*
+getHipHostPinnedMemoryAllocator();
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -49,6 +49,9 @@ void checkDevices()
     hipDeviceProp_t dp;
     ARCANE_CHECK_HIP(hipGetDeviceProperties(&dp, i));
 
+    int has_managed_memory = 0;
+    ARCANE_CHECK_HIP(hipDeviceGetAttribute(&has_managed_memory, hipDeviceAttributeManagedMemory, i));
+
     o << "\nDevice " << i << " name=" << dp.name << "\n";
     o << " computeCapability = " << dp.major << "." << dp.minor << "\n";
     o << " totalGlobalMem = " << dp.totalGlobalMem << "\n";
@@ -69,6 +72,7 @@ void checkDevices()
       << " " << dp.maxThreadsDim[2] << "\n";
     o << " maxGridSize = "<< dp.maxGridSize[0] << " " << dp.maxGridSize[1]
       << " " << dp.maxGridSize[2] << "\n";
+    o << " hasManagedMemory = " << has_managed_memory << "\n";
   }
 }
 

--- a/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
+++ b/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
@@ -633,10 +633,13 @@ init()
   const auto k_beg = this->k_beg();
 
   // Allocate the model data
+  Int32 size0 = NUM_VARS * (nz + 2 * hs) * (nx + 2 * hs);
+  info() << "Allocate memory for NumArray nx=" << nx << " nz=" << nz << " hs=" << hs << " size0=" << size0;
   nstate.resize(NUM_VARS,(nz + 2 * hs),(nx + 2 * hs));
   nstate_tmp.resize(NUM_VARS,(nz + 2 * hs),(nx + 2 * hs));
   nflux.resize(NUM_VARS,nz+1,nx+1); 
   ntend.resize(NUM_VARS,nz,nx);
+
   hy_dens_cell.resize(nz + 2 * hs);
   hy_dens_theta_cell.resize(nz + 2 * hs);
   hy_dens_int.resize(nz + 1);


### PR DESCRIPTION
- Add suport for `HostPinned` and `Device` memory
- Handle this platform in `ArcaneConfig.cmake`.
- Fix missing 'break' in 'switch' for HIP kernel launch. Because of that, sequential kernel was called after HIP kernel.