### PR TITLE
Use a class to specify rank of NumArray and associated classes

### DIFF
--- a/arcane/doc/accelerator.md
+++ b/arcane/doc/accelerator.md
@@ -209,7 +209,9 @@ associée est terminée ou le conteneur associé est modifié.
 %Arcane propose des vues sur les variables (Arcane::IVariable) ou sur la classe Arcane::NumArray.
 
 Quel que soit le conteneur associé, la déclaration des vues est la
-même:
+même. Les constantes Arcane::MDDim1, Arcane::MDDim2, Arcane::MDDim3 et
+Arcane::MDDim4 permettent de spécifier le rang (la dimension) du
+tableau Arcane::NumArray (A partir de la version 3.7.7 de %Arcane).
 
 ~~~{.cpp}
 #include "arcane/utils/NumArray.h"
@@ -220,9 +222,9 @@ même:
 using namespace Arcane;
 using namespace Arcane::Accelerator;
 RunCommand& command = ...;
-Arcane::NumArray<Real,1> a;
-Arcane::NumArray<Real,1> b;
-Arcane::NumArray<Real,1> c;
+Arcane::NumArray<Real,MDDim1> a;
+Arcane::NumArray<Real,MDDim1> b;
+Arcane::NumArray<Real,MDDim1> c;
 VariableCellReal var_c = ...;
 auto in_a = viewIn(command,a); // Vue en entrée
 auto inout_b = viewInOut(command,b); // Vue en entrée/sortie
@@ -283,8 +285,8 @@ Arcane::Accelerator::RunQueue sont asynchrones. Par exemple:
 using namespace Arcane::Accelerator;
 RunQueue& queue = ...;
 queue.setAsync(true);
-Arcane::NumArray<Real,1> a;
-Arcane::NumArray<Real,1> b;
+Arcane::NumArray<Real,MDDim1> a;
+Arcane::NumArray<Real,MDDim1> b;
 
 RunCommand& command = makeCommand(queue);
 auto in_a = viewIn(command,a);
@@ -347,7 +349,7 @@ public:
 void A::f1()
 {
   Arcane::Accelerator::RunCommand& command = ...
-  Arcane::NumArray<int,1> a(100);
+  Arcane::NumArray<int,MDDim1> a(100);
   auto out_a = viewIn(command,a);
   command << RUNCOMMAND_LOOP1(iter,100){
     out_a(iter) = my_value+5; // BAD !!
@@ -356,7 +358,7 @@ void A::f1()
 void A::f2()
 {
   Arcane::Accelerator::RunCommand& command = ...
-  Arcane::NumArray<int,1> a(100);
+  Arcane::NumArray<int,MDDim1> a(100);
   auto out_a = viewIn(command,a);
   int v = my_value;
   command << RUNCOMMAND_LOOP1(iter,100){
@@ -389,8 +391,8 @@ main(int argc,char* argv[])
 
 
     // Définit 2 tableaux 'a' et 'b' et effectue leur initialisation.
-    NumArray<Int64,1> a(nb_value);
-    NumArray<Int64,1> b(nb_value);
+    NumArray<Int64,MDDim1> a(nb_value);
+    NumArray<Int64,MDDim1> b(nb_value);
     for( int i=0; i<nb_value; ++i ){
       a.s(i) = i+2;
       b.s(i) = i+3;

--- a/arcane/src/arcane/accelerator/NumArrayViews.h
+++ b/arcane/src/arcane/accelerator/NumArrayViews.h
@@ -34,9 +34,9 @@ namespace Arcane::Accelerator
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename DataType,int N,typename LayoutType>
+template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType>
 class NumArrayViewSetter;
-template<typename Accessor,int N,typename LayoutType>
+template<typename Accessor,A_MDRANK_TYPE(N),typename LayoutType>
 class NumArrayView;
 
 /*---------------------------------------------------------------------------*/
@@ -61,13 +61,13 @@ class NumArrayViewBase
  * \brief Vue en lecture, écriture ou lecture/écriture sur un 'NumArray' 1D.
  */
 template<typename Accessor,typename LayoutType>
-class NumArrayView<Accessor,1,LayoutType>
+class NumArrayView<Accessor,MDDim1,LayoutType>
 : public NumArrayViewBase
 {
  public:
 
   using DataType = typename Accessor::ValueType;
-  using SpanType = MDSpan<DataType,1,LayoutType>;
+  using SpanType = MDSpan<DataType,MDDim1,LayoutType>;
   using AccessorReturnType = typename Accessor::AccessorReturnType;
 
  public:
@@ -107,13 +107,13 @@ class NumArrayView<Accessor,1,LayoutType>
  * \brief Vue en lecture, écriture ou lecture/écriture sur un 'NumArray' 2D.
  */
 template<typename Accessor,typename LayoutType>
-class NumArrayView<Accessor,2,LayoutType>
+class NumArrayView<Accessor,MDDim2,LayoutType>
 : public NumArrayViewBase
 {
  public:
 
   using DataType = typename Accessor::ValueType;
-  using SpanType = MDSpan<DataType,2,LayoutType>;
+  using SpanType = MDSpan<DataType,MDDim2,LayoutType>;
   using AccessorReturnType = typename Accessor::AccessorReturnType;
 
  public:
@@ -145,13 +145,13 @@ class NumArrayView<Accessor,2,LayoutType>
  * \brief Vue en lecture, écriture ou lecture/écriture sur un 'NumArray' 3D.
  */
 template<typename Accessor,typename LayoutType>
-class NumArrayView<Accessor,3,LayoutType>
+class NumArrayView<Accessor,MDDim3,LayoutType>
 : public NumArrayViewBase
 {
  public:
 
   using DataType = typename Accessor::ValueType;
-  using SpanType = MDSpan<DataType,3,LayoutType>;
+  using SpanType = MDSpan<DataType,MDDim3,LayoutType>;
   using AccessorReturnType = typename Accessor::AccessorReturnType;
 
  public:
@@ -183,13 +183,13 @@ class NumArrayView<Accessor,3,LayoutType>
  * \brief Vue en lecture, écriture ou lecture/écriture sur un 'NumArray' 4D.
  */
 template<typename Accessor,typename LayoutType>
-class NumArrayView<Accessor,4,LayoutType>
+class NumArrayView<Accessor,MDDim4,LayoutType>
 : public NumArrayViewBase
 {
  public:
 
   using DataType = typename Accessor::ValueType;
-  using SpanType = MDSpan<DataType,4,LayoutType>;
+  using SpanType = MDSpan<DataType,MDDim4,LayoutType>;
   using AccessorReturnType = typename Accessor::AccessorReturnType;
 
  public:
@@ -220,7 +220,7 @@ class NumArrayView<Accessor,4,LayoutType>
 /*!
  * \brief Vue en écriture.
  */
-template<typename DataType,int N,typename LayoutType> auto
+template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType> auto
 viewOut(RunCommand& command,NumArray<DataType,N,LayoutType>& var)
 {
   using Accessor = DataViewSetter<DataType>;
@@ -233,7 +233,7 @@ viewOut(RunCommand& command,NumArray<DataType,N,LayoutType>& var)
 /*!
  * \brief Vue en lecture/écriture.
  */
-template<typename DataType,int N,typename LayoutType> auto
+template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType> auto
 viewInOut(RunCommand& command,NumArray<DataType,N,LayoutType>& v)
 {
   using Accessor = DataViewGetterSetter<DataType>;
@@ -245,7 +245,7 @@ viewInOut(RunCommand& command,NumArray<DataType,N,LayoutType>& v)
 /*!
  * \brief Vue en lecture.
  */
-template<typename DataType,int N,typename LayoutType> auto
+template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType> auto
 viewIn(RunCommand& command,const NumArray<DataType,N,LayoutType>& v)
 {
   using Accessor = DataViewGetter<DataType>;

--- a/arcane/src/arcane/accelerator/RunCommandLoop.h
+++ b/arcane/src/arcane/accelerator/RunCommandLoop.h
@@ -93,7 +93,7 @@ _applyGenericLoop(RunCommand& command,LoopBoundType<N> bounds,const Lambda& func
 
 //! Applique la lambda \a func sur l'intervalle d'itération donnée par \a bounds
 template<int N,typename Lambda> void
-run(RunCommand& command,ArrayBounds<N> bounds,const Lambda& func)
+run(RunCommand& command,ArrayBounds<A_MDDIM(N)> bounds,const Lambda& func)
 {
   impl::_applyGenericLoop(command,SimpleLoopRanges(bounds),func);
 }
@@ -134,7 +134,7 @@ class ArrayBoundRunCommand
 };
 
 template<int N> ArrayBoundRunCommand<N,SimpleLoopRanges<N>>
-operator<<(RunCommand& command,const ArrayBounds<N>& bounds)
+operator<<(RunCommand& command,const ArrayBounds<A_MDDIM(N)>& bounds)
 {
   return {command,bounds};
 }
@@ -171,23 +171,23 @@ void operator<<(ArrayBoundRunCommand<N,LoopBoundType<N>>&& nr,const Lambda& f)
 
 //! Boucle sur accélérateur
 #define RUNCOMMAND_LOOPN(iter_name, N, ...)                           \
-  A_FUNCINFO << ArrayBounds<N>(__VA_ARGS__) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<N> iter_name )
+  A_FUNCINFO << ArrayBounds<A_MDDIM(N)>(__VA_ARGS__) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<N> iter_name )
 
 //! Boucle sur accélérateur
 #define RUNCOMMAND_LOOP1(iter_name, x1)                             \
-  A_FUNCINFO << ArrayBounds<1>(x1) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<1> iter_name )
+  A_FUNCINFO << ArrayBounds<MDDim1>(x1) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<1> iter_name )
 
 //! Boucle sur accélérateur
 #define RUNCOMMAND_LOOP2(iter_name, x1, x2)                             \
-  A_FUNCINFO << ArrayBounds<2>(x1,x2) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<2> iter_name )
+  A_FUNCINFO << ArrayBounds<MDDim2>(x1,x2) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<2> iter_name )
 
 //! Boucle sur accélérateur
 #define RUNCOMMAND_LOOP3(iter_name, x1, x2, x3) \
-  A_FUNCINFO << ArrayBounds<3>(x1,x2,x3) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<3> iter_name )
+  A_FUNCINFO << ArrayBounds<MDDim3>(x1,x2,x3) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<3> iter_name )
 
 //! Boucle sur accélérateur
 #define RUNCOMMAND_LOOP4(iter_name, x1, x2, x3, x4)                        \
-  A_FUNCINFO << ArrayBounds<4>(x1,x2,x3,x4) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<4> iter_name )
+  A_FUNCINFO << ArrayBounds<MDDim4>(x1,x2,x3,x4) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<4> iter_name )
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/cuda/runtime/Test.cu
+++ b/arcane/src/arcane/accelerator/cuda/runtime/Test.cu
@@ -77,7 +77,7 @@ __global__ void MyVecAdd2(Span<const double> a,Span<const double>b,Span<double> 
   }
 }
 
-__global__ void MyVecAdd3(MDSpan<const double,1> a,MDSpan<const double,1> b,MDSpan<double,1> out)
+__global__ void MyVecAdd3(MDSpan<const double,MDDim1> a,MDSpan<const double,MDDim1> b,MDSpan<double,MDDim1> out)
 {
   int size = a.dim1Size();
   int i = blockDim.x * blockIdx.x + threadIdx.x;
@@ -99,7 +99,7 @@ void _initArrays(Span<double> a,Span<double> b,Span<double> c,int base)
   }
 }
 
-void _initArrays(MDSpan<double,1> a,MDSpan<double,1> b,MDSpan<double,1> c,int base)
+void _initArrays(MDSpan<double,MDDim1> a,MDSpan<double,MDDim1> b,MDSpan<double,MDDim1> c,int base)
 {
   Int64 vsize = a.dim1Size();
   for( Int64 i = 0; i<vsize; ++i ){
@@ -352,10 +352,10 @@ int arcaneTestCudaNumArray()
   IMemoryAllocator* cuda_allocator2 = Arcane::platform::getAcceleratorHostMemoryAllocator();
   if (!cuda_allocator2)
     ARCANE_FATAL("platform::getAcceleratorHostMemoryAllocator() is null");
-  NumArray<double,1> d_a;
+  NumArray<double,MDDim1> d_a;
   MyTestFunc1();
-  NumArray<double,1> d_b;
-  NumArray<double,1> d_out;
+  NumArray<double,MDDim1> d_b;
+  NumArray<double,MDDim1> d_out;
   d_a.resize(vsize);
   d_b.resize(vsize);
   d_out.resize(vsize);
@@ -382,9 +382,9 @@ int arcaneTestCudaNumArray()
 
     dim3 dimGrid(threadsPerBlock, 1, 1), dimBlock(blocksPerGrid, 1, 1);
 
-    MDSpan<const double,1> d_a_span = d_a.constSpan();
-    MDSpan<const double,1> d_b_span = d_b.constSpan();
-    MDSpan<double,1> d_out_view = d_out.span();
+    MDSpan<const double,MDDim1> d_a_span = d_a.constSpan();
+    MDSpan<const double,MDDim1> d_b_span = d_b.constSpan();
+    MDSpan<double,MDDim1> d_out_view = d_out.span();
 
     void *kernelArgs[] = {
       (void*)&d_a_span,
@@ -403,9 +403,9 @@ int arcaneTestCudaNumArray()
   // Lance une lambda
   {
     _initArrays(d_a,d_b,d_out,3);
-    MDSpan<const double,1> d_a_span = d_a.constSpan();
-    MDSpan<const double,1> d_b_span = d_b.constSpan();
-    MDSpan<double,1> d_out_span = d_out.span();
+    MDSpan<const double,MDDim1> d_a_span = d_a.constSpan();
+    MDSpan<const double,MDDim1> d_b_span = d_b.constSpan();
+    MDSpan<double,MDDim1> d_out_span = d_out.span();
     auto func = [=] ARCCORE_HOST_DEVICE (int i)
                 {
                   d_out_span(i) = d_a_span(i) + d_b_span(i);
@@ -429,8 +429,8 @@ int arcaneTestCudaNumArray()
 
   // Utilise les Real3 avec un tableau multi-dimensionel
   {
-    NumArray<Real,2> d_a3(vsize,3);
-    NumArray<Real,2> d_b3(vsize,3);
+    NumArray<Real,MDDim2> d_a3(vsize,3);
+    NumArray<Real,MDDim2> d_b3(vsize,3);
     for( Integer i=0; i<vsize; ++i ){
       Real a = (Real)(i+2);
       Real b = (Real)(i*i+3);
@@ -444,9 +444,9 @@ int arcaneTestCudaNumArray()
       d_b3.s(i,2) = b + 2.0;
     }
 
-    MDSpan<const Real,2> d_a3_span = d_a3.constSpan();
-    MDSpan<const Real,2> d_b3_span = d_b3.constSpan();
-    MDSpan<double,1> d_out_span = d_out.span();
+    MDSpan<const Real,MDDim2> d_a3_span = d_a3.constSpan();
+    MDSpan<const Real,MDDim2> d_b3_span = d_b3.constSpan();
+    MDSpan<double,MDDim1> d_out_span = d_out.span();
     auto func2 = [=] ARCCORE_HOST_DEVICE (int i) {
                    Real3 xa(d_a3_span(i,0),d_a3_span(i,1),d_a3_span(i,2));
                    Real3 xb(d_b3_span(i,0),d_b3_span(i,1),d_b3_span(i,2));
@@ -506,7 +506,7 @@ void arcaneTestCudaReductionX(int vsize,ax::RunQueue& queue)
     //if (i<10)
     //printf("Do Reduce i=%d v=%d %lf\n",i,xa[i],vxa);
   };
-  run(command,ArrayBounds<1>(vsize),func2);
+  run(command,ArrayBounds<MDDim1>(vsize),func2);
   std::cout << "SumReducer v_int=" << sum_reducer.reduce()
             << " v_double=" << sum_double_reducer.reduce()
             << "\n";

--- a/arcane/src/arcane/datatype/RealArray2Variant.cc
+++ b/arcane/src/arcane/datatype/RealArray2Variant.cc
@@ -34,7 +34,7 @@ _arcaneTestRealArray2Variant()
   Real2x2 a22{ Real2{ -1.0, -2.5 }, Real2{ -2.0, 3.7 } };
   Real3x3 a33{ Real3{ -2.1, 3.9, 1.5 }, Real3{ 9.2, 3.4, 2.1 }, Real3{ 7.1, 4.5, 3.2 } };
 
-  NumArray<Real,2> num_data(3, 2, {1.4, 2.3, 4.5, 5.7, 2.9 , 6.5 });
+  NumArray<Real,MDDim2> num_data(3, 2, {1.4, 2.3, 4.5, 5.7, 2.9 , 6.5 });
 
   const Integer nb_variants = 3;
   RealArray2Variant variants[nb_variants] = { RealArray2Variant(a), RealArray2Variant(a22), RealArray2Variant(a33) };
@@ -51,7 +51,7 @@ _arcaneTestRealArray2Variant()
   }
 
   RealArray2Variant variant2{num_data};
-  NumArray<Real,2> num_data_copy(variant2);
+  NumArray<Real,MDDim2> num_data_copy(variant2);
   Span<const Real> variant2_span(variant2.data(),variant2.dim1Size()*variant2.dim2Size());
   std::cout << "NUM_DATA     =" << num_data.to1DSpan() << "\n";
   std::cout << "NUM_DATA_COPY=" << num_data_copy.to1DSpan() << "\n";

--- a/arcane/src/arcane/datatype/RealArray2Variant.h
+++ b/arcane/src/arcane/datatype/RealArray2Variant.h
@@ -45,7 +45,7 @@ class RealArray2Variant
   : RealArray2Variant(v.constView())
   {}
   template<typename LayoutType>
-  RealArray2Variant(const NumArray<Real,2,LayoutType>& v)
+  RealArray2Variant(const NumArray<Real,MDDim2,LayoutType>& v)
   : RealArray2Variant(v.span())
   {}
   RealArray2Variant(ConstArray2View<Real> v)
@@ -53,12 +53,12 @@ class RealArray2Variant
     _setValue(v.data(), v.dim1Size(), v.dim2Size());
   }
   template<typename LayoutType>
-  RealArray2Variant(MDSpan<Real,2,LayoutType> v)
+  RealArray2Variant(MDSpan<Real,MDDim2,LayoutType> v)
   {
     _setValue(v.to1DSpan().data(), v.dim1Size(), v.dim2Size());
   }
   template<typename LayoutType>
-  RealArray2Variant(MDSpan<const Real,2,LayoutType> v)
+  RealArray2Variant(MDSpan<const Real,MDDim2,LayoutType> v)
   {
     _setValue(v.to1DSpan().data(), v.dim1Size(), v.dim2Size());
   }
@@ -131,9 +131,9 @@ class RealArray2Variant
                               m_value[2][0], m_value[2][1], m_value[2][2]);
   }
   template<typename LayoutType>
-  operator NumArray<Real,2,LayoutType>() const
+  operator NumArray<Real,MDDim2,LayoutType>() const
   {
-    NumArray<Real,2> v(m_nb_dim1,m_nb_dim2);
+    NumArray<Real,MDDim2> v(m_nb_dim1,m_nb_dim2);
     for( Integer i=0, m=m_nb_dim1; i<m; ++i )
       for( Integer j=0, n=m_nb_dim2; j<n; ++j )
         v(i,j) = m_value[i][j];

--- a/arcane/src/arcane/datatype/RealArrayVariant.cc
+++ b/arcane/src/arcane/datatype/RealArrayVariant.cc
@@ -29,7 +29,7 @@ namespace Arcane
 extern "C++" ARCANE_CORE_EXPORT
 void _arcaneTestRealArrayVariant()
 {
-  NumArray<Real,1> num_data(4, { 2.4, 5.6, 3.3, 5.4 });
+  NumArray<Real,MDDim1> num_data(4, { 2.4, 5.6, 3.3, 5.4 });
 
   UniqueArray<Real> a1_({2.4, 5.6, 3.3, 5.4});
   ConstArrayView<Real> a1 = a1_.constView();
@@ -47,7 +47,7 @@ void _arcaneTestRealArrayVariant()
   }
 
   RealArrayVariant variant2{num_data};
-  NumArray<Real,1> num_data_copy(variant2);
+  NumArray<Real,MDDim1> num_data_copy(variant2);
   if (num_data_copy.to1DSpan()!=num_data.to1DSpan())
     ARCANE_FATAL("Bad value for copy");
 }

--- a/arcane/src/arcane/datatype/RealArrayVariant.h
+++ b/arcane/src/arcane/datatype/RealArrayVariant.h
@@ -44,7 +44,7 @@ class RealArrayVariant
   : RealArrayVariant(v.constView())
   {}
   template<typename LayoutType>
-  RealArrayVariant(const NumArray<Real,1,LayoutType>& v)
+  RealArrayVariant(const NumArray<Real,MDDim1,LayoutType>& v)
   : RealArrayVariant(v.span())
   {}
   RealArrayVariant(ConstArrayView<Real> v)
@@ -52,12 +52,12 @@ class RealArrayVariant
     _setValue(v.data(), v.size());
   }
   template<typename LayoutType>
-  RealArrayVariant(MDSpan<Real,1,LayoutType> v)
+  RealArrayVariant(MDSpan<Real,MDDim1,LayoutType> v)
   {
     _setValue(v.to1DSpan().data(), v.extent(0));
   }
   template<typename LayoutType>
-  RealArrayVariant(MDSpan<const Real,1,LayoutType> v)
+  RealArrayVariant(MDSpan<const Real,MDDim1,LayoutType> v)
   {
     _setValue(v.to1DSpan().data(), v.extent(0));
   }
@@ -114,9 +114,9 @@ class RealArrayVariant
   operator ConstArrayView<Real>() const { return ConstArrayView<Real>(m_nb_value, m_value); }
   operator Real2() const { return Real2(m_value[0], m_value[1]); }
   operator Real3() const { return Real3(m_value[0], m_value[1], m_value[2]); }
-  operator NumArray<Real,1>() const
+  operator NumArray<Real,MDDim1>() const
   {
-    NumArray<Real,1> v(m_nb_value);
+    NumArray<Real,MDDim1> v(m_nb_value);
     for( Integer i=0, n=m_nb_value; i<n; ++i )
       v[i] = m_value[i];
     return v;

--- a/arcane/src/arcane/impl/NumArrayData.cc
+++ b/arcane/src/arcane/impl/NumArrayData.cc
@@ -65,10 +65,10 @@ class INumArrayDataT
  public:
 
   //! Vue constante sur la donnée
-  virtual MDSpan<const DataType,RankValue> view() const = 0;
+  virtual MDSpan<const DataType,A_MDDIM(RankValue)> view() const = 0;
 
   //! Vue sur la donnée
-  virtual MDSpan<DataType,RankValue> view() = 0;
+  virtual MDSpan<DataType,A_MDDIM(RankValue)> view() = 0;
 
   //! Clone la donnée
   virtual Ref<ThatClass> cloneTrueRef() = 0;
@@ -112,8 +112,8 @@ class NumArrayDataT
   void serialize(ISerializer* sbuf, Int32ConstArrayView ids, IDataOperation* operation) override;
   //NumArray<DataType,RankValue>& value() override { return m_value; }
   //const NumArray<DataType,RankValue>& value() const override { return m_value; }
-  MDSpan<DataType,RankValue> view() override { return m_value.span(); }
-  MDSpan<const DataType,RankValue> view() const override { return m_value.span(); }
+  MDSpan<DataType,A_MDDIM(RankValue)> view() override { return m_value.span(); }
+  MDSpan<const DataType,A_MDDIM(RankValue)> view() const override { return m_value.span(); }
   void resize(Integer new_size) override;
   IData* clone() override { return _cloneTrue(); }
   IData* cloneEmpty() override { return _cloneTrueEmpty(); };
@@ -167,7 +167,7 @@ class NumArrayDataT
 
  private:
 
-  NumArray<DataType,RankValue> m_value; //!< Donnée
+  NumArray<DataType,A_MDDIM(RankValue)> m_value; //!< Donnée
   ITraceMng* m_trace;
 
  private:
@@ -367,7 +367,7 @@ allocateBufferForSerializedData(ISerializedData* sdata)
   std::array<Int32,RankValue> numarray_extents;
   for( Int32 i=0; i<RankValue; ++i )
     numarray_extents[i] = CheckedConvert::toInt32(sdata_extents[i]);
-  ArrayExtents<RankValue> extents = ArrayExtents<RankValue>::fromSpan(numarray_extents);
+  auto extents = ArrayExtents<A_MDDIM(RankValue)>::fromSpan(numarray_extents);
   m_value.resize(extents);
 
   Byte* byte_data = reinterpret_cast<Byte*>(m_value.to1DSpan().data());
@@ -431,7 +431,7 @@ serialize(ISerializer* sbuf,IDataOperation* operation)
     case ISerializer::ReadReplace:
       {
         //m_trace->info() << "READ REPLACE count=" << count << " dim2_size=" << dim2_size;
-        m_value.resize(ArrayExtents<RankValue>::fromSpan(extents_span));
+        m_value.resize(ArrayExtents<A_MDDIM(RankValue)>::fromSpan(extents_span));
         if (operation)
           ARCANE_THROW(NotImplementedException,"serialize(ReadReplace) with IDataOperation");
         BasicType* bt = reinterpret_cast<BasicType*>(m_value.to1DSpan().data());

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -158,33 +158,33 @@ _toTBBRangeWithGrain(const tbb::blocked_rangeNd<Int32,4>& r,std::size_t grain_si
 inline ComplexLoopRanges<2>
 _fromTBBRange(const tbb::blocked_rangeNd<Int32,2>& r)
 {
-  ArrayBounds<2> lower_bounds(r.dim(0).begin(),r.dim(1).begin());
+  ArrayBounds<MDDim2> lower_bounds(r.dim(0).begin(),r.dim(1).begin());
   auto s0 = static_cast<Int32>(r.dim(0).size());
   auto s1 = static_cast<Int32>(r.dim(1).size());
-  ArrayBounds<2> sizes(s0,s1);
+  ArrayBounds<MDDim2> sizes(s0,s1);
   return { lower_bounds, sizes };
 }
 
 inline ComplexLoopRanges<3>
 _fromTBBRange(const tbb::blocked_rangeNd<Int32,3> & r)
 {
-  ArrayBounds<3> lower_bounds(r.dim(0).begin(),r.dim(1).begin(),r.dim(2).begin());
+  ArrayBounds<MDDim3> lower_bounds(r.dim(0).begin(),r.dim(1).begin(),r.dim(2).begin());
   auto s0 = static_cast<Int32>(r.dim(0).size());
   auto s1 = static_cast<Int32>(r.dim(1).size());
   auto s2 = static_cast<Int32>(r.dim(2).size());
-  ArrayBounds<3> sizes(s0,s1,s2);
+  ArrayBounds<MDDim3> sizes(s0,s1,s2);
   return { lower_bounds, sizes };
 }
 
 inline ComplexLoopRanges<4>
 _fromTBBRange(const tbb::blocked_rangeNd<Int32,4>& r)
 {
-  ArrayBounds<4> lower_bounds(r.dim(0).begin(),r.dim(1).begin(),r.dim(2).begin(),r.dim(3).begin());
+  ArrayBounds<MDDim4> lower_bounds(r.dim(0).begin(),r.dim(1).begin(),r.dim(2).begin(),r.dim(3).begin());
   auto s0 = static_cast<Int32>(r.dim(0).size());
   auto s1 = static_cast<Int32>(r.dim(1).size());
   auto s2 = static_cast<Int32>(r.dim(2).size());
   auto s3 = static_cast<Int32>(r.dim(3).size());
-  ArrayBounds<4> sizes(s0,s1,s2,s3);
+  ArrayBounds<MDDim4> sizes(s0,s1,s2,s3);
   return { lower_bounds, sizes };
 }
 

--- a/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
@@ -567,9 +567,9 @@ _executeTestMemoryCopy()
     dest_mem = eMemoryRessource::Device;
 
   const int nb_value = 100000;
-  NumArray<Int32,1> a(nb_value,source_mem);
-  NumArray<Int32,1> b(nb_value,source_mem);
-  NumArray<Int32,1> c(nb_value,source_mem);
+  NumArray<Int32,MDDim1> a(nb_value,source_mem);
+  NumArray<Int32,MDDim1> b(nb_value,source_mem);
+  NumArray<Int32,MDDim1> c(nb_value,source_mem);
 
   // Initialise les tableaux
   for( int i=0; i<nb_value; ++i ){
@@ -577,9 +577,9 @@ _executeTestMemoryCopy()
     b[i] = i + 5;
   }
 
-  NumArray<Int32,1> d_a(nb_value,dest_mem);
-  NumArray<Int32,1> d_b(nb_value,dest_mem);
-  NumArray<Int32,1> d_c(nb_value,dest_mem);
+  NumArray<Int32,MDDim1> d_a(nb_value,dest_mem);
+  NumArray<Int32,MDDim1> d_b(nb_value,dest_mem);
+  NumArray<Int32,MDDim1> d_c(nb_value,dest_mem);
 
   // Copie explicitement les données dans le device
   // Test la construction en donnant les tailles explicitement.

--- a/arcane/src/arcane/tests/accelerator/ArcaneTestStandaloneAcceleratorMng.cc
+++ b/arcane/src/arcane/tests/accelerator/ArcaneTestStandaloneAcceleratorMng.cc
@@ -23,9 +23,9 @@ _testSum(IAcceleratorMng* acc_mng)
   // Test la somme de deux tableaux 'a' et 'b' dans un tableau 'c'.
 
   int nb_value = 10000;
-  NumArray<Int64,1> a(nb_value);
-  NumArray<Int64,1> b(nb_value);
-  NumArray<Int64,1> c(nb_value);
+  NumArray<Int64,MDDim1> a(nb_value);
+  NumArray<Int64,MDDim1> b(nb_value);
+  NumArray<Int64,MDDim1> c(nb_value);
   for( int i=0; i<nb_value; ++i ){
     a.s(i) = i+2;
     b.s(i) = i+3;

--- a/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
@@ -79,7 +79,7 @@ class NumArrayUnitTest
   }
 
   template <int Rank,typename LayoutType> double
-  _doSum(NumArray<double, Rank, LayoutType> values, ArrayBounds<Rank> bounds)
+  _doSum(NumArray<double, A_MDDIM(Rank), LayoutType> values, ArrayBounds<A_MDDIM(Rank)> bounds)
   {
     double total = 0.0;
     SimpleLoopRanges<Rank> lb(bounds);
@@ -176,13 +176,13 @@ _executeTest1(eMemoryRessource mem_kind)
   constexpr double expected_sum4 = 164736000.0;
 
   {
-    NumArray<double, 1> t1(mem_kind);
+    NumArray<double, MDDim1> t1(mem_kind);
     t1.resize(n1);
 
-    NumArray<double, 1> t2(mem_kind);
+    NumArray<double, MDDim1> t2(mem_kind);
     t2.resize(n1);
 
-    NumArray<double, 1> t3(mem_kind);
+    NumArray<double, MDDim1> t3(mem_kind);
     t3.resize(n1);
 
     {
@@ -197,7 +197,7 @@ _executeTest1(eMemoryRessource mem_kind)
         else
           out_t1[i] = _getValue(i);
       };
-      NumArray<double, 1> host_t1(eMemoryRessource::Host);
+      NumArray<double, MDDim1> host_t1(eMemoryRessource::Host);
       host_t1.copy(t1);
       double s1 = _doSum<1>(host_t1, { n1 });
       info() << "SUM1 = " << s1;
@@ -206,7 +206,7 @@ _executeTest1(eMemoryRessource mem_kind)
     {
       auto command = makeCommand(queue);
       auto in_t1 = t1.constSpan();
-      MDSpan<double,1> out_t2 = t2.span();
+      MDSpan<double,MDDim1> out_t2 = t2.span();
 
       command << RUNCOMMAND_LOOP1(iter, n1)
       {
@@ -216,7 +216,7 @@ _executeTest1(eMemoryRessource mem_kind)
         span2[i] = span1[i];
       };
 
-      NumArray<double, 1> host_t2(eMemoryRessource::Host);
+      NumArray<double, MDDim1> host_t2(eMemoryRessource::Host);
       host_t2.copy(t2);
       double s2 = _doSum<1>(host_t2, { n1 });
       info() << "SUM1_2 = " << s2;
@@ -233,7 +233,7 @@ _executeTest1(eMemoryRessource mem_kind)
         out_t3.to1DSpan()[i] = in_t1.to1DSpan()[i];
       };
 
-      NumArray<double, 1> host_t3(eMemoryRessource::Host);
+      NumArray<double, MDDim1> host_t3(eMemoryRessource::Host);
       host_t3.copy(t3);
       double s3 = _doSum<1>(host_t3, { n1 });
       info() << "SUM1_3 = " << s3;
@@ -242,7 +242,7 @@ _executeTest1(eMemoryRessource mem_kind)
   }
 
   {
-    NumArray<double, 2> t1(mem_kind);
+    NumArray<double, MDDim2> t1(mem_kind);
     t1.resize(n1, n2);
 
     auto command = makeCommand(queue);
@@ -253,7 +253,7 @@ _executeTest1(eMemoryRessource mem_kind)
       auto [i, j] = iter();
       out_t1(i, j) = _getValue(i, j);
     };
-    NumArray<double, 2> host_t1(eMemoryRessource::Host);
+    NumArray<double, MDDim2> host_t1(eMemoryRessource::Host);
     host_t1.copy(t1);
     double s2 = _doSum<2>(host_t1, { n1, n2 });
     info() << "SUM2 = " << s2;
@@ -261,7 +261,7 @@ _executeTest1(eMemoryRessource mem_kind)
   }
 
   {
-    NumArray<double, 3, LeftLayout3> t1(mem_kind);
+    NumArray<double, MDDim3, LeftLayout3> t1(mem_kind);
     t1.resize(n1, n2, n3);
 
     auto command = makeCommand(queue);
@@ -272,7 +272,7 @@ _executeTest1(eMemoryRessource mem_kind)
       auto [i, j, k] = iter();
       out_t1(i, j, k) = _getValue(i, j, k);
     };
-    NumArray<double, 3, LeftLayout3> host_t1(eMemoryRessource::Host);
+    NumArray<double, MDDim3, LeftLayout3> host_t1(eMemoryRessource::Host);
     host_t1.copy(t1);
     double s3 = _doSum<3>(host_t1, { n1, n2, n3 });
     info() << "SUM3 = " << s3;
@@ -280,7 +280,7 @@ _executeTest1(eMemoryRessource mem_kind)
   }
 
   {
-    NumArray<double, 3, RightLayout3> t1(mem_kind);
+    NumArray<double, MDDim3, RightLayout3> t1(mem_kind);
     t1.resize(n1, n2, n3);
 
     auto command = makeCommand(queue);
@@ -291,7 +291,7 @@ _executeTest1(eMemoryRessource mem_kind)
       auto [i, j, k] = iter();
       out_t1(i, j, k) = _getValue(i, j, k);
     };
-    NumArray<double, 3, RightLayout3> host_t1(eMemoryRessource::Host);
+    NumArray<double, MDDim3, RightLayout3> host_t1(eMemoryRessource::Host);
     host_t1.copy(t1);
     double s3 = _doSum<3>(host_t1, { n1, n2, n3 });
     info() << "SUM3 = " << s3;
@@ -299,7 +299,7 @@ _executeTest1(eMemoryRessource mem_kind)
   }
 
   {
-    NumArray<double, 4> t1(mem_kind);
+    NumArray<double, MDDim4> t1(mem_kind);
     t1.resize(n1, n2, n3, n4);
 
     auto command = makeCommand(queue);
@@ -310,7 +310,7 @@ _executeTest1(eMemoryRessource mem_kind)
       auto [i, j, k, l] = iter();
       out_t1(i, j, k, l) = _getValue(i, j, k, l);
     };
-    NumArray<double, 4> host_t1(eMemoryRessource::Host);
+    NumArray<double, MDDim4> host_t1(eMemoryRessource::Host);
     host_t1.copy(t1);
     double s4 = _doSum<4>(host_t1, { n1, n2, n3, n4 });
     info() << "SUM4 = " << s4;
@@ -343,7 +343,7 @@ _executeTest2()
   auto queue3 = makeQueue(m_runner);
   queue3.setAsync(true);
 
-  NumArray<double, 4> t1(n1, n2, n3, n4);
+  NumArray<double, MDDim4> t1(n1, n2, n3, n4);
 
   // NOTE: Normalement il ne devrait pas être autorisé d'accéder au
   // même tableau depuis plusieurs commandes sur des files différentes

--- a/arcane/src/arcane/tests/accelerator/RunQueueUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/RunQueueUnitTest.cc
@@ -126,7 +126,7 @@ _executeTest1(bool use_priority)
   Integer nb_thread = 8;
   Integer N = 1000000;
 
-  UniqueArray<NumArray<Int32, 1>> values(8);
+  UniqueArray<NumArray<Int32, MDDim1>> values(8);
   for (Integer i = 0; i < nb_thread; ++i)
     values[i].resize(N);
 
@@ -187,7 +187,7 @@ _executeTest2()
   queue2.setAsync(true);
 
   Integer nb_value = 100000;
-  NumArray<Int32, 1> values(nb_value);
+  NumArray<Int32, MDDim1> values(nb_value);
   {
     auto command1 = makeCommand(queue1);
     auto v = viewOut(command1, values);
@@ -236,7 +236,7 @@ _executeTest3()
   queue2.setAsync(true);
 
   Integer nb_value = 100000;
-  NumArray<Int32, 1> values(nb_value);
+  NumArray<Int32, MDDim1> values(nb_value);
   {
     auto command1 = makeCommand(queue1);
     auto v = viewOut(command1, values);

--- a/arcane/src/arcane/utils/ArrayBounds.h
+++ b/arcane/src/arcane/utils/ArrayBounds.h
@@ -43,7 +43,7 @@ constexpr T fastmod(T a , T b)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<int RankValue>
+template<A_MDRANK_TYPE(RankValue)>
 class ArrayBoundsBase
 : private ArrayExtents<RankValue>
 {
@@ -53,7 +53,7 @@ class ArrayBoundsBase
   constexpr ArrayBoundsBase() : m_nb_element(0) {}
  public:
   ARCCORE_HOST_DEVICE constexpr Int64 nbElement() const { return m_nb_element; }
-  ARCCORE_HOST_DEVICE constexpr std::array<Int32,RankValue> asStdArray() const { return ArrayExtents<RankValue>::asStdArray(); }
+  ARCCORE_HOST_DEVICE constexpr std::array<Int32,A_MDRANK_RANK_VALUE(RankValue)> asStdArray() const { return ArrayExtents<RankValue>::asStdArray(); }
  protected:
   constexpr void _computeNbElement()
   {
@@ -65,16 +65,16 @@ class ArrayBoundsBase
 };
 
 template<>
-class ArrayBounds<1>
-: public ArrayBoundsBase<1>
+class ArrayBounds<MDDim1>
+: public ArrayBoundsBase<MDDim1>
 {
  public:
   using IndexType = ArrayBoundsIndex<1>;
-  using ArrayBoundsBase<1>::m_extents;
+  using ArrayBoundsBase<MDDim1>::m_extents;
   // Note: le constructeur ne doit pas être explicite pour permettre la conversion
   // à partir d'un entier.
   constexpr ArrayBounds(Int32 dim1)
-  : ArrayBoundsBase<1>()
+  : ArrayBoundsBase<MDDim1>()
   {
     m_extents[0] = dim1;
     _computeNbElement();
@@ -86,14 +86,14 @@ class ArrayBounds<1>
 };
 
 template<>
-class ArrayBounds<2>
-: public ArrayBoundsBase<2>
+class ArrayBounds<MDDim2>
+: public ArrayBoundsBase<MDDim2>
 {
  public:
   using IndexType = ArrayBoundsIndex<2>;
-  using ArrayBoundsBase<2>::m_extents;
+  using ArrayBoundsBase<MDDim2>::m_extents;
   constexpr ArrayBounds(Int32 dim1,Int32 dim2)
-  : ArrayBoundsBase<2>()
+  : ArrayBoundsBase<MDDim2>()
   {
     m_extents[0] = dim1;
     m_extents[1] = dim2;
@@ -108,14 +108,14 @@ class ArrayBounds<2>
 };
 
 template<>
-class ArrayBounds<3>
-: public ArrayBoundsBase<3>
+class ArrayBounds<MDDim3>
+: public ArrayBoundsBase<MDDim3>
 {
  public:
   using IndexType = ArrayBoundsIndex<3>;
-  using ArrayBoundsBase<3>::m_extents;
+  using ArrayBoundsBase<MDDim3>::m_extents;
   constexpr ArrayBounds(Int32 dim1,Int32 dim2,Int32 dim3)
-  : ArrayBoundsBase<3>()
+  : ArrayBoundsBase<MDDim3>()
   {
     m_extents[0] = dim1;
     m_extents[1] = dim2;
@@ -134,14 +134,14 @@ class ArrayBounds<3>
 };
 
 template<>
-class ArrayBounds<4>
-: public ArrayBoundsBase<4>
+class ArrayBounds<MDDim4>
+: public ArrayBoundsBase<MDDim4>
 {
  public:
   using IndexType = ArrayBoundsIndex<4>;
-  using ArrayBoundsBase<4>::m_extents;
+  using ArrayBoundsBase<MDDim4>::m_extents;
   constexpr ArrayBounds(Int32 dim1,Int32 dim2,Int32 dim3,Int32 dim4)
-  : ArrayBoundsBase<4>()
+  : ArrayBoundsBase<MDDim4>()
   {
     m_extents[0] = dim1;
     m_extents[1] = dim2;

--- a/arcane/src/arcane/utils/ArrayLayout.h
+++ b/arcane/src/arcane/utils/ArrayLayout.h
@@ -78,25 +78,25 @@ class ArrayLayout3
 /*---------------------------------------------------------------------------*/
 // Layout par défaut pour chaque dimension
 
-template<int RankValue> class RightLayout;
-template<int RankValue> class LeftLayout;
+template<A_MDRANK_TYPE(RankValue)> class RightLayout;
+template<A_MDRANK_TYPE(RankValue)> class LeftLayout;
 
-template<> class RightLayout<2> : public ArrayLayout2<0,1> {};
-template<> class RightLayout<3> : public ArrayLayout3<0,1,2> {};
-using RightLayout2 = RightLayout<2>;
-using RightLayout3 = RightLayout<3>;
+template<> class RightLayout<MDDim2> : public ArrayLayout2<0,1> {};
+template<> class RightLayout<MDDim3> : public ArrayLayout3<0,1,2> {};
+using RightLayout2 = RightLayout<MDDim2>;
+using RightLayout3 = RightLayout<MDDim3>;
 
-template<> class LeftLayout<2> : public ArrayLayout2<1,0> {};
-template<> class LeftLayout<3> : public ArrayLayout3<2,1,0> {};
-using LeftLayout2 = LeftLayout<2>;
-using LeftLayout3 = LeftLayout<3>;
+template<> class LeftLayout<MDDim2> : public ArrayLayout2<1,0> {};
+template<> class LeftLayout<MDDim3> : public ArrayLayout3<2,1,0> {};
+using LeftLayout2 = LeftLayout<MDDim2>;
+using LeftLayout3 = LeftLayout<MDDim3>;
 
 #ifdef ARCANE_DEFAULT_LAYOUT_IS_LEFT
-template<> class DefaultLayout<2> : public LeftLayout<2> {};
-template<> class DefaultLayout<3> : public LeftLayout<3> {};
+template<> class DefaultLayout<MDDim2> : public LeftLayout<MDDim2> {};
+template<> class DefaultLayout<MDDim3> : public LeftLayout<MDDim3> {};
 #else
-template<> class DefaultLayout<2> : public RightLayout<2> {};
-template<> class DefaultLayout<3> : public RightLayout<3> {};
+template<> class DefaultLayout<MDDim2> : public RightLayout<MDDim2> {};
+template<> class DefaultLayout<MDDim3> : public RightLayout<MDDim3> {};
 #endif
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/LoopRanges.h
+++ b/arcane/src/arcane/utils/LoopRanges.h
@@ -57,17 +57,20 @@ class SimpleLoopRanges
 {
   friend class ComplexLoopRanges<N>;
  public:
-  typedef typename ArrayBounds<N>::IndexType IndexType;
+  using ArrayBoundsType = ArrayBounds<A_MDDIM(N)>;
+  using ArrayBoundsIndexType = ArrayBoundsIndex<N>;
  public:
-  SimpleLoopRanges(ArrayBounds<N> b) : m_bounds(b){}
+  typedef typename ArrayBoundsType::IndexType IndexType;
+ public:
+  SimpleLoopRanges(ArrayBoundsType b) : m_bounds(b){}
  public:
   constexpr Int32 lowerBound(int) const { return 0; }
   constexpr Int32 upperBound(int i) const { return m_bounds.extent(i); }
   constexpr Int32 extent(int i) const { return m_bounds.extent(i); }
   constexpr Int64 nbElement() const { return m_bounds.nbElement(); }
-  constexpr ArrayBoundsIndex<N> getIndices(Int32 i) const { return m_bounds.getIndices(i); }
+  constexpr ArrayBoundsIndexType getIndices(Int32 i) const { return m_bounds.getIndices(i); }
  private:
-  ArrayBounds<N> m_bounds;
+  ArrayBoundsType m_bounds;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -83,9 +86,12 @@ template <int N>
 class ComplexLoopRanges
 {
  public:
-  typedef typename ArrayBounds<N>::IndexType IndexType;
+  using ArrayBoundsType = ArrayBounds<A_MDDIM(N)>;
+  using ArrayBoundsIndexType = ArrayBoundsIndex<N>;
  public:
-  ComplexLoopRanges(ArrayBounds<N> lower,ArrayBounds<N> extents)
+  typedef typename ArrayBoundsType::IndexType IndexType;
+ public:
+  ComplexLoopRanges(ArrayBoundsType lower,ArrayBoundsType extents)
   : m_lower_bounds(lower.asStdArray()), m_extents(extents){}
   ComplexLoopRanges(const SimpleLoopRanges<N>& bounds)
   : m_extents(bounds.m_bounds){}
@@ -94,15 +100,15 @@ class ComplexLoopRanges
   constexpr Int32 upperBound(int i) const { return m_lower_bounds[i]+m_extents.extent(i); }
   constexpr Int32 extent(int i) const { return m_extents.extent(i); }
   constexpr Int64 nbElement() const { return m_extents.nbElement(); }
-  constexpr ArrayBoundsIndex<N> getIndices(Int32 i) const
+  constexpr ArrayBoundsIndexType getIndices(Int32 i) const
   {
     auto x = m_extents.getIndices(i);
     x.add(m_lower_bounds);
     return x;
   }
  private:
-  ArrayBoundsIndex<N> m_lower_bounds;
-  ArrayBounds<N> m_extents;
+  ArrayBoundsIndexType m_lower_bounds;
+  ArrayBoundsType m_extents;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -111,7 +117,7 @@ class ComplexLoopRanges
 inline SimpleLoopRanges<1>
 makeLoopRanges(Int32 n1)
 {
-  ArrayBounds<1> bounds(n1);
+  SimpleLoopRanges<1>::ArrayBoundsType bounds(n1);
   return bounds;
 }
 
@@ -119,7 +125,7 @@ makeLoopRanges(Int32 n1)
 inline SimpleLoopRanges<2>
 makeLoopRanges(Int32 n1,Int32 n2)
 {
-  ArrayBounds<2> bounds(n1,n2);
+  SimpleLoopRanges<2>::ArrayBoundsType bounds(n1,n2);
   return bounds;
 }
 
@@ -127,7 +133,7 @@ makeLoopRanges(Int32 n1,Int32 n2)
 inline SimpleLoopRanges<3>
 makeLoopRanges(Int32 n1,Int32 n2,Int32 n3)
 {
-  ArrayBounds<3> bounds(n1,n2,n3);
+  SimpleLoopRanges<3>::ArrayBoundsType bounds(n1,n2,n3);
   return bounds;
 }
 
@@ -135,7 +141,7 @@ makeLoopRanges(Int32 n1,Int32 n2,Int32 n3)
 inline SimpleLoopRanges<4>
 makeLoopRanges(Int32 n1,Int32 n2,Int32 n3,Int32 n4)
 {
-  ArrayBounds<4> bounds(n1,n2,n3,n4);
+  SimpleLoopRanges<4>::ArrayBoundsType bounds(n1,n2,n3,n4);
   return bounds;
 }
 
@@ -143,8 +149,8 @@ makeLoopRanges(Int32 n1,Int32 n2,Int32 n3,Int32 n4)
 inline ComplexLoopRanges<1>
 makeLoopRanges(LoopRange n1)
 {
-  ArrayBounds<1> lower_bounds(n1.lowerBound());
-  ArrayBounds<1> sizes(n1.size());
+  ComplexLoopRanges<1>::ArrayBoundsType lower_bounds(n1.lowerBound());
+  ComplexLoopRanges<1>::ArrayBoundsType sizes(n1.size());
   return {lower_bounds,sizes};
 }
 
@@ -152,8 +158,8 @@ makeLoopRanges(LoopRange n1)
 inline ComplexLoopRanges<2>
 makeLoopRanges(LoopRange n1,LoopRange n2)
 {
-  ArrayBounds<2> lower_bounds(n1.lowerBound(),n2.lowerBound());
-  ArrayBounds<2> sizes(n1.size(),n2.size());
+  ComplexLoopRanges<2>::ArrayBoundsType lower_bounds(n1.lowerBound(),n2.lowerBound());
+  ComplexLoopRanges<2>::ArrayBoundsType sizes(n1.size(),n2.size());
   return {lower_bounds,sizes};
 }
 
@@ -161,8 +167,8 @@ makeLoopRanges(LoopRange n1,LoopRange n2)
 inline ComplexLoopRanges<3>
 makeLoopRanges(LoopRange n1,LoopRange n2,LoopRange n3)
 {
-  ArrayBounds<3> lower_bounds(n1.lowerBound(),n2.lowerBound(),n3.lowerBound());
-  ArrayBounds<3> sizes(n1.size(),n2.size(),n3.size());
+  ComplexLoopRanges<3>::ArrayBoundsType lower_bounds(n1.lowerBound(),n2.lowerBound(),n3.lowerBound());
+  ComplexLoopRanges<3>::ArrayBoundsType sizes(n1.size(),n2.size(),n3.size());
   return {lower_bounds,sizes};
 }
 
@@ -170,8 +176,8 @@ makeLoopRanges(LoopRange n1,LoopRange n2,LoopRange n3)
 inline ComplexLoopRanges<4>
 makeLoopRanges(LoopRange n1,LoopRange n2,LoopRange n3,LoopRange n4)
 {
-  ArrayBounds<4> lower_bounds(n1.lowerBound(),n2.lowerBound(),n3.lowerBound(),n4.lowerBound());
-  ArrayBounds<4> sizes(n1.size(),n2.size(),n3.size(),n4.size());
+  ComplexLoopRanges<4>::ArrayBoundsType lower_bounds(n1.lowerBound(),n2.lowerBound(),n3.lowerBound(),n4.lowerBound());
+  ComplexLoopRanges<4>::ArrayBoundsType sizes(n1.size(),n2.size(),n3.size(),n4.size());
   return {lower_bounds,sizes};
 }
 

--- a/arcane/src/arcane/utils/MDSpan.cc
+++ b/arcane/src/arcane/utils/MDSpan.cc
@@ -22,10 +22,10 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template class MDSpan<Real, 4>;
-template class MDSpan<Real, 3>;
-template class MDSpan<Real, 2>;
-template class MDSpan<Real, 1>;
+template class MDSpan<Real, MDDim4>;
+template class MDSpan<Real, MDDim3>;
+template class MDSpan<Real, MDDim2>;
+template class MDSpan<Real, MDDim1>;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MDSpan.h
+++ b/arcane/src/arcane/utils/MDSpan.h
@@ -52,13 +52,15 @@ namespace Arcane
  * d'une de ses spécialisations suivant le rang comme MDSpan<DataType,1>,
  * MDSpan<DataType,2>, MDSpan<DataType,3> ou MDSpan<DataType,4>.
  */
-template<typename DataType,int RankValue,typename LayoutType>
+template<typename DataType,A_MDRANK_TYPE(RankValue),typename LayoutType>
 class MDSpanBase
 {
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
   friend class NumArrayBase<UnqualifiedValueType,RankValue,LayoutType>;
   // Pour que MDSpan<const T> ait accès à MDSpan<T>
   friend class MDSpanBase<const UnqualifiedValueType,RankValue,LayoutType>;
+ public:
+  using ArrayBoundsIndexType = ArrayBoundsIndex<A_MDRANK_RANK_VALUE(RankValue)>;
  public:
   MDSpanBase() = default;
   ARCCORE_HOST_DEVICE MDSpanBase(DataType* ptr,ArrayExtentsWithOffset<RankValue,LayoutType> extents)
@@ -83,17 +85,17 @@ class MDSpanBase
   }
   Int32 extent(int i) const { return m_extents(i); }
  public:
-  ARCCORE_HOST_DEVICE Int64 offset(ArrayBoundsIndex<RankValue> idx) const
+  ARCCORE_HOST_DEVICE Int64 offset(ArrayBoundsIndexType idx) const
   {
     return m_extents.offset(idx);
   }
   //! Valeur pour l'élément \a i
-  ARCCORE_HOST_DEVICE DataType& operator()(ArrayBoundsIndex<RankValue> idx) const
+  ARCCORE_HOST_DEVICE DataType& operator()(ArrayBoundsIndexType idx) const
   {
     return m_ptr[offset(idx)];
   }
   //! Pointeur sur la valeur pour l'élément \a i
-  ARCCORE_HOST_DEVICE DataType* ptrAt(ArrayBoundsIndex<RankValue> idx) const
+  ARCCORE_HOST_DEVICE DataType* ptrAt(ArrayBoundsIndexType idx) const
   {
     return m_ptr+offset(idx);
   }
@@ -107,7 +109,7 @@ class MDSpanBase
   {
     Int64 dim1_size = m_extents(0);
     Int64 dim2_size = 1;
-    for (int i=1; i<RankValue; ++i )
+    for (int i=1; i<A_MDRANK_RANK_VALUE(RankValue); ++i )
       dim2_size *= m_extents(i);
     return { m_ptr, dim1_size, dim2_size };
   }
@@ -125,12 +127,12 @@ class MDSpanBase
  * \brief Vue multi-dimensionnelle à 1 dimension.
  */
 template<class DataType,typename LayoutType>
-class MDSpan<DataType,1,LayoutType>
-: public MDSpanBase<DataType,1,LayoutType>
+class MDSpan<DataType,MDDim1,LayoutType>
+: public MDSpanBase<DataType,MDDim1,LayoutType>
 {
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
-  friend class NumArrayBase<UnqualifiedValueType,1,LayoutType>;
-  using BaseClass = MDSpanBase<DataType,1,LayoutType>;
+  friend class NumArrayBase<UnqualifiedValueType,MDDim1,LayoutType>;
+  using BaseClass = MDSpanBase<DataType,MDDim1,LayoutType>;
   using BaseClass::m_extents;
   using BaseClass::m_ptr;
  public:
@@ -146,7 +148,7 @@ class MDSpan<DataType,1,LayoutType>
     m_extents.setSize(dim1_size);
     m_ptr = ptr;
   }
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<1,LayoutType> extents_and_offset)
+  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<MDDim1,LayoutType> extents_and_offset)
   : BaseClass(ptr,extents_and_offset) {}
 
  public:
@@ -167,8 +169,8 @@ class MDSpan<DataType,1,LayoutType>
   template<typename X = DataType,typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type >
   ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i,Int32 a,Int32 b) const { return m_ptr[offset(i)][a][b]; }
  public:
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,1,LayoutType> constSpan() const
-  { return MDSpan<const DataType,1,LayoutType>(m_ptr,m_extents); }
+  ARCCORE_HOST_DEVICE MDSpan<const DataType,MDDim1,LayoutType> constSpan() const
+  { return MDSpan<const DataType,MDDim1,LayoutType>(m_ptr,m_extents); }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -177,12 +179,12 @@ class MDSpan<DataType,1,LayoutType>
  * \brief Vue multi-dimensionnelle à 2 dimensions.
  */
 template<class DataType,typename LayoutType>
-class MDSpan<DataType,2,LayoutType>
-: public MDSpanBase<DataType,2,LayoutType>
+class MDSpan<DataType,MDDim2,LayoutType>
+: public MDSpanBase<DataType,MDDim2,LayoutType>
 {
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
-  friend class NumArrayBase<UnqualifiedValueType,2,LayoutType>;
-  using BaseClass = MDSpanBase<DataType,2,LayoutType>;
+  friend class NumArrayBase<UnqualifiedValueType,MDDim2,LayoutType>;
+  using BaseClass = MDSpanBase<DataType,MDDim2,LayoutType>;
   using BaseClass::m_extents;
   using BaseClass::m_ptr;
  public:
@@ -198,7 +200,7 @@ class MDSpan<DataType,2,LayoutType>
     m_extents.setSize(dim1_size,dim2_size);
     m_ptr = ptr;
   }
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<2,LayoutType> extents_and_offset)
+  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<MDDim2,LayoutType> extents_and_offset)
   : BaseClass(ptr,extents_and_offset) {}
 
  public:
@@ -219,9 +221,9 @@ class MDSpan<DataType,2,LayoutType>
   template<typename X = DataType,typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type >
   ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i,Int32 j,Int32 a,Int32 b) const { return m_ptr[offset(i,j)][a][b]; }
  public:
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,2,LayoutType> constSpan() const
+  ARCCORE_HOST_DEVICE MDSpan<const DataType,MDDim2,LayoutType> constSpan() const
   {
-    return MDSpan<const DataType,2,LayoutType>(m_ptr,m_extents);
+    return MDSpan<const DataType,MDDim2,LayoutType>(m_ptr,m_extents);
   }
 };
 
@@ -231,12 +233,12 @@ class MDSpan<DataType,2,LayoutType>
  * \brief Vue multi-dimensionnelle à 3 dimensions.
  */
 template<class DataType,typename LayoutType>
-class MDSpan<DataType,3,LayoutType>
-: public MDSpanBase<DataType,3,LayoutType>
+class MDSpan<DataType,MDDim3,LayoutType>
+: public MDSpanBase<DataType,MDDim3,LayoutType>
 {
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
-  friend class NumArrayBase<UnqualifiedValueType,3,LayoutType>;
-  using BaseClass = MDSpanBase<DataType,3,LayoutType>;
+  friend class NumArrayBase<UnqualifiedValueType,MDDim3,LayoutType>;
+  using BaseClass = MDSpanBase<DataType,MDDim3,LayoutType>;
   using BaseClass::m_extents;
   using BaseClass::m_ptr;
   using value_type = typename std::remove_cv<DataType>::type;
@@ -252,10 +254,10 @@ class MDSpan<DataType,3,LayoutType>
   {
     _setSize(ptr,dim1_size,dim2_size,dim3_size);
   }
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<3,LayoutType> extents_and_offset)
+  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<MDDim3,LayoutType> extents_and_offset)
   : BaseClass(ptr,extents_and_offset) {}
   template<typename X,typename = std::enable_if_t<std::is_same_v<X,UnqualifiedValueType>>>
-  ARCCORE_HOST_DEVICE MDSpan(const MDSpan<X,3>& rhs) : BaseClass(rhs){}
+  ARCCORE_HOST_DEVICE MDSpan(const MDSpan<X,MDDim3>& rhs) : BaseClass(rhs){}
  private:
   void _setSize(DataType* ptr,Int32 dim1_size,Int32 dim2_size,Int32 dim3_size)
   {
@@ -288,9 +290,9 @@ class MDSpan<DataType,3,LayoutType>
     return m_ptr[offset(i,j,k)][a][b];
   }
  public:
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,3,LayoutType> constSpan() const
+  ARCCORE_HOST_DEVICE MDSpan<const DataType,MDDim3,LayoutType> constSpan() const
   {
-    return MDSpan<const DataType,3,LayoutType>(m_ptr,m_extents);
+    return MDSpan<const DataType,MDDim3,LayoutType>(m_ptr,m_extents);
   }
 };
 
@@ -300,12 +302,12 @@ class MDSpan<DataType,3,LayoutType>
  * \brief Vue multi-dimensionnelle à 4 dimensions.
  */
 template<class DataType,typename LayoutType>
-class MDSpan<DataType,4,LayoutType>
-: public MDSpanBase<DataType,4,LayoutType>
+class MDSpan<DataType,MDDim4,LayoutType>
+: public MDSpanBase<DataType,MDDim4,LayoutType>
 {
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
-  friend class NumArrayBase<UnqualifiedValueType,4,LayoutType>;
-  using BaseClass = MDSpanBase<DataType,4,LayoutType>;
+  friend class NumArrayBase<UnqualifiedValueType,MDDim4,LayoutType>;
+  using BaseClass = MDSpanBase<DataType,MDDim4,LayoutType>;
   using BaseClass::m_extents;
   using BaseClass::m_ptr;
  public:
@@ -321,7 +323,7 @@ class MDSpan<DataType,4,LayoutType>
   {
     _setSize(ptr,dim1_size,dim2_size,dim3_size,dim4_size);
   }
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<4,LayoutType> extents_and_offset)
+  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr,ArrayExtentsWithOffset<MDDim4,LayoutType> extents_and_offset)
   : BaseClass(ptr,extents_and_offset) {}
  private:
   void _setSize(DataType* ptr,Int32 dim1_size,Int32 dim2_size,Int32 dim3_size,Int32 dim4_size)
@@ -368,9 +370,9 @@ class MDSpan<DataType,4,LayoutType>
     return m_ptr[offset(i,j,k,l)][a][b];
   }
  public:
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,4,LayoutType> constSpan() const
+  ARCCORE_HOST_DEVICE MDSpan<const DataType,MDDim4,LayoutType> constSpan() const
   {
-    return MDSpan<const DataType,4,LayoutType>(m_ptr,m_extents);
+    return MDSpan<const DataType,MDDim4,LayoutType>(m_ptr,m_extents);
   }
 };
 

--- a/arcane/src/arcane/utils/NumArray.cc
+++ b/arcane/src/arcane/utils/NumArray.cc
@@ -70,15 +70,15 @@ _copy(Span<const std::byte> from, eMemoryRessource from_mem,
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template class NumArray<Real, 4>;
-template class NumArray<Real, 3>;
-template class NumArray<Real, 2>;
-template class NumArray<Real, 1>;
+template class NumArray<Real, MDDim4>;
+template class NumArray<Real, MDDim3>;
+template class NumArray<Real, MDDim2>;
+template class NumArray<Real, MDDim1>;
 
-template class NumArrayBase<Real, 4>;
-template class NumArrayBase<Real, 3>;
-template class NumArrayBase<Real, 2>;
-template class NumArrayBase<Real, 1>;
+template class NumArrayBase<Real, MDDim4>;
+template class NumArrayBase<Real, MDDim3>;
+template class NumArrayBase<Real, MDDim2>;
+template class NumArrayBase<Real, MDDim1>;
 
 template class ArrayStridesBase<1>;
 template class ArrayStridesBase<2>;

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -122,7 +122,7 @@ namespace impl
  * initialisé (\ref arcanedoc_accelerator). C'est pourquoi il ne faut pas
  * utiliser de variables globales de cette classe ou d'une classe dérivée.
  */
-template<typename DataType,int RankValue,typename LayoutType>
+template<typename DataType,A_MDRANK_TYPE(RankValue),typename LayoutType>
 class NumArrayBase
 : public NumArrayBaseCommon
 {
@@ -131,6 +131,7 @@ class NumArrayBase
   using ConstSpanType = MDSpan<const DataType,RankValue,LayoutType>;
   using SpanType = MDSpan<DataType,RankValue,LayoutType>;
   using ArrayWrapper = impl::NumArrayContainer<DataType>;
+  using ArrayBoundsIndexType = typename SpanType::ArrayBoundsIndexType;
 
  public:
 
@@ -168,7 +169,7 @@ class NumArrayBase
     Int32 dim1_size = extent(0);
     Int32 dim2_size = 1;
     // TODO: vérifier débordement.
-    for (int i=1; i<RankValue; ++i )
+    for (int i=1; i< A_MDRANK_RANK_VALUE(RankValue) ; ++i )
       dim2_size *= extent(i);
     m_total_nb_element = dim1_size * dim2_size;
     m_data.resize(m_total_nb_element);
@@ -176,7 +177,7 @@ class NumArrayBase
   }
  public:
   void fill(const DataType& v) { m_data.fill(v); }
-  Int32 nbDimension() const { return RankValue; }
+  constexpr Int32 nbDimension() const { return A_MDRANK_RANK_VALUE(RankValue); }
   ArrayExtents<RankValue> extents() const { return m_span.extents(); }
   ArrayExtentsWithOffset<RankValue,LayoutType> extentsWithOffset() const
   {
@@ -200,15 +201,15 @@ class NumArrayBase
     _copy(asBytes(rhs.to1DSpan()),rhs.m_memory_ressource,
           asWritableBytes(to1DSpan()),m_memory_ressource);
   }
-  const DataType& operator()(ArrayBoundsIndex<RankValue> idx) const
+  const DataType& operator()(ArrayBoundsIndexType idx) const
   {
     return m_span(idx);
   }
-  DataType& operator()(ArrayBoundsIndex<RankValue> idx)
+  DataType& operator()(ArrayBoundsIndexType idx)
   {
     return m_span(idx);
   }
-  DataType& s(ArrayBoundsIndex<RankValue> idx)
+  DataType& s(ArrayBoundsIndexType idx)
   {
     return m_span(idx);
   }
@@ -247,17 +248,17 @@ class NumArrayBase
  * \sa NumArrayBase
  */
 template<class DataType,typename LayoutType>
-class NumArray<DataType,1,LayoutType>
-: public NumArrayBase<DataType,1,LayoutType>
+class NumArray<DataType,MDDim1,LayoutType>
+: public NumArrayBase<DataType,MDDim1,LayoutType>
 {
  public:
-  using BaseClass = NumArrayBase<DataType,1,LayoutType>;
+  using BaseClass = NumArrayBase<DataType,MDDim1,LayoutType>;
   using BaseClass::extent;
   using BaseClass::resize;
   using BaseClass::operator();
   using BaseClass::s;
-  using ConstSpanType = MDSpan<const DataType,1,LayoutType>;
-  using SpanType = MDSpan<DataType,1,LayoutType>;
+  using ConstSpanType = MDSpan<const DataType,MDDim1,LayoutType>;
+  using SpanType = MDSpan<DataType,MDDim1,LayoutType>;
  private:
   using BaseClass::m_span;
  public:
@@ -266,9 +267,9 @@ class NumArray<DataType,1,LayoutType>
   explicit NumArray(eMemoryRessource r) : BaseClass(r){}
   //! Construit un tableau
   explicit NumArray(Int32 dim1_size)
-  : BaseClass(ArrayExtents<1>(dim1_size)){}
+  : BaseClass(ArrayExtents<MDDim1>(dim1_size)){}
   NumArray(Int32 dim1_size,eMemoryRessource r)
-  : BaseClass(ArrayExtents<1>{dim1_size},r){}
+  : BaseClass(ArrayExtents<MDDim1>{dim1_size},r){}
   //! Construit un tableau à partir de valeurs prédéfinies
   NumArray(Int32 dim1_size,std::initializer_list<DataType> alist)
   : NumArray(dim1_size)
@@ -289,7 +290,7 @@ class NumArray<DataType,1,LayoutType>
 
   void resize(Int32 dim1_size)
   {
-    this->resize(ArrayExtents<1>(dim1_size));
+    this->resize(ArrayExtents<MDDim1>(dim1_size));
   }
 
  public:
@@ -340,11 +341,11 @@ class NumArray<DataType,1,LayoutType>
  * \sa NumArrayBase
  */
 template<class DataType,typename LayoutType>
-class NumArray<DataType,2,LayoutType>
-: public NumArrayBase<DataType,2,LayoutType>
+class NumArray<DataType,MDDim2,LayoutType>
+: public NumArrayBase<DataType,MDDim2,LayoutType>
 {
  public:
-  using BaseClass = NumArrayBase<DataType,2,LayoutType>;
+  using BaseClass = NumArrayBase<DataType,MDDim2,LayoutType>;
   using BaseClass::extent;
   using BaseClass::resize;
   using BaseClass::operator();
@@ -357,9 +358,9 @@ class NumArray<DataType,2,LayoutType>
   explicit NumArray(eMemoryRessource r) : BaseClass(r){}
   //! Construit une vue
   NumArray(Int32 dim1_size,Int32 dim2_size)
-  : BaseClass(ArrayExtents<2>{dim1_size,dim2_size}){}
+  : BaseClass(ArrayExtents<MDDim2>{dim1_size,dim2_size}){}
   NumArray(Int32 dim1_size,Int32 dim2_size,eMemoryRessource r)
-  : BaseClass(ArrayExtents<2>{dim1_size,dim2_size},r){}
+  : BaseClass(ArrayExtents<MDDim2>{dim1_size,dim2_size},r){}
   /*!
    * \brief Construit un tableau à partir de valeurs prédéfinies.
    *
@@ -374,7 +375,7 @@ class NumArray<DataType,2,LayoutType>
  public:
   void resize(Int32 dim1_size,Int32 dim2_size)
   {
-    this->resize(ArrayExtents<2>(dim1_size,dim2_size));
+    this->resize(ArrayExtents<MDDim2>(dim1_size,dim2_size));
   }
 
  public:
@@ -424,11 +425,11 @@ class NumArray<DataType,2,LayoutType>
  * \sa NumArrayBase
  */
 template<class DataType,typename LayoutType>
-class NumArray<DataType,3,LayoutType>
-: public NumArrayBase<DataType,3,LayoutType>
+class NumArray<DataType,MDDim3,LayoutType>
+: public NumArrayBase<DataType,MDDim3,LayoutType>
 {
  public:
-  using BaseClass = NumArrayBase<DataType,3,LayoutType>;
+  using BaseClass = NumArrayBase<DataType,MDDim3,LayoutType>;
   using BaseClass::extent;
   using BaseClass::resize;
   using BaseClass::operator();
@@ -440,13 +441,13 @@ class NumArray<DataType,3,LayoutType>
   NumArray() = default;
   explicit NumArray(eMemoryRessource r) : BaseClass(r){}
   NumArray(Int32 dim1_size,Int32 dim2_size,Int32 dim3_size)
-  : BaseClass(ArrayExtents<3>(dim1_size,dim2_size,dim3_size)){}
+  : BaseClass(ArrayExtents<MDDim3>(dim1_size,dim2_size,dim3_size)){}
   NumArray(Int32 dim1_size,Int32 dim2_size,Int32 dim3_size,eMemoryRessource r)
-  : BaseClass(ArrayExtents<3>{dim1_size,dim2_size,dim3_size},r){}
+  : BaseClass(ArrayExtents<MDDim3>{dim1_size,dim2_size,dim3_size},r){}
  public:
   void resize(Int32 dim1_size,Int32 dim2_size,Int32 dim3_size)
   {
-    this->resize(ArrayExtents<3>(dim1_size,dim2_size,dim3_size));
+    this->resize(ArrayExtents<MDDim3>(dim1_size,dim2_size,dim3_size));
   }
 
  public:
@@ -501,11 +502,11 @@ class NumArray<DataType,3,LayoutType>
  * \sa NumArrayBase
  */
 template<class DataType,typename LayoutType>
-class NumArray<DataType,4,LayoutType>
-: public NumArrayBase<DataType,4,LayoutType>
+class NumArray<DataType,MDDim4,LayoutType>
+: public NumArrayBase<DataType,MDDim4,LayoutType>
 {
  public:
-  using BaseClass = NumArrayBase<DataType,4,LayoutType>;
+  using BaseClass = NumArrayBase<DataType,MDDim4,LayoutType>;
   using BaseClass::extent;
   using BaseClass::resize;
   using BaseClass::operator();
@@ -518,14 +519,14 @@ class NumArray<DataType,4,LayoutType>
   explicit NumArray(eMemoryRessource r) : BaseClass(r){}
   NumArray(Int32 dim1_size,Int32 dim2_size,
            Int32 dim3_size,Int32 dim4_size)
-  : BaseClass(ArrayExtents<4>(dim1_size,dim2_size,dim3_size,dim4_size)){}
+  : BaseClass(ArrayExtents<MDDim4>(dim1_size,dim2_size,dim3_size,dim4_size)){}
   NumArray(Int32 dim1_size,Int32 dim2_size,
            Int32 dim3_size,Int32 dim4_size,eMemoryRessource r)
-  : BaseClass(ArrayExtents<4>{dim1_size,dim2_size,dim3_size,dim4_size},r){}
+  : BaseClass(ArrayExtents<MDDim4>{dim1_size,dim2_size,dim3_size,dim4_size},r){}
  public:
   void resize(Int32 dim1_size,Int32 dim2_size,Int32 dim3_size,Int32 dim4_size)
   {
-    this->resize(ArrayExtents<4>(dim1_size,dim2_size,dim3_size,dim4_size));
+    this->resize(ArrayExtents<MDDim4>(dim1_size,dim2_size,dim3_size,dim4_size));
   }
 
  public:

--- a/arcane/src/arcane/utils/UtilsTypes.h
+++ b/arcane/src/arcane/utils/UtilsTypes.h
@@ -183,24 +183,65 @@ class Observer;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+class ArrayShape;
+
+namespace impl
+{
+template<int X> Int32 rankInfo();
+template<> Int32 rankInfo<1>();
+}
+
+template<int RankValue> class MDDim
+{
+ public:
+  static constexpr int rank() { return RankValue; }
+};
+
+//#define ARCANE_USE_TYPE_FOR_EXTENT
+#ifdef ARCANE_USE_TYPE_FOR_EXTENT
+
+using MDDim0 = MDDim<0>;
+using MDDim1 = MDDim<1>;
+using MDDim2 = MDDim<2>;
+using MDDim3 = MDDim<3>;
+using MDDim4 = MDDim<4>;
+
+#define A_MDRANK_TYPE(rank_name) typename rank_name
+#define A_MDRANK_RANK_VALUE(rank_name) (rank_name :: rank())
+#define A_MDDIM(rank_value) MDDim< rank_value >
+
+#else
+
+constexpr int MDDim0 = 0;
+constexpr int MDDim1 = 1;
+constexpr int MDDim2 = 2;
+constexpr int MDDim3 = 3;
+constexpr int MDDim4 = 4;
+
+#define A_MDRANK_TYPE(rank_name) int rank_name
+#define A_MDRANK_RANK_VALUE(rank_name) (rank_name)
+#define A_MDDIM(rank_value) rank_value
+
+#endif
+
 enum class eMemoryRessource;
-template<int RankValue> class DefaultLayout;
+template<A_MDRANK_TYPE(RankValue)> class DefaultLayout;
 class IMemoryRessourceMng;
-template<typename DataType,int RankValue,typename LayoutType = DefaultLayout<RankValue> >
+template<typename DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
 class MDSpanBase;
-template<class DataType,int RankValue,typename LayoutType = DefaultLayout<RankValue> >
+template<class DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
 class MDSpan;
-template<typename DataType,int RankValue,typename LayoutType = DefaultLayout<RankValue> >
+template<typename DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
 class NumArrayBase;
-template<class DataType,int RankValue,typename LayoutType = DefaultLayout<RankValue> >
+template<class DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
 class NumArray;
-template<int RankValue> class ArrayBounds;
+template<A_MDRANK_TYPE(RankValue)> class ArrayBounds;
 template<int RankValue> class ArrayBoundsIndexBase;
 template<int RankValue> class ArrayBoundsIndex;
-template<int RankValue> class ArrayExtentsBase;
-template<int RankValue> class ArrayExtents;
+template<A_MDRANK_TYPE(RankValue)> class ArrayExtentsBase;
+template<A_MDRANK_TYPE(RankValue)> class ArrayExtents;
 template<int RankValue> class ArrayStridesBase;
-template<int RankValue,typename LayoutType> class ArrayExtentsWithOffset;
+template<A_MDRANK_TYPE(RankValue),typename LayoutType> class ArrayExtentsWithOffset;
 class LoopRange;
 template<int RankValue> class SimpleLoopRanges;
 template<int RankValue> class ComplexLoopRanges;

--- a/arcane/src/arcane/utils/UtilsTypes.h
+++ b/arcane/src/arcane/utils/UtilsTypes.h
@@ -183,27 +183,29 @@ class Observer;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-class ArrayShape;
-
-namespace impl
-{
-template<int X> Int32 rankInfo();
-template<> Int32 rankInfo<1>();
-}
-
-template<int RankValue> class MDDim
+//! Classe pour un tableau dynamique de rang RankValue
+template<int RankValue>
+class MDDim
 {
  public:
   static constexpr int rank() { return RankValue; }
 };
 
+// A définir lorsqu'on voudra que le rang des classes NumArray et associées
+// soit spécifier par une classe au lieu d'un entier
 //#define ARCANE_USE_TYPE_FOR_EXTENT
+
 #ifdef ARCANE_USE_TYPE_FOR_EXTENT
 
+//! Constante pour un tableau dynamique de rang 0
 using MDDim0 = MDDim<0>;
+//! Constante pour un tableau dynamique de rang 1
 using MDDim1 = MDDim<1>;
+//! Constante pour un tableau dynamique de rang 2
 using MDDim2 = MDDim<2>;
+//! Constante pour un tableau dynamique de rang 3
 using MDDim3 = MDDim<3>;
+//! Constante pour un tableau dynamique de rang 4
 using MDDim4 = MDDim<4>;
 
 #define A_MDRANK_TYPE(rank_name) typename rank_name
@@ -212,10 +214,15 @@ using MDDim4 = MDDim<4>;
 
 #else
 
+//! Constante pour un tableau de rang 0
 constexpr int MDDim0 = 0;
+//! Constante pour un tableau de rang 1
 constexpr int MDDim1 = 1;
+//! Constante pour un tableau de rang 2
 constexpr int MDDim2 = 2;
+//! Constante pour un tableau de rang 3
 constexpr int MDDim3 = 3;
+//! Constante pour un tableau de rang 4
 constexpr int MDDim4 = 4;
 
 #define A_MDRANK_TYPE(rank_name) int rank_name

--- a/arcane/src/arcane/utils/tests/TestNumArray.cc
+++ b/arcane/src/arcane/utils/tests/TestNumArray.cc
@@ -25,7 +25,7 @@ TEST(NumArray,Basic)
 {
   std::cout << "TEST_NUMARRAY Basic\n";
 
-  NumArray<Real,1> array1(3);
+  NumArray<Real,MDDim1> array1(3);
   array1.s(1) = 5.0;
   ASSERT_EQ(array1(1),5.0);
   std::cout << " V=" << array1(1) << "\n";
@@ -35,31 +35,31 @@ TEST(NumArray,Basic)
   array1.resize(7);
   ASSERT_EQ(array1.totalNbElement(),7);
 
-  NumArray<Real,2> array2(2,3);
+  NumArray<Real,MDDim2> array2(2,3);
   array2.s(1,2) = 5.0;
   std::cout << " V=" << array2(1,2) << "\n";
   array2.resize(7,5);
   ASSERT_EQ(array2.totalNbElement(),(7*5));
 
-  NumArray<Real,3> array3(2,3,4);
+  NumArray<Real,MDDim3> array3(2,3,4);
   array3.s(1,2,3) = 5.0;
   std::cout << " V=" << array3(1,2,3) << "\n";
   array3.resize(12,4,6);
   ASSERT_EQ(array3.totalNbElement(),(12*4*6));
 
-  NumArray<Real,4> array4(2,3,4,5);
+  NumArray<Real,MDDim4> array4(2,3,4,5);
   array4.s(1,2,3,4) = 5.0;
   std::cout << " V=" << array4(1,2,3,4) << "\n";
   array4.resize(8,3,7,5);
   ASSERT_EQ(array4.totalNbElement(),(8*3*7*5));
 
-  NumArray<Real,1> num_data1(4, { 2.4, 5.6, 3.3, 5.4 });
+  NumArray<Real,MDDim1> num_data1(4, { 2.4, 5.6, 3.3, 5.4 });
   ASSERT_EQ(num_data1[0], 2.4);
   ASSERT_EQ(num_data1[1], 5.6);
   ASSERT_EQ(num_data1[2], 3.3);
   ASSERT_EQ(num_data1[3], 5.4);
 
-  NumArray<Real,2,RightLayout<2>> num_data2(3, 2, { 1.4, 15.6, 33.3, 7.4, 4.2, 6.5 });
+  NumArray<Real,MDDim2,RightLayout<MDDim2>> num_data2(3, 2, { 1.4, 15.6, 33.3, 7.4, 4.2, 6.5 });
   ASSERT_EQ(num_data2(0,0), 1.4);
   ASSERT_EQ(num_data2(0,1), 15.6);
   ASSERT_EQ(num_data2(1,0), 33.3);
@@ -75,22 +75,22 @@ TEST(NumArray,Basic2)
 {
   std::cout << "TEST_NUMARRAY Basic2\n";
 
-  NumArray<Real,1> array1;
+  NumArray<Real,MDDim1> array1;
   array1.resize(2);
   array1.s(1) = 5.0;
   std::cout << " V=" << array1(1) << "\n";
 
-  NumArray<Real,2> array2;
+  NumArray<Real,MDDim2> array2;
   array2.resize(2,3);
   array2.s(1,2) = 5.0;
   std::cout << " V=" << array2(1,2) << "\n";
 
-  NumArray<Real,3> array3(2,3,4);
+  NumArray<Real,MDDim3> array3(2,3,4);
   array3.resize(2,3,4);
   array3.s(1,2,3) = 5.0;
   std::cout << " V=" << array3(1,2,3) << "\n";
 
-  NumArray<Real,4> array4(2,3,4,5);
+  NumArray<Real,MDDim4> array4(2,3,4,5);
   array4.resize(2,3,4,5);
   array4.s(1,2,3,4) = 5.0;
   std::cout << " V=" << array4(1,2,3,4) << "\n";
@@ -105,7 +105,7 @@ TEST(NumArray3,Misc)
   constexpr int nb_y = 4;
   constexpr int nb_z = 5;
 
-  NumArray<Int64,3> v(nb_x,nb_y,nb_z);
+  NumArray<Int64,MDDim3> v(nb_x,nb_y,nb_z);
   v.fill(0);
   // Attention, v.extents() change si 'v' est redimensionné
   auto v_extents = v.extentsWithOffset();
@@ -173,27 +173,27 @@ TEST(NumArray3,Copy)
   int nb_x = 3;
   int nb_y = 4;
   int nb_z = 5;
-  NumArray<Real,3> v(nb_x,nb_y,nb_z);
+  NumArray<Real,MDDim3> v(nb_x,nb_y,nb_z);
   v.fill(3.2);
-  NumArray<Real,3> v2(nb_x*2,nb_y/2,nb_z*3);
+  NumArray<Real,MDDim3> v2(nb_x*2,nb_y/2,nb_z*3);
 
   v.copy(v2.span());
 
   {
-    NumArray<int,1> vi0(4,{1,3,5,7});
-    NumArray<int,1> vi1(vi0);
-    NumArray<int,1> vi2;
+    NumArray<int,MDDim1> vi0(4,{1,3,5,7});
+    NumArray<int,MDDim1> vi1(vi0);
+    NumArray<int,MDDim1> vi2;
     vi2 = vi1;
     ASSERT_EQ(vi1.to1DSpan(),vi0.to1DSpan());
     ASSERT_EQ(vi2.to1DSpan(),vi1.to1DSpan());
-    NumArray<int,1> vi3(vi0.to1DSpan());
+    NumArray<int,MDDim1> vi3(vi0.to1DSpan());
     ASSERT_EQ(vi3.to1DSpan(),vi0.to1DSpan());
   }
 
   {
-    NumArray<int,1> vi0(4,{1,3,5,7});
-    NumArray<int,1> vi1(vi0);
-    NumArray<int,1> vi2;
+    NumArray<int,MDDim1> vi0(4,{1,3,5,7});
+    NumArray<int,MDDim1> vi1(vi0);
+    NumArray<int,MDDim1> vi2;
     vi2 = vi1;
     ASSERT_EQ(vi1.to1DSpan(),vi0.to1DSpan());
     ASSERT_EQ(vi2.to1DSpan(),vi1.to1DSpan());
@@ -245,7 +245,7 @@ TEST(NumArray2,Layout)
   std::cout << "TEST_NUMARRAY2 Layout\n";
 
   {
-    NumArray<Real,2,RightLayout2> a(3,5);
+    NumArray<Real,MDDim2,RightLayout2> a(3,5);
     ASSERT_EQ(a.totalNbElement(),(3*5));
     _setNumArray2Values(a);
     auto values = a.to1DSpan();
@@ -255,7 +255,7 @@ TEST(NumArray2,Layout)
   }
 
   {
-    NumArray<Real,2,LeftLayout2> a(3,5);
+    NumArray<Real,MDDim2,LeftLayout2> a(3,5);
     ASSERT_EQ(a.totalNbElement(),(3*5));
     _setNumArray2Values(a);
     auto values = a.to1DSpan();
@@ -273,7 +273,7 @@ TEST(NumArray3,Layout)
   std::cout << "TEST_NUMARRAY3 Layout\n";
 
   {
-    NumArray<Real,3,RightLayout3> a(2,3,5);
+    NumArray<Real,MDDim3,RightLayout3> a(2,3,5);
     ASSERT_EQ(a.totalNbElement(),(2*3*5));
     _setNumArray3Values(a);
     auto values = a.to1DSpan();
@@ -287,7 +287,7 @@ TEST(NumArray3,Layout)
   }
 
   {
-    NumArray<Real,3,LeftLayout3> a(2,3,5);
+    NumArray<Real,MDDim3,LeftLayout3> a(2,3,5);
     ASSERT_EQ(a.totalNbElement(),(2*3*5));
     _setNumArray3Values(a);
     auto values = a.to1DSpan();
@@ -307,14 +307,14 @@ TEST(NumArray3,Layout)
 TEST(NumArray,RealN)
 {
   {
-    NumArray<Real2,1> a(5);
+    NumArray<Real2,MDDim1> a(5);
     a(2) = Real2(0.0,3.2);
     a(3,1) = 2.0;
     ASSERT_EQ(a(3).y,2.0);
   }
 
   {
-    NumArray<Real3,1> a(5);
+    NumArray<Real3,MDDim1> a(5);
     const Real3 v(0.0,3.2,5.6);
     a(0) = v;
     a(4,1) = 4.0;
@@ -323,7 +323,7 @@ TEST(NumArray,RealN)
   }
 
   {
-    NumArray<Real2x2,1> a(5);
+    NumArray<Real2x2,MDDim1> a(5);
     const Real2 v0(1.2,1.7);
     const Real2x2 v(Real2(3.2,5.6), Real2(3.4,1.7));
     a(0) = v;
@@ -336,7 +336,7 @@ TEST(NumArray,RealN)
   }
 
   {
-    NumArray<Real3x3,1> a(5);
+    NumArray<Real3x3,MDDim1> a(5);
     const Real3 v0(1.2,3.4,1.7);
     const Real3x3 v(Real3(0.0,3.2,5.6), Real3(1.2,3.4,1.7), Real3(9.2,1.4,5.0));
     a(0) = v;
@@ -355,15 +355,15 @@ TEST(NumArray,RealN)
 
 namespace Arcane
 {
-template class NumArray<float,4,RightLayout<4>>;
-template class NumArray<float,3,RightLayout<3>>;
-template class NumArray<float,2,RightLayout<2>>;
+template class NumArray<float,MDDim4,RightLayout<MDDim4>>;
+template class NumArray<float,MDDim3,RightLayout<MDDim3>>;
+template class NumArray<float,MDDim2,RightLayout<MDDim2>>;
 
-template class NumArray<float,4,LeftLayout<4>>;
-template class NumArray<float,3,LeftLayout<3>>;
-template class NumArray<float,2,LeftLayout<2>>;
+template class NumArray<float,MDDim4,LeftLayout<MDDim4>>;
+template class NumArray<float,MDDim3,LeftLayout<MDDim3>>;
+template class NumArray<float,MDDim2,LeftLayout<MDDim2>>;
 
-template class NumArray<float,1>;
+template class NumArray<float,MDDim1>;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The goal is to have the same template parameters than the future `std::mdspan` and `std::mdarray` classes.

This change is not yet used by default. A compatibility layer is introduced to allow smooth transition from current syntax to the new syntax. The use zill only have to change `NumArray<DataType,*>` to `NumArray<DataType,MDDim*>` (for example `NumArray<double,2>` to `NumArray<double,MDDim2>`).
