### PR TITLE
Add missing recompute of max connected items after after compacting items

### DIFF
--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -993,6 +993,7 @@ dumpStats(std::ostream& out) const
 void OneItemIncrementalItemConnectivity::
 compactConnectivityList()
 {
+  _computeMaxNbConnectedItem();
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The missing call is only for connectivity with at max one Item connected (like `Particle`)
