### PR TITLE
Remove information about ItemType in ItemSharedInfo

### DIFF
--- a/arcane/src/arcane/ItemInternal.h
+++ b/arcane/src/arcane/ItemInternal.h
@@ -517,7 +517,7 @@ class ARCANE_CORE_EXPORT ItemInternal
     return this->internalHChild(0)->isSubactive();
   }
   //! Numéro du type de l'entité
-  Integer typeId() const { return m_shared_info->typeId(); }
+  Integer typeId() const { return m_item_type_id; }
   //! Type de l'entité.
   ItemTypeInfo* typeInfo() const { return m_shared_info->typeInfoFromId(m_item_type_id); }
   //! Infos partagées de l'entité.

--- a/arcane/src/arcane/ItemInternal.h
+++ b/arcane/src/arcane/ItemInternal.h
@@ -519,7 +519,7 @@ class ARCANE_CORE_EXPORT ItemInternal
   //! Numéro du type de l'entité
   Integer typeId() const { return m_shared_info->typeId(); }
   //! Type de l'entité.
-  ItemTypeInfo* typeInfo() const { return m_shared_info->m_item_type; }
+  ItemTypeInfo* typeInfo() const { return m_shared_info->typeInfoFromId(m_item_type_id); }
   //! Infos partagées de l'entité.
   ItemSharedInfo* sharedInfo() const { return m_shared_info; }
   //! Famille dont est issue l'entité
@@ -699,9 +699,10 @@ class ARCANE_CORE_EXPORT ItemInternal
   void setLocalId(Int32 local_id) { m_local_id = local_id; }
   ARCANE_DEPRECATED_REASON("Y2022: This method always throws an exception.")
   void setDataIndex(Integer);
-  void setSharedInfo(ItemSharedInfo* shared_infos)
+  void setSharedInfo(ItemSharedInfo* shared_infos,Int32 type_id)
   {
     m_shared_info = shared_infos;
+    m_item_type_id = type_id;
   }
 
  public:
@@ -756,13 +757,11 @@ class ARCANE_CORE_EXPORT ItemInternal
    * Pour des raisons de performance, le numéro local doit être
    * le premier champs de la classe.
    */
-  Int32 m_local_id;
+  Int32 m_local_id = NULL_ITEM_LOCAL_ID;
   /*!
-   * \brief Indice des données de cette entité dans le tableau des données.
-   *
-   * Ce champs n'est plus utilisé depuis la version 3.7 de Arcane.
+   * \brief Type de l'entité.
    */
-  Int32 m_padding = 0;
+  Int32 m_item_type_id = 0;
   //! Infos partagées entre toutes les entités ayant les mêmes caractéristiques
   ItemSharedInfo* m_shared_info;
 

--- a/arcane/src/arcane/ItemSharedInfo.cc
+++ b/arcane/src/arcane/ItemSharedInfo.cc
@@ -52,7 +52,7 @@ ItemSharedInfo()
 /*---------------------------------------------------------------------------*/
 
 ItemSharedInfo::
-ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
+ItemSharedInfo(IItemFamily* family,MeshItemInternalList* items,
                ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views)
 : m_items(items)
 , m_connectivity(connectivity)
@@ -63,7 +63,6 @@ ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList*
 , m_owners(&(variable_views->m_owners_view))
 , m_flags(&(variable_views->m_flags_view))
 , m_item_kind(family->itemKind())
-, m_type_id(item_type->typeId())
 {
   _init(m_item_kind);
 }
@@ -78,8 +77,7 @@ print(std::ostream& o) const
     << " NbParent; " << m_nb_parent
     << " Items: " << m_items
     << " Connectivity: " << m_connectivity
-    << " Family: " << m_item_family->fullName()
-    << " TypeId: " << m_type_id;
+    << " Family: " << m_item_family->fullName();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -215,6 +213,15 @@ ItemTypeInfo* ItemSharedInfo::
 typeInfoFromId(Int32 type_id) const
 {
   return m_item_type_mng->typeFromId(type_id);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+Int32 ItemSharedInfo::
+typeId() const
+{
+  ARCANE_FATAL("This method is no longer valid");
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemSharedInfo.cc
+++ b/arcane/src/arcane/ItemSharedInfo.cc
@@ -57,11 +57,11 @@ ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList*
 : m_items(items)
 , m_connectivity(connectivity)
 , m_item_family(family)
+, m_item_type_mng(family->mesh()->itemTypeMng())
 , m_unique_ids(&(variable_views->m_unique_ids_view))
 , m_parent_item_ids(&(variable_views->m_parent_ids_view))
 , m_owners(&(variable_views->m_owners_view))
 , m_flags(&(variable_views->m_flags_view))
-, m_item_type(item_type)
 , m_item_kind(family->itemKind())
 , m_type_id(item_type->typeId())
 {
@@ -78,11 +78,11 @@ ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList*
 : m_items(items)
 , m_connectivity(connectivity)
 , m_item_family(family)
+, m_item_type_mng(family->mesh()->itemTypeMng())
 , m_unique_ids(&(variable_views->m_unique_ids_view))
 , m_parent_item_ids(&(variable_views->m_parent_ids_view))
 , m_owners(&(variable_views->m_owners_view))
 , m_flags(&(variable_views->m_flags_view))
-, m_item_type(item_type)
 , m_item_kind(family->itemKind())
 , m_type_id(item_type->typeId())
 {
@@ -176,7 +176,6 @@ print(std::ostream& o) const
     << " Items: " << m_items
     << " Connectivity: " << m_connectivity
     << " Family: " << m_item_family->fullName()
-    << " TypeInfo: " << m_item_type
     << " TypeId: " << m_type_id
     << " Index: " << m_index
     << " NbReference: " << m_nb_reference;
@@ -306,6 +305,15 @@ _parentPtr(Int32 local_id) const
 {
   // GG: ATTENTION: Cela ne fonctionne que si on a au plus un parent.
   return m_parent_item_ids->ptrAt(local_id);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ItemTypeInfo* ItemSharedInfo::
+typeInfoFromId(Int32 type_id) const
+{
+  return m_item_type_mng->typeFromId(type_id);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemSharedInfo.cc
+++ b/arcane/src/arcane/ItemSharedInfo.cc
@@ -70,103 +70,6 @@ ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList*
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-//! Constructeur de désérialisation
-ItemSharedInfo::
-ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
-               ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views,
-               Int32ConstArrayView buffer)
-: m_items(items)
-, m_connectivity(connectivity)
-, m_item_family(family)
-, m_item_type_mng(family->mesh()->itemTypeMng())
-, m_unique_ids(&(variable_views->m_unique_ids_view))
-, m_parent_item_ids(&(variable_views->m_parent_ids_view))
-, m_owners(&(variable_views->m_owners_view))
-, m_flags(&(variable_views->m_flags_view))
-, m_item_kind(family->itemKind())
-, m_type_id(item_type->typeId())
-{
-  // La taille du buffer dépend des versions de Arcane.
-  // Avant la 3.2 (Octobre 2021), la taille du buffer est 9 (non AMR) ou 13 (AMR)
-  // Entre la 3.2 et la 3.6 (Mai 2022), la taille vaut toujours 13
-  // A partir de la 3.6, la taille vaut 6.
-  //
-  // On ne cherche pas à faire de reprise avec des versions
-  // de Arcane antérieures à 3.2 donc on peut supposer que la taille
-  // du buffer vaut 13. Ces versions utilisent la nouvelle connectivité
-  // et donc le nombre des éléments est toujours 0 (ainsi que les *allocated)
-  // sauf pour m_nb_node.
-  //
-  // A partir de la 3.6, le nombre de noeuds n'est plus utilisé non
-  // plus et vaut toujours 0. On pourra donc pour les versions de fin
-  // 2022 supprimer ces champs de ItemSharedInfo.
-
-  // TODO: Indiquer qu'à partir de la version 3.7 on ne supporte
-  // que buf_size==6 avec le numéro de version 0x0307
-  Int32 buf_size = buffer.size();
-  if (buf_size>=9){
-    ARCANE_FATAL("Invalid buf size '{0}'. This is probably because your version of Arcane is too old",buf_size);
-  }
-  else if (buf_size>=4){
-    m_index = buffer[2];
-    m_nb_reference = buffer[3];
-  }
-
-  _init(m_item_kind);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-/*!
- * \brief Nombre d'informations à écrire pour les données.
- *
- * A partir de version 3.6, on ne conserve plus d'informations sur le
- * nombre d'entités connectées.
- */
-Integer ItemSharedInfo::
-serializeWriteSize()
-{
-  return 6;
-}
-
-Integer ItemSharedInfo::
-serializeSize()
-{
-	return serializeWriteSize();
-}
-
-Integer ItemSharedInfo::
-serializeAMRSize()
-{
-  return serializeWriteSize();
-}
-
-Integer ItemSharedInfo::
-serializeNoAMRSize()
-{
-  return serializeWriteSize();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemSharedInfo::
-serializeWrite(Int32ArrayView buffer)
-{
-  buffer[0] = m_type_id; // Doit toujours être le premier
-
-  buffer[1] = 0x0307; // Numéro de version (3.7).
-
-  buffer[2] = m_index;
-  buffer[3] = m_nb_reference;
-
-  buffer[4] = 0; // Réservé
-  buffer[5] = 0; // Réservé
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 
 void ItemSharedInfo::
 print(std::ostream& o) const
@@ -176,9 +79,7 @@ print(std::ostream& o) const
     << " Items: " << m_items
     << " Connectivity: " << m_connectivity
     << " Family: " << m_item_family->fullName()
-    << " TypeId: " << m_type_id
-    << " Index: " << m_index
-    << " NbReference: " << m_nb_reference;
+    << " TypeId: " << m_type_id;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -106,7 +106,7 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
 
   // Seule ItemSharedInfoList peut créer des instances de cette classe autre que
   // l'instance nulle.
-  ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
+  ItemSharedInfo(IItemFamily* family,MeshItemInternalList* items,
                  ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views);
 
  public:
@@ -129,7 +129,8 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   ARCANE_DEPRECATED_REASON("Y2020: This method always return 0")
   constexpr Int32 nbHChildren() const { return 0; }
 
-  Int32 typeId() const { return m_type_id; }
+  ARCANE_DEPRECATED_REASON("Y2022: This method always throws an exception. Use ItemInternal::typeId() instead")
+  Int32 typeId() const;
 
   ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
   Int32 firstNode() const { return 0; }
@@ -280,7 +281,6 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
 
  private:
 
-  Int32 m_type_id = IT_NullType;
   Int32 m_nb_parent = 0;
 
  public:

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -117,6 +117,7 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   eItemKind itemKind() const { return m_item_kind; }
   IItemFamily* itemFamily() const { return m_item_family; }
   Int32 nbParent() const { return m_nb_parent; }
+  ItemTypeInfo* typeInfoFromId(Int32 type_id) const;
 
   ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
   constexpr Int32 nbNode() const { return 0; }
@@ -273,11 +274,12 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   MeshItemInternalList* m_items = nullptr;
   ItemInternalConnectivityList* m_connectivity;
   IItemFamily* m_item_family = nullptr;
+  ItemTypeMng* m_item_type_mng = nullptr;
   Int64ArrayView* m_unique_ids = nullptr;
   Int32ArrayView* m_parent_item_ids = nullptr;
   Int32ArrayView* m_owners = nullptr;
   Int32ArrayView* m_flags = nullptr;
-  ItemTypeInfo* m_item_type = nullptr;
+  //ItemTypeInfo* m_item_type = nullptr;
   eItemKind m_item_kind = IK_Unknown;
 
  private:

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -109,9 +109,6 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
                  ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views);
 
-  ItemSharedInfo(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
-                 ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views,
-                 Int32ConstArrayView buffer);
  public:
 
   eItemKind itemKind() const { return m_item_kind; }
@@ -279,28 +276,12 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   Int32ArrayView* m_parent_item_ids = nullptr;
   Int32ArrayView* m_owners = nullptr;
   Int32ArrayView* m_flags = nullptr;
-  //ItemTypeInfo* m_item_type = nullptr;
   eItemKind m_item_kind = IK_Unknown;
 
  private:
 
   Int32 m_type_id = IT_NullType;
   Int32 m_nb_parent = 0;
-  Int32 m_index = NULL_INDEX;
-  Int32 m_nb_reference = 0;
-
- public:
-
-  Int32 index() const { return m_index; }
-  void setIndex(Int32 aindex) { m_index = aindex; }
-  Int32 nbReference() const { return m_nb_reference; }
-  void addReference(){ ++m_nb_reference; }
-  void removeReference(){ --m_nb_reference; }
-  void serializeWrite(Int32ArrayView buffer);
-  static Integer serializeWriteSize();
-  static Integer serializeSize();
-  static Integer serializeAMRSize();
-  static Integer serializeNoAMRSize();
 
  public:
 

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -27,6 +27,7 @@ namespace Arcane::mesh
 {
 class ItemSharedInfoList;
 class ItemFamily;
+class ItemSharedInfoWithType;
 }
 
 namespace Arcane
@@ -88,6 +89,7 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   friend class ItemInternal;
   friend class mesh::ItemSharedInfoList;
   friend class mesh::ItemFamily;
+  friend class mesh::ItemSharedInfoWithType;
 
   static const Int32 NULL_INDEX = static_cast<Int32>(-1);
 

--- a/arcane/src/arcane/mesh/CellFamily.cc
+++ b/arcane/src/arcane/mesh/CellFamily.cc
@@ -501,7 +501,7 @@ _addChildrenCellsToCell(ItemInternal* parent_cell,Int32ConstArrayView children_c
     ItemLocalId item_lid(parent_cell);
     c->addConnectedItems(item_lid,nb_children);
   }
-  _updateSharedInfoAdded(parent_cell);
+  _updateSharedInfo();
 
   auto x = _topologyModifier();
   for( Integer i=0; i<nb_children; ++i )

--- a/arcane/src/arcane/mesh/DoFFamily.h
+++ b/arcane/src/arcane/mesh/DoFFamily.h
@@ -155,7 +155,7 @@ private:
   ItemInternal* _allocDoFGhost(const Int64 uid, const Int32 owner);
   ItemInternal* _findOrAllocDoF(const Int64 uid,bool is_alloc);
 
-  ItemSharedInfo* m_shared_info;
+  ItemSharedInfoWithType* m_shared_info;
 
   friend class DynamicMesh;
 

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -3178,13 +3178,12 @@ mergeMeshes(ConstArrayView<IMesh*> meshes)
 void DynamicMesh::
 _printConnectivityPolicy()
 {
-  info() << "Using new connectivity accessor in ItemInternal";
-
   info() << "Connectivity policy=" << (int)m_connectivity_policy
          << " connectivity_size_policy=" << ARCANE_ITEM_CONNECTIVITY_SIZE_MODE
          << " sizeof(ItemInternal)=" << sizeof(ItemInternal)
          << " sizeof(ItemInternalConnectivityList)=" << sizeof(ItemInternalConnectivityList)
-         << " sizeof(ItemSharedInfo)=" << sizeof(ItemSharedInfo);
+         << " sizeof(ItemSharedInfo)=" << sizeof(ItemSharedInfo)
+         << " sizeof(Item)=" << sizeof(Item);
 
   if (m_connectivity_policy != InternalConnectivityPolicy::NewOnly)
     ARCANE_FATAL("Invalid value '{0}' for InternalConnectivityPolicy. Only '{1}' is allowed",

--- a/arcane/src/arcane/mesh/FaceFamily.cc
+++ b/arcane/src/arcane/mesh/FaceFamily.cc
@@ -357,7 +357,7 @@ addBackCellToFace(ItemInternal* face,ItemInternal* new_cell)
   if (nb_cell>=2)
     ARCANE_FATAL("face '{0}' already has two cells",FullItemPrinter(face));
 
-  _updateSharedInfoAdded(face);
+  _updateSharedInfo();
 
   // Si on a déjà une maille, il s'agit de la front cell.
   Int32 front_cell_lid = (nb_cell==1) ? face->cellLocalId(0) : NULL_ITEM_LOCAL_ID;
@@ -390,7 +390,7 @@ addFrontCellToFace(ItemInternal* face,ItemInternal* new_cell)
   if (nb_cell>=2)
     ARCANE_FATAL("face '{0}' already has two cells",FullItemPrinter(face));
 
-  _updateSharedInfoAdded(face);
+  _updateSharedInfo();
 
   // Si on a déjà une maille, il s'agit de la back cell.
   Int32 back_cell_lid = (nb_cell==1) ? face->cellLocalId(0) : NULL_ITEM_LOCAL_ID;
@@ -826,7 +826,7 @@ removeCellFromFace(ItemInternal* face,ItemLocalId cell_to_remove_lid)
           // Reste la back cell
           setBackAndFrontCells(face,cell0,null_cell_lid);
         }
-        _updateSharedInfoRemoved7(face2);
+        _updateSharedInfo();
       }
     }
   }
@@ -849,7 +849,7 @@ removeCellFromFace(ItemInternal* face,ItemLocalId cell_to_remove_lid)
     setBackAndFrontCells(face,null_cell_lid,null_cell_lid);
   }
 
-  _updateSharedInfoRemoved4(face);
+  _updateSharedInfo();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemConnectivityInfo.cc
+++ b/arcane/src/arcane/mesh/ItemConnectivityInfo.cc
@@ -36,16 +36,12 @@ ItemConnectivityInfo()
 /*---------------------------------------------------------------------------*/
 
 void ItemConnectivityInfo::
-fill(ItemSharedInfoList* item_shared_infos,ItemInternalConnectivityList* clist)
+fill(ItemInternalConnectivityList* clist)
 {
   m_infos[ICI_Node] = clist->maxNbConnectedItem(ItemInternalConnectivityList::NODE_IDX);
   m_infos[ICI_Edge] = clist->maxNbConnectedItem(ItemInternalConnectivityList::EDGE_IDX);
   m_infos[ICI_Face] = clist->maxNbConnectedItem(ItemInternalConnectivityList::FACE_IDX);
   m_infos[ICI_Cell] = clist->maxNbConnectedItem(ItemInternalConnectivityList::CELL_IDX);
-
-  m_infos[ICI_NodeItemTypeInfo] = item_shared_infos->maxLocalNodePerItemType();
-  m_infos[ICI_EdgeItemTypeInfo] = item_shared_infos->maxLocalEdgePerItemType();
-  m_infos[ICI_FaceItemTypeInfo] = item_shared_infos->maxLocalFacePerItemType();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemConnectivityInfo.h
+++ b/arcane/src/arcane/mesh/ItemConnectivityInfo.h
@@ -27,9 +27,11 @@ class ItemInternalConnectivityList;
 class IParallelMng;
 }
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 namespace Arcane::mesh
 {
-class ItemSharedInfoList;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -44,12 +46,9 @@ class ARCANE_MESH_EXPORT ItemConnectivityInfo
     ICI_Node = 0,
     ICI_Edge,
     ICI_Face,
-    ICI_Cell,
-    ICI_NodeItemTypeInfo,
-    ICI_EdgeItemTypeInfo,
-    ICI_FaceItemTypeInfo
+    ICI_Cell
   };
-  static const int NB_ICI = 7;
+  static const int NB_ICI = 4;
 
  public:
 
@@ -64,7 +63,7 @@ class ARCANE_MESH_EXPORT ItemConnectivityInfo
 
  public:
 
-  void fill(ItemSharedInfoList* isl,ItemInternalConnectivityList* clist);
+  void fill(ItemInternalConnectivityList* clist);
   void reduce(IParallelMng* pm);
 
  private:

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -2421,7 +2421,7 @@ _updateItemsSharedFlag()
 void ItemFamily::
 _computeConnectivityInfo(ItemConnectivityInfo* ici)
 {
-  ici->fill(m_item_shared_infos,itemInternalConnectivityList());
+  ici->fill(itemInternalConnectivityList());
   info(5) << "COMPUTE CONNECTIVITY INFO family=" << name() << " v=" << ici
           << " node=" << ici->maxNodePerItem() << " face=" << ici->maxFacePerItem()
           << " edge=" << ici->maxEdgePerItem() << " cell=" << ici->maxCellPerItem();

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1093,10 +1093,10 @@ readFromDump()
     ItemInternalList items(m_infos.itemsInternal());
     for( Integer i=0; i<nb_item; ++i ){
       Integer shared_data_index = items_shared_data_index[i];
-      ItemSharedInfo* isi = item_shared_infos[shared_data_index]->sharedInfo();
+      ItemSharedInfoWithType* isi = item_shared_infos[shared_data_index];
       Int64 uid = (*m_items_unique_id)[i];
       ItemInternal* item = m_infos.allocOne(uid);
-      item->setSharedInfo(isi);
+      item->setSharedInfo(isi->sharedInfo(),isi->itemTypeId());
     }
   }
   // Supprime les entités du groupe total car elles vont être remises à jour
@@ -1586,26 +1586,14 @@ _findSharedInfo(ItemTypeInfo* type)
 /*---------------------------------------------------------------------------*/
 
 void ItemFamily::
-_copyInfos(ItemInternal* item,ItemSharedInfo*,ItemSharedInfo* new_isi)
-{
-  // Signale qu'il faudra compacter les entités au moment du dump
-  m_item_need_prepare_dump = true;
-
-  item->setSharedInfo(new_isi);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
 _updateSharedInfoAdded(ItemInternal* item)
 {
   ItemSharedInfo* old_isi = item->sharedInfo();
-  ItemSharedInfo* new_isi = _findSharedInfo(old_isi->m_item_type)->sharedInfo();
-  item->setSharedInfo(new_isi);
+  ItemSharedInfoWithType* new_isi = _findSharedInfo(item->typeInfo());
+  item->setSharedInfo(new_isi->sharedInfo(),new_isi->itemTypeId());
 
   m_need_prepare_dump = true;
-  new_isi->addReference();
+  new_isi->sharedInfo()->addReference();
   old_isi->removeReference();
 }
 
@@ -1619,10 +1607,10 @@ _updateSharedInfoRemoved4(ItemInternal* item)
   m_need_prepare_dump = true;
 
   ItemSharedInfo* old_isi = item->sharedInfo();
-  ItemSharedInfo* new_isi = _findSharedInfo(old_isi->m_item_type)->sharedInfo();
-  item->setSharedInfo(new_isi);
+  ItemSharedInfoWithType* new_isi = _findSharedInfo(item->typeInfo());
+  item->setSharedInfo(new_isi->sharedInfo(),new_isi->itemTypeId());
 
-  new_isi->addReference();
+  new_isi->sharedInfo()->addReference();
   old_isi->removeReference();
 }
 
@@ -1666,7 +1654,7 @@ _allocateInfos(ItemInternal* item,Int64 uid,ItemSharedInfoWithType* isi)
     (*m_items_unique_id)[local_id] = uid;
   }
 
-  item->setSharedInfo(isi->sharedInfo());
+  item->setSharedInfo(isi->sharedInfo(),isi->itemTypeId());
   
   item->reinitialize(uid,m_default_sub_domain_owner,m_sub_domain_id);
   ++m_nb_allocate_info;

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -951,7 +951,8 @@ prepareForDump()
     }
     for( Integer i=0; i<nb_item; ++i ){
       ItemInternal* item = items[i];
-      items_shared_data_index[i] = item->sharedInfo()->index();
+      ItemSharedInfoWithType* isi = m_item_shared_infos->findSharedInfo(item->typeInfo());
+      items_shared_data_index[i] = isi->index();
 #if 0
 #ifdef ARCANE_DEBUG
       //if (itemKind()==IK_Particle){
@@ -1590,11 +1591,10 @@ _updateSharedInfoAdded(ItemInternal* item)
 {
   ItemSharedInfo* old_isi = item->sharedInfo();
   ItemSharedInfoWithType* new_isi = _findSharedInfo(item->typeInfo());
+  ARCANE_ASSERT(old_isi==new_isi->sharedInfo(),("Old and new ItemSharedInfo are different"));
   item->setSharedInfo(new_isi->sharedInfo(),new_isi->itemTypeId());
 
   m_need_prepare_dump = true;
-  new_isi->sharedInfo()->addReference();
-  old_isi->removeReference();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1608,10 +1608,8 @@ _updateSharedInfoRemoved4(ItemInternal* item)
 
   ItemSharedInfo* old_isi = item->sharedInfo();
   ItemSharedInfoWithType* new_isi = _findSharedInfo(item->typeInfo());
+  ARCANE_ASSERT(old_isi==new_isi->sharedInfo(),("Old and new ItemSharedInfo are different"));
   item->setSharedInfo(new_isi->sharedInfo(),new_isi->itemTypeId());
-
-  new_isi->sharedInfo()->addReference();
-  old_isi->removeReference();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1587,38 +1587,9 @@ _findSharedInfo(ItemTypeInfo* type)
 /*---------------------------------------------------------------------------*/
 
 void ItemFamily::
-_updateSharedInfoAdded(ItemInternal* item)
+_updateSharedInfo()
 {
-  ItemSharedInfo* old_isi = item->sharedInfo();
-  ItemSharedInfoWithType* new_isi = _findSharedInfo(item->typeInfo());
-  ARCANE_ASSERT(old_isi==new_isi->sharedInfo(),("Old and new ItemSharedInfo are different"));
-  item->setSharedInfo(new_isi->sharedInfo(),new_isi->itemTypeId());
-
-  m_need_prepare_dump = true;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
-_updateSharedInfoRemoved4(ItemInternal* item)
-{
-  // TODO: regarder pourquoi _updateSharedInfoRemoved7() n'a pas le même code.
-  m_need_prepare_dump = true;
-
-  ItemSharedInfo* old_isi = item->sharedInfo();
-  ItemSharedInfoWithType* new_isi = _findSharedInfo(item->typeInfo());
-  ARCANE_ASSERT(old_isi==new_isi->sharedInfo(),("Old and new ItemSharedInfo are different"));
-  item->setSharedInfo(new_isi->sharedInfo(),new_isi->itemTypeId());
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
-_updateSharedInfoRemoved7(ItemInternal*)
-{
-  // TODO: regarder fusion possible avec les autres surcharges de _updateSharedInfo
+  //TODO: Regarder si cela est toujours utile
   m_need_prepare_dump = true;
 }
 

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -462,7 +462,6 @@ class ARCANE_MESH_EXPORT ItemFamily
   ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
   Integer _allocMany(Integer memory);
   void _setSharedInfosPtr(Integer* ptr);
-  void _copyInfos(ItemInternal* item,ItemSharedInfo*,ItemSharedInfo* new_isi);
   void _checkValid();
   void _checkValidConnectivity();
   void _notifyDataIndexChanged();

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -392,9 +392,7 @@ class ARCANE_MESH_EXPORT ItemFamily
  protected:
 
   void _checkNeedEndUpdate() const;
-  void _updateSharedInfoAdded(ItemInternal* item);
-  void _updateSharedInfoRemoved4(ItemInternal* item);
-  void _updateSharedInfoRemoved7(ItemInternal* item);
+  void _updateSharedInfo();
 
   void _allocateInfos(ItemInternal* item,Int64 uid,ItemSharedInfoWithType* isi);
   void _allocateInfos(ItemInternal* item,Int64 uid,ItemTypeInfo* type);

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -396,7 +396,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   void _updateSharedInfoRemoved4(ItemInternal* item);
   void _updateSharedInfoRemoved7(ItemInternal* item);
 
-  void _allocateInfos(ItemInternal* item,Int64 uid,ItemSharedInfo* isi);
+  void _allocateInfos(ItemInternal* item,Int64 uid,ItemSharedInfoWithType* isi);
   void _allocateInfos(ItemInternal* item,Int64 uid,ItemTypeInfo* type);
   void _endUpdate(bool need_check_remove);
   bool _partialEndUpdate();
@@ -457,7 +457,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   ARCANE_DEPRECATED_REASON("Y2022: This method is a now a no-operation")
   void _resizeInfos(Integer memory);
 
-  ItemSharedInfo* _findSharedInfo(ItemTypeInfo* type);
+  ItemSharedInfoWithType* _findSharedInfo(ItemTypeInfo* type);
 
   ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
   Integer _allocMany(Integer memory);

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.cc
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.cc
@@ -111,9 +111,6 @@ ItemSharedInfoList(ItemFamily* family)
 , m_item_kind(family->itemKind())
 , m_item_shared_infos_buffer(new MultiBufferT<ItemSharedInfo>(100))
 , m_infos_map(new ItemSharedInfoMap())
-, m_max_node_per_item_type(0)
-, m_max_edge_per_item_type(0)
-, m_max_face_per_item_type(0)
 {
   {
     String var_name(family->name());
@@ -309,62 +306,6 @@ dumpSharedInfos()
     info() << "INE: " << i->first;
     info() << "ISI: " << *i->second;
   }
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemSharedInfoList::
-maxLocalNodePerItemType()
-{
-  _checkConnectivityInfo();
-  return m_max_node_per_item_type;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemSharedInfoList::
-maxLocalEdgePerItemType()
-{
-  _checkConnectivityInfo();
-  return m_max_edge_per_item_type;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Integer ItemSharedInfoList::
-maxLocalFacePerItemType()
-{
-  _checkConnectivityInfo();
-  return m_max_face_per_item_type;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemSharedInfoList::
-_checkConnectivityInfo()
-{
-  if (!m_connectivity_info_changed)
-    return;
-
-  m_max_node_per_item_type = 0;
-  m_max_edge_per_item_type = 0;
-  m_max_face_per_item_type = 0;
-
-  for( ConstIterT<ItemSharedInfoMap> i(*m_infos_map); i(); ++i ){
-    ItemSharedInfo* isi = i->second;
-    m_max_node_per_item_type = math::max(m_max_node_per_item_type,
-                                         isi->m_item_type->nbLocalNode());
-    m_max_edge_per_item_type = math::max(m_max_edge_per_item_type,
-                                         isi->m_item_type->nbLocalEdge());
-    m_max_face_per_item_type = math::max(m_max_face_per_item_type,
-                                         isi->m_item_type->nbLocalFace());
-  }
-
-  m_connectivity_info_changed = false;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.cc
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.cc
@@ -35,9 +35,18 @@ namespace Arcane::mesh
 
 ItemSharedInfoWithType::
 ItemSharedInfoWithType(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
+                       ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views)
+: ItemSharedInfo(family,items,connectivity,variable_views)
+, m_type_id(item_type->typeId())
+{
+}
+
+ItemSharedInfoWithType::
+ItemSharedInfoWithType(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
                        ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views,
                        Int32ConstArrayView buffer)
-: ItemSharedInfo(family,item_type,items,connectivity,variable_views)
+: ItemSharedInfo(family,items,connectivity,variable_views)
+, m_type_id(item_type->typeId())
 {
   // La taille du buffer dépend des versions de Arcane.
   // Avant la 3.2 (Octobre 2021), la taille du buffer est 9 (non AMR) ou 13 (AMR)

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.cc
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.cc
@@ -109,7 +109,7 @@ ItemSharedInfoList(ItemFamily* family)
 : TraceAccessor(family->traceMng())
 , m_family(family)
 , m_item_kind(family->itemKind())
-, m_item_shared_infos_buffer(new MultiBufferT<ItemSharedInfo>(100))
+, m_item_shared_infos_buffer(new MultiBufferT<ItemSharedInfoWithType>(100))
 , m_infos_map(new ItemSharedInfoMap())
 {
   {
@@ -204,8 +204,8 @@ readFromDump()
     Int32ConstArrayView buffer(m_variables->m_infos_values[i]);
     // Le premier élément du tampon contient toujours le type de l'entité
     ItemTypeInfo* it = itm->typeFromId(buffer[0]);
-    ItemSharedInfo* isi = m_item_shared_infos[i];
-    *isi = ItemSharedInfo(m_family,it,miil,iicl,m_family->viewsForItemSharedInfo(),buffer);
+    ItemSharedInfoWithType* isi = m_item_shared_infos[i];
+    *isi = ItemSharedInfoWithType(m_family,it,miil,iicl,m_family->viewsForItemSharedInfo(),buffer);
 
     ItemNumElements ine(it->typeId());
     std::pair<ItemSharedInfoMap::iterator,bool> old = m_infos_map->insert(std::make_pair(ine,isi));
@@ -259,7 +259,7 @@ checkValid()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ItemSharedInfo* ItemSharedInfoList::
+ItemSharedInfoWithType* ItemSharedInfoList::
 findSharedInfo(ItemTypeInfo* type)
 {
   ItemNumElements ine(type->typeId());
@@ -269,9 +269,9 @@ findSharedInfo(ItemTypeInfo* type)
   MeshItemInternalList* miil = m_family->mesh()->meshItemInternalList();
   ItemInternalConnectivityList* iicl = m_family->itemInternalConnectivityList();
   // Infos pas trouvé. On en construit une nouvelle
-  ItemSharedInfo* isi = allocOne();
+  ItemSharedInfoWithType* isi = allocOne();
   Integer old_index = isi->index();
-  *isi = ItemSharedInfo(m_family,type,miil,iicl,m_family->viewsForItemSharedInfo());
+  *isi = ItemSharedInfoWithType(m_family,type,miil,iicl,m_family->viewsForItemSharedInfo());
   isi->setIndex(old_index);
   std::pair<ItemSharedInfoMap::iterator,bool> old = m_infos_map->insert(std::make_pair(ine,isi));
 

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.h
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.h
@@ -59,8 +59,7 @@ class ItemSharedInfoWithType
  private:
 
   ItemSharedInfoWithType(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
-                         ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views)
-  : ItemSharedInfo(family,item_type,items,connectivity,variable_views){}
+                         ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views);
 
   ItemSharedInfoWithType(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
                          ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views,
@@ -88,6 +87,7 @@ class ItemSharedInfoWithType
 
  private:
 
+  Int32 m_type_id = IT_NullType;
   Int32 m_index = NULL_INDEX;
   Int32 m_nb_reference = 0;
 };

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.h
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.h
@@ -64,13 +64,19 @@ class ItemSharedInfoWithType
 
   ItemSharedInfoWithType(IItemFamily* family,ItemTypeInfo* item_type,MeshItemInternalList* items,
                          ItemInternalConnectivityList* connectivity,ItemVariableViews* variable_views,
-                         Int32ConstArrayView buffer)
-  : ItemSharedInfo(family,item_type,items,connectivity,variable_views,buffer){}
+                         Int32ConstArrayView buffer);
 
  public:
 
   ItemSharedInfo* sharedInfo() { return this; }
   Int32 itemTypeId() { return this->m_type_id; }
+  Int32 index() const { return m_index; }
+  void setIndex(Int32 aindex) { m_index = aindex; }
+  Int32 nbReference() const { return m_nb_reference; }
+  void addReference(){ ++m_nb_reference; }
+  void removeReference(){ --m_nb_reference; }
+  void serializeWrite(Int32ArrayView buffer);
+  static Integer serializeSize() { return 6; }
 
  public:
 
@@ -79,6 +85,11 @@ class ItemSharedInfoWithType
     isi.print(o);
     return o;
   }
+
+ private:
+
+  Int32 m_index = NULL_INDEX;
+  Int32 m_nb_reference = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.h
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.h
@@ -70,6 +70,10 @@ class ItemSharedInfoWithType
  public:
 
   ItemSharedInfo* sharedInfo() { return this; }
+  Int32 itemTypeId() { return this->m_type_id; }
+
+ public:
+
   friend std::ostream& operator<<(std::ostream& o,const ItemSharedInfoWithType& isi)
   {
     isi.print(o);

--- a/arcane/src/arcane/mesh/ItemSharedInfoList.h
+++ b/arcane/src/arcane/mesh/ItemSharedInfoList.h
@@ -84,7 +84,6 @@ class ItemSharedInfoList
   void removeOne(ItemSharedInfo* item)
   {
     m_list_changed = true;
-    m_connectivity_info_changed = true;
     m_free_item_shared_infos.add(item);
     --m_nb_item_shared_info;
   }
@@ -112,10 +111,12 @@ class ItemSharedInfoList
   Integer maxFacePerItem() const { return 0; }
   ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
   Integer maxCellPerItem() const { return 0; }
-
-  Integer maxLocalNodePerItemType();
-  Integer maxLocalEdgePerItemType();
-  Integer maxLocalFacePerItemType();
+  ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
+  Integer maxLocalNodePerItemType() const { return 0; }
+  ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
+  Integer maxLocalEdgePerItemType() const { return 0; }
+  ARCANE_DEPRECATED_REASON("Y2022: This method always return 0")
+  Integer maxLocalFacePerItemType() const { return 0; }
 
  public:
 
@@ -128,7 +129,6 @@ class ItemSharedInfoList
     ItemSharedInfo* new_item = 0;
     Integer nb_free = m_free_item_shared_infos.size();
     m_list_changed = true;
-    m_connectivity_info_changed = true;
     if (nb_free!=0){
       new_item = m_free_item_shared_infos.back();
       m_free_item_shared_infos.popBack();
@@ -148,21 +148,13 @@ class ItemSharedInfoList
 
   ItemFamily* m_family = nullptr;
   Integer m_nb_item_shared_info = 0; //!< Nombre d'objets alloués
-  eItemKind m_item_kind= IK_Unknown;
+  eItemKind m_item_kind = IK_Unknown;
   UniqueArray<ItemSharedInfo*> m_item_shared_infos;
   UniqueArray<ItemSharedInfo*> m_free_item_shared_infos;
   MultiBufferT<ItemSharedInfo>* m_item_shared_infos_buffer;
   ItemSharedInfoMap* m_infos_map = nullptr;
   Variables* m_variables = nullptr;
   bool m_list_changed = false;
-  bool m_connectivity_info_changed = true;
-  Integer m_max_node_per_item_type = 0;
-  Integer m_max_edge_per_item_type = 0;
-  Integer m_max_face_per_item_type = 0;
-
- private:
-
-  void _checkConnectivityInfo();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ParticleFamily.h
+++ b/arcane/src/arcane/mesh/ParticleFamily.h
@@ -29,6 +29,7 @@ namespace Arcane::mesh
 {
 class IncrementalItemConnectivity;
 class OneItemIncrementalItemConnectivity;
+class ItemSharedInfoWithType;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -129,7 +130,7 @@ class ARCANE_MESH_EXPORT ParticleFamily
  private:
   
   ItemTypeInfo* m_particle_type_info;
-  ItemSharedInfo* m_particle_shared_info;
+  ItemSharedInfoWithType* m_particle_shared_info;
   Int32 m_sub_domain_id;
   bool m_enable_ghost_items;
   CellConnectivity* m_cell_connectivity;

--- a/arcane/src/arcane/mesh/PolyhedralMesh.cc
+++ b/arcane/src/arcane/mesh/PolyhedralMesh.cc
@@ -47,7 +47,7 @@ namespace mesh
 
 class PolyhedralFamily : public ItemFamily{
   IMesh* m_mesh;
-  ItemSharedInfo* m_shared_info = nullptr;
+  ItemSharedInfoWithType* m_shared_info = nullptr;
   Int32UniqueArray m_empty_connectivity {0};
   Int32UniqueArray m_empty_connectivity_indexes;
   Int32UniqueArray m_empty_connectivity_nb_item;

--- a/arcane/src/arcane/totalview/tv_display_arcane_types.cc
+++ b/arcane/src/arcane/totalview/tv_display_arcane_types.cc
@@ -217,7 +217,7 @@ TV_ttf_display_type(const Arcane::ItemInternal * obj)
   TV_ttf_add_row("kind","eItemKind",&shared_info->m_item_kind);
   
   snprintf(strtype,sizeof(strtype),"type=%s",obj->typeInfo()->typeName().localstr());
-  TV_ttf_add_row(strtype,"ItemTypeInfo*",&shared_info->m_item_type);
+  //TV_ttf_add_row(strtype,"ItemTypeInfo*",&shared_info->m_item_type);
 
   {
     // Nodes

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -195,13 +195,10 @@ namespace Arcane
     internal Int32ArrayView* m_parent_item_ids;
     internal Int32ArrayView* m_owners;
     internal Int32ArrayView* m_flags;
-    //internal IntPtr m_item_type; //ItemTypeInfo* m_item_type;
-    internal eItemKind m_item_kind; //eItemKind m_item_kind;
+    internal eItemKind m_item_kind;
 
     internal Int32 m_type_id;
     internal Int32 m_nb_parent;
-    internal Int32 m_index;
-    internal Int32 m_nb_reference;
 
     //! Pour l'entité nulle
     private static ItemSharedInfo* null_item_shared_info = null;
@@ -259,11 +256,8 @@ namespace Arcane
 
     internal static ItemInternal* null_item = null;
     public Int32 m_local_id;
-    public Int32 m_data_index;
+    public Int32 m_type_id;
     ItemSharedInfo* m_shared_info;
-    // Le champ 'm_connectivity' n'est actif que si Arcane a été compilé
-    // sans la macro 'ARCANE_USE_SHAREDINFO_CONNECTIVITY'
-    // public ItemInternalConnectivityList* m_connectivity;
     
     internal static ItemInternal* Zero
     {
@@ -273,7 +267,7 @@ namespace Arcane
           int size = Marshal.SizeOf(typeof(ItemInternal));
           null_item = (ItemInternal*)Marshal.AllocHGlobal(size);
           null_item->m_local_id = NULL_ITEM_LOCAL_ID;
-          null_item->m_data_index = 0;
+          null_item->m_type_id = 0;
           null_item->m_shared_info = ItemSharedInfo.Zero;
         }
         return null_item;

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -190,11 +190,12 @@ namespace Arcane
     internal MeshItemInternalList* m_items;
     internal ItemInternalConnectivityList* m_connectivity;
     internal IntPtr m_family; //IItemFamily* m_family;
+    internal IntPtr m_item_type_mng; //ItemTypeMng* m_item_type_mng = nullptr;
     internal Int64ArrayView* m_unique_ids;
     internal Int32ArrayView* m_parent_item_ids;
     internal Int32ArrayView* m_owners;
     internal Int32ArrayView* m_flags;
-    internal IntPtr m_item_type; //ItemTypeInfo* m_item_type;
+    //internal IntPtr m_item_type; //ItemTypeInfo* m_item_type;
     internal eItemKind m_item_kind; //eItemKind m_item_kind;
 
     internal Int32 m_type_id;

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -196,8 +196,6 @@ namespace Arcane
     internal Int32ArrayView* m_owners;
     internal Int32ArrayView* m_flags;
     internal eItemKind m_item_kind;
-
-    internal Int32 m_type_id;
     internal Int32 m_nb_parent;
 
     //! Pour l'entité nulle

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -189,8 +189,8 @@ namespace Arcane
   {
     internal MeshItemInternalList* m_items;
     internal ItemInternalConnectivityList* m_connectivity;
-    internal IntPtr m_family; //IItemFamily* m_family;
-    internal IntPtr m_item_type_mng; //ItemTypeMng* m_item_type_mng = nullptr;
+    internal IntPtr m_family; // IItemFamily*;
+    internal IntPtr m_item_type_mng; // ItemTypeMng*
     internal Int64ArrayView* m_unique_ids;
     internal Int32ArrayView* m_parent_item_ids;
     internal Int32ArrayView* m_owners;


### PR DESCRIPTION
This is the only remaining information which depends of an item.

Removing that information will allow us to have only one instance of `ItemSharedInfo` for all the items of a `ItemFamily`. 