### PR TITLE
Use variables to keep information about owner and flags of an item

### DIFF
--- a/arcane/src/arcane/ItemInternal.cc
+++ b/arcane/src/arcane/ItemInternal.cc
@@ -211,15 +211,10 @@ _internalCopyAndChangeSharedInfos(ItemSharedInfo* old_isi,ItemSharedInfo* new_is
 {
   ItemInternal* item = this;
 
-  Integer old_flags = item->flags();
-  Integer old_owner = item->owner();
   Int32* old_data = item->dataPtr();
 
   item->setSharedInfo(new_isi);
   item->setDataIndex(new_data_index);
-
-  new_isi->setFlags(new_data_index,old_flags);
-  new_isi->setOwner(new_data_index,old_owner);
 
   Int32* new_data = item->dataPtr();
 

--- a/arcane/src/arcane/ItemInternal.h
+++ b/arcane/src/arcane/ItemInternal.h
@@ -432,7 +432,7 @@ class ARCANE_CORE_EXPORT ItemInternal
   */
   void setOwner(Integer suid,Int32 current_sub_domain)
   {
-    m_shared_info->setOwner(m_data_index,suid);
+    m_shared_info->_setOwnerV2(m_local_id,suid);
     int f = flags();
     if (suid==current_sub_domain)
       f |= II_Own;
@@ -442,13 +442,13 @@ class ARCANE_CORE_EXPORT ItemInternal
   }
 
   //! Numéro du sous-domaine propriétaire de l'entité
-  Int32 owner() const { return m_shared_info->owner(m_data_index); }
+  Int32 owner() const { return m_shared_info->_ownerV2(m_local_id); }
 
   //! Flags de l'entité
-  Int32 flags() const { return m_shared_info->flags(m_data_index); }
+  Int32 flags() const { return m_shared_info->_flagsV2(m_local_id); }
 
   //! Positionne les flags de l'entité
-  void setFlags(Int32 f)  { m_shared_info->setFlags(m_data_index,f); }
+  void setFlags(Int32 f) { m_shared_info->_setFlagsV2(m_local_id,f); }
 
   //! Ajoute les flags \added_flags à ceux de l'entité
   void addFlags(Int32 added_flags)

--- a/arcane/src/arcane/ItemSharedInfo.cc
+++ b/arcane/src/arcane/ItemSharedInfo.cc
@@ -59,6 +59,8 @@ ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList*
 , m_item_family(family)
 , m_unique_ids(&(variable_views->m_unique_ids_view))
 , m_parent_item_ids(&(variable_views->m_parent_ids_view))
+, m_owners(&(variable_views->m_owners_view))
+, m_flags(&(variable_views->m_flags_view))
 , m_item_type(item_type)
 , m_item_kind(family->itemKind())
 , m_type_id(item_type->typeId())
@@ -78,6 +80,8 @@ ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList*
 , m_item_family(family)
 , m_unique_ids(&(variable_views->m_unique_ids_view))
 , m_parent_item_ids(&(variable_views->m_parent_ids_view))
+, m_owners(&(variable_views->m_owners_view))
+, m_flags(&(variable_views->m_flags_view))
 , m_item_type(item_type)
 , m_item_kind(family->itemKind())
 , m_type_id(item_type->typeId())
@@ -276,6 +280,30 @@ parent(Integer,Integer) const
 
 void ItemSharedInfo::
 setParent(Integer,Integer,Integer) const
+{
+  ARCANE_FATAL("This method is no longer valid");
+}
+
+Int32 ItemSharedInfo::
+owner(Int32) const
+{
+  ARCANE_FATAL("This method is no longer valid");
+}
+
+void ItemSharedInfo::
+setOwner(Int32,Int32) const
+{
+  ARCANE_FATAL("This method is no longer valid");
+}
+
+Int32 ItemSharedInfo::
+flags(Int32) const
+{
+  ARCANE_FATAL("This method is no longer valid");
+}
+
+void ItemSharedInfo::
+setFlags(Int32,Int32) const
 {
   ARCANE_FATAL("This method is no longer valid");
 }

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -275,6 +275,8 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   IItemFamily* m_item_family = nullptr;
   Int64ArrayView* m_unique_ids = nullptr;
   Int32ArrayView* m_parent_item_ids = nullptr;
+  Int32ArrayView* m_owners = nullptr;
+  Int32ArrayView* m_flags = nullptr;
   ItemTypeInfo* m_item_type = nullptr;
   eItemKind m_item_kind = IK_Unknown;
  private:
@@ -301,19 +303,24 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   static Integer serializeSize();
   static Integer serializeAMRSize();
   static Integer serializeNoAMRSize();
- public:
-
-  Int32 owner(Int32 data_index) const
-  { return m_infos[data_index+OWNER_INDEX]; }
-  void setOwner(Int32 data_index,Int32 aowner) const
-  { m_infos[data_index+OWNER_INDEX] = aowner; }
 
  public:
 
-  Int32 flags(Int32 data_index) const
-  { return m_infos[data_index+FLAGS_INDEX]; }
-  void setFlags(Int32 data_index,Int32 f) const
-  { m_infos[data_index+FLAGS_INDEX] = f; }
+  ARCANE_DEPRECATED_REASON("Y2022: This method always throws an exception. Use _ownerV2() instead")
+  Int32 owner(Int32 data_index) const;
+  ARCANE_DEPRECATED_REASON("Y2022: This method always throws an exception. Use _setOwnerV2() instead")
+  void setOwner(Int32 data_index,Int32 aowner) const;
+  ARCANE_DEPRECATED_REASON("Y2022: This method always throws an exception. Use _flagsV2() instead")
+  Int32 flags(Int32 data_index) const;
+  ARCANE_DEPRECATED_REASON("Y2022: This method always throws an exception. Use _setFlagsV2() instead")
+  void setFlags(Int32 data_index,Int32 f) const;
+
+ private:
+
+  Int32 _ownerV2(Int32 local_id) const { return (*m_owners)[local_id]; }
+  void _setOwnerV2(Int32 local_id,Int32 aowner) const { (*m_owners)[local_id] = aowner; }
+  Int32 _flagsV2(Int32 local_id) const { return (*m_flags)[local_id]; }
+  void _setFlagsV2(Int32 local_id,Int32 f) const { (*m_flags)[local_id] = f; }
 
  private:
 

--- a/arcane/src/arcane/mesh/DynamicMeshKindInfos.cc
+++ b/arcane/src/arcane/mesh/DynamicMeshKindInfos.cc
@@ -672,20 +672,26 @@ finishCompactItems(ItemFamilyCompactInfos& compact_infos)
   // TODO: tableau a supprimer
   UniqueArray<ItemInternal> new_items(m_nb_item);
   UniqueArray<Int64> new_uids(m_nb_item);
-  for( Integer i=0, n=m_nb_item; i<n; ++i )
-  {
+  UniqueArray<Int32> new_owners(m_nb_item);
+  UniqueArray<Int32> new_flags(m_nb_item);
+
+  for( Integer i=0, n=m_nb_item; i<n; ++i ) {
     ItemInternal* old_item = m_internals[ new_to_old_local_ids[ i ] ];
     new_uids[i] = old_item->uniqueId().asInt64();
-    //Integer current_local_id = old_item->localId();
+    new_owners[i] = old_item->owner();
+    new_flags[i] = old_item->flags();
     new_items[i] = *old_item;
   }
 
   Integer nb_error = 0;
+  Int32 sid = m_mesh->meshPartInfo().partRank();
 
   for( Integer i=0; i<m_nb_item; ++i ){
     ItemInternal* ii = m_internals[i];
     *ii = new_items[i];
     ii->setLocalId(i);
+    ii->setFlags(new_flags[i]);
+    ii->setOwner(new_owners[i],sid);
     ii->setUniqueId(new_uids[i]);
     // L'entité est marqué comme créée
     //_setAdded(ii);

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -991,14 +991,6 @@ prepareForDump()
   }
   m_item_need_prepare_dump = false;
   if (m_need_prepare_dump){
-    // Dans les versions d'Arcane antérieures à la 3.7, les
-    // champs owner(), flags() et typeId() des entités sont conservés
-    // dans ItemSharedInfo. Pour pouvoir faire une protection qui sera
-    // lisible avec une version ultérieure de Arcane, on sauve ces informations
-    // dans les trois variables qui seront à terme le seul endroit où ces
-    // valeurs seront disponibles.
-    ArrayView<Int32> items_flags_view = m_items_flags->view();
-    ArrayView<Int32> items_owner_view = m_items_owner->view();
     m_internal_variables->m_current_id = m_current_id;
     info(4) << " SET FAMILY ID name=" << name() << " id= " << m_current_id
             << " saveid=" << m_internal_variables->m_current_id();
@@ -1019,8 +1011,6 @@ prepareForDump()
     for( Integer i=0; i<nb_item; ++i ){
       ItemInternal* item = items[i];
       items_shared_data_index[i] = item->sharedInfo()->index();
-      items_owner_view[i] = item->owner();
-      items_flags_view[i] = item->flags();
 #if 0
 #ifdef ARCANE_DEBUG
       //if (itemKind()==IK_Particle){


### PR DESCRIPTION
Before this PR, these information were stored in the dynamic part of `ItemSharedInfo`.