### PR TITLE
Improve win32 compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ Debug*
 .vscode
 .vs
 /build
+/out

--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT ARCANE_CEA_MESH_PATH)
 endif()
 
 add_executable(arcanecea_tests_exec ${Arcane_SOURCE_DIR}/src/arcane/tests/ArcaneTestMain.cc)
+arcane_target_set_standard_path(arcanecea_tests_exec)
+
 set_target_properties(arcanecea_tests_exec PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 if (WIN32)
   set_target_properties(arcanecea_tests_exec PROPERTIES SUFFIX ".exe")

--- a/arcane/src/arcane/CaseOptions.h
+++ b/arcane/src/arcane/CaseOptions.h
@@ -287,9 +287,6 @@ class CaseOptionSimpleT
 	
   Type m_value; //!< Valeur de l'option
 
- private:
-
-  void _copyValue(const Type& rhs);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/EnumeratorTraceWrapper.h
+++ b/arcane/src/arcane/EnumeratorTraceWrapper.h
@@ -27,7 +27,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -37,7 +38,15 @@ ARCANE_BEGIN_NAMESPACE
 class EnumeratorTraceInfo
 {
  public:
-  Int64ArrayView counters() { return Int64ArrayView(8,m_counters); }
+  EnumeratorTraceInfo()
+  {
+    for (int i = 0; i < 8; ++i)
+      m_counters[i] = 0;
+  }
+
+ public:
+  Int64ArrayView counters() { return Int64ArrayView(8, m_counters); }
+
  private:
   Int64 m_counters[8];
 };
@@ -54,28 +63,31 @@ class EnumeratorTraceInfo
  * - une méthode enterEnumerator() et une méthode exitEnumerator() pour
  * chaque type d'énumérateur supporté.
  */
-template<typename TrueEnumerator,typename TracerInterface>
+template <typename TrueEnumerator, typename TracerInterface>
 class EnumeratorTraceWrapper
 : public TrueEnumerator
 {
  public:
   EnumeratorTraceWrapper(TrueEnumerator&& tenum)
-  : TrueEnumerator(tenum), m_tracer(TracerInterface::singleton())
+  : TrueEnumerator(tenum)
+  , m_tracer(TracerInterface::singleton())
   {
     if (m_tracer)
-      m_tracer->enterEnumerator(*this,m_infos,nullptr);
+      m_tracer->enterEnumerator(*this, m_infos, nullptr);
   }
-  EnumeratorTraceWrapper(TrueEnumerator&& tenum,const TraceInfo& ti)
-  : TrueEnumerator(tenum), m_tracer(TracerInterface::singleton())
+  EnumeratorTraceWrapper(TrueEnumerator&& tenum, const TraceInfo& ti)
+  : TrueEnumerator(tenum)
+  , m_tracer(TracerInterface::singleton())
   {
     if (m_tracer)
-      m_tracer->enterEnumerator(*this,m_infos,&ti);
+      m_tracer->enterEnumerator(*this, m_infos, &ti);
   }
   ~EnumeratorTraceWrapper() ARCANE_NOEXCEPT_FALSE
   {
     if (m_tracer)
-      m_tracer->exitEnumerator(*this,m_infos);
+      m_tracer->exitEnumerator(*this, m_infos);
   }
+
  private:
   TracerInterface* m_tracer;
   EnumeratorTraceInfo m_infos;
@@ -86,8 +98,8 @@ class EnumeratorTraceWrapper
 
 #if defined(ARCANE_TRACE_ENUMERATOR)
 #define A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) \
-  ::Arcane::EnumeratorTraceWrapper< _EnumeratorClassName, ::Arcane::IItemEnumeratorTracer >
-#define A_TRACE_ENUMERATOR_WHERE   ,A_FUNCINFO
+  ::Arcane::EnumeratorTraceWrapper< _EnumeratorClassName, ::Arcane::IItemEnumeratorTracer>
+#define A_TRACE_ENUMERATOR_WHERE , A_FUNCINFO
 #else
 #define A_TRACE_ITEM_ENUMERATOR(_EnumeratorClassName) \
   _EnumeratorClassName
@@ -97,7 +109,7 @@ class EnumeratorTraceWrapper
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/MeshPartialVariableScalarRef.h
+++ b/arcane/src/arcane/MeshPartialVariableScalarRef.h
@@ -215,7 +215,7 @@ class MeshPartialVariableScalarRefT
  private:
 
   static VariableFactoryRegisterer m_auto_registerer;
-  static VariableInfo _buildVariableInfo(const VariableBuildInfo& vbi);
+  //static VariableInfo _buildVariableInfo(const VariableBuildInfo& vbi);
   static VariableTypeInfo _buildVariableTypeInfo();
   static VariableRef* _autoCreate(const VariableBuildInfo& vb);
 };

--- a/arcane/src/arcane/mesh/MeshExchange.cc
+++ b/arcane/src/arcane/mesh/MeshExchange.cc
@@ -1,4 +1,4 @@
-﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
 // Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
@@ -252,7 +252,7 @@ computeInfos()
     _markRemovableParticles();
     _computeItemsToSend2();
   }
-  else if (m_mesh->itemFamilyNetwork() && m_mesh->itemFamilyNetwork()->isActivated() > 0)
+  else if (m_mesh->itemFamilyNetwork() && m_mesh->itemFamilyNetwork()->isActivated())
   {
     if(m_mesh->useMeshItemFamilyDependencies())
     {
@@ -314,7 +314,7 @@ _computeGraphConnectivityInfos()
   m_neighbour_extra_cells_owner     = new DynamicMultiArray<Int32>(cell_variable_size);
   m_neighbour_extra_cells_new_owner = new DynamicMultiArray<Int32>(cell_variable_size);
   
-  if (m_mesh->itemFamilyNetwork() && m_mesh->itemFamilyNetwork()->isActivated() > 0 )
+  if (m_mesh->itemFamilyNetwork() && m_mesh->itemFamilyNetwork()->isActivated())
   {
       _addGraphConnectivityToNewConnectivityInfo();
   }

--- a/arcane/src/arcane/tests/ArcaneTestInit.cc
+++ b/arcane/src/arcane/tests/ArcaneTestInit.cc
@@ -30,6 +30,7 @@ arcaneTestSetApplicationInfo()
 #ifdef ARCANE_OS_WIN32
   app_build_info.addDynamicLibrary("PerfectGas");
   app_build_info.addDynamicLibrary("StiffenedGas");
+  app_build_info.addDynamicLibrary("arcane_cea_tests");
 #endif
 
   // Modifie le répertoire de sortie pour prendren en compte le nom du

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -65,6 +65,14 @@ arcane_add_arccon_packages(arcane_tests_lib PRIVATE ${PKGS})
 add_executable(arcane_tests_exec ${ARCANE_SRC_PATH}/arcane/tests/ArcaneTestMain.cc)
 set(ARCANE_TEST_PATH ${ARCANEBUILDROOT}/src/arcane/tests)
 
+# Recopie dans le répertoire les DLLs nécessaires à l'exécutable de test
+if (WIN32)
+  add_custom_command(TARGET arcane_tests_exec POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:arcane_tests_exec> $<TARGET_FILE_DIR:arcane_tests_exec>
+    COMMAND_EXPAND_LISTS
+    )
+endif()
+
 file(MAKE_DIRECTORY ${ARCANEBUILDROOT}/arcane/tests)
 file(MAKE_DIRECTORY ${ARCANEBUILDROOT}/arcane/tests/geometry)
 file(MAKE_DIRECTORY ${ARCANEBUILDROOT}/arcane/tests/solvers)


### PR DESCRIPTION
- Remove some compilation warnings
- automatically copy DLLs needed for the tests in the right directory (`/lib`)