### PR TITLE
Cleanup class ItemInternalVectorView

### DIFF
--- a/arcane/src/arcane/Item.h
+++ b/arcane/src/arcane/Item.h
@@ -494,7 +494,7 @@ class ARCANE_CORE_EXPORT Node
   // AMR
 
   //! Enumére les mailles connectées au noeud
-  ItemVectorView activeCells(Int32Array& local_ids) const
+  CellVectorView activeCells(Int32Array& local_ids) const
   {
     return ItemBase::activeCells(local_ids);
   }

--- a/arcane/src/arcane/ItemInternal.cc
+++ b/arcane/src/arcane/ItemInternal.cc
@@ -172,7 +172,7 @@ activeCells(Int32Array& local_ids) const
       local_ids.add(local_id);
     }
   }
-  return ItemInternalVectorView(m_shared_info->m_items->m_cell_shared_info,m_shared_info->m_items->cells,local_ids);
+  return ItemInternalVectorView(m_shared_info->m_items->m_cell_shared_info,local_ids);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -196,7 +196,7 @@ activeFaces(Int32Array& local_ids) const
         local_ids.add(face.localId());
     }
   }
-  return ItemInternalVectorView(m_shared_info->m_items->m_face_shared_info,m_shared_info->m_items->faces,local_ids);
+  return ItemInternalVectorView(m_shared_info->m_items->m_face_shared_info,local_ids);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -262,12 +262,9 @@ _isValid()
   if (!m_shared_info)
     ARCANE_FATAL("Null ItemSharedInfo");
   if (!m_local_ids.empty()){
-    auto* items_data = m_items.data();
+    auto* items_data = items().data();
     if (!items_data)
       ARCANE_FATAL("Null ItemsInternal list");
-    auto* shared_info_items_data = m_shared_info->m_items_internal.data();
-    if (shared_info_items_data!=items_data)
-      ARCANE_FATAL("Incoherent ItemInternal list from_shared_info={0} from_internal={1}",shared_info_items_data,items_data);
   }
   return true;
 }

--- a/arcane/src/arcane/ItemInternal.cc
+++ b/arcane/src/arcane/ItemInternal.cc
@@ -164,15 +164,15 @@ whichChildAmI(const ItemInternal *iitem) const
 ItemInternalVectorView impl::ItemBase::
 activeCells(Int32Array& local_ids) const
 {
-	const Integer nbcell = this->nbCell();
-	for(Integer icell = 0 ; icell < nbcell ; ++icell) {
+  const Integer nbcell = this->nbCell();
+  for(Integer icell = 0 ; icell < nbcell ; ++icell) {
     ItemBase cell = this->cellBase(icell);
     if (cell.isActive()){
       const Int32 local_id = cell.localId();
       local_ids.add(local_id);
     }
-	}
-	return ItemInternalVectorView(m_shared_info,m_shared_info->m_items->cells,local_ids);
+  }
+  return ItemInternalVectorView(m_shared_info->m_items->m_cell_shared_info,m_shared_info->m_items->cells,local_ids);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -181,22 +181,22 @@ activeCells(Int32Array& local_ids) const
 ItemInternalVectorView impl::ItemBase::
 activeFaces(Int32Array& local_ids) const
 {
-	const Integer nbface = this->nbFace();
-	for(Integer iface = 0 ; iface < nbface ; ++iface) {
-		ItemBase face = this->faceBase(iface);
-		if (!face.isBoundary()){
-			ItemBase bcell = face.backCell();
+  const Integer nbface = this->nbFace();
+  for(Integer iface = 0 ; iface < nbface ; ++iface) {
+    ItemBase face = this->faceBase(iface);
+    if (!face.isBoundary()){
+      ItemBase bcell = face.backCell();
       ItemBase fcell = face.frontCell();
-			if ( (!bcell.null() && bcell.isActive()) && (!fcell.null() && fcell.isActive()) )
-				local_ids.add(face.localId());
-		}
-		else {
-			ItemBase bcell = face.boundaryCell();
-			if ( (!bcell.null() && bcell.isActive()) )
-				local_ids.add(face.localId());
-		}
-	}
-	return ItemInternalVectorView(m_shared_info,m_shared_info->m_items->faces,local_ids);
+      if ( (!bcell.null() && bcell.isActive()) && (!fcell.null() && fcell.isActive()) )
+        local_ids.add(face.localId());
+    }
+    else{
+      ItemBase bcell = face.boundaryCell();
+      if ( (!bcell.null() && bcell.isActive()) )
+        local_ids.add(face.localId());
+    }
+  }
+  return ItemInternalVectorView(m_shared_info->m_items->m_face_shared_info,m_shared_info->m_items->faces,local_ids);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -248,6 +248,28 @@ void ItemInternal::
 setDataIndex(Integer)
 {
   ARCANE_FATAL("This method is no longer valid");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool ItemInternalVectorView::
+_isValid()
+{
+  if (!m_shared_info)
+    ARCANE_FATAL("Null ItemSharedInfo");
+  if (!m_local_ids.empty()){
+    auto* items_data = m_items.data();
+    if (!items_data)
+      ARCANE_FATAL("Null ItemsInternal list");
+    auto* shared_info_items_data = m_shared_info->m_items_internal.data();
+    if (shared_info_items_data!=items_data)
+      ARCANE_FATAL("Incoherent ItemInternal list from_shared_info={0} from_internal={1}",shared_info_items_data,items_data);
+  }
+  return true;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemInternal.h
+++ b/arcane/src/arcane/ItemInternal.h
@@ -23,6 +23,7 @@
 #include "arcane/ItemLocalId.h"
 #include "arcane/ItemTypeId.h"
 #include "arcane/ItemConnectivityContainerView.h"
+#include "arcane/ItemInternalVectorView.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemInternal.h
+++ b/arcane/src/arcane/ItemInternal.h
@@ -312,13 +312,13 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
   { return ItemBaseBuildInfo(_hChildLocalIdV2(lid,aindex),m_items->m_cell_shared_info); }
 
   ItemInternalVectorView nodesV2(Int32 lid) const
-  { return ItemInternalVectorView(m_items->m_node_shared_info,m_items->nodes,_nodeLocalIdsV2(lid),_nbNodeV2(lid)); }
+  { return ItemInternalVectorView(m_items->m_node_shared_info,_nodeLocalIdsV2(lid),_nbNodeV2(lid)); }
   ItemInternalVectorView edgesV2(Int32 lid) const
-  { return ItemInternalVectorView(m_items->m_edge_shared_info,m_items->edges,_edgeLocalIdsV2(lid),_nbEdgeV2(lid)); }
+  { return ItemInternalVectorView(m_items->m_edge_shared_info,_edgeLocalIdsV2(lid),_nbEdgeV2(lid)); }
   ItemInternalVectorView facesV2(Int32 lid) const
-  { return ItemInternalVectorView(m_items->m_face_shared_info,m_items->faces,_faceLocalIdsV2(lid),_nbFaceV2(lid)); }
+  { return ItemInternalVectorView(m_items->m_face_shared_info,_faceLocalIdsV2(lid),_nbFaceV2(lid)); }
   ItemInternalVectorView cellsV2(Int32 lid) const
-  { return ItemInternalVectorView(m_items->m_cell_shared_info,m_items->cells,_cellLocalIdsV2(lid),_nbCellV2(lid)); }
+  { return ItemInternalVectorView(m_items->m_cell_shared_info,_cellLocalIdsV2(lid),_nbCellV2(lid)); }
 
   Int32ConstArrayView nodeLocalIdsV2(Int32 lid) const
   { return Int32ConstArrayView(_nbNodeV2(lid),_nodeLocalIdsV2(lid)); }

--- a/arcane/src/arcane/ItemInternalVectorView.h
+++ b/arcane/src/arcane/ItemInternalVectorView.h
@@ -16,6 +16,7 @@
 
 #include "arcane/utils/ArrayView.h"
 #include "arcane/ItemTypes.h"
+#include "arcane/ItemSharedInfo.h"
 
 #include <iterator>
 
@@ -111,7 +112,7 @@ class ItemInternalVectorViewConstIterator
  * \brief Vue sur un tableau indexé d'entités.
  * \see ItemVectorView
  */
-class ItemInternalVectorView
+class ARCANE_CORE_EXPORT ItemInternalVectorView
 {
  public:
 
@@ -127,27 +128,30 @@ class ItemInternalVectorView
  private:
 
   ItemInternalVectorView(ItemSharedInfo* si,ItemInternalArrayView aitems,Int32ConstArrayView local_ids)
-  : m_items(aitems), m_local_ids(local_ids), m_shared_info(si) { }
+  : m_items(aitems), m_local_ids(local_ids), m_shared_info(si)
+  {
+    ARCANE_ASSERT(_isValid(),("Bad ItemInternalVectorView"));
+  }
 
   ItemInternalVectorView(ItemSharedInfo* si,ItemInternalArrayView aitems,const Int32* local_ids,Integer count)
-  : m_items(aitems), m_local_ids(count,local_ids), m_shared_info(si) { }
+  : m_items(aitems), m_local_ids(count,local_ids), m_shared_info(si)
+  {
+    ARCANE_ASSERT(_isValid(),("Bad ItemInternalVectorView"));
+  }
 
  public:
 
   //! Accède au \a i-ème élément du vecteur
-  inline ItemInternal* operator[](Integer index) const
-  {
-    return m_items[ m_local_ids[index] ];
-  }
+  ItemInternal* operator[](Integer index) const { return m_items[ m_local_ids[index] ]; }
 
   //! Nombre d'éléments du vecteur
-  inline Integer size() const { return m_local_ids.size(); }
+  Integer size() const { return m_local_ids.size(); }
 
   //! Tableau des entités
-  inline ItemInternalArrayView items() const { return m_items; }
+  ItemInternalArrayView items() const { return m_items; }
 
   //! Tableau des numéros locaux des entités
-  inline Int32ConstArrayView localIds() const { return m_local_ids; }
+  Int32ConstArrayView localIds() const { return m_local_ids; }
 
  public:
 
@@ -165,7 +169,11 @@ class ItemInternalVectorView
 
   ItemInternalArrayView m_items;
   Int32ConstArrayView m_local_ids;
-  ItemSharedInfo* m_shared_info = nullptr;
+  ItemSharedInfo* m_shared_info = ItemSharedInfo::nullInstance();
+
+ private:
+
+  bool _isValid();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemSharedInfo.cc
+++ b/arcane/src/arcane/ItemSharedInfo.cc
@@ -246,6 +246,39 @@ typeId() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+ItemInternalVectorView ItemSharedInfo::
+nodes(Int32) const
+{
+  return ItemInternalVectorView();
+}
+
+ItemInternalVectorView ItemSharedInfo::
+edges(Int32) const
+{
+  return ItemInternalVectorView();
+}
+
+ItemInternalVectorView ItemSharedInfo::
+faces(Int32) const
+{
+  return ItemInternalVectorView();
+}
+
+ItemInternalVectorView ItemSharedInfo::
+cells(Int32) const
+{
+  return ItemInternalVectorView();
+}
+
+ItemInternalVectorView ItemSharedInfo::
+hChildren(Int32) const
+{
+  return ItemInternalVectorView();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -17,7 +17,6 @@
 #include "arcane/ArcaneTypes.h"
 #include "arcane/ItemTypes.h"
 #include "arcane/ItemTypeInfo.h"
-#include "arcane/ItemInternalVectorView.h"
 #include "arcane/MeshItemInternalList.h"
 
 /*---------------------------------------------------------------------------*/
@@ -37,6 +36,7 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 class ItemInternal;
+class ItemInternalVectorView;
 class ItemInternalConnectivityList;
 
 /*---------------------------------------------------------------------------*/
@@ -59,6 +59,7 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   friend class mesh::ItemFamily;
   friend class mesh::DynamicMeshKindInfos;
   friend class mesh::ItemSharedInfoWithType;
+  friend class ItemInternalVectorView;
 
  public:
 
@@ -140,19 +141,19 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
  public:
 
   ARCANE_DEPRECATED_REASON("Y2022: This list is always empty")
-  ItemInternalVectorView nodes(Int32) const { return ItemInternalVectorView(); }
+  ItemInternalVectorView nodes(Int32) const;
 
   ARCANE_DEPRECATED_REASON("Y2020: This list is always empty")
-  ItemInternalVectorView edges(Int32) const { return ItemInternalVectorView(); }
+  ItemInternalVectorView edges(Int32) const;
 
   ARCANE_DEPRECATED_REASON("Y2020: This list is always empty")
-  ItemInternalVectorView faces(Int32) const { return ItemInternalVectorView(); }
+  ItemInternalVectorView faces(Int32) const;
 
   ARCANE_DEPRECATED_REASON("Y2020: This list is always empty")
-  ItemInternalVectorView cells(Int32) const { return ItemInternalVectorView(); }
+  ItemInternalVectorView cells(Int32) const;
 
   ARCANE_DEPRECATED_REASON("Y2020: This list is always empty")
-  ItemInternalVectorView hChildren(Int32) const { return ItemInternalVectorView(); }
+  ItemInternalVectorView hChildren(Int32) const;
 
  public:
 

--- a/arcane/src/arcane/ItemVectorView.h
+++ b/arcane/src/arcane/ItemVectorView.h
@@ -191,7 +191,7 @@ class ARCANE_CORE_EXPORT ItemVectorView
 
   operator ItemInternalVectorView() const
   {
-    return ItemInternalVectorView(m_shared_info,m_items,m_local_ids);
+    return ItemInternalVectorView(m_shared_info,m_local_ids);
   }
 
   //! Accède au \a i-ème élément du vecteur

--- a/arcane/src/arcane/ItemVectorView.h
+++ b/arcane/src/arcane/ItemVectorView.h
@@ -233,7 +233,7 @@ class ARCANE_CORE_EXPORT ItemVectorView
   
   ItemInternalArrayView m_items;
   ItemIndexArrayView m_local_ids;
-  ItemSharedInfo* m_shared_info = nullptr;
+  ItemSharedInfo* m_shared_info = ItemSharedInfo::nullInstance();
 
  private:
 

--- a/arcane/src/arcane/MeshItemInternalList.h
+++ b/arcane/src/arcane/MeshItemInternalList.h
@@ -39,6 +39,7 @@ class MeshItemInternalList
 {
   friend class mesh::DynamicMesh;
   friend class ItemInternalConnectivityList;
+  friend class impl::ItemBase;
 
  public:
 


### PR DESCRIPTION
Remove usage of `ItemInternalArrayView` in class `ItemInternalVectorView` and use an instance de `ItemSharedInfo*` instead.