### PR TITLE
Remove 'using' in ArcaneGlobal for iostream classes

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -710,6 +710,10 @@ message(STATUS "ARCANE_EXTERNAL_LIBRARY_DIRS is ${ARCANE_EXTERNAL_LIBRARY_DIRS}"
 
 # ----------------------------------------------------------------------------
 
+# TODO: ajouter en INTERFACE 'ARCANE_NO_USING_FOR_STREAM' mi-2022 lorsque toutes
+# les branches de développement de Arcane auront été fusionnées
+# target_compile_definitions(arcane_build_compile_flags INTERFACE ARCANE_NO_USING_FOR_STREAM)
+
 if (UNIX)
   # Sur certaines plateformes (ex: centos7), il faut ajouter ces options
   # pour la compilation.

--- a/arcane/ceapart/src/arcane/cea/LimaCutInfosReader.cc
+++ b/arcane/ceapart/src/arcane/cea/LimaCutInfosReader.cc
@@ -61,7 +61,7 @@ LimaCutInfosReader(IParallelMng* parallel_mng)
 static Integer
 _readList(Int64ArrayView& int_list,const char* buf)
 {
-  istringstream istr(buf);
+  std::istringstream istr(buf);
   Integer index = 0;
   while (!istr.eof()){
     Int64 v = 0;

--- a/arcane/ceapart/src/arcane/materials/IMeshMaterialMng.h
+++ b/arcane/ceapart/src/arcane/materials/IMeshMaterialMng.h
@@ -370,10 +370,10 @@ class ARCANE_MATERIALS_EXPORT IMeshMaterialMng
   virtual IMeshMaterialVariable* checkVariable(IVariable* global_var) =0;
 
   //! Ecrit les infos des matériaux et milieux sur le flot \a o
-  virtual void dumpInfos(ostream& o) =0;
+  virtual void dumpInfos(std::ostream& o) =0;
 
   //! Ecrit les infos de la maille \a cell sur le flot \a o
-  virtual void dumpCellInfos(Cell cell,ostream& o) =0;
+  virtual void dumpCellInfos(Cell cell,std::ostream& o) =0;
 
   //! Vérifie la validité des structures internes
   virtual void checkValid() =0;

--- a/arcane/ceapart/src/arcane/materials/IMeshMaterialVariable.h
+++ b/arcane/ceapart/src/arcane/materials/IMeshMaterialVariable.h
@@ -150,12 +150,12 @@ class IMeshMaterialVariable
   /*!
    * \brief Affiche les valeurs de la variable sur le flot \a ostr.
    */
-  virtual void dumpValues(ostream& ostr) =0;
+  virtual void dumpValues(std::ostream& ostr) =0;
 
   /*!
    * \brief Affiche les valeurs de la variable pour la vue \a view sur le flot \a ostr.
    */
-  virtual void dumpValues(ostream& ostr,AllEnvCellVectorView view) =0;
+  virtual void dumpValues(std::ostream& ostr,AllEnvCellVectorView view) =0;
 
   /*!
    * \brief Remplit les valeurs partielles avec la valeur de la maille globale associée.

--- a/arcane/ceapart/src/arcane/materials/MatVarIndex.cc
+++ b/arcane/ceapart/src/arcane/materials/MatVarIndex.cc
@@ -30,7 +30,8 @@ MATERIALS_BEGIN_NAMESPACE
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ostream& operator<<(ostream& o,const MatVarIndex& mvi)
+std::ostream&
+operator<<(std::ostream& o,const MatVarIndex& mvi)
 {
   o << mvi.arrayIndex() << ":" << mvi.valueIndex();
   return o;
@@ -39,7 +40,8 @@ ostream& operator<<(ostream& o,const MatVarIndex& mvi)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ostream& operator<<(ostream& o,const ComponentItemLocalId& mvi)
+std::ostream&
+operator<<(std::ostream& o,const ComponentItemLocalId& mvi)
 {
   o << mvi.localId();
   return o;

--- a/arcane/ceapart/src/arcane/materials/MatVarIndex.h
+++ b/arcane/ceapart/src/arcane/materials/MatVarIndex.h
@@ -85,7 +85,8 @@ class ARCANE_MATERIALS_EXPORT MatVarIndex
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_MATERIALS_EXPORT ostream& operator<<(ostream& o,const MatVarIndex& mvi);
+ARCANE_MATERIALS_EXPORT std::ostream&
+operator<<(std::ostream& o,const MatVarIndex& mvi);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -140,8 +141,8 @@ class PureMatVarIndex
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_MATERIALS_EXPORT ostream&
-operator<<(ostream& o,const ComponentItemLocalId& mvi);
+ARCANE_MATERIALS_EXPORT std::ostream&
+operator<<(std::ostream& o,const ComponentItemLocalId& mvi);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/ceapart/src/arcane/materials/MaterialsGlobal.cc
+++ b/arcane/ceapart/src/arcane/materials/MaterialsGlobal.cc
@@ -21,15 +21,15 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-MATERIALS_BEGIN_NAMESPACE
+namespace Arcane::Materials
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 //! Opérateur de sortie sur un flot
-extern "C++" ostream&
-operator<< (ostream& o,eOperation operation)
+extern "C++" std::ostream&
+operator<< (std::ostream& o,eOperation operation)
 {
   switch(operation){
   case eOperation::Add:
@@ -48,8 +48,7 @@ operator<< (ostream& o,eOperation operation)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-MATERIALS_END_NAMESPACE
-ARCANE_END_NAMESPACE
+} // End namespace Arcane::Materials
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/ceapart/src/arcane/materials/MaterialsGlobal.h
+++ b/arcane/ceapart/src/arcane/materials/MaterialsGlobal.h
@@ -153,8 +153,8 @@ enum class eOperation
 };
 
 //! Opérateur de sortie sur un flot
-extern "C++" ostream&
-operator<< (ostream& ostr,eOperation operation);
+extern "C++" std::ostream&
+operator<< (std::ostream& ostr,eOperation operation);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/ceapart/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/ceapart/src/arcane/materials/MeshMaterialMng.cc
@@ -746,7 +746,7 @@ removeVariable(IMeshMaterialVariable* var)
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialMng::
-dumpInfos(ostream& o)
+dumpInfos(std::ostream& o)
 {
   Integer nb_mat = m_materials.size();
   Integer nb_env = m_environments.size();
@@ -789,7 +789,7 @@ dumpInfos(ostream& o)
 /*---------------------------------------------------------------------------*/
 // TODO: fusionner dumpInfos2() et dumpInfo().
 void MeshMaterialMng::
-dumpInfos2(ostream& o)
+dumpInfos2(std::ostream& o)
 {
   Integer nb_mat = m_materials.size();
   Integer nb_env = m_environments.size();
@@ -871,7 +871,7 @@ checkMaterialsInCells(Integer max_print)
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialMng::
-dumpCellInfos(Cell cell,ostream& o)
+dumpCellInfos(Cell cell,std::ostream& o)
 {
   CellToAllEnvCellConverter all_env_cell_converter(this);
   AllEnvCell all_env_cell = all_env_cell_converter[cell];

--- a/arcane/ceapart/src/arcane/materials/MeshMaterialMng.h
+++ b/arcane/ceapart/src/arcane/materials/MeshMaterialMng.h
@@ -126,8 +126,8 @@ class MeshMaterialMng
   IMeshMaterialVariable* findVariable(const String& name) override;
   IMeshMaterialVariable* checkVariable(IVariable* global_var) override;
 
-  void dumpInfos(ostream& o) override;
-  void dumpCellInfos(Cell cell,ostream& o) override;
+  void dumpInfos(std::ostream& o) override;
+  void dumpCellInfos(Cell cell,std::ostream& o) override;
 
   void checkValid() override;
 
@@ -194,7 +194,7 @@ class MeshMaterialMng
   void syncVariablesReferences();
 
   void incrementTimestamp() { ++m_timestamp; }
-  void dumpInfos2(ostream& o);
+  void dumpInfos2(std::ostream& o);
 
   const MeshHandle& meshHandle() const { return m_mesh_handle; }
 

--- a/arcane/ceapart/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/ceapart/src/arcane/materials/MeshMaterialVariable.h
@@ -374,8 +374,8 @@ class ItemMaterialVariableScalar
 
   ARCANE_MATERIALS_EXPORT void synchronize() override;
   ARCANE_MATERIALS_EXPORT void synchronize(MeshMaterialVariableSynchronizerList& sync_list) override;
-  ARCANE_MATERIALS_EXPORT void dumpValues(ostream& ostr) override;
-  ARCANE_MATERIALS_EXPORT void dumpValues(ostream& ostr,AllEnvCellVectorView view) override;
+  ARCANE_MATERIALS_EXPORT void dumpValues(std::ostream& ostr) override;
+  ARCANE_MATERIALS_EXPORT void dumpValues(std::ostream& ostr,AllEnvCellVectorView view) override;
   ARCANE_MATERIALS_EXPORT void serialize(ISerializer* sbuffer,Int32ConstArrayView ids) override;
 
  public:
@@ -514,8 +514,8 @@ class ItemMaterialVariableArray
 
   ARCANE_MATERIALS_EXPORT void synchronize() override;
   ARCANE_MATERIALS_EXPORT void synchronize(MeshMaterialVariableSynchronizerList& sync_list) override;
-  ARCANE_MATERIALS_EXPORT void dumpValues(ostream& ostr) override;
-  ARCANE_MATERIALS_EXPORT void dumpValues(ostream& ostr,AllEnvCellVectorView view) override;
+  ARCANE_MATERIALS_EXPORT void dumpValues(std::ostream& ostr) override;
+  ARCANE_MATERIALS_EXPORT void dumpValues(std::ostream& ostr,AllEnvCellVectorView view) override;
   ARCANE_MATERIALS_EXPORT void serialize(ISerializer* sbuffer,Int32ConstArrayView ids) override;
   ARCANE_MATERIALS_EXPORT Int32 dataTypeSize() const override;
 

--- a/arcane/ceapart/src/arcane/materials/MeshMaterialVariableArray.cc
+++ b/arcane/ceapart/src/arcane/materials/MeshMaterialVariableArray.cc
@@ -124,7 +124,7 @@ ItemMaterialVariableArray(const MaterialVariableBuildInfo& v,PrivatePartType* gl
 
 template<typename DataType> void
 ItemMaterialVariableArray<DataType>::
-dumpValues(ostream& ostr)
+dumpValues(std::ostream& ostr)
 {
   ARCANE_UNUSED(ostr);
   throw NotImplementedException(A_FUNCINFO);
@@ -135,7 +135,7 @@ dumpValues(ostream& ostr)
 
 template<typename DataType> void
 ItemMaterialVariableArray<DataType>::
-dumpValues(ostream& ostr,AllEnvCellVectorView view)
+dumpValues(std::ostream& ostr,AllEnvCellVectorView view)
 {
   ARCANE_UNUSED(ostr);
   ARCANE_UNUSED(view);

--- a/arcane/ceapart/src/arcane/materials/MeshMaterialVariableScalar.cc
+++ b/arcane/ceapart/src/arcane/materials/MeshMaterialVariableScalar.cc
@@ -613,7 +613,7 @@ _synchronizeV5()
 
 template<typename DataType> void
 ItemMaterialVariableScalar<DataType>::
-dumpValues(ostream& ostr,AllEnvCellVectorView view)
+dumpValues(std::ostream& ostr,AllEnvCellVectorView view)
 {
   ostr << "Dumping values for material variable name=" << this->name() << '\n';
   ENUMERATE_ALLENVCELL(iallenvcell,view){
@@ -635,7 +635,7 @@ dumpValues(ostream& ostr,AllEnvCellVectorView view)
 
 template<typename DataType> void
 ItemMaterialVariableScalar<DataType>::
-dumpValues(ostream& ostr)
+dumpValues(std::ostream& ostr)
 {
   ostr << "Dumping values for material variable name=" << this->name() << '\n';
   IItemFamily* family = m_global_variable->itemFamily();

--- a/arcane/ceapart/src/arcane/tests/AMRCartesianMeshTesterModule.cc
+++ b/arcane/ceapart/src/arcane/tests/AMRCartesianMeshTesterModule.cc
@@ -394,7 +394,7 @@ _processPatches()
       String filename = String::format("Patch{0}-{1}-{2}.svg",i,comm_rank,comm_size);
       Directory directory = subDomain()->exportDirectory();
       String full_filename = directory.file(filename);
-      ofstream ofile(full_filename.localstr());
+      std::ofstream ofile(full_filename.localstr());
       SimpleSVGMeshExporter exporter(ofile);
       exporter.write(patch_own_cell);
     }

--- a/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.cc
+++ b/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.cc
@@ -821,7 +821,7 @@ _saveSVG()
   ICartesianMesh* cm = m_cartesian_mesh;
   IMesh* mesh = cm->mesh();
   info() << "Saving mesh to SVG format";
-  ofstream ofile("toto.svg");
+  std::ofstream ofile("toto.svg");
   SimpleSVGMeshExporter writer(ofile);
   writer.write(mesh->allCells());
 }

--- a/arcane/ceapart/src/arcane/tests/UnitTestCartesianMeshPatch.cc
+++ b/arcane/ceapart/src/arcane/tests/UnitTestCartesianMeshPatch.cc
@@ -343,7 +343,7 @@ UnitTestCartesianMeshPatchService::setUpForClass()
     for( Integer i=0; i<nb_patch; ++i ){
       ICartesianMeshPatch* patch = m_cartesian_mesh->patch(i);
       String filename = export_dir.file(String::format("Patch{0}.svg",i));
-      ofstream ofile(filename.localstr());
+      std::ofstream ofile(filename.localstr());
       SimpleSVGMeshExporter writer(ofile);
       writer.write(patch->cells());
     }

--- a/arcane/src/arcane/accelerator/core/AcceleratorCore.cc
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCore.cc
@@ -113,7 +113,7 @@ setHIPRunQueueRuntime(impl::IRunQueueRuntime* v)
 
 //! Affiche le nom de la politique d'exécution
 extern "C++" ARCANE_ACCELERATOR_CORE_EXPORT
-ostream& operator<<(ostream& o,eExecutionPolicy exec_policy)
+std::ostream& operator<<(std::ostream& o,eExecutionPolicy exec_policy)
 {
   switch(exec_policy){
   case eExecutionPolicy::None: o << "None"; break;

--- a/arcane/src/arcane/impl/ArcaneMain.cc
+++ b/arcane/src/arcane/impl/ArcaneMain.cc
@@ -548,7 +548,7 @@ callFunctorWithCatchedException(IFunctor* functor,IArcaneMain* exec_main,
         *clean_abort = true;
         ret_val = 5;
         if (is_master && is_print){
-          ofstream ofile("fatal");
+          std::ofstream ofile("fatal");
           ofile << ret_val << '\n';
           ofile.flush();
           trace->error() << "ParallelFatalErrorException caught in ArcaneMain::callFunctor: " << ex << '\n';
@@ -581,7 +581,7 @@ callFunctorWithCatchedException(IFunctor* functor,IArcaneMain* exec_main,
         *clean_abort = true;
         ret_val = 5;
         if (is_master && is_print){
-          ofstream ofile("fatal");
+          std::ofstream ofile("fatal");
           ofile << ret_val << '\n';
           ofile.flush();
           trace->error() << "ParallelFatalErrorException caught in ArcaneMain::callFunctor: " << ex << '\n';
@@ -1275,7 +1275,7 @@ setErrorCode(int errcode)
     // dans ce cas n'importe quel PE peut le faire.
     if (ArcaneMain::m_is_master_io || errcode==4){
       String errname = "fatal_" + String::fromNumber(errcode);
-      ofstream ofile(errname.localstr());
+      std::ofstream ofile(errname.localstr());
       ofile.close();
     }
   }

--- a/arcane/src/arcane/impl/CaseDocument.cc
+++ b/arcane/src/arcane/impl/CaseDocument.cc
@@ -94,8 +94,8 @@ class CaseDocument
   void addWarning(const CaseOptionError& case_error) override;
   bool hasError() const override;
   bool hasWarnings() const override;
-  void printErrors(ostream& o) override;
-  void printWarnings(ostream& o) override;
+  void printErrors(std::ostream& o) override;
+  void printWarnings(std::ostream& o) override;
   void clearErrorsAndWarnings() override;
 
  public:
@@ -137,7 +137,7 @@ class CaseDocument
   
   XmlNode _forceCreateChild(XmlNode& parent,const String& us);
   void _assignLanguage(const String& langname);
-  void _printErrorsOrWarnings(ostream& o,ConstArrayView<CaseOptionError> errors);
+  void _printErrorsOrWarnings(std::ostream& o,ConstArrayView<CaseOptionError> errors);
 };
 
 /*---------------------------------------------------------------------------*/
@@ -357,7 +357,7 @@ hasWarnings() const
 /*---------------------------------------------------------------------------*/
 
 void CaseDocument::
-printErrors(ostream& o)
+printErrors(std::ostream& o)
 {
   _printErrorsOrWarnings(o,m_errors);
 }
@@ -366,7 +366,7 @@ printErrors(ostream& o)
 /*---------------------------------------------------------------------------*/
 
 void CaseDocument::
-printWarnings(ostream& o)
+printWarnings(std::ostream& o)
 {
   _printErrorsOrWarnings(o,m_warnings);
 }
@@ -385,7 +385,7 @@ clearErrorsAndWarnings()
 /*---------------------------------------------------------------------------*/
 
 void CaseDocument::
-_printErrorsOrWarnings(ostream& o,ConstArrayView<CaseOptionError> errors)
+_printErrorsOrWarnings(std::ostream& o,ConstArrayView<CaseOptionError> errors)
 {
   for( const CaseOptionError& error : errors.range() ){
     if (arcaneIsCheck()){

--- a/arcane/src/arcane/impl/CaseMng.cc
+++ b/arcane/src/arcane/impl/CaseMng.cc
@@ -330,7 +330,7 @@ _checkTranslateDocument()
     CaseDocumentLangTranslator translator(traceMng());
     String convert_string = translator.translate(this,tr_lang);
     {
-      ofstream ofile("convert_info.txt");
+      std::ofstream ofile("convert_info.txt");
       convert_string.writeBytes(ofile);
     }
   }

--- a/arcane/src/arcane/impl/CheckpointMng.cc
+++ b/arcane/src/arcane/impl/CheckpointMng.cc
@@ -401,7 +401,7 @@ writeDefaultCheckpoint(ICheckpointWriter* writer)
   if (m_sub_domain->allReplicaParallelMng()->isMasterIO()){
     Directory export_directory(m_sub_domain->exportDirectory());
     String info_file(export_directory.file("checkpoint_info.xml"));
-    ofstream ofile(info_file.localstr());
+    std::ofstream ofile(info_file.localstr());
     ofile.write((const char*)bytes_infos.unguardedBasePointer(),bytes_infos.size());
     if (!ofile.good())
       ARCANE_THROW(IOException,"Can not write file '{0}'",info_file);

--- a/arcane/src/arcane/impl/Configuration.cc
+++ b/arcane/src/arcane/impl/Configuration.cc
@@ -142,7 +142,7 @@ class Configuration
   IConfiguration* clone() const override;
   void merge(const IConfiguration* c) override;
   void dump() const override;
-  void dump(ostream& o) const override;
+  void dump(std::ostream& o) const override;
 
  public:
 
@@ -284,7 +284,7 @@ dump() const
 /*---------------------------------------------------------------------------*/
 
 void Configuration::
-dump(ostream& o) const
+dump(std::ostream& o) const
 {
   o << "Configuration:\n";
   for( auto& i : m_values ){

--- a/arcane/src/arcane/impl/EntryPointMng.cc
+++ b/arcane/src/arcane/impl/EntryPointMng.cc
@@ -46,7 +46,7 @@ class EntryPointMng
  public:
   
   virtual void addEntryPoint(IEntryPoint*);
-  virtual void dumpList(ostream&);
+  virtual void dumpList(std::ostream&);
   virtual IEntryPoint* findEntryPoint(const String& s);
   virtual IEntryPoint* findEntryPoint(const String& module_name,const String& s);
   virtual EntryPointCollection entryPoints() { return m_entry_points; }
@@ -98,7 +98,7 @@ addEntryPoint(IEntryPoint* v)
 /*---------------------------------------------------------------------------*/
 
 void EntryPointMng::
-dumpList(ostream& o)
+dumpList(std::ostream& o)
 {
   o << "** EntryPointMng::dump_list: " << m_entry_points.count();
   o << '\n';

--- a/arcane/src/arcane/impl/IOMng.cc
+++ b/arcane/src/arcane/impl/IOMng.cc
@@ -128,7 +128,7 @@ writeXmlFile(IXmlDocumentHolder* doc, const String& filename, const bool to_inde
 {
   if (!doc)
     return true;
-  ofstream ofile(filename.localstr());
+  std::ofstream ofile(filename.localstr());
 
   // Check if stream is OK
   if (!ofile.good())

--- a/arcane/src/arcane/impl/ModuleMng.cc
+++ b/arcane/src/arcane/impl/ModuleMng.cc
@@ -47,7 +47,7 @@ class ModuleMng
 
   void addModule(Ref<IModule>) override;
   void removeModule(Ref<IModule>) override;
-  void dumpList(ostream&) override;
+  void dumpList(std::ostream&) override;
   ModuleCollection modules() const override { return m_modules; }
   void removeAllModules() override;
   bool isModuleActive(const String& name) override;
@@ -129,7 +129,7 @@ removeModule(Ref<IModule> module)
 /*---------------------------------------------------------------------------*/
 
 void ModuleMng::
-dumpList(ostream& o)
+dumpList(std::ostream& o)
 {
   o << "** ModuleMng::dump_list: " << m_modules.count();
   o << '\n';

--- a/arcane/src/arcane/impl/PropertyMng.cc
+++ b/arcane/src/arcane/impl/PropertyMng.cc
@@ -61,7 +61,7 @@ class PropertyMng
   void serialize(ISerializer* serializer) override;
   void writeTo(ByteArray& bytes) override;
   void readFrom(Span<const Byte> bytes) override;
-  void print(ostream& o) const override;
+  void print(std::ostream& o) const override;
   IObservable* writeObservable() override { return &m_write_observable; }
   IObservable* readObservable() override { return &m_read_observable; }
 
@@ -257,7 +257,7 @@ readFrom(Span<const Byte> bytes)
  * \brief Affiche les propriétés et leurs valeurs sur le flot \a o.
  */
 void PropertyMng::
-print(ostream& o) const
+print(std::ostream& o) const
 {
   for (auto v : m_properties_map) {
     const Properties& p = v.second;

--- a/arcane/src/arcane/impl/SubDomain.cc
+++ b/arcane/src/arcane/impl/SubDomain.cc
@@ -239,7 +239,7 @@ class SubDomain
   Int32 nbSubDomain() const override { return m_parallel_mng->commSize(); }
   void setIsContinue() override { m_is_continue = true; }
   bool isContinue() const override { return m_is_continue; }
-  void dumpInfo(ostream&) override;
+  void dumpInfo(std::ostream&) override;
   void doInitModules() override;
   void doExitModules() override;
   IMesh* defaultMesh() override { return m_default_mesh_handle.mesh(); }
@@ -585,7 +585,7 @@ destroy()
 /*---------------------------------------------------------------------------*/
 
 void SubDomain::
-dumpInfo(ostream& o)
+dumpInfo(std::ostream& o)
 {
   m_module_mng->dumpList(o);
 }

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -884,7 +884,7 @@ dumpHistory(bool is_verbose)
   Integer master_io_rank = parallel_mng->masterIORank() ;
 
   if (m_is_master_io) {
-    ofstream ofile(out_dir.file("time_history.xml").localstr());
+    std::ofstream ofile(out_dir.file("time_history.xml").localstr());
     ofile << "<?xml version='1.0' ?>\n";
     ofile << "<curves>\n";
     for( ConstIterT<HistoryList> i(m_history_list); i(); ++i ){

--- a/arcane/src/arcane/impl/TimeLoopMng.cc
+++ b/arcane/src/arcane/impl/TimeLoopMng.cc
@@ -1601,8 +1601,8 @@ _dumpTimeInfos(JSONWriter& json_writer)
   else if (timer_type==Timer::TimerReal)
     info() << " Use the clock time (elapsed) for the statistics";
 
-  ostringstream o;
-  std::ios_base::fmtflags f = o.flags(ios::right);
+  std::ostringstream o;
+  std::ios_base::fmtflags f = o.flags(std::ios::right);
   Integer nb_cell = 0;
   IMesh * mesh = subDomain()->defaultMesh();
   if (mesh)
@@ -1901,7 +1901,7 @@ doComputeLoop(Integer max_loop)
         Integer iteration = subDomain()->commonVariables().globalIteration();
         mem_info->setIteration(iteration);
 
-        ostringstream ostr;
+        std::ostringstream ostr;
         if (iteration>0)
           mem_info->printAllocatedMemory(ostr,iteration-1);
         if (iteration>1)

--- a/arcane/src/arcane/impl/TimeStats.cc
+++ b/arcane/src/arcane/impl/TimeStats.cc
@@ -151,7 +151,7 @@ class TimeStats::Action
   void merge(AllActionsInfo& save_info,Integer* index);
   void dumpJSON(JSONWriter& writer,eTimeType tt);
   void computeCumulativeTimes();
-  void dumpCurrentStats(ostream& ostr,int level,Real unit);
+  void dumpCurrentStats(std::ostream& ostr,int level,Real unit);
  private:
   Action* m_parent; //!< Action parente
   String m_name; //!< Nom de l'action
@@ -210,7 +210,7 @@ class TimeStats::ActionSeries
     m_main_action.merge(all_actions_info,&index);
     m_main_action.computeCumulativeTimes();
   }
-  void dumpStats(ostream& ostr,bool is_verbose,Real nb,const String& name,
+  void dumpStats(std::ostream& ostr,bool is_verbose,Real nb,const String& name,
                  bool use_elapsed_time,const String& message);
  public:
 
@@ -218,9 +218,9 @@ class TimeStats::ActionSeries
   Int64 m_nb_iteration_loop = 0;
 
  private:
-  void _dumpStats(ostream& ostr,Action& action,eTimeType tt,int level,int max_level,Real nb);
-  void _dumpAllPhases(ostream& ostr,Action& action,eTimeType tt,int tc,Real nb);
-  void _dumpCurrentStats(ostream& ostr,Action& action,int level,Real unit);
+  void _dumpStats(std::ostream& ostr,Action& action,eTimeType tt,int level,int max_level,Real nb);
+  void _dumpAllPhases(std::ostream& ostr,Action& action,eTimeType tt,int tc,Real nb);
+  void _dumpCurrentStats(std::ostream& ostr,Action& action,int level,Real unit);
 };
 
 /*---------------------------------------------------------------------------*/
@@ -305,7 +305,7 @@ endGatherStats()
     sb += m_name;
     sb += ".xml";
     String s(sb);
-    ofstream ofile(s.localstr());
+    std::ofstream ofile(s.localstr());
     ofile << m_full_stats_str.str();
   }
 }
@@ -441,7 +441,7 @@ findSubActionRecursive(const String& action_name) const
 /*---------------------------------------------------------------------------*/
 
 void TimeStats::ActionSeries::
-dumpStats(ostream& ostr,bool is_verbose,Real nb,const String& name,
+dumpStats(std::ostream& ostr,bool is_verbose,Real nb,const String& name,
           bool use_elapsed_time,const String& message)
 {
   Int64 nb_iteration_loop = this->nbIterationLoop();
@@ -457,7 +457,7 @@ dumpStats(ostream& ostr,bool is_verbose,Real nb,const String& name,
   else if (tt==TT_Virtual)
     ostr << " (CPU time)";
   ostr << ":\n";
-  std::ios_base::fmtflags f = ostr.flags(ios::right);
+  std::ios_base::fmtflags f = ostr.flags(std::ios::right);
 
   ostr << Trace::Width(50) << "        Action       "
        << Trace::Width(11) << "  Time  "
@@ -487,7 +487,7 @@ dumpStats(ostream& ostr,bool is_verbose,Real nb,const String& name,
 /*---------------------------------------------------------------------------*/
 
 void TimeStats::
-dumpStats(ostream& ostr,bool is_verbose,Real nb,const String& name,
+dumpStats(std::ostream& ostr,bool is_verbose,Real nb,const String& name,
           bool use_elapsed_time)
 {
   _computeCumulativeTimes();
@@ -525,7 +525,7 @@ dumpCurrentStats(const String& action_name)
 namespace
 {
 void
-_writeValue(ostream& ostr,Real value,Real unit)
+_writeValue(std::ostream& ostr,Real value,Real unit)
 {
   ostr.width(12);
   Real v2 = value * unit;
@@ -540,7 +540,7 @@ _writeValue(ostream& ostr,Real value,Real unit)
 /*---------------------------------------------------------------------------*/
 
 void
-_printIndentedName(ostream& ostr,const String& name,int level)
+_printIndentedName(std::ostream& ostr,const String& name,int level)
 {
   StringBuilder indent_str;
   StringBuilder after_str;
@@ -559,7 +559,7 @@ _printIndentedName(ostream& ostr,const String& name,int level)
 /*---------------------------------------------------------------------------*/
 
 void
-_printPercentage(ostream& ostr,Real value,Real cumulative_value)
+_printPercentage(std::ostream& ostr,Real value,Real cumulative_value)
 {
   Real percent = 1.0;
   // Normalement il faut juste vérifier que cumulative_value n'est pas nul
@@ -583,7 +583,7 @@ _printPercentage(ostream& ostr,Real value,Real cumulative_value)
 /*---------------------------------------------------------------------------*/
 
 void TimeStats::Action::
-dumpCurrentStats(ostream& ostr,int level,Real unit)
+dumpCurrentStats(std::ostream& ostr,int level,Real unit)
 {
   Action& action = *this;
   _printIndentedName(ostr,action.name(),level);
@@ -612,7 +612,7 @@ _computeCumulativeTimes()
 /*---------------------------------------------------------------------------*/
 
 void TimeStats::ActionSeries::
-_dumpStats(ostream& ostr,Action& action,eTimeType tt,int level,int max_level,Real nb)
+_dumpStats(std::ostream& ostr,Action& action,eTimeType tt,int level,int max_level,Real nb)
 {
   PhaseValue& pv = action.m_phases[TP_Computation];
 
@@ -634,7 +634,7 @@ _dumpStats(ostream& ostr,Action& action,eTimeType tt,int level,int max_level,Rea
 /*---------------------------------------------------------------------------*/
 
 void TimeStats::
-_dumpCumulativeTime(ostream& ostr,Action& action,eTimePhase tp,eTimeType tt)
+_dumpCumulativeTime(std::ostream& ostr,Action& action,eTimePhase tp,eTimeType tt)
 {
   Real current_time = action.m_phases[tp].m_time[tt][TC_Local];
   Real cumulative_time = action.m_phases[tp].m_time[tt][TC_Cumulative];
@@ -659,7 +659,7 @@ _dumpCumulativeTime(ostream& ostr,Action& action,eTimePhase tp,eTimeType tt)
 /*---------------------------------------------------------------------------*/
 
 void TimeStats::ActionSeries::
-_dumpAllPhases(ostream& ostr,Action& action,eTimeType tt,int tc,Real nb)
+_dumpAllPhases(std::ostream& ostr,Action& action,eTimeType tt,int tc,Real nb)
 {
   Real all_phase_time = action.m_total_time.m_time[tt][tc];
 

--- a/arcane/src/arcane/impl/TimeStats.h
+++ b/arcane/src/arcane/impl/TimeStats.h
@@ -128,7 +128,7 @@ class TimeStats
 
  public:
 
-  void dumpStats(ostream& ostr,bool is_verbose,Real nb,
+  void dumpStats(std::ostream& ostr,bool is_verbose,Real nb,
                  const String& name,bool use_elapsed_time) override;
   void dumpCurrentStats(const String& action) override;
 
@@ -159,7 +159,7 @@ class TimeStats
   Action* m_current_action = nullptr;
   std::stack<eTimePhase> m_phases_type;
   bool m_need_compute_elapsed_time = false;
-  ostringstream m_full_stats_str;
+  std::ostringstream m_full_stats_str;
   bool m_full_stats;
   String m_name;
   ITimeMetricCollector* m_metric_collector = nullptr;
@@ -170,8 +170,8 @@ class TimeStats
   PhaseValue _currentPhaseValue();
   void _checkGathering();
   void _computeCumulativeTimes();
-  void _dumpCumulativeTime(ostream& ostr,Action& action,eTimePhase tp,eTimeType tt);
-  void _dumpAllPhases(ostream& ostr,Action& action,eTimeType tt,int tc,Real nb);
+  void _dumpCumulativeTime(std::ostream& ostr,Action& action,eTimePhase tp,eTimeType tt);
+  void _dumpAllPhases(std::ostream& ostr,Action& action,eTimeType tt,int tc,Real nb);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableMng.cc
+++ b/arcane/src/arcane/impl/VariableMng.cc
@@ -193,8 +193,8 @@ class VariableMng
   void addVariable(IVariable* var) override;
   void removeVariableRef(VariableRef*) override;
   void removeVariable(IVariable* var) override;
-  void dumpList(ostream&,IModule*) override;
-  void dumpList(ostream&) override;
+  void dumpList(std::ostream&,IModule*) override;
+  void dumpList(std::ostream&) override;
   void initializeVariables(bool) override;
   String generateTemporaryVariableName() override;
   void variables(VariableRefCollection,IModule*) override;
@@ -215,7 +215,7 @@ class VariableMng
   IVariable* findMeshVariable(IMesh* mesh,const String& name) override;
   IVariable* findVariableFullyQualified(const String& name) override;
 
-  void dumpStats(ostream& ostr,bool is_verbose) override;
+  void dumpStats(std::ostream& ostr,bool is_verbose) override;
   void dumpStatsJSON(JSONWriter& writer) override;
   IVariableUtilities* utilities() const override { return m_utilities; }
 
@@ -288,7 +288,7 @@ class VariableMng
  private:
 
   //! Ecrit la valeur de la variable \a v sur le flot \a o
-  void _dumpVariable(const VariableRef& v,ostream& o);
+  void _dumpVariable(const VariableRef& v,std::ostream& o);
   void _writeVariables(IDataWriter* writer,const VariableCollection& vars,bool use_hash);
 
   const char* _msgClassName() const { return "Variable"; }
@@ -760,7 +760,7 @@ generateTemporaryVariableName()
 /*---------------------------------------------------------------------------*/
 
 void VariableMng::
-dumpList(ostream& o,IModule* c)
+dumpList(std::ostream& o,IModule* c)
 {
   o << "  ** VariableMng::Variable list\n";
   for( auto i : m_full_name_variable_map ){
@@ -776,7 +776,7 @@ dumpList(ostream& o,IModule* c)
 /*---------------------------------------------------------------------------*/
 
 void VariableMng::
-dumpList(ostream& o)
+dumpList(std::ostream& o)
 {
   o << "  ** VariableMng::Variable list\n";
   for( auto i : m_full_name_variable_map ){
@@ -797,7 +797,7 @@ dumpList(ostream& o)
 /*---------------------------------------------------------------------------*/
 
 void VariableMng::
-_dumpVariable(const VariableRef& var,ostream& o)
+_dumpVariable(const VariableRef& var,std::ostream& o)
 {
   o << "  ** Variable: " << &var << " : ";
   o.width(15);
@@ -1570,7 +1570,7 @@ _checkHashFunction(const VariableMetaDataList& vmd_list)
       Ref<ISerializedData> sdata(data->createSerializedDataRef(false));
       Span<const Byte> buf(sdata->constBytes());
       String fname = listing_dir.file(String::format("dump-{0}-sid_{1}",var->fullName(),sid));
-      ofstream ofile(fname.localstr());
+      std::ofstream ofile(fname.localstr());
       ofile.write(reinterpret_cast<const char*>(buf.data()),buf.size());
     }
   }
@@ -1758,7 +1758,7 @@ class VariableSizeSorter
 };
 
 void VariableMng::
-dumpStats(ostream& ostr,bool is_verbose)
+dumpStats(std::ostream& ostr,bool is_verbose)
 {
   ostr.precision(20);
   ostr << "\nMemory statistics for variables:\n";

--- a/arcane/src/arcane/impl/VariableUtilities.cc
+++ b/arcane/src/arcane/impl/VariableUtilities.cc
@@ -56,7 +56,7 @@ VariableUtilities::
 /*---------------------------------------------------------------------------*/
 
 void VariableUtilities::
-dumpAllVariableDependencies(ostream& ostr,bool is_recursive)
+dumpAllVariableDependencies(std::ostream& ostr,bool is_recursive)
 {
   VariableCollection used_variables = m_variable_mng->usedVariables();
   for( VariableCollection::Enumerator ivar(used_variables); ++ivar; ){
@@ -69,7 +69,7 @@ dumpAllVariableDependencies(ostream& ostr,bool is_recursive)
 /*---------------------------------------------------------------------------*/
 
 void VariableUtilities::
-dumpDependencies(IVariable* var,ostream& ostr,bool is_recursive)
+dumpDependencies(IVariable* var,std::ostream& ostr,bool is_recursive)
 {
   // Ensemble des variables déjà traitées pour éviter les récursions infinies
   _dumpDependencies(var,ostr,is_recursive);
@@ -79,7 +79,7 @@ dumpDependencies(IVariable* var,ostream& ostr,bool is_recursive)
 /*---------------------------------------------------------------------------*/
 
 void VariableUtilities::
-_dumpDependencies(IVariable* var,ostream& ostr,bool is_recursive)
+_dumpDependencies(IVariable* var,std::ostream& ostr,bool is_recursive)
 {
   std::set<IVariable*> done_vars;
   done_vars.insert(var);
@@ -108,7 +108,7 @@ _dumpDependencies(IVariable* var,ostream& ostr,bool is_recursive)
 /*---------------------------------------------------------------------------*/
 
 void VariableUtilities::
-_dumpDependencies(VariableDependInfo& vdi,ostream& ostr,bool is_recursive,
+_dumpDependencies(VariableDependInfo& vdi,std::ostream& ostr,bool is_recursive,
                   std::set<IVariable*>& done_vars,Integer indent_level)
 {
   IVariable* var = vdi.variable();

--- a/arcane/src/arcane/impl/VariableUtilities.h
+++ b/arcane/src/arcane/impl/VariableUtilities.h
@@ -47,8 +47,8 @@ class VariableUtilities
  public:
 
   virtual IVariableMng* variableMng() const { return m_variable_mng; }
-  virtual void dumpDependencies(IVariable* var,ostream& ostr,bool is_recursive);
-  virtual void dumpAllVariableDependencies(ostream& ostr,bool is_recursive);
+  virtual void dumpDependencies(IVariable* var,std::ostream& ostr,bool is_recursive);
+  virtual void dumpAllVariableDependencies(std::ostream& ostr,bool is_recursive);
   virtual VariableCollection filterCommonVariables(IParallelMng* pm,
                                                    const VariableCollection input_variables,
                                                    bool dump_not_common);
@@ -57,8 +57,8 @@ class VariableUtilities
 
   IVariableMng* m_variable_mng;
 
-  void _dumpDependencies(IVariable* var,ostream& ostr,bool is_recursive);
-  void _dumpDependencies(VariableDependInfo& vdi,ostream& ostr,bool is_recursive,
+  void _dumpDependencies(IVariable* var,std::ostream& ostr,bool is_recursive);
+  void _dumpDependencies(VariableDependInfo& vdi,std::ostream& ostr,bool is_recursive,
                          std::set<IVariable*>& done_vars,Integer indent_level);
 };
 

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -1228,7 +1228,7 @@ _writeMesh(const String& base_name)
 /*---------------------------------------------------------------------------*/
 
 void DynamicMesh::
-_printMesh(ostream& ostr)
+_printMesh(std::ostream& ostr)
 {
   ostr << "----------- Mesh\n";
   ostr << " Nodes: " << nbNode() << '\n';
@@ -2745,9 +2745,9 @@ void DynamicMesh::
 _writeCells(const String& filename)
 {
   CellGroup cells(m_cell_family->allItems());
-  ofstream ofile(filename.localstr());
+  std::ofstream ofile(filename.localstr());
   ENUMERATE_CELL(icell,cells){
-    const Cell& cell = *icell;
+    Cell cell = *icell;
     ofile << "CELL: uid=" << cell.uniqueId() << " isown="
           << cell.isOwn() << " owner=" << cell.owner() << '\n';
   }

--- a/arcane/src/arcane/mesh/DynamicMesh.h
+++ b/arcane/src/arcane/mesh/DynamicMesh.h
@@ -544,7 +544,7 @@ public:
 
  private:
 
-  void _printMesh(ostream& ostr);
+  void _printMesh(std::ostream& ostr);
   void _allocateCells(Integer mesh_nb_cell,
                       Int64ConstArrayView cells_info,
                       Int32ArrayView cells = Int32ArrayView(),

--- a/arcane/src/arcane/mesh/FaceUniqueIdBuilder.cc
+++ b/arcane/src/arcane/mesh/FaceUniqueIdBuilder.cc
@@ -580,7 +580,7 @@ _computeFacesUniqueIdsParallelV1()
     info() << ostr.str();
     String file_name("faces_uid.");
     file_name = file_name + my_rank;    
-    ofstream ofile(file_name.localstr());
+    std::ofstream ofile(file_name.localstr());
     ofile << ostr.str();
   }
 }

--- a/arcane/src/arcane/mesh/FullItemInfo.cc
+++ b/arcane/src/arcane/mesh/FullItemInfo.cc
@@ -59,7 +59,7 @@ FullCellInfo(Int64ConstArrayView cells_infos,Integer cell_index,
 /*---------------------------------------------------------------------------*/
 
 void FullCellInfo::
-print(ostream& o) const
+print(std::ostream& o) const
 {
   o << "Cell uid=" << uniqueId()
     << " nb_node=" << nbNode()

--- a/arcane/src/arcane/mesh/FullItemInfo.h
+++ b/arcane/src/arcane/mesh/FullItemInfo.h
@@ -91,7 +91,7 @@ class FullCellInfo
   Integer whichChildAmI () const { return CheckedConvert::toInteger(m_infos[m_first_hParent_cell + 2]); }
   Int32 flags() const { return CheckedConvert::toInt32(m_with_flags?m_infos[m_first_hParent_cell + 3]:0) ; }
 
-  friend inline ostream& operator<<(ostream& o,const FullCellInfo& i)
+  friend inline std::ostream& operator<<(std::ostream& o,const FullCellInfo& i)
   {
     i.print(o);
     return o;
@@ -99,7 +99,7 @@ class FullCellInfo
 
  public:
   
-  void print(ostream& o) const;
+  void print(std::ostream& o) const;
 
  public:
 

--- a/arcane/src/arcane/mesh/GhostLayerBuilder.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder.cc
@@ -115,7 +115,7 @@ addGhostLayers(bool is_allocate)
 /*---------------------------------------------------------------------------*/
 
 void GhostLayerBuilder::
-_printItem(ItemInternal* ii,ostream& o)
+_printItem(ItemInternal* ii,std::ostream& o)
 {
   o << ItemPrinter(ii);
 }

--- a/arcane/src/arcane/mesh/GhostLayerBuilder.h
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder.h
@@ -69,7 +69,7 @@ class GhostLayerBuilder
   
   void _addOneGhostLayerV2();
   void _exchangeData(IParallelExchanger* exchanger,BoundaryInfosMap& boundary_infos_to_send);
-  void _printItem(ItemInternal* ii,ostream& o);
+  void _printItem(ItemInternal* ii,std::ostream& o);
   void _exchangeCells(HashTableMapT<Int32,SharedArray<Int32>>& cells_to_send,bool with_flags);
 };
 

--- a/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
@@ -82,7 +82,7 @@ class GhostLayerBuilder2
 
  private:
   
-  void _printItem(ItemInternal* ii,ostream& o);
+  void _printItem(ItemInternal* ii,std::ostream& o);
   void _markBoundaryItems();
   void _sendAndReceiveCells(SubDomainItemMap& cells_to_send);
   void _sortBoundaryNodeList(Array<BoundaryNodeInfo>& boundary_node_list);
@@ -117,7 +117,7 @@ GhostLayerBuilder2::
 /*---------------------------------------------------------------------------*/
 
 void GhostLayerBuilder2::
-_printItem(ItemInternal* ii,ostream& o)
+_printItem(ItemInternal* ii,std::ostream& o)
 {
   o << ItemPrinter(ii);
 }

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -636,7 +636,7 @@ setPreAllocatedSize(Integer prealloc_size)
 /*---------------------------------------------------------------------------*/
 
 void IncrementalItemConnectivity::
-dumpStats(ostream& out) const
+dumpStats(std::ostream& out) const
 {
   size_t allocated_size = m_p->m_connectivity_list_array.capacity()
   + m_p->m_connectivity_index_array.capacity()
@@ -921,7 +921,7 @@ notifyReadFromDump()
 /*---------------------------------------------------------------------------*/
 
 void OneItemIncrementalItemConnectivity::
-dumpStats(ostream& out) const
+dumpStats(std::ostream& out) const
 {
   size_t allocated_size = m_p->m_connectivity_list_array.capacity()
   + m_p->m_connectivity_index_array.capacity()

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
@@ -193,7 +193,7 @@ class ARCANE_MESH_EXPORT IncrementalItemConnectivity
   Integer preAllocatedSize() const override final { return m_pre_allocated_size; }
   void setPreAllocatedSize(Integer value) override final;
 
-  void dumpStats(ostream& out) const override;
+  void dumpStats(std::ostream& out) const override;
 
   void compactConnectivityList();
 
@@ -254,7 +254,7 @@ class ARCANE_MESH_EXPORT OneItemIncrementalItemConnectivity
 
  public:
 
-  void dumpStats(ostream& out) const override;
+  void dumpStats(std::ostream& out) const override;
 
   void compactConnectivityList();
 

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.cc
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.cc
@@ -117,7 +117,7 @@ class ItemSharedInfoList::ItemNumElements
       return m_cell_allocated<b.m_cell_allocated;
     }
  public:
-  void print(ostream& o) const
+  void print(std::ostream& o) const
     {
       o << " Type=" << m_type
         << " Edge=" << m_nb_edge
@@ -143,7 +143,7 @@ bool ItemSharedInfoList::ItemNumElements::m_debug = false;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ostream& operator<<(ostream& o,const ItemSharedInfoList::ItemNumElements& v)
+std::ostream& operator<<(std::ostream& o,const ItemSharedInfoList::ItemNumElements& v)
 {
   v.print(o);
   return o;

--- a/arcane/src/arcane/mesh/NewWithLegacyConnectivity.h
+++ b/arcane/src/arcane/mesh/NewWithLegacyConnectivity.h
@@ -117,7 +117,7 @@ public:
   void setPreAllocatedSize(Integer value) override {Base::setPreAllocatedSize(value);}
 
   //! Sort sur le flot \a out des statistiques sur l'utilisation et la mémoire utilisée
-  void dumpStats(ostream& out) const override {Base::trueCustomConnectivity()->dumpStats(out);}
+  void dumpStats(std::ostream& out) const override {Base::trueCustomConnectivity()->dumpStats(out);}
 
   //! Nombre d'entité connectées à l'entité source de numéro local \a lid
   Integer nbConnectedItem(ItemLocalId lid) const override {return Base::trueCustomConnectivity()->nbConnectedItem(lid);}

--- a/arcane/src/arcane/mesh/ParallelAMRConsistency.h
+++ b/arcane/src/arcane/mesh/ParallelAMRConsistency.h
@@ -336,7 +336,7 @@ private:
 
   void _gatherAllNodesInfo();
 
-  void _printFaces(ostream& o, FaceInfoMap& face_map);
+  void _printFaces(std::ostream& o, FaceInfoMap& face_map);
 
   void _addFaceToList(Face face, FaceInfoMap& face_map);
 

--- a/arcane/src/arcane/mesh/TiedInterface.cc
+++ b/arcane/src/arcane/mesh/TiedInterface.cc
@@ -58,7 +58,7 @@ class TiedInterfaceBuilderInfos
  public:
   void printInfos()
   {
-    ostream& o = cout;
+    std::ostream& o = cout;
     o << " MasterFacesUid=" << m_master_faces_uid.size()
       << " SlaveNodesUid=" << m_slave_nodes_uid.size()
       << " SlaveFacesUid=" << m_slave_faces_uid.size()
@@ -371,7 +371,7 @@ class TiedInterfaceBuilder
   void _gatherFaces(ConstArrayView<ItemUniqueId> faces_to_send,
                     TiedInterfaceFaceMap& face_map);
   void _gatherAllNodesInfo();
-  void _printFaces(ostream& o,TiedInterfaceFaceMap& face_map);
+  void _printFaces(std::ostream& o,TiedInterfaceFaceMap& face_map);
   void _computeProjectionInfos(TiedInterfaceBuilderInfos& infos,bool is_structured);
   void _addFaceToList(const Face& face,TiedInterfaceFaceMap& face_map);
   void _detectStructuration(const TiedInterfaceMasterFace& master_face,
@@ -1214,7 +1214,7 @@ _detectStructurationRecursive(Array<ItemUniqueId>& slave_faces,
 /*---------------------------------------------------------------------------*/
 
 void TiedInterfaceBuilder::
-_printFaces(ostream& o,TiedInterfaceFaceMap& face_map)
+_printFaces(std::ostream& o,TiedInterfaceFaceMap& face_map)
 {
   // Utilise une map pour trier les faces suivant leur uniqueId() afin
   // que l'affichage soit toujours le meme.

--- a/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.cc
+++ b/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.cc
@@ -518,7 +518,7 @@ probe(const MP::PointToPointMessageInfo& message)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ostream& operator<<(ostream& o,const FullRankInfo& fri)
+std::ostream& operator<<(std::ostream& o,const FullRankInfo& fri)
 {
   return o << "(local=" << fri.m_local_rank << ",global="
            << fri.m_global_rank << ",mpi=" << fri.m_mpi_rank << ")";

--- a/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.h
+++ b/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.h
@@ -51,7 +51,7 @@ class FullRankInfo
     fri.m_mpi_rank.setValue(r / local_nb_rank);
     return fri;
   }
-  friend ostream& operator<<(ostream& o,const FullRankInfo& fri);
+  friend std::ostream& operator<<(std::ostream& o,const FullRankInfo& fri);
 
  public:
 

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -430,7 +430,7 @@ class TBBTaskImplementation
     return m_default_loop_options;
   }
 
-  void printInfos(ostream& o) const final;
+  void printInfos(std::ostream& o) const final;
 
  public:
 
@@ -650,7 +650,7 @@ class TBBParallelFor
   {
 #ifdef ARCANE_CHECK
     if (TaskFactory::verboseLevel()>=3){
-      ostringstream o;
+      std::ostringstream o;
       o << "TBB: INDEX=" << TaskFactory::currentTaskThreadIndex()
         << " id=" << std::this_thread::get_id()
         << " MAX_ALLOWED=" << m_nb_allowed_thread
@@ -689,7 +689,7 @@ class TBBMDParallelFor
   {
 #ifdef ARCANE_CHECK
     if (TaskFactory::verboseLevel()>=3){
-      ostringstream o;
+      std::ostringstream o;
       o << "TBB: INDEX=" << TaskFactory::currentTaskThreadIndex()
         << " id=" << std::this_thread::get_id()
         << " MAX_ALLOWED=" << m_nb_allowed_thread
@@ -805,7 +805,7 @@ class TBBDeterministicParallelFor
     iter_begin += m_begin_index;
 #ifdef ARCANE_CHECK
     if (TaskFactory::verboseLevel()>=3){
-      ostringstream o;
+      std::ostringstream o;
       o << "TBB: DoBlock: BLOCK task_id=" << task_id << " block_id=" << block_id
         << " iter_begin=" << iter_begin << " iter_size=" << iter_size << '\n';
       std::cout << o.str();
@@ -969,7 +969,7 @@ nbAllowedThread() const
 /*---------------------------------------------------------------------------*/
 
 void TBBTaskImplementation::
-printInfos(ostream& o) const
+printInfos(std::ostream& o) const
 {
 #ifdef ARCANE_USE_ONETBB
   o << "OneTBBTaskImplementation"

--- a/arcane/src/arcane/std/ArcaneCurveWriter.cc
+++ b/arcane/src/arcane/std/ArcaneCurveWriter.cc
@@ -48,7 +48,7 @@ class ArcaneCurveWriter
     Impl(IApplication* app,ITraceMng* tm,const String& path);
    public:
     String m_file_name;
-    ofstream m_stream;
+    std::ofstream m_stream;
     ScopedPtrT<IXmlDocumentHolder> m_curves_doc;
     XmlNode m_root_element;
   };
@@ -100,7 +100,7 @@ Impl(IApplication* app,ITraceMng* tm,const String& path)
 {
   String full_path = path + "/" + m_file_name + ".acv";
   info() << "Begin write curves full_path=" << full_path;
-  m_stream.open(full_path.localstr(),ios::trunc);
+  m_stream.open(full_path.localstr(),std::ios::trunc);
   if (!m_stream)
     warning() << "Can not open file '" << full_path << "' for writing curves";
   m_curves_doc = app->ressourceMng()->createXmlDocument();

--- a/arcane/src/arcane/std/BasicReaderWriter.cc
+++ b/arcane/src/arcane/std/BasicReaderWriter.cc
@@ -1060,7 +1060,7 @@ setMetaData(const String& meta_data)
   else{
     Int32 my_rank = m_parallel_mng->commRank();
     String filename = _getMetaDataFileName(my_rank);
-    ofstream ofile(filename.localstr());
+    std::ofstream ofile(filename.localstr());
     meta_data.writeBytes(ofile);
   }
 }
@@ -1108,14 +1108,14 @@ endWrite()
       StringBuilder filename = m_path;
       filename += "/arcane_acr_db.json";
       String fn = filename.toString();
-      ofstream ofile(fn.localstr());
+      std::ofstream ofile(fn.localstr());
       ofile << jsw.getBuffer();
     }
     else{
       StringBuilder filename = m_path;
       filename += "/infos.txt";
       String fn = filename.toString();
-      ofstream ofile(fn.localstr());
+      std::ofstream ofile(fn.localstr());
       ofile << nb_part << '\n';
     }
   }
@@ -1253,7 +1253,7 @@ initialize()
     if (pm->isMasterIO()){
       Integer nb_part = 0;
       String filename = String::concat(m_path,"/infos.txt");
-      ifstream ifile(filename.localstr());
+      std::ifstream ifile(filename.localstr());
       ifile >> nb_part;
       info(4) << "** NB PART=" << nb_part;
       m_nb_written_part = nb_part;

--- a/arcane/src/arcane/std/BasicReaderWriterDatabase.cc
+++ b/arcane/src/arcane/std/BasicReaderWriterDatabase.cc
@@ -279,7 +279,7 @@ _writeEpilog()
     jsw.endArray();
   }
 
-  ostream& stream = m_p->m_writer.stream();
+  std::ostream& stream = m_p->m_writer.stream();
 
   // Conserve la position dans le fichier des méta-données
   // ainsi que leur taille.
@@ -487,7 +487,7 @@ void KeyValueTextReader::
 _readDirect(Int64 offset,Span<std::byte> bytes)
 {
   m_p->m_reader.setFileOffset(offset);
-  ifstream& s = m_p->m_reader.stream();
+  std::ifstream& s = m_p->m_reader.stream();
   s.read((char*)bytes.data(),bytes.size());
   if (s.fail())
     ARCANE_FATAL("Can not read file part offset={0} length={1}",offset,bytes.length());

--- a/arcane/src/arcane/std/DumpWEnsight7.cc
+++ b/arcane/src/arcane/std/DumpWEnsight7.cc
@@ -276,12 +276,12 @@ class DumpWEnsight7
  public:
 
   //void writeFileString(ostream& o,ConstCString str);
-  void writeFileString(ostream& o, const String& str);
-  void writeFileInt(ostream& o, int value);
-  void writeFileDouble(ostream& o, double value);
+  void writeFileString(std::ostream& o, const String& str);
+  void writeFileInt(std::ostream& o, int value);
+  void writeFileDouble(std::ostream& o, double value);
   Integer writeDoubleSize() const;
   Integer writeIntSize() const;
-  void writeFileArray(ostream& o, IntegerConstArrayView value);
+  void writeFileArray(std::ostream& o, IntegerConstArrayView value);
   bool isBinary() const { return m_is_binary; }
 
  public:
@@ -322,13 +322,13 @@ class DumpWEnsight7
     virtual void init()
     {
       m_ofile.precision(5);
-      m_ofile.flags(ios::scientific);
+      m_ofile.flags(std::ios::scientific);
     }
-    virtual void putValue(ostream& ofile)
+    virtual void putValue(std::ostream& ofile)
     {
       ofile << m_ofile.str();
     }
-    ostream& stream() { return m_ofile; }
+    std::ostream& stream() { return m_ofile; }
 
    protected:
 
@@ -466,11 +466,11 @@ class DumpWEnsight7
     {
       _init();
       xostr.precision(5);
-      xostr.flags(ios::scientific);
+      xostr.flags(std::ios::scientific);
       yostr.precision(5);
-      yostr.flags(ios::scientific);
+      yostr.flags(std::ios::scientific);
       zostr.precision(5);
-      zostr.flags(ios::scientific);
+      zostr.flags(std::ios::scientific);
     }
 
     void write(Integer index)
@@ -550,11 +550,11 @@ class DumpWEnsight7
     {
       _init();
       xostr.precision(5);
-      xostr.flags(ios::scientific);
+      xostr.flags(std::ios::scientific);
       yostr.precision(5);
-      yostr.flags(ios::scientific);
+      yostr.flags(std::ios::scientific);
       zostr.precision(5);
-      zostr.flags(ios::scientific);
+      zostr.flags(std::ios::scientific);
     }
 
     inline void write(Integer index)
@@ -659,8 +659,8 @@ class DumpWEnsight7
   IParallelMng* m_parallel_mng; //!< Gestionnaire du parallélisme
   Directory m_base_directory; //!< Nom du répertoire de stockage
   Directory m_part_directory; //!< Répertoire de stockage de l'itération courante
-  ofstream m_case_file; //!< Fichier décrivant le cas
-  ostringstream m_case_file_variables; //! description des variables sauvées
+  std::ofstream m_case_file; //!< Fichier décrivant le cas
+  std::ostringstream m_case_file_variables; //! description des variables sauvées
   RealUniqueArray m_times; //!< Liste des instants de temps
   VariableList m_save_variables; //!< Liste des variables a exporter
   ItemGroupList m_save_groups; //!< Liste des groupes a exporter
@@ -695,15 +695,15 @@ class DumpWEnsight7
   void _createCaseFile();
   void _buildFileName(const String& varname, String& filename);
   void _buildPartDirectory();
-  void _writeWildcardFilename(ostream& ofile, const String& filename, char joker = '*');
+  void _writeWildcardFilename(std::ostream& ofile, const String& filename, char joker = '*');
   int _fileOuttype() const;
-  void _writeFileHeader(ostream& o, bool write_c_binary);
+  void _writeFileHeader(std::ostream& o, bool write_c_binary);
   bool _isNewBlocFile() const;
 
   void _computeGroupParts(ItemGroupList list_group, Integer& partid);
-  void _saveGroup(ostream& ofile, const GroupPartInfo& ensight_grp,
+  void _saveGroup(std::ostream& ofile, const GroupPartInfo& ensight_grp,
                   ConstArrayView<Integer> nodes_index, WriteBase& wf);
-  void _saveVariableOnGroup(ostream& ofile, const GroupPartInfo& ensight_grp,
+  void _saveVariableOnGroup(std::ostream& ofile, const GroupPartInfo& ensight_grp,
                             WriteBase& from_func);
   bool _isSameKindOfGroup(const ItemGroup& group, eItemKind item_kind);
 
@@ -888,7 +888,7 @@ _computeGroupParts(ItemGroupList list_group, Integer& partid)
  \param wf écrivain
 */
 void DumpWEnsight7::
-_saveGroup(ostream& ofile, const GroupPartInfo& ensight_grp,
+_saveGroup(std::ostream& ofile, const GroupPartInfo& ensight_grp,
            ConstArrayView<Integer> nodes_index, WriteBase& wf)
 {
   ItemGroup igrp = ensight_grp.group();
@@ -1054,7 +1054,7 @@ _saveGroup(ostream& ofile, const GroupPartInfo& ensight_grp,
  \param from_func    fonctor
 */
 void DumpWEnsight7::
-_saveVariableOnGroup(ostream& ofile, const GroupPartInfo& ensight_grp,
+_saveVariableOnGroup(std::ostream& ofile, const GroupPartInfo& ensight_grp,
                      WriteBase& from_func)
 {
   ItemGroup igrp = ensight_grp.group();
@@ -1101,7 +1101,7 @@ _saveVariableOnGroup(ostream& ofile, const GroupPartInfo& ensight_grp,
 /*---------------------------------------------------------------------------*/
 
 void DumpWEnsight7::
-writeFileInt(ostream& o, int value)
+writeFileInt(std::ostream& o, int value)
 {
   if (m_is_binary) {
     o.write((const char*)&value, sizeof(int));
@@ -1128,7 +1128,7 @@ writeIntSize() const
 /*---------------------------------------------------------------------------*/
 
 void DumpWEnsight7::
-writeFileDouble(ostream& o, double value)
+writeFileDouble(std::ostream& o, double value)
 {
   if (m_is_binary) {
     float fvalue = (float)(value);
@@ -1137,7 +1137,7 @@ writeFileDouble(ostream& o, double value)
   else {
     o.width(12);
     o.precision(5);
-    o.flags(ios::scientific);
+    o.flags(std::ios::scientific);
     o << value;
     o << '\n';
   }
@@ -1157,7 +1157,7 @@ writeDoubleSize() const
 /*---------------------------------------------------------------------------*/
 
 void DumpWEnsight7::
-writeFileArray(ostream& o, IntegerConstArrayView value)
+writeFileArray(std::ostream& o, IntegerConstArrayView value)
 {
   if (m_is_binary) {
     o.write((const char*)value.data(), sizeof(Integer) * value.size());
@@ -1175,7 +1175,7 @@ writeFileArray(ostream& o, IntegerConstArrayView value)
 /*---------------------------------------------------------------------------*/
 
 void DumpWEnsight7::
-writeFileString(ostream& o, const String& str)
+writeFileString(std::ostream& o, const String& str)
 {
   if (m_is_binary) {
     char buf[g_line_length];
@@ -1194,13 +1194,13 @@ writeFileString(ostream& o, const String& str)
 /*---------------------------------------------------------------------------*/
 
 void DumpWEnsight7::
-_writeFileHeader(ostream& o, bool write_c_binary)
+_writeFileHeader(std::ostream& o, bool write_c_binary)
 {
   if (m_is_master) {
     if (_isNewBlocFile() && m_is_binary && write_c_binary)
       writeFileString(o, "C Binary");
     if (m_fileset_size != 0) {
-      ostringstream ostr;
+      std::ostringstream ostr;
       ostr << "BEGIN TIME STEP "
            << "# " << m_times.size();
       writeFileString(o, ostr.str().c_str());
@@ -1230,7 +1230,7 @@ class DumpWEnsight7OutFile
   , m_filestream(0)
   {
     if (m_is_master) {
-      m_filestream = new ofstream(filename.localstr(), (std::ios_base::openmode)outtype);
+      m_filestream = new std::ofstream(filename.localstr(), (std::ios_base::openmode)outtype);
       m_stream = &m_strstream;
       if (!(*m_filestream))
         m_dw.warning() << "Unable to open file " << filename;
@@ -1321,7 +1321,7 @@ class DumpWEnsight7OutFile
 
  public:
 
-  ostream& operator()() { return *m_stream; }
+  std::ostream& operator()() { return *m_stream; }
 
  private:
 
@@ -1329,9 +1329,9 @@ class DumpWEnsight7OutFile
   String m_filename;
   bool m_is_master;
   bool m_is_parallel_output;
-  ostream* m_stream;
+  std::ostream* m_stream;
   std::ostringstream m_strstream;
-  ofstream* m_filestream;
+  std::ofstream* m_filestream;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -1722,7 +1722,7 @@ _buildPartDirectory()
 /*---------------------------------------------------------------------------*/
 
 void DumpWEnsight7::
-_writeWildcardFilename(ostream& ofile, const String& filename, char joker)
+_writeWildcardFilename(std::ostream& ofile, const String& filename, char joker)
 {
   if (m_fileset_size == 0) {
     ofile << ' ' << filename << '/' << filename;
@@ -1770,7 +1770,7 @@ _isNewBlocFile() const
 int DumpWEnsight7::
 _fileOuttype() const
 {
-  return ((isBinary()) ? ios::binary : 0) | ((_isNewBlocFile()) ? ios::trunc : ios::app);
+  return ((isBinary()) ? std::ios::binary : 0) | ((_isNewBlocFile()) ? std::ios::trunc : std::ios::app);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/std/DumpWUCD.cc
+++ b/arcane/src/arcane/std/DumpWUCD.cc
@@ -163,12 +163,12 @@ DumpWUCD(ISubDomain* sd,IMesh* mesh,const String& filename,RealConstArrayView ti
   for( Integer i=0; i<nb_cell_var; ++i ){
     m_cell_streams[i] = makeRef(new OStringStream());
     m_cell_streams[i]->stream().precision(MAX_FLOAT_DIGIT);
-    m_cell_streams[i]->stream().flags(ios::scientific);
+    m_cell_streams[i]->stream().flags(std::ios::scientific);
   }
   for( Integer i=0; i<nb_node_var; ++i ){
     m_node_streams[i] = makeRef(new OStringStream());
     m_node_streams[i]->stream().precision(MAX_FLOAT_DIGIT);
-    m_node_streams[i]->stream().flags(ios::scientific);
+    m_node_streams[i]->stream().flags(std::ios::scientific);
   }
 
   debug() << "DumpWUCD::DumpWUCD - " 
@@ -291,7 +291,7 @@ endWrite()
   ostr() << m_times.size()-1;
   ostr() << ".inp\0";
   String buf = m_base_directory.file(ostr.str());
-  ofstream ucd_file(buf.localstr());
+  std::ofstream ucd_file(buf.localstr());
 
   // Ajout de l'entete du fichier
   // Comptage du nombre de donnees aux noeuds et aux mailles et de leurs 
@@ -312,10 +312,10 @@ endWrite()
   cdata_size_stream().precision(MAX_FLOAT_DIGIT);
   cdata_name_stream().precision(MAX_FLOAT_DIGIT);
 
-  ndata_size_stream().flags(ios::scientific);
-  ndata_name_stream().flags(ios::scientific);
-  cdata_size_stream().flags(ios::scientific);
-  cdata_name_stream().flags(ios::scientific);
+  ndata_size_stream().flags(std::ios::scientific);
+  ndata_name_stream().flags(std::ios::scientific);
+  cdata_size_stream().flags(std::ios::scientific);
+  cdata_name_stream().flags(std::ios::scientific);
 
   for(VariableList::Enumerator i(m_save_variables); ++i; ){
     IVariable* var = *i;
@@ -464,7 +464,7 @@ endWrite()
   code_ostr() << m_times.size()-1;
   code_ostr() << '\0';
   buf = m_base_directory.file(code_ostr.str());
-  ofstream code_file(buf.localstr());
+  std::ofstream code_file(buf.localstr());
   code_file << m_sub_domain->commonVariables().globalIteration() << '\n'
                  << m_times[m_times.size()-1] << '\n'
                  << "3" << '\n' << "1" << '\n'

--- a/arcane/src/arcane/std/EnsightHdfPostProcessor.cc
+++ b/arcane/src/arcane/std/EnsightHdfPostProcessor.cc
@@ -398,7 +398,7 @@ void EnsightHdfDataWriter::
 endWrite()
 {
   info() << "ENSIGHT HDF END WRITE";
-  ofstream ofile("a_hdf5");
+  std::ofstream ofile("a_hdf5");
   ofile << "SPECIAL HDF5 CASEFILE\n";
   ofile.width(10);
   Integer nb_time = m_times.size();

--- a/arcane/src/arcane/std/LibUnwindStackTraceService.cc
+++ b/arcane/src/arcane/std/LibUnwindStackTraceService.cc
@@ -228,8 +228,8 @@ _getGDBStack()
   if (file_length==0)
     return String();
 
-  ifstream ifile;
-  ifile.open(filename,ios::binary);
+  std::ifstream ifile;
+  ifile.open(filename,std::ios::binary);
   ByteUniqueArray bytes(arcaneCheckArraySize(file_length));
   ifile.read((char*)bytes.data(),file_length);
   return String(bytes);

--- a/arcane/src/arcane/std/MetisMeshPartitioner.cc
+++ b/arcane/src/arcane/std/MetisMeshPartitioner.cc
@@ -391,7 +391,7 @@ _partitionMesh(bool initial_partition,Int32 nb_part)
 
   const bool do_print_weight = false;
   if (do_print_weight){
-    ofstream dumpy;
+    std::ofstream dumpy;
     StringBuilder fname;
     Integer iteration = mesh->subDomain()->commonVariables().globalIteration();
     fname = "weigth-";

--- a/arcane/src/arcane/std/MshMeshReader.cc
+++ b/arcane/src/arcane/std/MshMeshReader.cc
@@ -1102,7 +1102,7 @@ _readMeshFromMshFile(IMesh* mesh, const XmlNode& mesh_node,
   ARCANE_UNUSED(mesh_node);
 
   info() << "Trying to read 'msh' file '" << filename << "'";
-  ifstream ifile(filename.localstr());
+  std::ifstream ifile(filename.localstr());
   if (!ifile) {
     error() << "Unable to read file '" << filename << "'";
     return RTError;

--- a/arcane/src/arcane/std/MshMeshWriter.cc
+++ b/arcane/src/arcane/std/MshMeshWriter.cc
@@ -169,7 +169,7 @@ bool MshMeshWriter::
 writeMeshToFile(IMesh* mesh,const String& file_name)
 {
   String mshFileName(file_name+".msh");
-	ofstream ofile(mshFileName.localstr());
+  std::ofstream ofile(mshFileName.localstr());
 	if (!ofile)
 		throw IOException("VtkMeshIOService::writeMeshToFile(): Unable to open file");
 

--- a/arcane/src/arcane/std/ProfilingInfo.cc
+++ b/arcane/src/arcane/std/ProfilingInfo.cc
@@ -873,7 +873,7 @@ printInfos(bool dump_file)
       sfile_name += process_id;
       sfile_name += ".xml";
       String file_name = sfile_name;
-      ofstream ofile(file_name.localstr());
+      std::ofstream ofile(file_name.localstr());
       ofile << "<?xml version='1.0'?>\n";
       ofile << "<addresses>\n";
       ProfInfos::AddrMap::const_iterator begin = global_infos->m_addr_map.begin();
@@ -949,7 +949,7 @@ printInfos(bool dump_file)
     std::sort(std::begin(sorted_stacks),std::end(sorted_stacks));
 
     String file_name = String("profiling.callstack") + platform::getProcessId();
-    ofstream ofile;
+    std::ofstream ofile;
     ofile.open(file_name.localstr());
 
     for( auto x : sorted_stacks.range() ){

--- a/arcane/src/arcane/std/TextReader.cc
+++ b/arcane/src/arcane/std/TextReader.cc
@@ -40,7 +40,7 @@ class TextReader::Impl
   : m_filename(filename) {}
  public:
   String m_filename;
-  ifstream m_istream;
+  std::ifstream m_istream;
   Integer m_current_line = 0;
   Int64 m_file_length = 0;
   Ref<IDataCompressor> m_data_compressor;
@@ -53,7 +53,7 @@ TextReader::
 TextReader(const String& filename)
 : m_p(new Impl(filename))
 {
-  ios::openmode mode = ios::in | ios::binary;
+  std::ios::openmode mode = std::ios::in | std::ios::binary;
   m_p->m_istream.open(filename.localstr(),mode);
   if (!m_p->m_istream)
     ARCANE_THROW(ReaderWriterException, "Can not read file '{0}' for reading", filename);
@@ -111,7 +111,7 @@ readIntegers(Span<Integer> values)
 void TextReader::
 _checkStream(const char* type, Int64 nb_read_value)
 {
-  istream& s = m_p->m_istream;
+  std::istream& s = m_p->m_istream;
   if (!s)
     ARCANE_THROW(IOException, "Can not read '{0}' (nb_val={1} bad?={2} "
                  "fail?={3} eof?={4} pos={5}) file='{6}'",
@@ -183,7 +183,7 @@ read(Span<Real> values)
 void TextReader::
 _binaryRead(void* values, Int64 len)
 {
-  istream& s = m_p->m_istream;
+  std::istream& s = m_p->m_istream;
   IDataCompressor* d = m_p->m_data_compressor.get();
   if (d && len > d->minCompressSize()) {
     UniqueArray<std::byte> compressed_values;
@@ -265,7 +265,7 @@ fileName() const
 void TextReader::
 setFileOffset(Int64 v)
 {
-  m_p->m_istream.seekg(v,ios::beg);
+  m_p->m_istream.seekg(v,std::ios::beg);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -289,7 +289,7 @@ dataCompressor() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ifstream& TextReader::
+std::ifstream& TextReader::
 stream()
 {
   return m_p->m_istream;

--- a/arcane/src/arcane/std/TextReader.h
+++ b/arcane/src/arcane/std/TextReader.h
@@ -59,7 +59,7 @@ class TextReader
   void setFileOffset(Int64 v);
   void setDataCompressor(Ref<IDataCompressor> ds);
   Ref<IDataCompressor> dataCompressor() const;
-  ifstream& stream();
+  std::ifstream& stream();
   Int64 fileLength() const;
  private:
   Impl* m_p;

--- a/arcane/src/arcane/std/TextWriter.cc
+++ b/arcane/src/arcane/std/TextWriter.cc
@@ -37,7 +37,7 @@ class TextWriter::Impl
 {
  public:
   String m_filename;
-  ofstream m_ostream;
+  std::ofstream m_ostream;
   Ref<IDataCompressor> m_data_compressor;
 };
 
@@ -76,7 +76,7 @@ void TextWriter::
 open(const String& filename)
 {
   m_p->m_filename = filename;
-  ios::openmode mode = ios::out | ios::binary;
+  std::ios::openmode mode = std::ios::out | std::ios::binary;
   m_p->m_ostream.open(filename.localstr(),mode);
   if (!m_p->m_ostream)
     ARCANE_THROW(ReaderWriterException,"Can not open file '{0}' for writing", filename);
@@ -164,7 +164,7 @@ _writeComments(const String& comment)
 void TextWriter::
 _binaryWrite(const void* bytes,Int64 len)
 {
-  ostream& o = m_p->m_ostream;
+  std::ostream& o = m_p->m_ostream;
   //cout << "** BINARY WRITE len=" << len << " deflater=" << m_data_compressor << '\n';
   IDataCompressor* d = m_p->m_data_compressor.get();
   if (d && len > d->minCompressSize()) {
@@ -182,7 +182,7 @@ _binaryWrite(const void* bytes,Int64 len)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ostream& TextWriter::
+std::ostream& TextWriter::
 stream()
 {
   return m_p->m_ostream;

--- a/arcane/src/arcane/std/TextWriter.h
+++ b/arcane/src/arcane/std/TextWriter.h
@@ -58,7 +58,7 @@ class TextWriter
   void setDataCompressor(Ref<IDataCompressor> ds);
   Ref<IDataCompressor> dataCompressor() const;
   Int64 fileOffset();
-  ostream& stream();
+  std::ostream& stream();
  private:
   Impl* m_p;
  private:

--- a/arcane/src/arcane/std/VoronoiMeshIOService.cc
+++ b/arcane/src/arcane/std/VoronoiMeshIOService.cc
@@ -123,16 +123,16 @@ private:
 
 class VoronoiFile
 {
-public:
+ public:
   static const int BUFSIZE = 10000;
-public:
-  VoronoiFile(istream* stream) : m_stream(stream) {}
+ public:
+  VoronoiFile(std::istream* stream) : m_stream(stream) {}
   const char* getNextLine();
   Real getReal();
   Integer getInteger();
   bool isEnd(){ (*m_stream) >> ws; return m_stream->eof(); }
-private:
-  istream* m_stream;
+ private:
+  std::istream* m_stream;
   char m_buf[BUFSIZE];
 };
 
@@ -255,7 +255,7 @@ _readMesh(IPrimaryMesh* mesh,const String& file_name,const String& dir_name,
 {
   ARCANE_UNUSED(dir_name);
 
-  ifstream ifile(file_name.localstr());
+  std::ifstream ifile(file_name.localstr());
   if (!ifile){
     error() << "Unable to read file '" << file_name << "'";
     return true;
@@ -288,7 +288,7 @@ _readNodesHybridGrid(IMesh* mesh,VoronoiFile& voronoi_file,Array<Real3>& node_co
 
   const char* func_name = "VoronoiMeshIOService::_readNodesHybridGrid()";
   const char* buf = voronoi_file.getNextLine();
-  istringstream iline(buf);
+  std::istringstream iline(buf);
   std::string points_str;
   std::string data_type_str;
   Integer nb_node = 0;
@@ -332,7 +332,7 @@ _readCellsHybridGrid(IMesh* mesh,VoronoiFile& voronoi_file,
 
   const char* func_name = "VoronoiMeshIOService::_readCellsHybridGrid()";
   const char* buf = voronoi_file.getNextLine();
-  istringstream iline(buf);
+  std::istringstream iline(buf);
   std::string cells_str;
   Integer nb_cell = 0;
   Integer nb_cell_node = 0;

--- a/arcane/src/arcane/std/VtkMeshIOService.cc
+++ b/arcane/src/arcane/std/VtkMeshIOService.cc
@@ -192,7 +192,7 @@ class VtkFile
  public:
   static const int BUFSIZE = 10000;
  public:
-  VtkFile(istream* stream) : m_stream(stream) {}
+  VtkFile(std::istream* stream) : m_stream(stream) {}
   const char* getNextLine();
   Real getReal();
   Integer getInteger();
@@ -204,7 +204,7 @@ class VtkFile
 
   bool isEnd(){ (*m_stream) >> ws; return m_stream->eof(); }
  private:
-  istream* m_stream;
+  std::istream* m_stream;
   char m_buf[BUFSIZE];
 };
 
@@ -332,7 +332,7 @@ VtkMeshIOService::
 bool VtkMeshIOService::
 readMesh(IPrimaryMesh* mesh,const String& file_name,const String& dir_name,bool use_internal_partition)
 {
-  ifstream ifile(file_name.localstr());
+  std::ifstream ifile(file_name.localstr());
   if (!ifile){
     error() << "Unable to read file '" << file_name << "'";
     return true;
@@ -352,7 +352,7 @@ readMesh(IPrimaryMesh* mesh,const String& file_name,const String& dir_name,bool 
   // lit les données. Dans ce cas, inutile que les autres ouvre le fichier.
   {
     buf = vtk_file.getNextLine();
-    istringstream mesh_type_line(buf);
+    std::istringstream mesh_type_line(buf);
     std::string dataset_str;
     std::string mesh_type_str;
     mesh_type_line >> ws >> dataset_str >> ws >> mesh_type_str;
@@ -402,7 +402,7 @@ _readStructuredGrid(IPrimaryMesh* mesh,VtkFile& vtk_file,bool use_internal_parti
   Integer nb_node_z = 0;
   {
     buf = vtk_file.getNextLine();
-    istringstream iline(buf);
+    std::istringstream iline(buf);
     std::string dimension_str;
     iline >> ws >> dimension_str >> ws >> nb_node_x
           >> ws >> nb_node_y >> ws >> nb_node_z;
@@ -421,7 +421,7 @@ _readStructuredGrid(IPrimaryMesh* mesh,VtkFile& vtk_file,bool use_internal_parti
   // Lecture du nombre de points: POINTS nb float
   {
     buf = vtk_file.getNextLine();
-    istringstream iline(buf);
+    std::istringstream iline(buf);
     std::string points_str;
     std::string float_str;
     Integer nb_node_read = 0;
@@ -643,7 +643,7 @@ _readNodesUnstructuredGrid(IMesh* mesh,VtkFile& vtk_file,Array<Real3>& node_coor
 
   const char* func_name = "VtkMeshIOService::_readNodesUnstructuredGrid()";
   const char* buf = vtk_file.getNextLine();
-  istringstream iline(buf);
+  std::istringstream iline(buf);
   std::string points_str;
   std::string data_type_str;
   Integer nb_node = 0;
@@ -686,7 +686,7 @@ _readCellsUnstructuredGrid(IMesh* mesh,VtkFile& vtk_file,
 
   const char* func_name = "VtkMeshIOService::_readCellsUnstructuredGrid()";
   const char* buf = vtk_file.getNextLine();
-  istringstream iline(buf);
+  std::istringstream iline(buf);
   std::string cells_str;
   Integer nb_cell = 0;
   Integer nb_cell_node = 0;
@@ -719,7 +719,7 @@ _readCellsUnstructuredGrid(IMesh* mesh,VtkFile& vtk_file,
   // Lecture du type des mailles
   {
     buf = vtk_file.getNextLine();
-    istringstream iline(buf);
+    std::istringstream iline(buf);
     std::string cell_types_str;
     Integer nb_cell_type;
     iline >> ws >> cell_types_str >> ws >> nb_cell_type;
@@ -887,7 +887,7 @@ _readFacesMesh(IMesh* mesh,const String& file_name,const String& dir_name,
 {
   ARCANE_UNUSED(dir_name);
 
-  ifstream ifile(file_name.localstr());
+  std::ifstream ifile(file_name.localstr());
   if (!ifile){
     info() << "No face descriptor file found '" << file_name << "'";
     return;
@@ -907,7 +907,7 @@ _readFacesMesh(IMesh* mesh,const String& file_name,const String& dir_name,
   // lit les données. Dans ce cas, inutile que les autres ouvre le fichier.
   {
     buf = vtk_file.getNextLine();
-    istringstream mesh_type_line(buf);
+    std::istringstream mesh_type_line(buf);
     std::string dataset_str;
     std::string mesh_type_str;
     mesh_type_line >> ws >> dataset_str >> ws >> mesh_type_str;
@@ -988,7 +988,7 @@ _readData(IMesh* mesh,VtkFile& vtk_file,bool use_internal_partition,
     bool reading_cell = false;
     while ( !vtk_file.isEnd() && ((buf = vtk_file.getNextLine()) != 0)) {
       debug() << "Read line";
-      istringstream iline(buf);
+      std::istringstream iline(buf);
       std::string data_str;
       iline >> data_str;
       if (VtkFile::isEqualString(data_str,"CELL_DATA")){
@@ -1205,7 +1205,7 @@ class VtkLegacyMeshWriter
   virtual bool writeMeshToFile(IMesh* mesh,const String& file_name);
  private:
   void _writeMeshToFile(IMesh* mesh,const String& file_name,eItemKind cell_kind);
-  void _saveGroups(IItemFamily* family,ostream& ofile);
+  void _saveGroups(IItemFamily* family,std::ostream& ofile);
 };
 
 /*---------------------------------------------------------------------------*/
@@ -1249,7 +1249,7 @@ writeMeshToFile(IMesh* mesh,const String& file_name)
 void VtkLegacyMeshWriter::
 _writeMeshToFile(IMesh* mesh,const String& file_name,eItemKind cell_kind)
 {
-  ofstream ofile(file_name.localstr());
+  std::ofstream ofile(file_name.localstr());
   ofile.precision(FloatInfo<Real>::maxDigit());
   if (!ofile)
     throw IOException("VtkMeshIOService::writeMeshToFile(): Unable to open file");
@@ -1340,7 +1340,7 @@ _writeMeshToFile(IMesh* mesh,const String& file_name,eItemKind cell_kind)
 /*---------------------------------------------------------------------------*/
 
 void VtkLegacyMeshWriter::
-_saveGroups(IItemFamily* family,ostream& ofile)
+_saveGroups(IItemFamily* family,std::ostream& ofile)
 {
   info() << "Saving groups for family name=" << family->name();
   UniqueArray<char> in_group_list(family->maxLocalId());

--- a/arcane/src/arcane/std/internal/IosFile.cc
+++ b/arcane/src/arcane/std/internal/IosFile.cc
@@ -127,7 +127,7 @@ lookForString(const String& str)
 {
   const char* bfr = getNextLine();
   //	ITraceMng::info() << "[IosFile::getString] Looking for " << str;
-  istringstream iline(bfr);
+  std::istringstream iline(bfr);
   std::string got;
   iline >> got;
   //	info() << "[IosFile::getString] got=" << got;

--- a/arcane/src/arcane/tests/ArrayUnitTest.cc
+++ b/arcane/src/arcane/tests/ArrayUnitTest.cc
@@ -98,8 +98,8 @@ class Wrapper
 
 template<typename DataType> Integer Wrapper<DataType>::nb_new = 0;
 
-template<class T> inline ostream&
-operator<<(ostream& o,const Wrapper<T>& v)
+template<class T> inline std::ostream&
+operator<<(std::ostream& o,const Wrapper<T>& v)
 {
   o << v.value();
   return o;

--- a/arcane/src/arcane/tests/ItemVectorUnitTest.cc
+++ b/arcane/src/arcane/tests/ItemVectorUnitTest.cc
@@ -66,7 +66,7 @@ class ItemPrinter2
 
  public:
 
-  void print(ostream& o) const;
+  void print(std::ostream& o) const;
 
   ItemPrinter2& assign(Item item)
   {
@@ -96,9 +96,9 @@ class ItemPrinter2
 
  private:
 
-  void _print(ostream& o,ItemVectorPrinter& ivp,ItemVectorView view,const String& name) const;
+  void _print(std::ostream& o,ItemVectorPrinter& ivp,ItemVectorView view,const String& name) const;
 
-  void _printIndent(ostream& o) const
+  void _printIndent(std::ostream& o) const
   {
     for( Integer z=0; z<m_indent_level*4; ++z ){
       o << ' ';
@@ -120,8 +120,8 @@ class ItemPrinter2
 
 };
 
-inline ostream&
-operator<<(ostream& o,const ItemPrinter2& ip)
+inline std::ostream&
+operator<<(std::ostream& o,const ItemPrinter2& ip)
 {
   ip.print(o);
   return o;
@@ -136,7 +136,7 @@ class ItemVectorPrinter
   ItemVectorPrinter() : m_indent_level(0) {}
   ItemVectorPrinter(ItemVectorView iv) : m_item_vector(iv),m_indent_level(0){}
  public:
-  void print(ostream& o) const
+  void print(std::ostream& o) const
   {
     Integer n = m_item_vector.size();
     o << "(";
@@ -184,7 +184,7 @@ class ItemVectorPrinter
   }
 
  private:
-  void _printIndent(ostream& o) const
+  void _printIndent(std::ostream& o) const
   {
     for( Integer z=0; z<m_indent_level*4; ++z ){
       o << ' ';
@@ -200,8 +200,8 @@ class ItemVectorPrinter
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-inline ostream&
-operator<<(ostream& o,const ItemVectorPrinter& ip)
+inline std::ostream&
+operator<<(std::ostream& o,const ItemVectorPrinter& ip)
 {
   ip.print(o);
   return o;
@@ -211,7 +211,7 @@ operator<<(ostream& o,const ItemVectorPrinter& ip)
 /*---------------------------------------------------------------------------*/
 
 void ItemPrinter2::
-print(ostream& o) const
+print(std::ostream& o) const
 {
   if (!m_item || m_item->localId()==NULL_ITEM_LOCAL_ID){
     o << "(null_item)";
@@ -258,7 +258,7 @@ print(ostream& o) const
 }
 
 void ItemPrinter2::
-_print(ostream& o,ItemVectorPrinter& ivp,ItemVectorView view,const String& name) const
+_print(std::ostream& o,ItemVectorPrinter& ivp,ItemVectorView view,const String& name) const
 {
   if (view.size()>0){
     _printIndent(o);

--- a/arcane/src/arcane/tests/JSONUnitTest.cc
+++ b/arcane/src/arcane/tests/JSONUnitTest.cc
@@ -150,7 +150,7 @@ _testJSON_2()
   StringView buf = serializer.getBuffer();
   info() << "BUF=" << buf;
   {
-    ofstream ofile("test1.json");
+    std::ofstream ofile("test1.json");
     ofile << buf;
   }
   

--- a/arcane/src/arcane/tests/ParallelTesterModule.cc
+++ b/arcane/src/arcane/tests/ParallelTesterModule.cc
@@ -324,7 +324,7 @@ class ParallelTesterModule
   void _testLoadBalance();
   void _testGhostItemsReduceOperation();
   void _testTransferValues();
-  void _writeAccumulateInfos(ostream& ofile,eItemKind ik,const String& msg);
+  void _writeAccumulateInfos(std::ostream& ofile,eItemKind ik,const String& msg);
   void _doInit();
   void _checkEnd();
   void _testBitonicSort();
@@ -920,7 +920,7 @@ _testMultiSynchronize()
 /*---------------------------------------------------------------------------*/
 
 void ParallelTesterModule::
-_writeAccumulateInfos(ostream& ofile,eItemKind ik,const String& msg)
+_writeAccumulateInfos(std::ostream& ofile,eItemKind ik,const String& msg)
 {
   ARCANE_UNUSED(ik);
   //IMesh* mesh = subDomain()->defaultMesh();
@@ -1001,7 +1001,7 @@ _testAccumulate()
   }
   
   if (need_write && !output_file_name.empty()){
-    ofstream ofile(output_file_name.localstr());
+    std::ofstream ofile(output_file_name.localstr());
     _writeAccumulateInfos(ofile,ik,"Send");
   }
 
@@ -1013,7 +1013,7 @@ _testAccumulate()
   //pm->accumulate(ik,m_accumulate_ids,variables);
   cell_family->reduceFromGhostItems(m_accumulate_real.variable(),Parallel::ReduceSum);
   if (need_write && !output_file_name.empty()){
-    ofstream ofile(output_file_name.localstr(),ios::app);
+    std::ofstream ofile(output_file_name.localstr(),std::ios::app);
     _writeAccumulateInfos(ofile,ik,"Recv");
   }
 }
@@ -1391,7 +1391,7 @@ _testBitonicSort()
     ConstArrayView<Real> true_array = true_data->view();
     {
       String fname(String("dump-")+pm->commRank());
-      ofstream ofile(fname.localstr());
+      std::ofstream ofile(fname.localstr());
       for( Integer z=0, zs=nb_item_as_integer; z<zs; ++z )
         ofile << " VALUE Z=" << z << " v=" << true_array[z] << " key=" << keys[z] << '\n';
     }

--- a/arcane/src/arcane/utils/ArcaneGlobal.h
+++ b/arcane/src/arcane/utils/ArcaneGlobal.h
@@ -53,15 +53,7 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 // TODO: supprimer l'inclusion de <iosfwd> et les using.
-// Pour l'instant ne les supprime que si on compile arcane_utils.
-#ifndef ARCANE_NO_USING_FOR_STREAM
-#  if defined(ARCANE_COMPONENT_arcane_utils)
-#    define ARCANE_NO_USING_FOR_STREAM
-#  endif
-#  if defined(ARCANE_COMPONENT_arcane_core)
-#    define ARCANE_NO_USING_FOR_STREAM
-#  endif
-#endif
+// Pour l'instant (2022), on supprime ces inclusions uniquement pour Arcane.
 
 #ifndef ARCANE_NO_USING_FOR_STREAM
 #include <iosfwd>

--- a/arcane/src/arcane/utils/CMakeLists.txt
+++ b/arcane/src/arcane/utils/CMakeLists.txt
@@ -8,7 +8,7 @@ arcane_add_library(arcane_utils
 
 arcane_add_arccon_packages(arcane_utils PRIVATE ${PKGS})
 
-target_compile_definitions(arcane_utils PRIVATE ARCANE_COMPONENT_arcane_utils ARCANE_NO_USING_FOR_STREAM)
+target_compile_definitions(arcane_utils PRIVATE ARCANE_COMPONENT_arcane_utils)
 
 target_include_directories(arcane_utils PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>)
 target_include_directories(arcane_utils PUBLIC $<BUILD_INTERFACE:${ARCANE_SRC_PATH}> $<INSTALL_INTERFACE:include>)

--- a/arcane/src/arcane/utils/CMakeLists.txt
+++ b/arcane/src/arcane/utils/CMakeLists.txt
@@ -8,7 +8,7 @@ arcane_add_library(arcane_utils
 
 arcane_add_arccon_packages(arcane_utils PRIVATE ${PKGS})
 
-target_compile_definitions(arcane_utils PRIVATE ARCANE_COMPONENT_arcane_utils)
+target_compile_definitions(arcane_utils PRIVATE ARCANE_COMPONENT_arcane_utils ARCANE_NO_USING_FOR_STREAM)
 
 target_include_directories(arcane_utils PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>)
 target_include_directories(arcane_utils PUBLIC $<BUILD_INTERFACE:${ARCANE_SRC_PATH}> $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
These `using` are removed if we compile with macro `-DARCANE_NO_USING_FOR_STREAM`.
