### PR TITLE
Remove some deprecated methods

### DIFF
--- a/arcane/src/arcane/IApplication.h
+++ b/arcane/src/arcane/IApplication.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IApplication.h                                              (C) 2000-2021 */
+/* IApplication.h                                              (C) 2000-2022 */
 /*                                                                           */
 /* Interface de l'application.                                               */
 /*---------------------------------------------------------------------------*/
@@ -109,46 +109,10 @@ class ARCANE_CORE_EXPORT IApplication
   //! Nom de l'utilisateur
   virtual String userName() const =0;
 
-  /*!
-   * \brief Elément racine du DOM de la configuration globale.
-   *
-   * \deprecated Ne pas utiliser car suivant l'implémentation
-   * (actuellement Xerces), l'accès au document retourné n'est pas nécessairement
-   * thread-safe. Utiliser configBytes() à la place et lire le fichier
-   * si besoin.
-   */
-  virtual ARCANE_DEPRECATED_120 XmlNode configRootElement() const =0;
-
-  /*
-   * \brief Contenu du fichier Xml de configuration du code.
-   *
-   * \deprecated Utitiliser configBuffer() à la place
-   */
-  ARCCORE_DEPRECATED_2020("Use configBuffer() instead") virtual
-  ByteConstArrayView configBytes() const =0;
-
   /*
    * \brief Contenu du fichier Xml de configuration du code.
    */
   virtual ByteConstSpan configBuffer() const =0;
-
-  /*!
-   * \brief Elément racine du DOM de la configuration utilisateur.
-   *
-   * \deprecated Ne pas utiliser car suivant l'implémentation
-   * (actuellement Xerces), l'accès au document retourné n'est pas nécessairement
-   * thread-safe. Utiliser userConfigBuffer() à la place et lire le fichier
-   * si besoin.
-   */
-  virtual ARCANE_DEPRECATED_120 XmlNode userConfigRootElement() const =0;
-
-  /*
-   * \brief Contenu du fichier Xml de configuration utilisateur.
-   *
-   * \deprecated Utitiliser userConfigBuffer() à la place
-   */
-  ARCCORE_DEPRECATED_2020("Use configBuffer() instead") virtual
-  ByteConstArrayView userConfigBytes() const =0;
 
   /*
    * \brief Contenu du fichier Xml de configuration utilisateur
@@ -169,9 +133,6 @@ class ARCANE_CORE_EXPORT IApplication
 
   //! Manufacture principale.
   virtual IMainFactory* mainFactory() const =0;
-
-  //! Liste des informations sur les fabriques des services
-  virtual ARCANE_DEPRECATED_200 ServiceFactoryInfoCollection serviceFactoryInfos() =0;
 
   //! Liste des informations sur les fabriques des modules
   virtual ModuleFactoryInfoCollection moduleFactoryInfos() =0;

--- a/arcane/src/arcane/IItemFamily.h
+++ b/arcane/src/arcane/IItemFamily.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IItemFamily.h                                               (C) 2000-2020 */
+/* IItemFamily.h                                               (C) 2000-2022 */
 /*                                                                           */
 /* Interface d'une famille d'entités.                                        */
 /*---------------------------------------------------------------------------*/
@@ -128,12 +128,6 @@ class IItemFamily
   virtual Integer nbItem() const =0;
 
   /*!
-   * \brief Taille nécessaire pour dimensionner les variables sur ces entités.
-   * \deprecated Utiliser maxLocalId() à la place.
-   */
-  virtual ARCANE_DEPRECATED_112 Int32 variableMaxSize() const =0;
-
-  /*!
    * Taille nécessaire pour dimensionner les variables sur ces entités.
    *
    * Il s'agit du maximum des Item::localId() des entités de cette famille plus 1.
@@ -195,58 +189,6 @@ class IItemFamily
 
  public:
 
-#if 1
-  /*!
-   * \brief Alloue des entités.
-   *
-   * Après appel à cette opération, il faut appeler endUpdate() pour notifier
-   * à l'instance la fin des modifications. Il est possible d'enchaîner plusieurs
-   * allocations avant d'appeler endUpdate(). Les \a unique_ids doivent
-   * être unique sur l'ensemble des sous-domaines. Il est possible de vérifier
-   * cela via checkUniqueIds().
-   * \a items doit avoir le même nombre d'éléments que \a unique_ids
-   * et sera remplit en retour avec les numéros locaux des entités créées.
-   * Il est possible après création d'obtenir une vue sur les entités créés via view().
-   * \code
-   * Int64UniqueArray my_unique_ids;
-   * Int32UniqueArray my_local_ids;
-   * my_unique_ids.add(25);
-   * my_unique_ids.add(32);
-   * family->addItems(my_unique_ids,my_local_ids);
-   * family->endUpdate();
-   * ENUMERATE_ITEM(iitem,family->view(my_local_ids)){
-   *   const Item& item = *iitem;
-   *   info() << "Item local_id=" << item.localId() << " unique_id=" << item.uniqueId();
-   * }
-   * \endcode
-   */
-  virtual ARCANE_DEPRECATED_114 void addItems(Int64ConstArrayView unique_ids,Int32ArrayView items) =0;
-
-  /*!
-   * \deprecated.
-   * Il faut utiliser addItems(Int64ConstArrayView,Int32ArrayView)
-   */
-  virtual ARCANE_DEPRECATED_114 void addItems(Int64ConstArrayView unique_ids,ArrayView<Item> items) =0;
-
-  /*!
-   * \deprecated.
-   * Il faut utiliser addItems(Int64ConstArrayView,Int32ArrayView)
-   */
-  virtual ARCANE_DEPRECATED_114 void addItems(Int64ConstArrayView unique_ids,ItemGroup item_group) =0;
-
-  /*!
-   * \brief Échange des entités.
-   *
-   * Cette méthode n'est supportée que pour les familles de particule.
-   * Pour les éléments du maillage comme les noeuds, faces ou maille, il faut utiliser IMesh::exchangeItems().
-   *
-   * Les nouveaux propriétaires des entités sont données par la itemsNewOwner().
-   *
-   * Cette opération est bloquante et collective.
-   */
-  virtual ARCANE_DEPRECATED_114 void exchangeItems() =0;
-#endif
-
   /*!
    * \brief Vue sur les entités.
    *
@@ -263,27 +205,20 @@ class IItemFamily
    */
   virtual ItemVectorView view() =0;
 
-#if 1
   /*!
    * \brief Supprime des entités.
+   *
+   * Utilise le graphe (Familles, Connectivités) ItemFamilyNetwork
    */
-  virtual ARCANE_DEPRECATED_114 void removeItems(Int32ConstArrayView local_ids,bool keep_ghost=false) =0;
-#endif
-  
-  /*!
-     * \brief Supprime des entités.
-     *
-     * Utilise le graphe (Familles, Connectivités) ItemFamilyNetwork
-     */
-    virtual void removeItems2(mesh::ItemDataList& item_data_list) =0;
+  virtual void removeItems2(mesh::ItemDataList& item_data_list) =0;
 
-    /*!
-     * \brief Supprime des entités et met a jour les connectivites. Ne supprime pas d'eventuels sous items orphelins.
-     *
-     * Contexte d'utilisation avec un graphe des familles. Les sous items orphelins ont du eux aussi etre marque NeedRemove.
-     * Il n'y a donc pas besoin de les gerer dans les familles parentes.
-     */
-    virtual void removeNeedRemoveMarkedItems() =0;
+  /*!
+   * \brief Supprime des entités et met a jour les connectivites. Ne supprime pas d'eventuels sous items orphelins.
+   *
+   * Contexte d'utilisation avec un graphe des familles. Les sous items orphelins ont du eux aussi etre marque NeedRemove.
+   * Il n'y a donc pas besoin de les gerer dans les familles parentes.
+   */
+  virtual void removeNeedRemoveMarkedItems() =0;
 
   /*
    * \brief Entité de numéro unique \a unique_id.
@@ -291,29 +226,6 @@ class IItemFamily
    * Si aucune entité avec cet \a unique_id n'est trouvé, retourne null.
    */
   virtual ItemInternal* findOneItem(Int64 unique_id) =0;
- 
-  /** 
-   * Fusionne deux entités en une plus grande. Par exemple, deux
-   * mailles partageant une face. L'intérêt est de conserver ainsi les
-   * uniqueIds() en parallèle.
-   * 
-   * @note La maille résultante est construite en remplacement de la
-   * première maille, de numéro \a local_id1
-   * 
-   * @param local_id1 numéro local de la première entité
-   * @param local_id2 numéro local de la seconde entité
-   */
-  ARCANE_DEPRECATED_240 virtual void mergeItems(Int32 local_id1,Int32 local_id2) = 0;
-
-  /** 
-   * Détermine quel sera le localId de la maille apres fusion.
-   * 
-   * @param local_id1 numéro local de la première entité
-   * @param local_id2 numéro local de la seconde entité
-   * 
-   * @return le local id de la maille fusionnée
-   */
-  ARCANE_DEPRECATED_240 virtual Int32 getMergedItemLID(Int32 local_id1,Int32 local_id2) = 0;
 
   /*! \brief Notifie la fin de modification de la liste des entités.
    *

--- a/arcane/src/arcane/ItemVector.h
+++ b/arcane/src/arcane/ItemVector.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemVector.h                                                (C) 2000-2018 */
+/* ItemVector.h                                                (C) 2000-2022 */
 /*                                                                           */
 /* Vue sur un vecteur (tableau indirect) d'entités.                          */
 /*---------------------------------------------------------------------------*/
@@ -21,10 +21,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -61,19 +59,6 @@ class ItemVector
   //! Créé un vecteur associé à la famille \a family et contenant les entités \a local_ids.
   ItemVector(IItemFamily* afamily,Int32ConstArrayView local_ids)
   : m_items(afamily->itemsInternal()), m_local_ids(local_ids), m_family(afamily) {}
-  /*!
-   * \brief Constructeur par référence sur ItemInternals et liste de localId.
-   *
-   * Ce constructeur est obsolète et l'argument do_clone n'est plus utilisé. Les
-   * entités de \a lids sont toujours copiées.
-   *
-   * \deprecated Utiliser ItemVector(IItemFamily*,Int32ConstArrayView) à la place.
-   */
-  ARCANE_DEPRECATED_280 ItemVector(IItemFamily* afamily, const SharedArray<Int32>& lids, bool do_clone)
-  : m_items(afamily->itemsInternal()), m_local_ids(lids.clone()), m_family(afamily)
-  {
-    ARCANE_UNUSED(do_clone);
-  }
 
   //! Créé un vecteur pour \a size éléments associé à la famille \a family.
   ItemVector(IItemFamily* afamily,Integer asize)
@@ -159,24 +144,6 @@ class ItemVector
     return m_local_ids.constView();
   }
 
-  //! Conteneur de localIds
-  /*! Peut etre directement utilisé pour construire un ItemGroup 
-   *  Redondance avec viewAsArray car fusion impl cea et ifp
-   */
-  ARCANE_DEPRECATED Int32ConstArrayView localIds() const 
-  { 
-    return m_local_ids; 
-  }
-
-  /*!
-   * \brief Supprime l'entité à l'index \a index.
-   * \deprecated Utiliser removeAt() à la place.
-   */
-  ARCANE_DEPRECATED_240 void remoteAt(Int32 index)
-  {
-    m_local_ids.remove(index);
-  }
-
   //! Supprime l'entité à l'index \a index
   void removeAt(Int32 index)
   {
@@ -255,16 +222,6 @@ class ItemVectorT
   //! Créé un vecteur associé à la famille \a afamily et contenant les entités \a local_ids.
   ItemVectorT(IItemFamily* afamily,Int32ConstArrayView local_ids)
   : ItemVector(afamily, local_ids) {}
-  /*!
-   * \brief Constructeur par référence sur ItemInternals et liste de localId.
-   *
-   * Ce constructeur est obsolète et l'argument do_clone n'est plus utilisé. Les
-   * entités de \a lids sont toujours copiées.
-   *
-   * \deprecated Utiliser ItemVectorT(IItemFamily*,Int32ConstArrayView) à la place.
-   */
-  ARCANE_DEPRECATED_280 ItemVectorT(IItemFamily* afamily, const SharedArray<Int32>& lids, bool do_clone)
-  : ItemVector(afamily,lids,do_clone){}
   //! Constructeur par copie
   ItemVectorT(const ItemVector &rhs)
   : ItemVector(rhs) {}
@@ -326,7 +283,7 @@ ItemVectorViewT(const ItemVectorT<ItemType>& rhs)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/MathUtils.h
+++ b/arcane/src/arcane/MathUtils.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MathUtils.h                                                 (C) 2000-2021 */
+/* MathUtils.h                                                 (C) 2000-2022 */
 /*                                                                           */
 /* Fonctions mathématiques diverses.                                         */
 /*---------------------------------------------------------------------------*/
@@ -26,7 +26,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -197,22 +198,6 @@ prodTens(Real3 u,Real3 v)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Produit scalaire matrice 
- * \warning Cette fonction ne doit plus être utilisée car elle n'est pas
- * cohérente avec les conventions choisies pour Real3x3.
- * \deprecated Il faut utiliser l'opérateur * du Real3x3 à la place.
- */
-inline ARCANE_DEPRECATED_116 Real3x3
-prodTensScal(Real3x3 t,Real a)
-{
-  return Real3x3::fromColumns(a*t.x.x, a*t.x.y, a*t.x.z,
-                              a*t.y.x, a*t.y.y, a*t.y.z,
-                              a*t.z.x, a*t.z.y, a*t.z.z);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
  * \brief Produit matrice vecteur entre un tenseur et un vecteur.
  *
  * \ingroup GroupMathUtils
@@ -241,29 +226,6 @@ ARCCORE_HOST_DEVICE inline Real3
 prodVecTens(Real3 v,Real3x3 t)
 {
   return Real3(dot(v,Real3(t.x.x,t.y.x,t.z.x)),dot(v,Real3(t.x.y,t.y.y,t.z.y)),dot(v,Real3(t.x.z,t.y.z,t.z.z)));
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Produit matrice matrice entre deux tenseurs
- *
- * \warning Cette fonction ne doit plus être utilisée car elle n'est pas
- * cohérente avec les conventions choisies pour Real3x3.
- * \deprecated Il faut utiliser matrixProduct() à la place.
- */
-inline ARCANE_DEPRECATED_116 Real3x3
-prodTensTens(Real3x3 t,Real3x3 v)
-{
-  return Real3x3::fromColumns(t.x.x*v.x.x+t.x.y*v.y.x+t.x.z*v.z.x,
-                              t.x.x*v.x.y+t.x.y*v.y.y+t.x.z*v.z.y,
-                              t.x.x*v.x.z+t.x.y*v.y.z+t.x.z*v.z.z,
-                              t.y.x*v.x.x+t.y.y*v.y.x+t.y.z*v.z.x,
-                              t.y.x*v.x.y+t.y.y*v.y.y+t.y.z*v.z.y,
-                              t.y.x*v.x.z+t.y.y*v.y.z+t.y.z*v.z.z,
-                              t.z.x*v.x.x+t.z.y*v.y.x+t.z.z*v.z.x,
-                              t.z.x*v.x.y+t.z.y*v.y.y+t.z.z*v.z.y,
-                              t.z.x*v.x.z+t.z.y*v.y.z+t.z.z*v.z.z);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -685,22 +647,6 @@ matrixDeterminant(Real3x3 m)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief  Calcul du déterminant d'une matrice 3x3 dans le bon sens
- *
- * \deprecated Ne pas utiliser car ne respecte la convention ligne
- * des Real3x3. Utiliser det() à la place
- */
-inline ARCANE_DEPRECATED_116 Real
-matrix3x3Det2(Real3x3 m) {
-  return
-      m.x.x*(m.y.y*m.z.z-m.z.y*m.y.z)
-    - m.y.x*(m.x.y*m.z.z-m.z.y*m.x.z)
-    + m.z.x*(m.x.y*m.y.z-m.y.y*m.x.z);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
  * \brief Norme d'un vecteur
  *
  * \deprecated Utiliser Real3.abs() à la place.
@@ -722,21 +668,6 @@ matrix3x3Id()
   return Real3x3(Real3(1.0, 0.0, 0.0),
                  Real3(0.0, 1.0, 0.0),
                  Real3(0.0, 0.0, 1.0));
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Calcul du déterminant d'une matrice 3x3.
- *
- * \deprecated Utiliser matrixDeterminant()
- */
-inline ARCANE_DEPRECATED_116 Real
-matrix3x3Det(Real3x3 m)
-{
-  return m.x.x*(m.y.y*m.z.z-m.y.z*m.z.y)
-  - m.x.y*(m.y.x*m.z.z-m.y.z*m.z.x)
-  + m.x.z*(m.y.x*m.z.y-m.y.y*m.z.x);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -764,57 +695,6 @@ inverseMatrix(Real3x3 m)
 {
   Real d = m.determinant();
   return inverseMatrix(m,d);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief  Calcul de l'inverse d'une matrice 3x3 dans le bon sens
- * \deprecated Utiliser inverseMatrix() à la place
- */
-inline ARCANE_DEPRECATED_116 Real3x3
-matrix3x3Inv2(Real3x3 m, Real d)
-{
-  Real3x3 inv_m;
-
-  inv_m = Real3x3::fromColumns(-m.y.z*m.z.y + m.y.y*m.z.z,
-                               m.y.z*m.z.x - m.y.x*m.z.z,
-                               -m.y.y*m.z.x + m.y.x*m.z.y,
-                               m.x.z*m.z.y - m.x.y*m.z.z,
-                               -m.x.z*m.z.x + m.x.x*m.z.z,
-                               m.x.y*m.z.x - m.x.x*m.z.y,
-                               -m.x.z*m.y.y + m.x.y*m.y.z,
-                               m.x.z*m.y.x - m.x.x*m.y.z,
-                               -m.x.y*m.y.x + m.x.x*m.y.y);
-
-  inv_m /= d;
-
-  return inv_m;
-}
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Inverse d'une matrice 3x3 pleine à déterminant non nul (issu de Mathematica).
- * \deprecated Utiliser inverseMatrix() à la place
- */
-inline ARCANE_DEPRECATED_116 Real3x3
-matrix3x3Inv(Real3x3 m, Real d)
-{
-  Real inv_d = 1.0 / d;
-  Real3x3 inv_m = Real3x3::fromColumns((-m.y.z*m.z.y + m.y.y*m.z.z),
-                                       ( m.y.z*m.z.x - m.y.x*m.z.z),
-                                       (-m.y.y*m.z.x + m.y.x*m.z.y),
-                                       ( m.x.z*m.z.y - m.x.y*m.z.z),
-                                       (-m.x.z*m.z.x + m.x.x*m.z.z),
-                                       ( m.x.y*m.z.x - m.x.x*m.z.y),
-                                       (-m.x.z*m.y.y + m.x.y*m.y.z),
-                                       ( m.x.z*m.y.x - m.x.x*m.y.z),
-                                       (-m.x.y*m.y.x + m.x.x*m.y.y)
-                                       );
-  
-  inv_m *= inv_d;
-
-  return inv_m;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -917,23 +797,6 @@ matrix3x3Prod(Real3x3 m1, Real3x3 m2)
 /*---------------------------------------------------------------------------*/
 /*!
  * \brief Produit matrice 3x3 . vecteur 
- * \warning Cette fonction ne doit plus être utilisée car elle n'est pas
- * cohérente avec les conventions choisies pour Real3x3.
- * \deprecated Il faut utiliser la méthode multiply() à la place.
- */
-inline ARCANE_DEPRECATED Real3
-matrix3x3VectProd(Real3x3 m, Real3 v)
-{
-  return Real3( m.x.x*v.x + m.y.x*v.y + m.z.x*v.z,
-                m.x.y*v.x + m.y.y*v.y + m.z.y*v.z,
-                m.x.z*v.x + m.y.z*v.y + m.z.z*v.z 
-                );
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Produit matrice 3x3 . vecteur 
  */
 inline Real3
 multiply(Real3x3 m, Real3 v)
@@ -966,38 +829,6 @@ isNearlyId(Real3x3 m, Real epsilon = 1.e-10)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Produit scalaire de deux vecteurs à 3 composantes
- *
- * \deprecated Utiliser dot() à la place.
- */
-inline ARCANE_DEPRECATED_118 Real
-dotProduct3(Real3 v1, Real3 v2)  // meth.
-{
-  return v1.x*v2.x + v1.y*v2.y + v1.z*v2.z;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Symétrie d'un vecteur u par rapport à un plan de normale n.
- *
- * \deprecated Utiliser planarSymmetric() (avec 2 m) à la place.
- */
-inline ARCANE_DEPRECATED Real3 
-planarSymetric(const Real3 u, const Real3 n) 
-{
-  Real3 u_tilde;
-  if (n.normL2()==0){
-    arcaneMathError(n.normL2(),"planarSymetric");
-  }	
-  Real3 norm = n / n.normL2();
-  u_tilde = u - 2.0 * dot(norm,u) * norm;
-  return u_tilde;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
  * \ingroup GroupMathUtils
  * \brief Symétrie d'un vecteur \a u par rapport à un plan de normale \a n.
  */
@@ -1014,25 +845,6 @@ planarSymmetric(Real3 u,Real3 n)
   u_tilde = u - 2.0 * dot(norm,u) * norm;
   return u_tilde;
 }
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Symétrie d'un vecteur \a u par rapport à un axe de vecteur directeur \a a.
- *
- * \deprecated Utiliser axisSymmetric() (avec 2 m) à la place.
- */ 
-inline ARCANE_DEPRECATED_118 Real3
-axisSymetric(const Real3 u, const Real3 a)
-{
-  Real3 u_tilde;
-  if (a.normL2()==0){
-    arcaneMathError(Convert::toDouble(a.normL2()),"axisSymetric");
-  }	
-  Real3 norm = a / a.normL2();    
-  u_tilde = 2.0 * dot(u,norm) * norm - u;
-  return u_tilde;	
-} 
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -1196,7 +1008,7 @@ power(ArrayView<T> lhs,T o)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/MeshToMeshTransposer.cc
+++ b/arcane/src/arcane/MeshToMeshTransposer.cc
@@ -118,13 +118,14 @@ _transpose(IItemFamily * familyA, IItemFamily * familyB, const ItemVectorView & 
   // Ne traite que la transposition sur un seul niveau
   if (parent_familyA == familyB) {
     // meshA est sous-maillage de meshB
-    SharedArray<Int32> lidsB(itemsA.size(),NULL_ITEM_LOCAL_ID);
+    UniqueArray<Int32> lidsB(itemsA.size(),NULL_ITEM_LOCAL_ID);
     ENUMERATE_ITEM(iitem,itemsA) {
       const Item & item = *iitem;
       lidsB[iitem.index()] = item.parent().localId();
     }
-    return ItemVector(familyB,lidsB,false);
-  } else if (parent_familyB == familyA) {
+    return ItemVector(familyB,lidsB);
+  }
+  else if (parent_familyB == familyA) {
     // meshB est sous-maillage de meshA
     if (kindB==IK_Node || kindB==IK_Face || kindB==IK_Edge || kindB==IK_Cell ) {
       // Actuellement les uids sont les mêmes entre sous-maillages et maillage parent 
@@ -133,10 +134,11 @@ _transpose(IItemFamily * familyA, IItemFamily * familyB, const ItemVectorView & 
       ENUMERATE_ITEM(iitem,itemsA) {
         uidsA[iitem.index()] = iitem->uniqueId();
       }
-      SharedArray<Int32> lidsB(uidsA.size());
+      UniqueArray<Int32> lidsB(uidsA.size());
       familyB->itemsUniqueIdToLocalId(lidsB,uidsA,do_fatal);
-      return ItemVector(familyB,lidsB,false);
-    } else {
+      return ItemVector(familyB,lidsB);
+    }
+    else {
       throw NotImplementedException(A_FUNCINFO,"Cannot only transpose item to cell or node");
     }
   } else if (familyA == familyB) {

--- a/arcane/src/arcane/Properties.cc
+++ b/arcane/src/arcane/Properties.cc
@@ -788,20 +788,6 @@ operator=(const Properties& rhs)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-bool Properties::
-setBoolProperty(const String& aname,bool value)
-{
-  return m_p->setScalarValue(aname,value);
-}
-bool Properties::
-boolProperty(const String& aname)
-{
-  return getBool(aname);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 void Properties::
 setBool(const String& aname,bool value)
 {   

--- a/arcane/src/arcane/Properties.h
+++ b/arcane/src/arcane/Properties.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Properties.h                                                (C) 2000-2020 */
+/* Properties.h                                                (C) 2000-2022 */
 /*                                                                           */
 /* Liste de propriétés.                                                      */
 /*---------------------------------------------------------------------------*/
@@ -78,28 +78,6 @@ class ARCANE_CORE_EXPORT Properties
   virtual ~Properties();
 
  public:
-
-  /*!
-   * \brief Positionne une propriété booléenne.
-   *
-   * \param name nom de la propriété
-   * \param value valeur de la propriété à positionner.
-   * \retval ancienne valeur de la propriété.
-   *
-   * \deprecated Utiliser setBool().
-   */
-  ARCANE_DEPRECATED_122 bool setBoolProperty(const String& name,bool value);
-  
-  /*!
-   * \brief Valeur d'une propriété booléenne.
-   *
-   * \param name nom de la propriété
-   * \retval vrai si la propriété existe et a pour valeur \a true.
-   * \retval faux si la propriété est absente ou a pour valeur \a false.
-   *
-   * \deprecated Utiliser getBool().
-   */
-  ARCANE_DEPRECATED_122 bool boolProperty(const String& name); 
 
   //! Positionne une propriété de type bool de nom \a name et de valeur \a value.
   void setBool(const String& name,bool value);

--- a/arcane/src/arcane/impl/Application.cc
+++ b/arcane/src/arcane/impl/Application.cc
@@ -881,15 +881,6 @@ removeSession(ISession* session)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ServiceFactoryInfoCollection Application::
-serviceFactoryInfos()
-{
-  return m_service_and_module_factory_mng->serviceFactoryInfos();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 ServiceFactory2Collection Application::
 serviceFactories2()
 {

--- a/arcane/src/arcane/impl/Application.h
+++ b/arcane/src/arcane/impl/Application.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Application.h                                               (C) 2000-2020 */
+/* Application.h                                               (C) 2000-2022 */
 /*                                                                           */
 /* Implémentation IApplication.                                              */
 /*---------------------------------------------------------------------------*/
@@ -93,18 +93,13 @@ class ARCANE_IMPL_EXPORT Application
   String userConfigPath() const override { return m_user_config_path; }
   IMainFactory* mainFactory() const override { return m_main_factory; }
 
-  ByteConstArrayView configBytes() const override { return m_config_bytes; }
   ByteConstSpan configBuffer() const override { return asBytes(m_config_bytes.constSpan()); }
-  XmlNode configRootElement() const  override { return m_config_root_element; }
-  ByteConstArrayView userConfigBytes() const override { return m_user_config_bytes; }
   ByteConstSpan userConfigBuffer() const override { return asBytes(m_user_config_bytes.constSpan()); }
-  XmlNode userConfigRootElement() const override { return m_user_config_root_element; }
   
   SessionCollection sessions() override { return m_sessions; }
   void addSession(ISession* s) override;
   void removeSession(ISession* s) override;
 
-  ServiceFactoryInfoCollection serviceFactoryInfos() override;
   ServiceFactory2Collection serviceFactories2() override;
   ModuleFactoryInfoCollection moduleFactoryInfos() override;
 

--- a/arcane/src/arcane/impl/InternalInfosDumper.cc
+++ b/arcane/src/arcane/impl/InternalInfosDumper.cc
@@ -256,7 +256,7 @@ dumpInternalAllInfos()
   IMainFactory* main_factory = m_application->mainFactory();
   Ref<ICodeService> code_service = _getDefaultService();
 
-  ByteConstArrayView config_bytes = m_application->configBytes();
+  ByteConstSpan config_bytes = m_application->configBuffer();
   ScopedPtrT<IXmlDocumentHolder> config_doc(m_application->ioMng()->parseXmlBuffer(config_bytes,String()));
   if (!config_doc.get())
     ARCANE_FATAL("Can not parse code configuration file");
@@ -429,7 +429,7 @@ dumpArcaneDatabase()
   ISubDomain* sub_domain(session->createSubDomain(sdbi));
   ScopedPtrT<IServiceLoader> service_loader(main_factory->createServiceLoader());
 
-  ByteConstArrayView config_bytes = m_application->configBytes();
+  ByteConstSpan config_bytes = m_application->configBuffer();
   ScopedPtrT<IXmlDocumentHolder> config_doc(app->ioMng()->parseXmlBuffer(config_bytes,String()));
   if (!config_doc.get())
     ARCANE_FATAL("Can not parse code configuration file");

--- a/arcane/src/arcane/impl/ServiceLoader.cc
+++ b/arcane/src/arcane/impl/ServiceLoader.cc
@@ -5,13 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ServiceLoader.cc                                            (C) 2000-2018 */
+/* ServiceLoader.cc                                            (C) 2000-2022 */
 /*                                                                           */
 /* Chargeur des services disponibles dans le code.                           */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-#include "arcane/utils/ArcanePrecomp.h"
 
 #include "arcane/utils/Iostream.h"
 #include "arcane/utils/Collection.h"
@@ -35,7 +33,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -199,13 +198,14 @@ loadSingletonService(ISubDomain* sd,const String& name)
     return true;
   }
 
-  ServiceFactoryInfoCollection service_factory_infos(sd->application()->serviceFactoryInfos());
-  for( ServiceFactoryInfoCollection::Enumerator i(service_factory_infos); ++i; ){
-    IServiceFactoryInfo* sfi = *i;
+  ServiceFactory2Collection service_factory_infos(sd->application()->serviceFactories2());
+  for( ServiceFactory2Collection::Enumerator i(service_factory_infos); ++i; ){
+    Internal::IServiceFactory2* sf2 = *i;
+    IServiceInfo* si = sf2->serviceInfo();
+    IServiceFactoryInfo* sfi = si->factoryInfo();
     if (!do_all)
       if (!sfi->isSingleton())
         continue;
-    IServiceInfo* si = sfi->serviceInfo();
     if (si->localName()!=name)
       continue;
 
@@ -229,15 +229,16 @@ _loadServices(IApplication* application,const ServiceBuildInfoBase& sbib)
   // (ils ont la propriété isAutoload() à vrai).
   IServiceMng* service_mng = sbib.serviceParent()->serviceMng();
  
-  ServiceFactoryInfoCollection service_factory_infos(application->serviceFactoryInfos());
-  for( ServiceFactoryInfoCollection::Enumerator i(service_factory_infos); ++i; ){
-    IServiceFactoryInfo* sfi = *i;
+  ServiceFactory2Collection service_factory_infos(application->serviceFactories2());
+  for( ServiceFactory2Collection::Enumerator i(service_factory_infos); ++i; ){
+    Internal::IServiceFactory2* sf2 = *i;
+    IServiceInfo* si = sf2->serviceInfo();
+    IServiceFactoryInfo* sfi = si->factoryInfo();
     if (!sfi->isSingleton())
       continue;
     if (!sfi->isAutoload())
       continue;
 
-    IServiceInfo* si = sfi->serviceInfo();
     _createSingletonInstance(service_mng,si,sbib);
   }
 }
@@ -283,7 +284,7 @@ initializeModuleFactories(ISubDomain* sd)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/CellFamily.cc
+++ b/arcane/src/arcane/mesh/CellFamily.cc
@@ -358,34 +358,6 @@ internalRemoveItems(Int32ConstArrayView local_ids,bool keep_ghost)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-void CellFamily::
-mergeItems(Int32 local_id1,Int32 local_id2)
-{
-  ItemInternal* icell1 = m_item_internal_list->cells[local_id1];
-  ItemInternal* icell2 = m_item_internal_list->cells[local_id2];
-
-  CellMerger cm(traceMng());
-  cm.merge(icell1, icell2);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Int32 CellFamily::
-getMergedItemLID(Int32 local_id1,Int32 local_id2)
-{
-  ItemInternal* icell1 = m_item_internal_list->cells[local_id1];
-  ItemInternal* icell2 = m_item_internal_list->cells[local_id2];
-
-  CellMerger cm(traceMng());
-  ItemInternal* remaining_cell = cm.getItemInternal(icell1, icell2);
-
-  return (remaining_cell==icell1) ? local_id1 : local_id2;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 /*!
  * \brief Remplace le noeud d'index \a index de la maille \a cell avec
  * celui de localId() \a node.

--- a/arcane/src/arcane/mesh/CellFamily.h
+++ b/arcane/src/arcane/mesh/CellFamily.h
@@ -106,29 +106,6 @@ class ARCANE_MESH_EXPORT CellFamily
    */
   virtual void internalRemoveItems(Int32ConstArrayView local_ids,bool keep_ghost=false) override;
 
-  /**
-   * Fusionne deux entités en une plus grande. Par exemple, deux
-   * mailles partageant une face. L'intérêt est de conserver ainsi les
-   * uniqueIds() en parallèle.
-   *
-   * @note La maille résultante est construite en remplacement de la
-   * première maille, de numéro \a local_id1
-   *
-   * @param local_id1 numéro local de la première entité
-   * @param local_id2 numéro local de la seconde entité
-   */
-  void mergeItems(Int32 local_id1,Int32 local_id2) override;
-
-  /**
-   * Détermine quel sera le localId de la maille apres fusion.
-   *
-   * @param local_id1 numéro local de la première entité
-   * @param local_id2 numéro local de la seconde entité
-   *
-   * @return le local id de la maille fusionnée
-   */
-  Int32 getMergedItemLID(Int32 local_id1,Int32 local_id2) override;
-
   //! Définit la connectivité active pour le maillage associé
   /*! Ceci conditionne les connectivités à la charge de cette famille */
   void setConnectivity(const Integer c);

--- a/arcane/src/arcane/mesh/DoFFamily.cc
+++ b/arcane/src/arcane/mesh/DoFFamily.cc
@@ -60,7 +60,7 @@ DoFFamily::
 addDoFs(Int64ConstArrayView dof_uids, Int32ArrayView dof_lids)
 {
   ARCANE_ASSERT((dof_uids.size() == dof_lids.size()),("in addDofs(uids,lids) given uids and lids array must have same size"))
-  addItems(dof_uids,dof_lids);
+  _addItems(dof_uids,dof_lids);
   return view(dof_lids);
 }
 
@@ -79,9 +79,8 @@ addGhostDoFs(Int64ConstArrayView dof_uids, Int32ArrayView dof_lids, Int32ConstAr
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void
-DoFFamily::
-addItems(Int64ConstArrayView unique_ids, Int32ArrayView items)
+void DoFFamily::
+_addItems(Int64ConstArrayView unique_ids, Int32ArrayView items)
 {
   Integer nb_item = unique_ids.size();
    if (nb_item==0)

--- a/arcane/src/arcane/mesh/DoFFamily.h
+++ b/arcane/src/arcane/mesh/DoFFamily.h
@@ -138,9 +138,9 @@ public:
 private:
 
   void build() override; //! Construction de l'item Family. C'est le DoFManager qui en a la responsabilite.
-  void addItems(Int64ConstArrayView unique_ids, Int32ArrayView items) override;
+  void _addItems(Int64ConstArrayView unique_ids, Int32ArrayView items);
   void addGhostItems(Int64ConstArrayView unique_ids, Int32ArrayView items, Int32ConstArrayView owners) override;
-  void removeItems(Int32ConstArrayView local_ids,bool keep_ghost =false) override {internalRemoveItems(local_ids,keep_ghost);};
+  void _removeItems(Int32ConstArrayView local_ids,bool keep_ghost =false) {internalRemoveItems(local_ids,keep_ghost);};
   void internalRemoveItems(Int32ConstArrayView local_ids,bool keep_ghost=false) override;
 //  void compactItems(bool do_sort) {m_need_prepare_dump = false;} //! Surcharge ItemFamily::compactItems car pas de compactage pour l'instant dans les DoFs.
 

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -1029,7 +1029,7 @@ removeCells(Int32ConstArrayView cells_local_id,bool update_graph)
   if (m_use_mesh_item_family_dependencies)
     removeItems(m_cell_family,cells_local_id);
   else
-    m_cell_family->removeItems(cells_local_id);  
+    m_cell_family->internalRemoveItems(cells_local_id);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1522,74 +1522,10 @@ _compactFromParentFamily(const ItemFamilyCompactInfos& compact_infos)
 /*---------------------------------------------------------------------------*/
 
 void ItemFamily::
-addItems(Int64ConstArrayView unique_ids,Int32ArrayView items)
-{
-  ARCANE_UNUSED(unique_ids);
-  ARCANE_UNUSED(items);
-  ARCANE_THROW(NotSupportedException,"this kind of family doesn't support this operation");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
-addItems(Int64ConstArrayView unique_ids,ArrayView<Item> items)
-{
-  ARCANE_UNUSED(unique_ids);
-  ARCANE_UNUSED(items);
-  ARCANE_THROW(NotSupportedException,"this kind of family doesn't support this operation");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
-addItems(Int64ConstArrayView unique_ids,ItemGroup items)
-{
-  ARCANE_UNUSED(unique_ids);
-  ARCANE_UNUSED(items);
-  ARCANE_THROW(NotSupportedException,"this kind of family doesn't support this operation");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
 internalRemoveItems(Int32ConstArrayView local_ids,bool keep_ghost)
 {
   ARCANE_UNUSED(local_ids);
   ARCANE_UNUSED(keep_ghost);
-  ARCANE_THROW(NotSupportedException,"this kind of family doesn't support this operation");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
-exchangeItems()
-{
-  ARCANE_THROW(NotSupportedException,"this kind of family doesn't support this operation");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ItemFamily::
-mergeItems(Int32 local_id1, Int32 local_id2)
-{
-  ARCANE_UNUSED(local_id1);
-  ARCANE_UNUSED(local_id2);
-  ARCANE_THROW(NotSupportedException,"this kind of family doesn't support this operation");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Int32 ItemFamily::
-getMergedItemLID(Int32 local_id1, Int32 local_id2)
-{
-  ARCANE_UNUSED(local_id1);
-  ARCANE_UNUSED(local_id2);
   ARCANE_THROW(NotSupportedException,"this kind of family doesn't support this operation");
 }
 

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -126,7 +126,6 @@ class ARCANE_MESH_EXPORT ItemFamily
   const String& fullName() const override { return m_full_name; }
   eItemKind itemKind() const override { return m_infos.kind(); }
   Integer nbItem() const override;
-  Int32 variableMaxSize() const override { return maxLocalId(); }
   Int32 maxLocalId() const override;
   ItemInternalList itemsInternal() override;
   VariableItemInt32& itemsNewOwner() override;
@@ -175,22 +174,12 @@ class ARCANE_MESH_EXPORT ItemFamily
 
  public:
 
-  void addItems(Int64ConstArrayView unique_ids,Int32ArrayView items) override;
-  void addItems(Int64ConstArrayView unique_ids,ArrayView<Item> items) override;
-  void addItems(Int64ConstArrayView unique_ids,ItemGroup item_group) override;
-  void removeItems(Int32ConstArrayView local_ids,bool keep_ghost =false) override
-  {
-    internalRemoveItems(local_ids,keep_ghost);
-  }
   void internalRemoveItems(Int32ConstArrayView local_ids,bool keep_ghost =false) override;
   void removeItems2(ItemDataList& item_data_list) override; // Remove items based on family dependencies (ItemFamilyNetwork)
   void removeNeedRemoveMarkedItems() override;
-  void exchangeItems() override;
+
   ItemVectorView view(Int32ConstArrayView local_ids) override;
   ItemVectorView view() override;
-
-  void mergeItems(Int32 local_id1,Int32 local_id2) override;
-  Int32 getMergedItemLID(Int32 local_id1,Int32 local_id2) override;
 
   ItemInternal* findOneItem(Int64 uid) override { return m_infos.findOne(uid) ; }
 

--- a/arcane/src/arcane/mesh/ParticleFamily.cc
+++ b/arcane/src/arcane/mesh/ParticleFamily.cc
@@ -144,7 +144,7 @@ _findOrAllocParticle(Int64 uid,bool& is_alloc)
 ParticleVectorView ParticleFamily::
 addParticles(Int64ConstArrayView unique_ids,Int32ArrayView items)
 {
-  addItems(unique_ids,items);
+  _addItems(unique_ids,items);
   return view(items);
 }
 
@@ -177,7 +177,7 @@ addParticles(Int64ConstArrayView unique_ids,
              Int32ConstArrayView cells_local_id,
              Int32ArrayView items)
 {
-  addItems(unique_ids,items);
+  _addItems(unique_ids,items);
   Integer n = items.size();
   for( Integer i=0; i<n; ++i ){
     _setCell(ItemLocalId(items[i]),ItemLocalId(cells_local_id[i]));
@@ -213,7 +213,7 @@ setParticlesCell(ParticleVectorView particles,CellVectorView new_cells)
 /*---------------------------------------------------------------------------*/
 
 void ParticleFamily::
-addItems(Int64ConstArrayView unique_ids,Int32ArrayView items)
+_addItems(Int64ConstArrayView unique_ids,Int32ArrayView items)
 {
   Integer nb_item = unique_ids.size();
   if (nb_item==0)
@@ -263,64 +263,6 @@ addItems(Int64ConstArrayView unique_ids,Int32ConstArrayView owners,Int32ArrayVie
 /*---------------------------------------------------------------------------*/
 
 void ParticleFamily::
-addItems(Int64ConstArrayView unique_ids,ArrayView<Item> items)
-{
-  Integer nb_item = unique_ids.size();
-  if (nb_item==0)
-    return;
-  preAllocate(nb_item);
-  bool need_alloc = false;
-  for( Integer i=0; i<nb_item; ++i ){
-    Int64 uid = unique_ids[i];
-    ItemInternal* ii = _allocParticle(uid,need_alloc);
-    items[i] = ii;
-  }
-
-  m_need_prepare_dump = true;
-  _printInfos(nb_item);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \deprecated Utiliser autres surcharges de addItems().
- */
-void ParticleFamily::
-addItems(Int64ConstArrayView unique_ids,ItemGroup item_group)
-{
-  Integer nb_item = unique_ids.size();
-  if (nb_item==0){
-    if (!item_group.null())
-      item_group.clear();
-    return;
-  }
-  preAllocate(nb_item);
-  bool need_alloc = false;
-  if (item_group.null()){
-    for( Integer i=0; i<nb_item; ++i ){
-      Int64 uid = unique_ids[i];
-      _allocParticle(uid,need_alloc);
-    }
-  }
-  else{
-    if (item_group.itemKind()!=itemKind())
-      throw FatalErrorException(A_FUNCINFO,"bad group type");
-    Int32UniqueArray items(nb_item);
-    for( Integer i=0; i<nb_item; ++i ){
-      Int64 uid = unique_ids[i];
-      ItemInternal* ii = _allocParticle(uid,need_alloc);
-      items[i] = ii->localId();
-    }
-    item_group.setItems(items);
-  }
-  m_need_prepare_dump = true;
-  _printInfos(nb_item);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ParticleFamily::
 exchangeParticles()
 {
   ItemsExchangeInfo2 ex(this);
@@ -334,15 +276,6 @@ exchangeParticles()
   endUpdate();
   ex.readGroups();
   ex.readVariables();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ParticleFamily::
-exchangeItems()
-{
-  exchangeParticles();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ParticleFamily.h
+++ b/arcane/src/arcane/mesh/ParticleFamily.h
@@ -82,15 +82,10 @@ class ARCANE_MESH_EXPORT ParticleFamily
                                           Int32ArrayView items_local_id) override;
   virtual void removeParticles(Int32ConstArrayView items_local_id) override;
 
-  virtual void addItems(Int64ConstArrayView unique_ids,Int32ArrayView items) override;
-  virtual void addItems(Int64ConstArrayView unique_ids,Int32ConstArrayView owners,Int32ArrayView items);
+  void addItems(Int64ConstArrayView unique_ids,Int32ConstArrayView owners,Int32ArrayView items);
 
-  virtual void addItems(Int64ConstArrayView unique_ids,ArrayView<Item> items) override;
-  virtual void addItems(Int64ConstArrayView unique_ids,ItemGroup item_group) override;
   virtual void internalRemoveItems(Int32ConstArrayView local_ids,bool keep_ghost) override;
   virtual void exchangeParticles() override;
-  virtual void exchangeItems() override;
-
 
   virtual void setParticleCell(Particle particle,Cell new_cell) override;
   virtual void setParticlesCell(ParticleVectorView particles,CellVectorView new_cells) override;
@@ -142,6 +137,7 @@ class ARCANE_MESH_EXPORT ParticleFamily
   void _setSharedInfo();
   inline void _setCell(ItemLocalId particle,ItemLocalId cell);
   inline void _initializeNewlyAllocatedParticle(ItemInternal* particle,Int64 uid);
+  void _addItems(Int64ConstArrayView unique_ids,Int32ArrayView items);
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Remove deprecated (for more than 3 years) methods from classes `ItemVector`, `IApplication`, `Properties`, `IItemFamily` and functions from namespace `Arcane::math`.
