### PR TITLE
Fix SEGV after a checkpoint when using 'Mpi' IParallelMng and when MPI_Comm_size()==1

### DIFF
--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -74,6 +74,7 @@ VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
     DispatcherType* dt = DispatcherType::create<SimpleVariableSynchronizeDispatcher>(bi);
     m_dispatcher = new VariableSynchronizerDispatcher(pm,dt);
   }
+  m_dispatcher->setItemGroupSynchronizeInfo(&m_sync_list);
   m_multi_dispatcher = new VariableSynchronizerMultiDispatcher(pm);
 
   {
@@ -177,7 +178,7 @@ compute()
   if (m_is_verbose){
     info() << "Begin compute dispatcher Date=" << platform::getCurrentDateTime();
   }
-  m_dispatcher->compute(&m_sync_list);
+  m_dispatcher->compute();
   if (m_is_verbose){
     info() << "End compute dispatcher Date=" << platform::getCurrentDateTime();
   }
@@ -692,7 +693,7 @@ changeLocalIds(Int32ConstArrayView old_to_new_ids)
     info(4) << "NEW_SHARE_SIZE=" << vsi.nbShare() << " old=" << old_nb_share;
     info(4) << "NEW_GHOST_SIZE=" << vsi.nbGhost() << " old=" << old_nb_ghost;
   }
-  m_dispatcher->compute(&m_sync_list);
+  m_dispatcher->compute();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -129,7 +129,8 @@ class ARCANE_IMPL_EXPORT IVariableSynchronizeDispatcher
  public:
   virtual ~IVariableSynchronizeDispatcher() = default;
  public:
-  virtual void compute(ItemGroupSynchronizeInfo* sync_list) =0;
+  virtual void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) =0;
+  virtual void compute() =0;
  protected:
 };
 
@@ -210,7 +211,8 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
   void applyDispatch(IArrayDataT<SimpleType>* data) override;
   void applyDispatch(IArray2DataT<SimpleType>* data) override;
   void applyDispatch(IMultiArray2DataT<SimpleType>* data) override;
-  void compute(ItemGroupSynchronizeInfo* sync_list) override;
+  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) override;
+  void compute() override;
 
  protected:
 
@@ -272,11 +274,9 @@ class ARCANE_IMPL_EXPORT VariableSynchronizerDispatcher
   {
   }
   ~VariableSynchronizerDispatcher();
-  void compute(ItemGroupSynchronizeInfo* sync_info);
-  IDataVisitor* visitor()
-  {
-    return m_dispatcher;
-  }
+  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info);
+  void compute();
+  IDataVisitor* visitor() { return m_dispatcher; }
  private:
   IParallelMng* m_parallel_mng;
   DispatcherType* m_dispatcher;

--- a/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.cc
@@ -64,16 +64,6 @@ MpiBlockVariableSynchronizeDispatcher(MpiBlockVariableSynchronizeDispatcherBuild
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> void
-MpiBlockVariableSynchronizeDispatcher<SimpleType>::
-compute(ItemGroupSynchronizeInfo* sync_info)
-{
-  VariableSynchronizeDispatcher<SimpleType>::compute(sync_info);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 template<typename SimpleType> bool
 MpiBlockVariableSynchronizeDispatcher<SimpleType>::
 _isSkipRank(Int32 rank,Int32 sequence) const

--- a/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.h
+++ b/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.h
@@ -80,8 +80,6 @@ class MpiBlockVariableSynchronizeDispatcher
 
   explicit MpiBlockVariableSynchronizeDispatcher(MpiBlockVariableSynchronizeDispatcherBuildInfo& bi);
 
-  void compute(ItemGroupSynchronizeInfo* sync_list) override;
-
  protected:
 
   void _beginSynchronize(SyncBuffer& sync_buffer) override;

--- a/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.cc
@@ -53,16 +53,6 @@ MpiDirectSendrecvVariableSynchronizeDispatcher(MpiDirectSendrecvVariableSynchron
 
 template<typename SimpleType> void
 MpiDirectSendrecvVariableSynchronizeDispatcher<SimpleType>::
-compute(ItemGroupSynchronizeInfo* sync_info)
-{
-  VariableSynchronizeDispatcher<SimpleType>::compute(sync_info);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename SimpleType> void
-MpiDirectSendrecvVariableSynchronizeDispatcher<SimpleType>::
 _beginSynchronize(SyncBuffer& sync_buffer)
 {
   auto sync_list = this->m_sync_info->infos();

--- a/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.h
+++ b/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.h
@@ -63,12 +63,12 @@ class MpiDirectSendrecvVariableSynchronizeDispatcher
 : public VariableSynchronizeDispatcher<SimpleType>
 {
  public:
+
   typedef typename VariableSynchronizeDispatcher<SimpleType>::SyncBuffer SyncBuffer;
+
  public:
 
   explicit MpiDirectSendrecvVariableSynchronizeDispatcher(MpiDirectSendrecvVariableSynchronizeDispatcherBuildInfo& bi);
-
-  void compute(ItemGroupSynchronizeInfo* sync_list) override;
 
  protected:
 
@@ -76,6 +76,7 @@ class MpiDirectSendrecvVariableSynchronizeDispatcher
   void _endSynchronize(SyncBuffer& sync_buffer) override;
 
  private:
+
   MpiParallelMng* m_mpi_parallel_mng;
 };
 

--- a/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.cc
@@ -55,11 +55,11 @@ MpiLegacyVariableSynchronizeDispatcher(MpiLegacyVariableSynchronizeDispatcherBui
 
 template<typename SimpleType> void
 MpiLegacyVariableSynchronizeDispatcher<SimpleType>::
-compute(ItemGroupSynchronizeInfo* sync_info)
+compute()
 {
   //m_mpi_parallel_mng->traceMng()->info() << "MPI COMPUTE";
-  VariableSynchronizeDispatcher<SimpleType>::compute(sync_info);
-  auto sync_list = sync_info->infos();
+  VariableSynchronizeDispatcher<SimpleType>::compute();
+  auto sync_list = this->m_sync_info->infos();
   if (m_use_derived_type){
     //TODO Utiliser des 'int' MPI au lieu de Int32
     Integer nb_message = sync_list.size();

--- a/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.h
+++ b/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.h
@@ -101,7 +101,7 @@ class MpiLegacyVariableSynchronizeDispatcher
     m_ghost_derived_types.clear();
   }
 
-  void compute(ItemGroupSynchronizeInfo* sync_list) override;
+  void compute() override;
 
  protected:
 

--- a/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
@@ -72,16 +72,6 @@ MpiVariableSynchronizeDispatcher(MpiVariableSynchronizeDispatcherBuildInfo& bi)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> void
-MpiVariableSynchronizeDispatcher<SimpleType>::
-compute(ItemGroupSynchronizeInfo* sync_info)
-{
-  VariableSynchronizeDispatcher<SimpleType>::compute(sync_info);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 template <typename SimpleType> void
 MpiVariableSynchronizeDispatcher<SimpleType>::
 _beginSynchronize(SyncBuffer& sync_buffer)

--- a/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.h
+++ b/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.h
@@ -73,8 +73,6 @@ class MpiVariableSynchronizeDispatcher
 
   explicit MpiVariableSynchronizeDispatcher(MpiVariableSynchronizeDispatcherBuildInfo& bi);
 
-  void compute(ItemGroupSynchronizeInfo* sync_list) override;
-
  protected:
 
   void _beginSynchronize(SyncBuffer& sync_buffer) override;


### PR DESCRIPTION
If `MPI_Comm_size()==1` we should use `MpiSequential` implementation of `IParallelMng` but this PR allows the use of the `Mpi` implementation. 