### PR TITLE
Improve Span2 and ArrayView implementation

### DIFF
--- a/arccore/src/base/arccore/base/Array2View.h
+++ b/arccore/src/base/arccore/base/Array2View.h
@@ -36,6 +36,8 @@ namespace Arccore
 template<class DataType>
 class Array2View
 {
+  friend class SmallSpan2<DataType>;
+  friend class SmallSpan2<const DataType>;
   friend class Span2<DataType>;
   friend class Span2<const DataType>;
  public:
@@ -78,6 +80,21 @@ class Array2View
     ARCCORE_CHECK_AT(j,m_dim2_size);
     m_ptr[(m_dim2_size*i) + j] = value;
   }
+  //! Valeur de l'élément [\a i][\a j]
+  constexpr const DataType operator()(Integer i,Integer j) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    return m_ptr[(m_dim2_size*i) + j];
+  }
+  //! Valeur de l'élément [\a i][\a j]
+  constexpr DataType& operator()(Integer i,Integer j)
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    return m_ptr[(m_dim2_size*i) + j];
+  }
+
  public:
   /*!
    * \brief Pointeur sur la mémoire allouée.
@@ -103,6 +120,8 @@ class Array2View
 template<class DataType>
 class ConstArray2View
 {
+  friend class SmallSpan2<const DataType>;
+  friend class Span2<const DataType>;
  public:
   constexpr ConstArray2View(const DataType* ptr,Integer dim1_size,Integer dim2_size)
   : m_ptr(ptr), m_dim1_size(dim1_size), m_dim2_size(dim2_size)
@@ -131,6 +150,13 @@ class ConstArray2View
     ARCCORE_CHECK_AT(j,m_dim2_size);
     return m_ptr[(m_dim2_size*i) + j];
   } 
+  //! Valeur de l'élément [\a i][\a j]
+  constexpr const DataType operator()(Integer i,Integer j) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    return m_ptr[(m_dim2_size*i) + j];
+  }
  public:
   /*!
    * \brief Pointeur sur la mémoire allouée.

--- a/arccore/src/base/arccore/base/Array3View.h
+++ b/arccore/src/base/arccore/base/Array3View.h
@@ -75,7 +75,14 @@ class Array3View
     ARCCORE_CHECK_AT(k,m_dim3_size);
     return m_ptr[(m_dim23_size*i) + m_dim3_size*j + k];
   }
-  constexpr DataType operator()(Integer i,Integer j,Integer k) const
+  constexpr const DataType& operator()(Integer i,Integer j,Integer k) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    ARCCORE_CHECK_AT(k,m_dim3_size);
+    return m_ptr[(m_dim23_size*i) + m_dim3_size*j + k];
+  }
+  constexpr DataType& operator()(Integer i,Integer j,Integer k)
   {
     ARCCORE_CHECK_AT(i,m_dim1_size);
     ARCCORE_CHECK_AT(j,m_dim2_size);
@@ -134,6 +141,13 @@ class ConstArray3View
     return ConstArray2View<DataType>(m_ptr + (m_dim23_size*i),m_dim2_size,m_dim3_size);
   }
   constexpr DataType item(Integer i,Integer j,Integer k) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    ARCCORE_CHECK_AT(k,m_dim3_size);
+    return m_ptr[(m_dim23_size*i) + m_dim3_size*j + k];
+  }
+  constexpr const DataType& operator()(Integer i,Integer j,Integer k) const
   {
     ARCCORE_CHECK_AT(i,m_dim1_size);
     ARCCORE_CHECK_AT(j,m_dim2_size);

--- a/arccore/src/base/arccore/base/Array4View.h
+++ b/arccore/src/base/arccore/base/Array4View.h
@@ -38,8 +38,8 @@ namespace Arccore
  * \endcode
  *
  * Il est néammoins préférable d'utiliser directement les méthodes
- * item() ou setItem() pour accéder en lecture ou écriture à un élément
- * du tableau.
+ * item() ou setItem() (ou l'opérateur operator()) pour accéder en lecture ou
+ * écriture à un élément du tableau.
  */
 template<class DataType>
 class Array4View
@@ -83,6 +83,24 @@ class Array4View
   }
   //! Valeur pour l'élément \a i,j,k,l
   constexpr DataType item(Integer i,Integer j,Integer k,Integer l) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    ARCCORE_CHECK_AT(k,m_dim3_size);
+    ARCCORE_CHECK_AT(l,m_dim4_size);
+    return m_ptr[(m_dim234_size*i) + m_dim34_size*j + m_dim4_size*k + l];
+  }
+  //! Valeur pour l'élément \a i,j,k,l
+  constexpr const DataType& operator()(Integer i,Integer j,Integer k,Integer l) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    ARCCORE_CHECK_AT(k,m_dim3_size);
+    ARCCORE_CHECK_AT(l,m_dim4_size);
+    return m_ptr[(m_dim234_size*i) + m_dim34_size*j + m_dim4_size*k + l];
+  }
+  //! Valeur pour l'élément \a i,j,k,l
+  constexpr DataType& operator()(Integer i,Integer j,Integer k,Integer l)
   {
     ARCCORE_CHECK_AT(i,m_dim1_size);
     ARCCORE_CHECK_AT(j,m_dim2_size);

--- a/arccore/src/base/arccore/base/ArrayView.h
+++ b/arccore/src/base/arccore/base/ArrayView.h
@@ -197,6 +197,28 @@ class ArrayView
    *
    * En mode \a check, vérifie les débordements.
    */
+  constexpr reference operator()(Integer i)
+  {
+    ARCCORE_CHECK_AT(i,m_size);
+    return m_ptr[i];
+  }
+
+  /*!
+   * \brief i-ème élément du tableau.
+   *
+   * En mode \a check, vérifie les débordements.
+   */
+  constexpr const_reference operator()(Integer i) const
+  {
+    ARCCORE_CHECK_AT(i,m_size);
+    return m_ptr[i];
+  }
+
+  /*!
+   * \brief i-ème élément du tableau.
+   *
+   * En mode \a check, vérifie les débordements.
+   */
   constexpr const_reference item(Integer i) const
   {
     ARCCORE_CHECK_AT(i,m_size);
@@ -612,6 +634,17 @@ class ConstArrayView
    * En mode \a check, vérifie les débordements.
    */
   constexpr const_reference operator[](Integer i) const
+  {
+    ARCCORE_CHECK_AT(i,m_size);
+    return m_ptr[i];
+  }
+
+  /*!
+   * \brief i-ème élément du tableau.
+   *
+   * En mode \a check, vérifie les débordements.
+   */
+  constexpr const_reference operator()(Integer i) const
   {
     ARCCORE_CHECK_AT(i,m_size);
     return m_ptr[i];

--- a/arccore/src/base/arccore/base/ArrayViewCommon.h
+++ b/arccore/src/base/arccore/base/ArrayViewCommon.h
@@ -104,6 +104,29 @@ areEqual(ViewType rhs, ViewType lhs)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+//! Indique si les deux vues sont égales
+template<typename View2DType> inline bool
+areEqual2D(View2DType rhs, View2DType lhs)
+{
+  using size_type = typename View2DType::size_type;
+  const size_type dim1_size = rhs.dim1Size();
+  const size_type dim2_size = rhs.dim2Size();
+  if (dim1_size!=lhs.dim1Size())
+    return false;
+  if (dim2_size!=lhs.dim2Size())
+    return false;
+  for( size_type i=0; i<dim1_size; ++i ){
+    for( size_type j=0; j<dim2_size; ++j ){
+      if (rhs(i,j)!=lhs(i,j))
+        return false;
+    }
+  }
+  return true;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 //! Lance une exception 'ArgumentException'
 extern "C++" ARCCORE_BASE_EXPORT void
 arccoreThrowTooBigInteger [[noreturn]] (std::size_t size);

--- a/arccore/src/base/arccore/base/BaseTypes.h
+++ b/arccore/src/base/arccore/base/BaseTypes.h
@@ -62,7 +62,9 @@ template<class DataType> class CoreArray;
 template<typename T,typename SizeType> class SpanImpl;
 template<typename T> class Span;
 template<typename T> class SmallSpan;
+template<typename T,typename SizeType> class Span2Impl;
 template<typename T> class Span2;
+template<typename T> class SmallSpan2;
 
 class StringImpl;
 class String;

--- a/arccore/src/base/arccore/base/Span.h
+++ b/arccore/src/base/arccore/base/Span.h
@@ -140,6 +140,17 @@ class SpanImpl
    *
    * En mode \a check, vérifie les débordements.
    */
+  constexpr ARCCORE_HOST_DEVICE reference operator()(SizeType i) const
+  {
+    ARCCORE_CHECK_AT(i,m_size);
+    return m_ptr[i];
+  }
+
+  /*!
+   * \brief i-ème élément du tableau.
+   *
+   * En mode \a check, vérifie les débordements.
+   */
   constexpr ARCCORE_HOST_DEVICE reference item(SizeType i) const
   {
     ARCCORE_CHECK_AT(i,m_size);
@@ -644,7 +655,6 @@ operator!=(SmallSpan<T> rhs, SmallSpan<T> lhs)
 {
   return !(rhs==lhs);
 }
-
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/Span2.h
+++ b/arccore/src/base/arccore/base/Span2.h
@@ -53,70 +53,98 @@ class View2TypeT<const T>
  *
  * Comme toute vue, une instance de cette classe n'est valide que tant
  * que le conteneur dont elle est issue ne change pas de nombre d'éléments.
+ * La vue est non modifiable si l'argument template est de type 'const T'.
+ * Cette classe permet d'accéder et d'utiliser un tableau d'éléments du
+ * type \a T de la même manière qu'un tableau C standard. \a SizeType est le
+ * type utilisé pour conserver le nombre d'éléments du tableau. Cela peut
+ * être 'Int32' ou 'Int64'.
  */
-template<class T>
-class Span2
+template<typename T,typename SizeType>
+class Span2Impl
 {
  public:
 
   using ElementType = T;
   using element_type = ElementType;
   using value_type = typename std::remove_cv<ElementType>::type;
-  using index_type = Int64;
-  using difference_type = Int64;
+  using index_type = SizeType;
+  using difference_type = SizeType;
+  using size_type = SizeType;
   using pointer = ElementType*;
   using const_pointer = typename std::add_const<ElementType*>::type;
   using reference = ElementType&;
+  using const_reference = const ElementType&;
   using view_type = typename detail::View2TypeT<ElementType>::view_type;
 
+  //! Indique si on peut convertir un 'X' ou 'const X' en un 'T'
+  template<typename X>
+  using is_same_const_type = std::enable_if_t<std::is_same_v<X,T> || std::is_same_v<std::add_const_t<X>,T>>;
+
  public:
+
   //! Créé une vue 2D de dimension [\a dim1_size][\a dim2_size]
-  ARCCORE_HOST_DEVICE Span2(ElementType* ptr,Int64 dim1_size,Int64 dim2_size)
+  ARCCORE_HOST_DEVICE Span2Impl(pointer ptr,SizeType dim1_size,SizeType dim2_size)
   : m_ptr(ptr), m_dim1_size(dim1_size), m_dim2_size(dim2_size) {}
   //! Créé une vue 2D vide.
-  ARCCORE_HOST_DEVICE Span2() : m_ptr(nullptr), m_dim1_size(0), m_dim2_size(0) {}
-  //! Constructeur de recopie depuis une autre vue
-  Span2(const Array2View<value_type>& from)
-  : m_ptr(from.m_ptr), m_dim1_size(from.dim1Size()),m_dim2_size(from.dim2Size()) {}
+  ARCCORE_HOST_DEVICE Span2Impl() : m_ptr(nullptr), m_dim1_size(0), m_dim2_size(0) {}
   // Constructeur à partir d'un ConstArrayView. Cela n'est autorisé que
   // si T est const.
   template<typename X,typename = std::enable_if_t<std::is_same_v<X,value_type>> >
-  Span2(const ConstArray2View<X>& from)
+  Span2Impl(const ConstArray2View<X>& from)
   : m_ptr(from.data()), m_dim1_size(from.dim1Size()),m_dim2_size(from.dim2Size()) {}
   // Pour un Span<const T>, on a le droit de construire depuis un Span<T>
   template<typename X,typename = std::enable_if_t<std::is_same_v<X,value_type>> >
-  ARCCORE_HOST_DEVICE Span2(const Span2<X>& from)
+  ARCCORE_HOST_DEVICE Span2Impl(const Span2<X>& from)
   : m_ptr(from.data()), m_dim1_size(from.dim1Size()),m_dim2_size(from.dim2Size()) {}
-  //! Construit une vue sur une zone mémoire commencant par \a ptr et
-  // contenant \a asize éléments.
+
  public:
+
   //! Nombre d'éléments de la première dimension
-  ARCCORE_HOST_DEVICE Int64 dim1Size() const { return m_dim1_size; }
+  constexpr ARCCORE_HOST_DEVICE SizeType dim1Size() const { return m_dim1_size; }
   //! Nombre d'éléments de la deuxième dimension
-  ARCCORE_HOST_DEVICE Int64 dim2Size() const { return m_dim2_size; }
+  constexpr ARCCORE_HOST_DEVICE SizeType dim2Size() const { return m_dim2_size; }
   //! Nombre total d'éléments.
-  ARCCORE_HOST_DEVICE Int64 totalNbElement() const { return m_dim1_size*m_dim2_size; }
+  constexpr ARCCORE_HOST_DEVICE SizeType totalNbElement() const { return m_dim1_size*m_dim2_size; }
+
  public:
-  ARCCORE_HOST_DEVICE Span<ElementType> operator[](Int64 i) const
+
+  ARCCORE_HOST_DEVICE SpanImpl<ElementType,SizeType> operator[](SizeType i) const
   {
     ARCCORE_CHECK_AT(i,m_dim1_size);
-    return Span<ElementType>(m_ptr + (m_dim2_size*i),m_dim2_size);
+    return SpanImpl<ElementType,SizeType>(m_ptr + (m_dim2_size*i),m_dim2_size);
   }
-  //! Valeur de l'élément [\a i][\a j]
-  ARCCORE_HOST_DEVICE ElementType item(Int64 i,Int64 j) const
+
+  ARCCORE_HOST_DEVICE SpanImpl<ElementType,SizeType> operator()(SizeType i) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    return SpanImpl<ElementType,SizeType>(m_ptr + (m_dim2_size*i),m_dim2_size);
+  }
+
+  ARCCORE_HOST_DEVICE reference operator()(SizeType i,SizeType j) const
   {
     ARCCORE_CHECK_AT(i,m_dim1_size);
     ARCCORE_CHECK_AT(j,m_dim2_size);
     return m_ptr[(m_dim2_size*i) + j];
   }
+
+  //! Valeur de l'élément [\a i][\a j]
+  ARCCORE_HOST_DEVICE ElementType item(SizeType i,SizeType j) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    ARCCORE_CHECK_AT(j,m_dim2_size);
+    return m_ptr[(m_dim2_size*i) + j];
+  }
+
   //! Positionne l'élément [\a i][\a j] à \a value
-  ARCCORE_HOST_DEVICE ElementType setItem(Int64 i,Int64 j,const ElementType& value)
+  ARCCORE_HOST_DEVICE ElementType setItem(SizeType i,SizeType j,const ElementType& value)
   {
     ARCCORE_CHECK_AT(i,m_dim1_size);
     ARCCORE_CHECK_AT(j,m_dim2_size);
     m_ptr[(m_dim2_size*i) + j] = value;
   }
+
  public:
+
   /*!
    * \brief Vue constante sur cette vue.
    */
@@ -136,7 +164,9 @@ class Span2
     Integer s2 = arccoreCheckArraySize(m_dim2_size);
     return ConstArrayView<value_type>(m_ptr,s1,s2);
   }
+
  public:
+
   /*!
    * \brief Pointeur sur la mémoire allouée.
    */
@@ -149,11 +179,210 @@ class Span2
    * \brief Pointeur constant sur la mémoire allouée.
    */
   ARCCORE_HOST_DEVICE inline const ElementType* data() const { return m_ptr; }
- private:
+
+ protected:
+
   ElementType* m_ptr;
-  Int64 m_dim1_size;
-  Int64 m_dim2_size;
+  SizeType m_dim1_size;
+  SizeType m_dim2_size;
 };
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \ingroup Collection
+ *
+ * \brief Vue pour un tableau 2D dont la taille est un 'Int32'
+ *
+ * Comme toute vue, une instance de cette classe n'est valide que tant
+ * que le conteneur dont elle est issue ne change pas de nombre d'éléments.
+ */
+template<class T>
+class SmallSpan2
+: public Span2Impl<T,Int32>
+{
+  friend class Span2<T>;
+
+ public:
+
+  using ThatClass = SmallSpan2<T>;
+  using BaseClass = Span2Impl<T,Int32>;
+  using size_type = Int32;
+  using value_type = typename BaseClass::value_type;
+  using pointer = typename BaseClass::pointer;
+  using BaseClass::operator();
+  using BaseClass::operator[];
+  using ElementType = typename BaseClass::ElementType;
+
+ private:
+
+  using BaseClass::m_ptr;
+  using BaseClass::m_dim1_size;
+  using BaseClass::m_dim2_size;
+
+ public:
+
+  //! Créé une vue 2D de dimension [\a dim1_size][\a dim2_size]
+  ARCCORE_HOST_DEVICE SmallSpan2(pointer ptr,Int32 dim1_size,Int32 dim2_size)
+  : BaseClass(ptr,dim1_size,dim2_size) {}
+  //! Créé une vue 2D vide.
+  ARCCORE_HOST_DEVICE SmallSpan2() : BaseClass() {}
+  //! Constructeur de recopie depuis une autre vue
+  SmallSpan2(const Array2View<value_type>& from)
+  : BaseClass(from.m_ptr,from.dim1Size(),from.dim2Size()) {}
+  // Constructeur à partir d'un ConstArrayView. Cela n'est autorisé que
+  // si T est const.
+  template<typename X,typename = std::enable_if_t<std::is_same_v<X,value_type>> >
+  SmallSpan2(const ConstArray2View<X>& from)
+  : BaseClass(from.m_ptr,from.dim1Size(),from.dim2Size()) {}
+  // Pour un Span<const T>, on a le droit de construire depuis un Span<T>
+  template<typename X,typename = std::enable_if_t<std::is_same_v<X,value_type>> >
+  ARCCORE_HOST_DEVICE SmallSpan2(const SmallSpan2<X>& from)
+  : BaseClass(from.data(),from.dim1Size(),from.dim2Size()) {}
+
+ public:
+
+  ARCCORE_HOST_DEVICE SmallSpan<ElementType> operator[](Int32 i) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    return SmallSpan<ElementType>(m_ptr + (m_dim2_size*i),m_dim2_size);
+  }
+
+  ARCCORE_HOST_DEVICE SmallSpan<ElementType> operator()(Int32 i) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    return SmallSpan<ElementType>(m_ptr + (m_dim2_size*i),m_dim2_size);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \ingroup Collection
+ *
+ * \brief Vue pour un tableau 2D dont la taille est un 'Int64'
+ *
+ * Comme toute vue, une instance de cette classe n'est valide que tant
+ * que le conteneur dont elle est issue ne change pas de nombre d'éléments.
+ */
+template<class T>
+class Span2
+: public Span2Impl<T,Int64>
+{
+ public:
+
+  using ThatClass = Span2<T>;
+  using BaseClass = Span2Impl<T,Int64>;
+  using size_type = Int64;
+  using value_type = typename BaseClass::value_type;
+  using pointer = typename BaseClass::pointer;
+  using BaseClass::operator();
+  using BaseClass::operator[];
+  using ElementType = typename BaseClass::ElementType;
+
+ private:
+
+  using BaseClass::m_ptr;
+  using BaseClass::m_dim1_size;
+  using BaseClass::m_dim2_size;
+
+ public:
+
+  //! Créé une vue 2D de dimension [\a dim1_size][\a dim2_size]
+  ARCCORE_HOST_DEVICE Span2(pointer ptr,Int64 dim1_size,Int64 dim2_size)
+  : BaseClass(ptr,dim1_size,dim2_size) {}
+  //! Créé une vue 2D vide.
+  ARCCORE_HOST_DEVICE Span2() : BaseClass() {}
+  //! Constructeur de recopie depuis une autre vue
+  Span2(const Array2View<value_type>& from)
+  : BaseClass(from.m_ptr,from.dim1Size(),from.dim2Size()) {}
+  // Constructeur à partir d'un ConstArrayView. Cela n'est autorisé que
+  // si T est const.
+  template<typename X,typename = std::enable_if_t<std::is_same_v<X,value_type>> >
+  Span2(const ConstArray2View<X>& from)
+  : BaseClass(from.m_ptr,from.dim1Size(),from.dim2Size()) {}
+
+  //! Constructeur de recopie depuis un 'SmallSpan'
+  Span2(const SmallSpan2<T>& from)
+  : BaseClass(from.m_ptr,from.dim1Size(),from.dim2Size()) {}
+
+  // Pour un Span<const T>, on a le droit de construire depuis un Span<T>
+  template<typename X,typename = std::enable_if_t<std::is_same_v<X,value_type>> >
+  ARCCORE_HOST_DEVICE Span2(const Span2<X>& from)
+  : BaseClass(from) {}
+
+  // Pour un Span<const T>, on a le droit de construire depuis un Span<T>
+  template<typename X,typename = std::enable_if_t<std::is_same_v<X,value_type>> >
+  ARCCORE_HOST_DEVICE Span2(const SmallSpan2<X>& from)
+  : BaseClass(from.data(), from.dim1Size(), from.dim2Size()) {}
+
+ public:
+
+  ARCCORE_HOST_DEVICE Span<ElementType> operator[](Int64 i) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    return Span<ElementType>(m_ptr + (m_dim2_size*i),m_dim2_size);
+  }
+
+  ARCCORE_HOST_DEVICE Span<ElementType> operator()(Int64 i) const
+  {
+    ARCCORE_CHECK_AT(i,m_dim1_size);
+    return Span<ElementType>(m_ptr + (m_dim2_size*i),m_dim2_size);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template<typename T,typename SizeType> inline bool
+operator==(Span2Impl<const T,SizeType> rhs, Span2Impl<const T,SizeType> lhs)
+{
+  return impl::areEqual2D(rhs,lhs);
+}
+
+template<typename T> inline bool
+operator==(Span2<const T> rhs, Span2<const T> lhs)
+{
+  Span2Impl<const T,Int64> a = rhs;
+  Span2Impl<const T,Int64> b = lhs;
+  return a==b;
+}
+
+template<typename T> inline bool
+operator!=(Span2<const T> rhs, Span2<const T> lhs)
+{
+  return !(rhs==lhs);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template<typename T> inline bool
+operator==(Span2<T> rhs, Span2<T> lhs)
+{
+  return impl::areEqual2D(rhs,lhs);
+}
+
+template<typename T> inline bool
+operator!=(Span2<T> rhs, Span2<T> lhs)
+{
+  return !(rhs==lhs);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template<typename T> inline bool
+operator==(SmallSpan2<T> rhs, SmallSpan2<T> lhs)
+{
+  return operator==(Span2<const T>(rhs),Span2<const T>(lhs));
+}
+
+template<typename T> inline bool
+operator!=(SmallSpan2<T> rhs, SmallSpan2<T> lhs)
+{
+  return !(rhs==lhs);
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/tests/TestArrayView.cc
+++ b/arccore/src/base/tests/TestArrayView.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "arccore/base/Span.h"
+#include "arccore/base/Span2.h"
 #include "arccore/base/ArrayView.h"
 #include "arccore/base/Array3View.h"
 #include "arccore/base/Array4View.h"
@@ -184,6 +185,26 @@ void _checkSame(A1& a1,A2& a2,const char* message)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+// Vérifie que \a a1 et \a a2 sont identiques
+template<typename A1,typename A2>
+void _checkSame2(A1& a1,A2& a2,const char* message)
+{
+  using namespace Arccore;
+  using size_type = typename A1::size_type;
+  const Int64 s1_dim1 = a1.dim1Size();
+  const Int64 s2_dim1 = a2.dim1Size();
+  ASSERT_EQ(s1_dim1,s2_dim1) << "Bad size " << message;
+  const Int64 s1_dim2 = a1.dim2Size();
+  const Int64 s2_dim2 = a2.dim2Size();
+  ASSERT_EQ(s1_dim2,s2_dim2) << "Bad size " << message;
+  for( size_type i=0; i<s1_dim1; ++i )
+    for( size_type j=0; j<s1_dim2; ++j )
+      ASSERT_EQ(a1[i][j],a2[i][j]) << "Bad value[" << i << ',' << j << "]" << message;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 TEST(ArrayView,StdArray)
 {
   using namespace Arccore;
@@ -224,8 +245,7 @@ TEST(ArrayView,StdArray)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SpanType,typename ConstSpanType>
-void
+template<typename SpanType,typename ConstSpanType> void
 _testSpanStdArray()
 {
   using namespace Arccore;
@@ -291,6 +311,79 @@ TEST(SmallSpan,StdArray)
 {
   using namespace Arccore;
   _testSpanStdArray<SmallSpan<Int64>,SmallSpan<const Int64>>();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template<typename SpanType,typename ConstSpanType> void
+_testSpan2StdArray()
+{
+  using namespace Arccore;
+  std::array<Int64,0> v0;
+  std::array<Int64,6> v1 { 5, 7, 9, 32, -5, -6 };
+  std::array<Int64,5> v2 { 1, 9, 32, 41, -5 };
+  std::array<const Int64,12> v3 { 12, 33, 47, 55, 36, 13, 9, 7, 5, 1, 45, 38 };
+
+  SpanType s0 { };
+  SpanType s1 { v1.data(), 3, 2 };
+  SpanType s2 { v2.data(), 1, 5 };
+  ConstSpanType s3 { v3.data(), 4, 3 };
+
+  {
+    SpanType span0 { s0 };
+    _checkSame2(span0,s0,"span0==s0");
+
+    SpanType span1 { s1 };
+    _checkSame2(span1,s1,"span1==s1");
+
+    SpanType span2 { s1 };
+    ASSERT_TRUE(span1==span2);
+    ASSERT_FALSE(span1!=span2);
+
+    SpanType const_span2 { s1 };
+    ASSERT_TRUE(span1==const_span2);
+    ASSERT_FALSE(span1!=const_span2);
+  }
+
+  {
+    ConstSpanType span0 { s0 };
+    _checkSame2(span0,s0,"const span0==s0");
+
+    ConstSpanType span1 { s1 };
+    _checkSame2(span1,s1,"const span1==s1");
+
+    span0 = s2;
+    _checkSame2(span0,s2,"const span0==s2");
+
+    ConstSpanType span2 { s3 };
+    _checkSame2(span2,s3,"const span2==s3");
+
+    ConstSpanType span3 { s3 };
+    ASSERT_TRUE(span2==span3);
+    ASSERT_FALSE(span2!=span3);
+
+    span1 = s3;
+    _checkSame2(span1,s3,"const span1==s3");
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(Span2,StdArray)
+{
+  using namespace Arccore;
+  _testSpan2StdArray<Span2<Int64>,Span2<const Int64>>();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(SmallSpan2,StdArray)
+{
+  using namespace Arccore;
+  _testSpan2StdArray<SmallSpan2<Int64>,SmallSpan2<const Int64>>();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -383,6 +476,16 @@ template class SmallSpan<Int32>;
 template class SmallSpan<const Int32>;
 template class SmallSpan<double>;
 template class SmallSpan<const double>;
+
+template class Span2<Int32>;
+template class Span2<const Int32>;
+template class Span2<double>;
+template class Span2<const double>;
+
+template class SmallSpan2<Int32>;
+template class SmallSpan2<const Int32>;
+template class SmallSpan2<double>;
+template class SmallSpan2<const double>;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
- Add `operator()` to access values of `ArrayView`, `ArrayView2`, `ArrayView3`, `ArrayView4`, `Span`, `Span2` and const versions of these views
- Add `SmallSpan2` implementation for 2D arrays whose `size_type` is an `Int32`.
