### PR TITLE
Store maximum number of connected items in 'IncrementalItemConnectivity' instead of 'ItemSharedInfo'

### DIFF
--- a/arcane/src/arcane/IIncrementalItemConnectivity.h
+++ b/arcane/src/arcane/IIncrementalItemConnectivity.h
@@ -99,6 +99,14 @@ class ARCANE_CORE_EXPORT IIncrementalItemConnectivity
 
   //! Sort sur le flot \a out des statistiques sur l'utilisation et la mémoire utilisée
   virtual void dumpStats(std::ostream& out) const =0;
+
+  /*!
+   * \brief Nombre maximum d'entités connectées à une entité source.
+   *
+   * Cette valeur peut être supérieure au nombre maximum actuel d'entités
+   * connectées s'il y a eu des appels à removeConnectedItem() et removeConnectedItems().
+   */
+  virtual Int32 maxNbConnectedItem() const =0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/IItemConnectivityInfo.h
+++ b/arcane/src/arcane/IItemConnectivityInfo.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IItemConnectivityInfo.h                                     (C) 2000-2013 */
+/* IItemConnectivityInfo.h                                     (C) 2000-2022 */
 /*                                                                           */
 /* Interface des informations sur la connectivité par type d'entité.         */
 /*---------------------------------------------------------------------------*/
@@ -19,10 +19,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -44,7 +42,7 @@ class IItemConnectivityInfo
 {
  public:
 
-  virtual ~IItemConnectivityInfo() {} //<! Libère les ressources
+  virtual ~IItemConnectivityInfo() = default; //<! Libère les ressources
 
  public:
 
@@ -59,21 +57,12 @@ class IItemConnectivityInfo
 
   //! Nombre maximal de mailles par entité
   virtual Integer maxCellPerItem() const =0;
-
-  //! Nombre maximal de noeuds pour les ItemTypeInfo de ce type d'entité
-  virtual Integer maxNodeInItemTypeInfo() const =0;
-  
-  //! Nombre maximal d'arêtes pour les ItemTypeInfo de ce type d'entité
-  virtual Integer maxEdgeInItemTypeInfo() const =0;
-
-  //! Nombre maximal de faces pour les ItemTypeInfo de ce type d'entité
-  virtual Integer maxFaceInItemTypeInfo() const =0;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/IItemFamily.h
+++ b/arcane/src/arcane/IItemFamily.h
@@ -374,36 +374,7 @@ class IItemFamily
 
  public:
 
-  /*!
-   * \name Informations sur la connectivité.
-   *
-   * Ces informations sont recalculées dynamiquement lorsque le maillage évolue.
-   *
-   *
-   */
-  //@{
-  /*! Nombre maximal de noeuds par entité.
-   * \deprecated Utiliser localConnectivityInfos()->maxNodePerItem() à la place.
-   */    
-  virtual ARCANE_DEPRECATED_122 Integer maxNodePerItem() const =0;
-  
-  /*! Nombre maximal d'arêtes par entité
-   * \deprecated Utiliser localConnectivityInfos()->maxEdgePerItem() à la place.
-   */
-  virtual ARCANE_DEPRECATED_122 Integer maxEdgePerItem() const =0;
-
-  /*! Nombre maximal de faces par entité
-   * \deprecated Utiliser localConnectivityInfos()->maxFacePerItem() à la place.
-   */
-  virtual ARCANE_DEPRECATED_122 Integer maxFacePerItem() const =0;
-
-  /*! Nombre maximal de mailles par entité
-   * \deprecated Utiliser localConnectivityInfos()->maxCellPerItem() à la place.
-   */
-  virtual ARCANE_DEPRECATED_122 Integer maxCellPerItem() const =0;
-  //@}
-
-  //! Informations sur la connectivité locales au sous-domaine pour à cette famille
+  //! Informations sur la connectivité locale au sous-domaine pour à cette famille
   virtual IItemConnectivityInfo* localConnectivityInfos() const =0;
 
   //! Informations sur la connectivité globales à tous les sous-domaines.

--- a/arcane/src/arcane/IItemFamily.h
+++ b/arcane/src/arcane/IItemFamily.h
@@ -401,21 +401,6 @@ class IItemFamily
    * \deprecated Utiliser localConnectivityInfos()->maxCellPerItem() à la place.
    */
   virtual ARCANE_DEPRECATED_122 Integer maxCellPerItem() const =0;
-
-  /*! Nombre maximal de noeuds pour un type d'entité
-   * \deprecated Utiliser localConnectivityInfos()->maxNodeInItemTypeInfo() à la place.
-   */
-  virtual ARCANE_DEPRECATED_122 Integer maxLocalNodePerItemType() const =0;
-  
-  /*! Nombre maximal d'arêtes pour un type d'entité
-   * \deprecated Utiliser localConnectivityInfos()->maxEdgeInItemTypeInfo() à la place.
-   */
-  virtual ARCANE_DEPRECATED_122 Integer maxLocalEdgePerItemType() const =0;
-
-  /*! Nombre maximal de faces pour un type d'entité
-   * \deprecated Utiliser localConnectivityInfos()->maxFaceInItemTypeInfo() à la place.
-   */
-  virtual ARCANE_DEPRECATED_122 Integer maxLocalFacePerItemType() const =0;
   //@}
 
   //! Informations sur la connectivité locales au sous-domaine pour à cette famille

--- a/arcane/src/arcane/ItemInternal.h
+++ b/arcane/src/arcane/ItemInternal.h
@@ -72,7 +72,11 @@ namespace Arcane
  */
 class ARCANE_CORE_EXPORT ItemInternalConnectivityList
 {
+  // IMPORTANT: Cette structure doit avoir le même agencement mémoire
+  // que la structure C# de même nom.
+
  private:
+
   /*!
    * \brief Vue spécifique pour gérer les entités nulles.
    *
@@ -119,8 +123,11 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
     Int32 m_size;
     Int32* m_data;
   };
+
  public:
-  enum {
+
+  enum
+  {
     NODE_IDX = 0,
     EDGE_IDX = 1,
     FACE_IDX = 2,
@@ -129,9 +136,13 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
     HCHILD_IDX = 5,
     MAX_ITEM_KIND = 6
   };
+
  public:
+
   static ItemInternalConnectivityList nullInstance;
+
  public:
+
   ItemInternalConnectivityList()
   : m_items(nullptr), m_nb_access_all(0), m_nb_access(0)
   {
@@ -141,9 +152,12 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
       m_nb_item_null_data[i][0] = 0;
       m_nb_item_null_data[i][1] = 0;
       m_nb_item[i].setNull(&m_nb_item_null_data[i][1]);
+      m_max_nb_item[i] = 0;
     }
   }
+
  public:
+
   /*!
    * \brief Liste des localId() des entités de type \a item_kind
    * connectées à l'entité de de localid() \a lid.
@@ -185,6 +199,11 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
   {
     m_nb_item[item_kind] = v;
   }
+  //! Positionne le nombre maximum d'entités connectées.
+  void setMaxNbConnectedItem(Int32 item_kind,Int32 v)
+  {
+    m_max_nb_item[item_kind] = v;
+  }
   //! Tableau d'index des connectivités pour les entités de genre \a item_kind
   Int32ConstArrayView connectivityIndex(Int32 item_kind) const
   {
@@ -200,6 +219,12 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
   {
     return m_nb_item[item_kind];
   }
+  //! Nombre maximum d'entités connectées.
+  Int32 maxNbConnectedItem(Int32 item_kind) const
+  {
+    return m_max_nb_item[item_kind];
+  }
+
  public:
 
   ItemInternal* nodeV2(Int32 lid,Int32 aindex) const
@@ -259,27 +284,37 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
   { return itemLocalId(ItemInternalConnectivityList::HPARENT_IDX,lid,index); }
   Int32 _hChildLocalIdV2(Int32 lid,Int32 index) const
   { return itemLocalId(ItemInternalConnectivityList::HCHILD_IDX,lid,index); }
+
  public:
+
   Int32 _nbNodeV2(Int32 lid) const { return m_nb_item[NODE_IDX][lid]; }
   Int32 _nbEdgeV2(Int32 lid) const { return m_nb_item[EDGE_IDX][lid]; }
   Int32 _nbFaceV2(Int32 lid) const { return m_nb_item[FACE_IDX][lid]; }
   Int32 _nbCellV2(Int32 lid) const { return m_nb_item[CELL_IDX][lid]; }
   Int32 _nbHParentV2(Int32 lid) const { return m_nb_item[HPARENT_IDX][lid]; }
   Int32 _nbHChildrenV2(Int32 lid) const { return m_nb_item[HCHILD_IDX][lid]; }
+
  private:
+
   // Ces deux tableaux utilisent une vue modifiable par compatibilité avec les anciens
   // mécanismes. Une fois que ceci auront été supprimés alors il sera
   // constant
   Int32ArrayView m_indexes[MAX_ITEM_KIND];
   Int32View m_nb_item[MAX_ITEM_KIND];
   Int32ConstArrayView m_list[MAX_ITEM_KIND];
+  Int32 m_max_nb_item[MAX_ITEM_KIND];
+
  public:
+
   MeshItemInternalList* m_items;
+
  private:
   // Compte le nombre d'accès pour vérification. A supprimer par la suite.
   mutable Int64 m_nb_access_all;
   mutable Int64 m_nb_access;
+
  public:
+
   Int32ArrayView _mutableConnectivityIndex(Int32 item_kind) const
   {
     return m_indexes[item_kind];
@@ -290,8 +325,10 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
   }
   Int32Array* m_indexes_array[MAX_ITEM_KIND];
   Int32Array* m_nb_item_array[MAX_ITEM_KIND];
+
  private:
- Int32 m_nb_item_null_data[MAX_ITEM_KIND][2];
+
+  Int32 m_nb_item_null_data[MAX_ITEM_KIND][2];
 };
 
 /*---------------------------------------------------------------------------*/
@@ -589,7 +626,8 @@ class ARCANE_CORE_EXPORT ItemInternal
   inline bool isSlaveFace() const { return flags() & II_SlaveFace; }
 
  public:
-  void reinitialize(Int64 uid,Integer aowner,Int32 owner_rank)
+
+  void reinitialize(Int64 uid,Int32 aowner,Int32 owner_rank)
   {
     setUniqueId(uid);
     setFlags(0);
@@ -693,8 +731,7 @@ class ARCANE_CORE_EXPORT ItemInternal
    * \warning Ces méthodes ne doivent être appelées que sur les entités
    * qui possèdent la connectivité associée ET qui sont au nouveau format.
    * Par exemple, cela ne fonctionne pas sur Cell->Cell car il n'y a pas de
-   * connectivité maille/maille, ni sur les Link car ils n'utilisent pas
-   * les nouvelles connectivités. En cas de mauvaise utilisation, cela
+   * connectivité maille/maille. En cas de mauvaise utilisation, cela
    * se traduit par un débordement de tableau.
    * 
    */

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -261,8 +261,11 @@ _notifyConnectivityNbItemChanged()
 void IncrementalItemConnectivityBase::
 _setNewMaxNbConnectedItems(Int32 new_max)
 {
-  if (new_max > m_p->m_max_nb_item)
+  if (new_max > m_p->m_max_nb_item){
     m_p->m_max_nb_item = new_max;
+    if (m_item_connectivity_list)
+      m_item_connectivity_list->setMaxNbConnectedItem(m_item_connectivity_index,new_max);
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -194,7 +194,7 @@ IncrementalItemConnectivityBase(IItemFamily* source_family,IItemFamily* target_f
   typedef IncrementalItemConnectivityBase ThatClass;
   // Récupère les évènements de lecture pour indiquer qu'il faut mettre
   // à jour les vues.
-  m_p->m_observers.addObserver(this,&ThatClass::_notifyConnectivityNbItemChanged,
+  m_p->m_observers.addObserver(this,&ThatClass::_notifyConnectivityNbItemChangedFromObservable,
                                m_p->m_connectivity_nb_item_variable.variable()->readObservable());
 
   m_p->m_observers.addObserver(this,&ThatClass::_notifyConnectivityIndexChanged,
@@ -208,9 +208,7 @@ IncrementalItemConnectivityBase(IItemFamily* source_family,IItemFamily* target_f
   // il peut être réalloué et donc la vue associée devenir invalide.
   _notifyConnectivityListChanged();
   _notifyConnectivityIndexChanged();
-  _notifyConnectivityNbItemChanged();
-
-  _computeMaxNbConnectedItem();
+  _notifyConnectivityNbItemChangedFromObservable();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -253,6 +251,19 @@ _notifyConnectivityNbItemChanged()
   m_connectivity_nb_item = m_p->m_connectivity_nb_item_array.view();
   if (m_item_connectivity_list)
     m_item_connectivity_list->setConnectivityNbItem(m_item_connectivity_index,m_connectivity_nb_item);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * Méthode appelée lorsque la le nombre d'entité est modifié de manière externe,
+ * par exemple en reprise ou après un retour-arrière.
+ */
+void IncrementalItemConnectivityBase::
+_notifyConnectivityNbItemChangedFromObservable()
+{
+  _notifyConnectivityNbItemChanged();
+  _computeMaxNbConnectedItem();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -131,16 +131,20 @@ class IncrementalItemConnectivityContainer
 
   ObserverPool m_observers;
 
+  /*!
+   * \brief Nombre maximum d'entités connectées.
+   *
+   * Il s'agit d'un majorant du nombre maximum d'entité connectées.
+   * Pour des raisons de performance, cette valeur n'est pas mise à jour
+   * si des entités sont retirées.
+   */
+  Int32 m_max_nb_item = 0;
+
  public:
-  Integer size() const {
-    return m_connectivity_nb_item_array.size() ;
-  }
 
-  bool isAllocated() const {
-    return size() > 0 ;
-  }
+  Integer size() const { return m_connectivity_nb_item_array.size(); }
 
-
+  bool isAllocated() const { return size()>0; }
 
   void _checkResize(Int32 lid)
   {
@@ -205,6 +209,8 @@ IncrementalItemConnectivityBase(IItemFamily* source_family,IItemFamily* target_f
   _notifyConnectivityListChanged();
   _notifyConnectivityIndexChanged();
   _notifyConnectivityNbItemChanged();
+
+  _computeMaxNbConnectedItem();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -247,6 +253,40 @@ _notifyConnectivityNbItemChanged()
   m_connectivity_nb_item = m_p->m_connectivity_nb_item_array.view();
   if (m_item_connectivity_list)
     m_item_connectivity_list->setConnectivityNbItem(m_item_connectivity_index,m_connectivity_nb_item);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IncrementalItemConnectivityBase::
+_setNewMaxNbConnectedItems(Int32 new_max)
+{
+  if (new_max > m_p->m_max_nb_item)
+    m_p->m_max_nb_item = new_max;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IncrementalItemConnectivityBase::
+_computeMaxNbConnectedItem()
+{
+  // Force la remise à zéro pour être sur qu'il sera mis à jour
+  m_p->m_max_nb_item = -1;
+  Int32 max_nb_item = 0;
+  for( Int32 x : m_connectivity_nb_item )
+    if (x>max_nb_item)
+      max_nb_item = x;
+  _setNewMaxNbConnectedItems(max_nb_item);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+Int32 IncrementalItemConnectivityBase::
+maxNbConnectedItem() const
+{
+  return m_p->m_max_nb_item;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -470,6 +510,7 @@ addConnectedItem(ItemLocalId source_item,ItemLocalId target_item)
     }
   }
   ++(m_connectivity_nb_item[lid]);
+  _setNewMaxNbConnectedItems(m_connectivity_nb_item[lid]);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -504,6 +545,7 @@ addConnectedItems(ItemLocalId source_item,Integer nb_item)
   Integer new_pos_in_list = _increaseConnectivityList(NULL_ITEM_LOCAL_ID,alloc_size);
   m_connectivity_index[lid] = new_pos_in_list;
   m_connectivity_nb_item[lid] += nb_item;
+  _setNewMaxNbConnectedItems(m_connectivity_nb_item[lid]);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -708,7 +750,7 @@ compactConnectivityList()
     Int32 lid = i;
     Int32 nb = m_connectivity_nb_item[lid];
     Int32 index = m_connectivity_index[lid];
-    Int32ConstArrayView con_list(nb,old_connectivity_list.unguardedBasePointer()+index);
+    Int32ConstArrayView con_list(nb,old_connectivity_list.data()+index);
     Integer alloc_size = _computeAllocSize(nb);
     m_connectivity_index[lid] = new_pos_in_list;
     new_pos_in_list += alloc_size;
@@ -728,6 +770,7 @@ compactConnectivityList()
       m_connectivity_index[lid] = 0;
   }
   _notifyConnectivityListChanged();
+  _computeMaxNbConnectedItem();
   info(4) << "Compacting IncrementalItemConnectivity name=" << name()
           << " nb_item=" << nb_item << " old_size=" << old_size
           << " new_size=" << m_connectivity_list.size()
@@ -772,6 +815,7 @@ addConnectedItem(ItemLocalId source_item,ItemLocalId target_item)
   Int32 target_lid = target_item.localId();
   m_connectivity_list[lid] = target_lid;
   m_connectivity_nb_item[lid] = 1;
+  _setNewMaxNbConnectedItems(1);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
@@ -161,6 +161,7 @@ class ARCANE_MESH_EXPORT IncrementalItemConnectivityBase
   void _notifyConnectivityListChanged();
   void _notifyConnectivityIndexChanged();
   void _notifyConnectivityNbItemChanged();
+  void _notifyConnectivityNbItemChangedFromObservable();
   void _computeMaxNbConnectedItem();
   void _setNewMaxNbConnectedItems(Int32 new_max);
 };

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
@@ -111,6 +111,8 @@ class ARCANE_MESH_EXPORT IncrementalItemConnectivityBase
   IndexedItemConnectivityViewBase connectivityView() const;
   IndexedItemConnectivityAccessor connectivityAccessor() const;
 
+  Int32 maxNbConnectedItem() const override;
+
  public:
 
   Int32ConstArrayView _connectedItemsLocalId(ItemLocalId lid) const
@@ -159,6 +161,8 @@ class ARCANE_MESH_EXPORT IncrementalItemConnectivityBase
   void _notifyConnectivityListChanged();
   void _notifyConnectivityIndexChanged();
   void _notifyConnectivityNbItemChanged();
+  void _computeMaxNbConnectedItem();
+  void _setNewMaxNbConnectedItems(Int32 new_max);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemConnectivityInfo.cc
+++ b/arcane/src/arcane/mesh/ItemConnectivityInfo.cc
@@ -5,13 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemConnectivityInfo.cc                                     (C) 2000-2013 */
+/* ItemConnectivityInfo.cc                                     (C) 2000-2022 */
 /*                                                                           */
 /* Informations sur la connectivité par type d'entité.                       */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-#include "arcane/utils/ArcanePrecomp.h"
 
 #include "arcane/mesh/ItemConnectivityInfo.h"
 #include "arcane/mesh/ItemSharedInfoList.h"
@@ -21,12 +19,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_MESH_BEGIN_NAMESPACE
+namespace Arcane::mesh
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -42,12 +36,18 @@ ItemConnectivityInfo()
 /*---------------------------------------------------------------------------*/
 
 void ItemConnectivityInfo::
-fill(ItemSharedInfoList* item_shared_infos)
+fill(ItemSharedInfoList* item_shared_infos,ItemInternalConnectivityList* clist)
 {
   m_infos[ICI_Node] = item_shared_infos->maxNodePerItem();
   m_infos[ICI_Edge] = item_shared_infos->maxEdgePerItem();
   m_infos[ICI_Face] = item_shared_infos->maxFacePerItem();
   m_infos[ICI_Cell] = item_shared_infos->maxCellPerItem();
+
+  m_infos[ICI_Node] = clist->maxNbConnectedItem(ItemInternalConnectivityList::NODE_IDX);
+  m_infos[ICI_Edge] = clist->maxNbConnectedItem(ItemInternalConnectivityList::EDGE_IDX);
+  m_infos[ICI_Face] = clist->maxNbConnectedItem(ItemInternalConnectivityList::FACE_IDX);
+  m_infos[ICI_Cell] = clist->maxNbConnectedItem(ItemInternalConnectivityList::CELL_IDX);
+
   m_infos[ICI_NodeItemTypeInfo] = item_shared_infos->maxLocalNodePerItemType();
   m_infos[ICI_EdgeItemTypeInfo] = item_shared_infos->maxLocalEdgePerItemType();
   m_infos[ICI_FaceItemTypeInfo] = item_shared_infos->maxLocalFacePerItemType();
@@ -65,8 +65,7 @@ reduce(IParallelMng* pm)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_MESH_END_NAMESPACE
-ARCANE_END_NAMESPACE
+} // End namespace Arcane::mesh
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemConnectivityInfo.h
+++ b/arcane/src/arcane/mesh/ItemConnectivityInfo.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemConnectivityInfo.h                                      (C) 2000-2013 */
+/* ItemConnectivityInfo.h                                      (C) 2000-2022 */
 /*                                                                           */
 /* Informations sur la connectivité par type d'entité.                       */
 /*---------------------------------------------------------------------------*/
@@ -21,21 +21,14 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
+namespace Arcane
+{
+class ItemInternalConnectivityList;
 class IParallelMng;
+}
 
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_MESH_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
+namespace Arcane::mesh
+{
 class ItemSharedInfoList;
 
 /*---------------------------------------------------------------------------*/
@@ -61,30 +54,20 @@ class ARCANE_MESH_EXPORT ItemConnectivityInfo
  public:
 
   ItemConnectivityInfo();
-  virtual ~ItemConnectivityInfo() {} //<! Libère les ressources
 
  public:
 
- public:
-
-  virtual Integer maxNodePerItem() const
-  { return m_infos[ICI_Node]; }
-  virtual Integer maxEdgePerItem() const
-  { return m_infos[ICI_Edge]; }
-  virtual Integer maxFacePerItem() const
-  { return m_infos[ICI_Face]; }
-  virtual Integer maxCellPerItem() const
-  { return m_infos[ICI_Cell]; }
-  virtual Integer maxNodeInItemTypeInfo() const
-  { return m_infos[ICI_NodeItemTypeInfo]; }
-  virtual Integer maxEdgeInItemTypeInfo() const
-  { return m_infos[ICI_EdgeItemTypeInfo]; }
-  virtual Integer maxFaceInItemTypeInfo() const
-  { return m_infos[ICI_FaceItemTypeInfo]; }
+  Integer maxNodePerItem() const override { return m_infos[ICI_Node]; }
+  Integer maxEdgePerItem() const override { return m_infos[ICI_Edge]; }
+  Integer maxFacePerItem() const override { return m_infos[ICI_Face]; }
+  Integer maxCellPerItem() const override { return m_infos[ICI_Cell]; }
+  Integer maxNodeInItemTypeInfo() const override { return m_infos[ICI_NodeItemTypeInfo]; }
+  Integer maxEdgeInItemTypeInfo() const override { return m_infos[ICI_EdgeItemTypeInfo]; }
+  Integer maxFaceInItemTypeInfo() const override { return m_infos[ICI_FaceItemTypeInfo]; }
 
  public:
 
-  void fill(ItemSharedInfoList* isl);
+  void fill(ItemSharedInfoList* isl,ItemInternalConnectivityList* clist);
   void reduce(IParallelMng* pm);
 
  private:
@@ -95,8 +78,7 @@ class ARCANE_MESH_EXPORT ItemConnectivityInfo
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_MESH_END_NAMESPACE
-ARCANE_END_NAMESPACE
+} // End namespace Arcane::mesh
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemConnectivityInfo.h
+++ b/arcane/src/arcane/mesh/ItemConnectivityInfo.h
@@ -61,9 +61,6 @@ class ARCANE_MESH_EXPORT ItemConnectivityInfo
   Integer maxEdgePerItem() const override { return m_infos[ICI_Edge]; }
   Integer maxFacePerItem() const override { return m_infos[ICI_Face]; }
   Integer maxCellPerItem() const override { return m_infos[ICI_Cell]; }
-  Integer maxNodeInItemTypeInfo() const override { return m_infos[ICI_NodeItemTypeInfo]; }
-  Integer maxEdgeInItemTypeInfo() const override { return m_infos[ICI_EdgeItemTypeInfo]; }
-  Integer maxFaceInItemTypeInfo() const override { return m_infos[ICI_FaceItemTypeInfo]; }
 
  public:
 

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -2020,33 +2020,6 @@ maxCellPerItem() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-Integer ItemFamily::
-maxLocalNodePerItemType() const
-{
-  return m_local_connectivity_info->maxNodeInItemTypeInfo();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemFamily::
-maxLocalEdgePerItemType() const
-{
-  return m_local_connectivity_info->maxEdgeInItemTypeInfo();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemFamily::
-maxLocalFacePerItemType() const
-{
-  return m_local_connectivity_info->maxFaceInItemTypeInfo();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 IItemConnectivityInfo* ItemFamily::
 localConnectivityInfos() const
 {

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -450,7 +450,7 @@ void ItemFamily::
 notifyEndUpdateFromMesh()
 {
   // Recalcul les infos de connectivités globales à tous les sous-domaines
-  m_global_connectivity_info->fill(m_item_shared_infos);
+  _computeConnectivityInfo(m_global_connectivity_info);
   m_global_connectivity_info->reduce(parallelMng());
 }
 
@@ -495,13 +495,13 @@ _partialEndUpdate()
     // readFromDump() (par exemple suite à un retour-arrière), les données ne seront
     // pas restaurées si entre temps current_id n'a pas changé.
     if (m_need_prepare_dump){
-      m_local_connectivity_info->fill(m_item_shared_infos);
+      _computeConnectivityInfo(m_local_connectivity_info);
       ++m_current_id;
     }
     return true;
   }
   m_item_need_prepare_dump = true;
-  m_local_connectivity_info->fill(m_item_shared_infos);
+  _computeConnectivityInfo(m_local_connectivity_info);
   ++m_current_id;
   m_internal_variables->m_items_data.variable()->syncReferences();
   m_items_data = &m_internal_variables->m_items_data._internalTrueData()->_internalDeprecatedValue();
@@ -2589,6 +2589,15 @@ _updateItemsSharedFlag()
     for( auto id : shared_ids )
       items[id]->addFlags(ItemInternal::II_Shared);
   }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemFamily::
+_computeConnectivityInfo(ItemConnectivityInfo* ici)
+{
+  ici->fill(m_item_shared_infos,itemInternalConnectivityList());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1984,42 +1984,6 @@ findAdjencyItems(const ItemGroup& group,const ItemGroup& sub_group,
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-Integer ItemFamily::
-maxNodePerItem() const
-{
-  return m_local_connectivity_info->maxNodePerItem();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemFamily::
-maxEdgePerItem() const
-{
-  return m_local_connectivity_info->maxEdgePerItem();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemFamily::
-maxFacePerItem() const
-{
-  return m_local_connectivity_info->maxFacePerItem();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemFamily::
-maxCellPerItem() const
-{
-  return m_local_connectivity_info->maxCellPerItem();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 IItemConnectivityInfo* ItemFamily::
 localConnectivityInfos() const
 {

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -172,9 +172,6 @@ class ARCANE_MESH_EXPORT ItemFamily
   Integer maxEdgePerItem() const override;
   Integer maxFacePerItem() const override;
   Integer maxCellPerItem() const override;
-  Integer maxLocalNodePerItemType() const override;
-  Integer maxLocalEdgePerItemType() const override;
-  Integer maxLocalFacePerItemType() const override;
   IItemConnectivityInfo* localConnectivityInfos() const override;
   IItemConnectivityInfo* globalConnectivityInfos() const override;
 

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -168,10 +168,6 @@ class ARCANE_MESH_EXPORT ItemFamily
 
  public:
 
-  Integer maxNodePerItem() const override;
-  Integer maxEdgePerItem() const override;
-  Integer maxFacePerItem() const override;
-  Integer maxCellPerItem() const override;
   IItemConnectivityInfo* localConnectivityInfos() const override;
   IItemConnectivityInfo* globalConnectivityInfos() const override;
 

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -508,8 +508,10 @@ class ARCANE_MESH_EXPORT ItemFamily
   }
 
  private:
+
   void _getConnectedItems(IIncrementalItemConnectivity* parent_connectivity,ItemVector& target_family_connected_items);
   void _fillHasExtraParentProperty(ItemScalarProperty<bool>& child_families_has_extra_parent,ItemVectorView connected_items);
+  void _computeConnectivityInfo(ItemConnectivityInfo* ici);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/NewWithLegacyConnectivity.h
+++ b/arcane/src/arcane/mesh/NewWithLegacyConnectivity.h
@@ -125,7 +125,10 @@ public:
   //! localId() de la \a index-ième entitée connectées à l'entité source de numéro local \a lid
   Int32 connectedItemLocalId(ItemLocalId lid,Integer index) const override  {return Base::trueCustomConnectivity()->connectedItemLocalId(lid,index);}
 
-protected:
+  //! Nombre maximum d'entités connectées à une entité source.
+  Int32 maxNbConnectedItem() const override { return Base::trueCustomConnectivity()->maxNbConnectedItem(); }
+
+  protected:
 
   //! Implémente l'initialisation de \a civ pour cette connectivitée.
   void _initializeStorage(ConnectivityItemVector* civ) override {Base::trueCustomConnectivity()->_initializeStorage(civ);};

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -372,8 +372,6 @@ _dumpConnectivityInfos(IItemConnectivityInfo* cell_family,IItemConnectivityInfo*
   info() << "max node per cell = " << cell_family->maxNodePerItem();
   info() << "max edge per cell = " << cell_family->maxEdgePerItem();
   info() << "max face per cell = " << cell_family->maxFacePerItem();
-  info() << "max local edge per cell = " << cell_family->maxEdgeInItemTypeInfo();
-  info() << "max local face per cell = " << cell_family->maxFaceInItemTypeInfo();
 
   info() << "max node per face = " << face_family->maxNodePerItem();
   info() << "max edge per face = " << face_family->maxEdgePerItem();

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -116,6 +116,9 @@ namespace Arcane
       return m_nb_item_cell[local_id];
     }
 
+    // NOTE: Une fois qu'on sera passé à la version C# 10, on pourra utiliser
+    // des tableaux de taille fixe
+
     Int32ArrayView m_indexes_node;
     Int32ArrayView m_indexes_edge;
     Int32ArrayView m_indexes_face;
@@ -136,6 +139,13 @@ namespace Arcane
     Int32ConstArrayView m_list_cell;
     Int32ConstArrayView m_list_hparent;
     Int32ConstArrayView m_list_hchild;
+
+    Int32 m_max_nb_item0;
+    Int32 m_max_nb_item1;
+    Int32 m_max_nb_item2;
+    Int32 m_max_nb_item3;
+    Int32 m_max_nb_item4;
+    Int32 m_max_nb_item5;
 
     MeshItemInternalList* m_items;
 


### PR DESCRIPTION
The values stored in `ItemSharedInfo` are no longer valid when we use incremental connectivity.

This PR also remove deprecated methods from `IItemFamily` to access these information.