### PR TITLE
Fix bad filename for parallel run in ArcaneCeaVerifierService

### DIFF
--- a/arcane/ceapart/src/arcane/cea/ArcaneCeaVerifierModule.cc
+++ b/arcane/ceapart/src/arcane/cea/ArcaneCeaVerifierModule.cc
@@ -157,11 +157,9 @@ onExit()
   String reference_file_name = options()->referenceFile();
   if (reference_file_name.empty())
     reference_file_name = "check";
-  String base_reference_file_name = reference_file_name;
-  if (is_parallel && !compare_from_sequential){
-    base_reference_file_name = reference_file_name + "." + rank;
-  }
-  String base_file_name = base_reference_file_name;
+
+  info() << "Verification check is_parallel?=" << is_parallel << " compare_from_sequential?=" << compare_from_sequential;
+  String base_file_name = reference_file_name;
   verifier_service->setFileName(base_file_name);
 
   if (options()->generate()){

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -783,6 +783,7 @@ if (TARGET arcane_mpi)
   arcane_add_test_script(compare_par_par_v3 compare_par_par_v3.xml)
 endif()
 arcane_add_test_script(checkpoint_verifier_seq_v3 checkpoint_verifier_seq_v3.xml)
+arcane_add_test_script(checkpoint_verifier_seq_4pe_v3 checkpoint_verifier_seq_4pe_v3.xml)
 arcane_add_test_script(checkpoint_verifier_4pe_v3 checkpoint_verifier_4pe_v3.xml)
 
 #################################################################

--- a/arcane/tests/checkpoint_verifier_seq_4pe_v3.xml
+++ b/arcane/tests/checkpoint_verifier_seq_4pe_v3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <commands>
-  <test>-n 4 -m 5 @ARCANE_TEST_CASEPATH@/testCheckpoint-verifier-write.arc</test>
+  <test>-m 5 @ARCANE_TEST_CASEPATH@/testCheckpoint-verifier-write.arc</test>
   <test>-n 4 -m 5 @ARCANE_TEST_CASEPATH@/testCheckpoint-verifier-read.arc</test>
   <driver>compare checkpoint-test-verifier-file checkpoint-test-verifier-file</driver>
 </commands>


### PR DESCRIPTION
This bug was introduced in commit https://github.com/arcaneframework/framework/commit/265f05ca06d330080b2990029bfb4d0409f04aaf

The number of the rank was wrongly appended to the filename