### PR TITLE
Add a GH Actions header/encoding verificator

### DIFF
--- a/.github/scripts/header_check.sh
+++ b/.github/scripts/header_check.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-REGEX_EXCLUDE_FILES="/samples_build/samples|/arcane/extras|/arcane/tutorial"
+# Attention à ne pas ajouter d'espaces après le backslash.
+REGEX_EXCLUDE_FILES="/arcane/extras\
+|/arcane/src/arcane/utils/internal/json/rapidjson\
+|/arcane/src/arcane/dotnet/coreclr/hostfxr\.h\
+|/arcane/src/arcane/dotnet/coreclr/coreclr_delegates\.h\
+"
 
 CC_H_FILES=$(find $SOURCE -name '*.cc')
 CC_H_FILES+=" "

--- a/.github/scripts/header_check.sh
+++ b/.github/scripts/header_check.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+REGEX_EXCLUDE_FILES="/samples_build/samples|/arcane/extras|/arcane/tutorial"
+
+CC_H_FILES=$(find $SOURCE -name '*.cc')
+CC_H_FILES+=" "
+CC_H_FILES+=$(find $SOURCE -name '*.h')
+
+OUTPUT_LOG="Début script de vérification\n\n"
+
+for FILE in $CC_H_FILES;
+do
+
+  # On retire les fichiers qui font moins de 10 lignes.
+  NB_LINES=$(wc -l < $FILE)
+  if (( $NB_LINES < 10 ))
+  then
+    continue
+  fi
+
+  # On retire les fichiers que l'on ne veut pas vérifier.
+  COMPT=$(echo "$FILE" | grep -E "$REGEX_EXCLUDE_FILES" | wc -l)
+  if (( $COMPT != 0 ))
+  then
+    continue
+  fi
+
+
+  COPY_LOG=1
+  OUTPUT_LOG_FILE=""
+
+  # Vérification du formatage du fichier.
+  COMPT=$(file $FILE | grep "UTF-8 Unicode (with BOM)" | wc -l)
+  if (( $COMPT == 0 ))
+  then
+    OUTPUT_LOG_FILE+="  Mauvais format (format nécessaire : UTF-8 with BOM)\n"
+    COPY_LOG=0
+  fi
+
+  # Vérification du header Emacs.
+  COMPT=$(head -1 $FILE | grep -e "-*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-" | wc -l)
+  if (( $COMPT == 0 ))
+  then
+    OUTPUT_LOG_FILE+="  Header Emacs manquant ou mal orthographié\n"
+    COPY_LOG=0
+  fi
+
+
+  # On collecte les lignes avec "copyright".
+  TEMPO=$(head -30 $FILE | grep -iF "copyright")
+
+  COMPT=$(echo "$TEMPO" | wc -l)
+  if (( $COMPT == 0 ))
+  then
+    OUTPUT_LOG_FILE+="  Copyright manquant\n"
+    COPY_LOG=0
+  else
+    # On vérifie les lignes copyright.
+    COMPT=$(echo "$TEMPO" | grep "2000-2022" | wc -l)
+    if (( $COMPT == 0 ))
+    then
+      OUTPUT_LOG_FILE+="  Copyright : Dates manquantes ou non à jours\n"
+      COPY_LOG=0
+    fi
+
+    COMPT=$(echo "$TEMPO" | grep -i "CEA" | wc -l)
+    if (( $COMPT == 0 ))
+    then
+      OUTPUT_LOG_FILE+="  Copyright : Manque la mention CEA\n"
+      COPY_LOG=0
+    fi
+
+    COMPT=$(echo "$TEMPO" | grep -i "IFPEN" | wc -l)
+    if (( $COMPT == 0 ))
+    then
+      OUTPUT_LOG_FILE+="  Copyright : Manque la mention IFPEN\n"
+      COPY_LOG=0
+    fi
+
+    COMPT=$(echo "$TEMPO" | grep -iF "www.cea.fr" | wc -l)
+    if (( $COMPT == 0 ))
+    then
+      OUTPUT_LOG_FILE+="  Copyright : Manque le site web du CEA\n"
+      COPY_LOG=0
+    fi
+
+    COMPT=$(echo "$TEMPO" | grep -iF "www.ifpenergiesnouvelles.com" | wc -l)
+    if (( $COMPT == 0 ))
+    then
+      OUTPUT_LOG_FILE+="  Copyright : Manque le site web de l'IFPEN\n"
+      COPY_LOG=0
+    fi
+
+    COMPT=$(echo "$TEMPO" | grep -iF "See the top-level COPYRIGHT file for details." | wc -l)
+    if (( $COMPT == 0 ))
+    then
+      OUTPUT_LOG_FILE+="  Copyright : Manque la position du fichier contenant les détails du Copyright\n"
+      COPY_LOG=0
+    fi
+
+  fi
+
+  # On vérifie si la licence Apache est précisée.
+  COMPT=$(head -30 $FILE | grep "SPDX-License-Identifier: Apache-2.0" | wc -l)
+  if (( $COMPT == 0 ))
+  then
+    OUTPUT_LOG_FILE+="  Licence manquante ou mal orthographiée\n"
+    COPY_LOG=0
+  fi
+
+  # # On vérifie si les dates sont à jours.
+  # COMPT=$(head -30 $FILE | grep "(C) 2000-2022" | wc -l)
+  # if (( $COMPT == 0 ))
+  # then
+  #   OUTPUT_LOG_FILE+="  Dates manquantes ou non à jours\n"
+  #   COPY_LOG=0
+  # fi
+
+  # S'il y a au moins un problème, on copie dans la variable OUTPUT_LOG.
+  if (( $COPY_LOG == 0 ))
+  then
+    OUTPUT_LOG+="Fichier : $FILE\n$OUTPUT_LOG_FILE\n"
+  fi
+
+done
+
+OUTPUT_LOG+="\nFin script de vérification"
+echo -e $OUTPUT_LOG

--- a/.github/workflows/header_check.yml
+++ b/.github/workflows/header_check.yml
@@ -1,0 +1,35 @@
+name: Header/Encoding checker
+
+on:
+  # A executer que lorsque l'on demande.
+  workflow_dispatch:
+
+env:
+  # Arcane
+  ARCANE_SOURCE_DIR: '/home/runner/work/framework/framework/arcane'
+
+jobs:
+  check-headers:
+    name: check-headers-encoding
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.ARCANE_SOURCE_DIR }}
+          
+      - name: Check files
+        shell: bash
+        run: |
+          cd ${{ env.ARCANE_SOURCE_DIR }}
+          export SOURCE=.
+          chmod u+x ${{ env.ARCANE_SOURCE_DIR }}/.github/scripts/header_check.sh
+          ${{ env.ARCANE_SOURCE_DIR }}/.github/scripts/header_check.sh > ${{ env.ARCANE_SOURCE_DIR }}/output.log
+
+      - name: Upload log artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Header Log Verification
+          path: ${{ env.ARCANE_SOURCE_DIR }}/output.log
+          retention-days: 7

--- a/.github/workflows/header_check.yml
+++ b/.github/workflows/header_check.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Upload log artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Header Log Verification
+          name: Header Check Log
           path: ${{ env.ARCANE_SOURCE_DIR }}/output.log
           retention-days: 7


### PR DESCRIPTION
Ajout d'un vérificateur de header et d'encodage.
Le résultat de la vérification est à récupérer dans les artifacts.
Les exclusions sont peut-être à peaufiner.
Pour l'instant, le GH Action ne déclenche pas d'erreur et est à lancer manuellement.