### PR TITLE
Remove usage of 'ItemInternal' in classes managing cartesian mesh 

### DIFF
--- a/arcane/ceapart/src/arcane/cartesianmesh/CartesianConnectivity.cc
+++ b/arcane/ceapart/src/arcane/cartesianmesh/CartesianConnectivity.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CartesianConnectivity.cc                                    (C) 2000-2021 */
+/* CartesianConnectivity.cc                                    (C) 2000-2022 */
 /*                                                                           */
 /* Maillage cartésien.                                                       */
 /*---------------------------------------------------------------------------*/
@@ -22,13 +22,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -52,6 +47,9 @@ void CartesianConnectivity::
 computeInfos(IMesh* mesh,VariableNodeReal3& nodes_coord,
              VariableCellReal3& cells_coord)
 {
+  m_nodes = NodeInfoListView(mesh->nodeFamily());
+  m_cells = CellInfoListView(mesh->cellFamily());
+
   if (mesh->dimension()==2 || mesh->dimension()==1)
     _computeInfos2D(mesh,nodes_coord,cells_coord);
   else if (mesh->dimension()==3)
@@ -71,29 +69,27 @@ _computeInfos2D(IMesh* mesh,VariableNodeReal3& nodes_coord,
   IItemFamily* node_family = mesh->nodeFamily();  
   IItemFamily* cell_family = mesh->cellFamily();
 
-  ItemInternal* null_ii = ItemInternal::nullItem();
-
   ENUMERATE_NODE(inode,node_family->allItems()){
     Node node = *inode;
     Real3 node_coord = nodes_coord[inode];
     Index& idx = cc._index(node);
-    idx.fill(null_ii);
+    idx.fill(NULL_ITEM_LOCAL_ID);
     Integer nb_cell = node.nbCell();
     for( Integer i=0; i<nb_cell; ++i ){
       Cell cell = node.cell(i);
-      ItemInternal* cell_ii = cell.internal();
+      Int32 cell_lid = cell.localId();
       Real3 cell_coord = cells_coord[cell];
       if (cell_coord.y > node_coord.y){
         if (cell_coord.x > node_coord.x)
-          idx.v[P_UpperRight] = cell_ii;
+          idx.v[P_UpperRight] = cell_lid;
         else
-          idx.v[P_UpperLeft] = cell_ii;
+          idx.v[P_UpperLeft] = cell_lid;
       }
       else{
         if (cell_coord.x > node_coord.x)
-          idx.v[P_LowerRight] = cell_ii;
+          idx.v[P_LowerRight] = cell_lid;
         else
-          idx.v[P_LowerLeft] = cell_ii;
+          idx.v[P_LowerLeft] = cell_lid;
       }
     }
   }
@@ -102,23 +98,23 @@ _computeInfos2D(IMesh* mesh,VariableNodeReal3& nodes_coord,
     Cell cell = *icell;
     Real3 cell_coord = cells_coord[cell];
     Index& idx = _index(cell);
-    idx.fill(null_ii);
+    idx.fill(NULL_ITEM_LOCAL_ID);
     Integer nb_node = cell.nbNode();
     for( Integer i=0; i<nb_node; ++i ){
       Node node = cell.node(i);
-      ItemInternal* node_ii = node.internal();
+      Int32 node_lid = node.localId();
       Real3 node_coord = nodes_coord[node];
       if (node_coord.y > cell_coord.y){
         if (node_coord.x > cell_coord.x)
-          idx.v[P_UpperRight] = node_ii;
+          idx.v[P_UpperRight] = node_lid;
         else
-          idx.v[P_UpperLeft] = node_ii;
+          idx.v[P_UpperLeft] = node_lid;
       }
       else{
         if (node_coord.x > cell_coord.x)
-          idx.v[P_LowerRight] = node_ii;
+          idx.v[P_LowerRight] = node_lid;
         else
-          idx.v[P_LowerLeft] = node_ii;
+          idx.v[P_LowerLeft] = node_lid;
       }
     }
   }
@@ -135,45 +131,43 @@ _computeInfos3D(IMesh* mesh,VariableNodeReal3& nodes_coord,
   IItemFamily* node_family = mesh->nodeFamily();  
   IItemFamily* cell_family = mesh->cellFamily();
 
-  ItemInternal* null_ii = ItemInternal::nullItem();
-
   ENUMERATE_NODE(inode,node_family->allItems()){
     Node node = *inode;
     Real3 node_coord = nodes_coord[inode];
     Index& idx = cc._index(node);
-    idx.fill(null_ii);
+    idx.fill(NULL_ITEM_LOCAL_ID);
     Integer nb_cell = node.nbCell();
     for( Integer i=0; i<nb_cell; ++i ){
       Cell cell = node.cell(i);
-      ItemInternal* cell_ii = cell.internal();
+      Int32 cell_lid = cell.localId();
       Real3 cell_coord = cells_coord[cell];
 
       if (cell_coord.z > node_coord.z){
         if (cell_coord.y > node_coord.y){
           if (cell_coord.x > node_coord.x)
-            idx.v[P_TopZUpperRight] = cell_ii;
+            idx.v[P_TopZUpperRight] = cell_lid;
           else
-            idx.v[P_TopZUpperLeft] = cell_ii;
+            idx.v[P_TopZUpperLeft] = cell_lid;
         }
         else{
           if (cell_coord.x > node_coord.x)
-            idx.v[P_TopZLowerRight] = cell_ii;
+            idx.v[P_TopZLowerRight] = cell_lid;
           else
-            idx.v[P_TopZLowerLeft] = cell_ii;
+            idx.v[P_TopZLowerLeft] = cell_lid;
         }
       }
       else{
         if (cell_coord.y > node_coord.y){
           if (cell_coord.x > node_coord.x)
-            idx.v[P_UpperRight] = cell_ii;
+            idx.v[P_UpperRight] = cell_lid;
           else
-            idx.v[P_UpperLeft] = cell_ii;
+            idx.v[P_UpperLeft] = cell_lid;
         }
         else{
           if (cell_coord.x > node_coord.x)
-            idx.v[P_LowerRight] = cell_ii;
+            idx.v[P_LowerRight] = cell_lid;
           else
-            idx.v[P_LowerLeft] = cell_ii;
+            idx.v[P_LowerLeft] = cell_lid;
         }
       }
     }
@@ -183,39 +177,39 @@ _computeInfos3D(IMesh* mesh,VariableNodeReal3& nodes_coord,
     Cell cell = *icell;
     Real3 cell_coord = cells_coord[cell];
     Index& idx = _index(cell);
-    idx.fill(null_ii);
+    idx.fill(NULL_ITEM_LOCAL_ID);
     Integer nb_node = cell.nbNode();
     for( Integer i=0; i<nb_node; ++i ){
       Node node = cell.node(i);
-      ItemInternal* node_ii = node.internal();
+      Int32 node_lid = node.localId();
       Real3 node_coord = nodes_coord[node];
 
       if (node_coord.z > cell_coord.z){
         if (node_coord.y > cell_coord.y){
           if (node_coord.x > cell_coord.x)
-            idx.v[P_TopZUpperRight] = node_ii;
+            idx.v[P_TopZUpperRight] = node_lid;
           else
-            idx.v[P_TopZUpperLeft] = node_ii;
+            idx.v[P_TopZUpperLeft] = node_lid;
         }
         else{
           if (node_coord.x > cell_coord.x)
-            idx.v[P_TopZLowerRight] = node_ii;
+            idx.v[P_TopZLowerRight] = node_lid;
           else
-            idx.v[P_TopZLowerLeft] = node_ii;
+            idx.v[P_TopZLowerLeft] = node_lid;
         }
       }
       else{
         if (node_coord.y > cell_coord.y){
           if (node_coord.x > cell_coord.x)
-            idx.v[P_UpperRight] = node_ii;
+            idx.v[P_UpperRight] = node_lid;
           else
-            idx.v[P_UpperLeft] = node_ii;
+            idx.v[P_UpperLeft] = node_lid;
         }
         else{
           if (node_coord.x > cell_coord.x)
-            idx.v[P_LowerRight] = node_ii;
+            idx.v[P_LowerRight] = node_lid;
           else
-            idx.v[P_LowerLeft] = node_ii;
+            idx.v[P_LowerLeft] = node_lid;
         }
       }
     }
@@ -225,7 +219,7 @@ _computeInfos3D(IMesh* mesh,VariableNodeReal3& nodes_coord,
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/ceapart/src/arcane/cartesianmesh/CartesianConnectivity.h
+++ b/arcane/ceapart/src/arcane/cartesianmesh/CartesianConnectivity.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CartesianConnectivity.h                                     (C) 2000-2021 */
+/* CartesianConnectivity.h                                     (C) 2000-2022 */
 /*                                                                           */
 /* Informations de connectivité d'un maillage cartésien.                     */
 /*---------------------------------------------------------------------------*/
@@ -37,8 +37,6 @@ class NodeDirectionMng;
 /*!
  * \ingroup ArcaneCartesianMesh
  * \brief Informations de connectivité d'un maillage cartésien.
- *
- * Pour l'instant, cela ne fonctionne que pour les maillages 2D.
  *
  * Comme tous les objets liés au maillage cartésien, ces instances ne
  * sont valides que tant que la topologie du maillage n'évolue pas.
@@ -87,20 +85,22 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianConnectivity
   struct Index
   {
    public:
-    void fill(ItemInternal* i){ v[0] = v[1] = v[2] = v[3] = v[4] = v[5] = v[6] = v[7] = i; }
-    ItemInternal* v[8];
+    friend class CartesianConnectivity;
+   private:
+    void fill(Int32 i){ v[0] = v[1] = v[2] = v[3] = v[4] = v[5] = v[6] = v[7] = i; }
+    Int32 v[8];
   };
 
  public:
 
   //! Maille en haut à gauche du noeud \a n
-  Cell upperLeft(Node n) const { return m_nodes_to_cell[n.localId()].v[P_UpperLeft]; }
+  Cell upperLeft(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_UpperLeft]]; }
   //! Maille en haut à droite du noeud \a n
-  Cell upperRight(Node n) const { return m_nodes_to_cell[n.localId()].v[P_UpperRight]; }
+  Cell upperRight(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_UpperRight]]; }
   //! Maille en bas à droite du noeud \a n
-  Cell lowerRight(Node n) const { return m_nodes_to_cell[n.localId()].v[P_LowerRight]; }
+  Cell lowerRight(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_LowerRight]]; }
   //! Maille en bas à gauche du noeud \a n
-  Cell lowerLeft(Node n) const { return m_nodes_to_cell[n.localId()].v[P_LowerLeft]; }
+  Cell lowerLeft(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_LowerLeft]]; }
 
   //! Maille en haut à gauche du noeud \a n
   CellLocalId upperLeftId(NodeLocalId n) const { return CellLocalId(m_nodes_to_cell[n.localId()].v[P_UpperLeft]); }
@@ -112,13 +112,13 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianConnectivity
   CellLocalId lowerLeftId(NodeLocalId n) const { return CellLocalId(m_nodes_to_cell[n.localId()].v[P_LowerLeft]); }
 
   //! En 3D, maille en haut à gauche du noeud \a n
-  Cell topZUpperLeft(Node n) const { return m_nodes_to_cell[n.localId()].v[P_TopZUpperLeft]; }
+  Cell topZUpperLeft(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_TopZUpperLeft]]; }
   //! En 3D, maille en haut à droite du noeud \a n
-  Cell topZUpperRight(Node n) const { return m_nodes_to_cell[n.localId()].v[P_TopZUpperRight]; }
+  Cell topZUpperRight(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_TopZUpperRight]]; }
   //! En 3D, maille en bas à droite du noeud \a n
-  Cell topZLowerRight(Node n) const { return m_nodes_to_cell[n.localId()].v[P_TopZLowerRight]; }
+  Cell topZLowerRight(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_TopZLowerRight]]; }
   //! En 3D, maille en bas à gauche du noeud \a n
-  Cell topZLowerLeft(Node n) const { return m_nodes_to_cell[n.localId()].v[P_TopZLowerLeft]; }
+  Cell topZLowerLeft(Node n) const { return m_cells[m_nodes_to_cell[n.localId()].v[P_TopZLowerLeft]]; }
 
   //! En 3D, maille en haut à gauche du noeud \a n
   CellLocalId topZUpperLeftId(NodeLocalId n) const { return CellLocalId(m_nodes_to_cell[n.localId()].v[P_TopZUpperLeft]); }
@@ -130,13 +130,13 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianConnectivity
   CellLocalId topZLowerLeftId(NodeLocalId n) const { return CellLocalId(m_nodes_to_cell[n.localId()].v[P_TopZLowerLeft]); }
 
   //! Noeud en haut à gauche de la maille \a c
-  Node upperLeft(Cell c) const { return m_cells_to_node[c.localId()].v[P_UpperLeft]; }
+  Node upperLeft(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_UpperLeft]]; }
   //! Noeud en haut à droite de la maille \a c
-  Node upperRight(Cell c) const { return m_cells_to_node[c.localId()].v[P_UpperRight]; }
+  Node upperRight(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_UpperRight]]; }
   //! Noeud en bas à droite de la maille \a c
-  Node lowerRight(Cell c) const { return m_cells_to_node[c.localId()].v[P_LowerRight]; }
+  Node lowerRight(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_LowerRight]]; }
   //! Noeud en bad à gauche de la maille \a c
-  Node lowerLeft(Cell c) const { return m_cells_to_node[c.localId()].v[P_LowerLeft]; }
+  Node lowerLeft(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_LowerLeft]]; }
 
   //! Noeud en haut à gauche de la maille \a c
   NodeLocalId upperLeftId(CellLocalId c) const { return NodeLocalId(m_cells_to_node[c.localId()].v[P_UpperLeft]); }
@@ -148,13 +148,13 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianConnectivity
   NodeLocalId lowerLeftId(CellLocalId c) const { return NodeLocalId(m_cells_to_node[c.localId()].v[P_LowerLeft]); }
 
   //! En 3D, noeud au dessus en haut à gauche de la maille \a c
-  Node topZUpperLeft(Cell c) const { return m_cells_to_node[c.localId()].v[P_TopZUpperLeft]; }
+  Node topZUpperLeft(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_TopZUpperLeft]]; }
   //! En 3D, noeud au dessus en haut à droite de la maille \a c
-  Node topZUpperRight(Cell c) const { return m_cells_to_node[c.localId()].v[P_TopZUpperRight]; }
+  Node topZUpperRight(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_TopZUpperRight]]; }
   //! En 3D, noeud au dessus en bas à droite de la maille \a c
-  Node topZLowerRight(Cell c) const { return m_cells_to_node[c.localId()].v[P_TopZLowerRight]; }
+  Node topZLowerRight(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_TopZLowerRight]]; }
   //! En 3D, noeud au dessus en bas à gauche de la maille \a c
-  Node topZLowerLeft(Cell c) const { return m_cells_to_node[c.localId()].v[P_TopZLowerLeft]; }
+  Node topZLowerLeft(Cell c) const { return m_nodes[m_cells_to_node[c.localId()].v[P_TopZLowerLeft]]; }
 
   //! En 3D, noeud au dessus en haut à gauche de la maille \a c
   NodeLocalId topZUpperLeftId(CellLocalId c) const { return NodeLocalId(m_cells_to_node[c.localId()].v[P_TopZUpperLeft]); }
@@ -186,7 +186,9 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianConnectivity
 
   ArrayView<Index> m_nodes_to_cell;
   ArrayView<Index> m_cells_to_node;
-
+  CellInfoListView m_cells{nullptr};
+  NodeInfoListView m_nodes{nullptr};
+  
   void _computeInfos2D(IMesh* mesh,VariableNodeReal3& nodes_coord,VariableCellReal3& cells_coord);
   void _computeInfos3D(IMesh* mesh,VariableNodeReal3& nodes_coord,VariableCellReal3& cells_coord);
 };

--- a/arcane/ceapart/src/arcane/cartesianmesh/CartesianMesh.cc
+++ b/arcane/ceapart/src/arcane/cartesianmesh/CartesianMesh.cc
@@ -490,7 +490,7 @@ _computeMeshDirection(CartesianMeshPatch& cdi,eMeshDirection dir,VariableCellRea
       prev_cell = Cell();
     else if (prev_cell.level()!=my_level)
       prev_cell = Cell();
-    cell_dm.m_infos[icell.itemLocalId()] = CellDirectionMng::ItemDirectionInfo(next_cell.internal(),prev_cell.internal());
+    cell_dm.m_infos[icell.itemLocalId()] = CellDirectionMng::ItemDirectionInfo(next_cell.localId(),prev_cell.localId());
   }
   cell_dm._internalComputeInnerAndOuterItems(all_cells);
   face_dm._internalComputeInfos(cell_dm,cells_center,faces_center);

--- a/arcane/ceapart/src/arcane/cartesianmesh/CellDirectionMng.cc
+++ b/arcane/ceapart/src/arcane/cartesianmesh/CellDirectionMng.cc
@@ -48,6 +48,7 @@ CellDirectionMng::
 CellDirectionMng()
 : m_direction(MD_DirInvalid)
 , m_p(nullptr)
+, m_cells(nullptr)
 , m_next_face_index(-1)
 , m_previous_face_index(-1)
 , m_sub_domain_offset(-1)
@@ -104,9 +105,9 @@ _internalComputeInnerAndOuterItems(const ItemGroup& items)
   IItemFamily* family = items.itemFamily();
   ENUMERATE_ITEM(iitem,items){
     Int32 lid = iitem.itemLocalId();
-    ItemInternal* i1 = m_infos[lid].m_next_item;
-    ItemInternal* i2 = m_infos[lid].m_previous_item;
-    if (i1->null() || i2->null())
+    Int32 i1 = m_infos[lid].m_next_lid;
+    Int32 i2 = m_infos[lid].m_previous_lid;
+    if (i1==NULL_ITEM_LOCAL_ID || i2==NULL_ITEM_LOCAL_ID)
       outer_lids.add(lid);
     else
       inner_lids.add(lid);
@@ -118,7 +119,7 @@ _internalComputeInnerAndOuterItems(const ItemGroup& items)
   m_p->m_inner_all_items = family->createGroup(String("AllInner")+base_group_name,inner_lids,true);
   m_p->m_outer_all_items = family->createGroup(String("AllOuter")+base_group_name,outer_lids,true);
   m_p->m_all_items = items;
-  m_items = family->itemsInternal();
+  m_cells = CellInfoListView(family);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/ceapart/src/arcane/cartesianmesh/CellDirectionMng.h
+++ b/arcane/ceapart/src/arcane/cartesianmesh/CellDirectionMng.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CellDirectionMng.cc                                         (C) 2000-2021 */
+/* CellDirectionMng.cc                                         (C) 2000-2022 */
 /*                                                                           */
 /* Infos sur les mailles d'une direction X Y ou Z d'un maillage structuré.   */
 /*---------------------------------------------------------------------------*/
@@ -215,14 +215,14 @@ class ARCANE_CARTESIANMESH_EXPORT CellDirectionMng
      * à nullptr.
      */
     ItemDirectionInfo()
-    : m_next_item(nullptr), m_previous_item(nullptr){}
-    ItemDirectionInfo(ItemInternal* next,ItemInternal* prev)
-    : m_next_item(next), m_previous_item(prev){}
+    : m_next_lid(NULL_ITEM_LOCAL_ID), m_previous_lid(NULL_ITEM_LOCAL_ID){}
+    ItemDirectionInfo(Int32 next_id,Int32 prev_id)
+    : m_next_lid(next_id), m_previous_lid(prev_id){}
    public:
     //! entité après l'entité courante dans la direction
-    ItemInternal* m_next_item;
+    Int32 m_next_lid;
     //! entité avant l'entité courante dans la direction
-    ItemInternal* m_previous_item;
+    Int32 m_previous_lid;
   };
  public:
   
@@ -250,7 +250,7 @@ class ARCANE_CARTESIANMESH_EXPORT CellDirectionMng
   //! Maille avec infos directionnelles aux noeuds correspondant à la maille \a c.
   DirCellNode cellNode(CellLocalId c) const
   {
-    return DirCellNode(m_items[c.localId()],m_nodes_indirection);
+    return DirCellNode(m_cells[c.localId()],m_nodes_indirection);
   }
 
   //! Maille avec infos directionnelles aux faces correspondant à la maille \a c.
@@ -261,7 +261,7 @@ class ARCANE_CARTESIANMESH_EXPORT CellDirectionMng
   //! Maille avec infos directionnelles aux faces correspondant à la maille \a c.
   DirCellFace cellFace(CellLocalId c) const
   {
-    return DirCellFace(m_items[c.localId()],m_next_face_index,m_previous_face_index);
+    return DirCellFace(m_cells[c.localId()],m_next_face_index,m_previous_face_index);
   }
 
   //! Groupe de toutes les mailles dans la direction.
@@ -366,8 +366,8 @@ class ARCANE_CARTESIANMESH_EXPORT CellDirectionMng
   //! Maille direction correspondant à la maille de numéro local \a local_id
   DirCell _cell(Int32 local_id) const
   {
-    Cell next = Cell(m_infos[local_id].m_next_item);
-    Cell prev = Cell(m_infos[local_id].m_previous_item);
+    Cell next = m_cells[m_infos[local_id].m_next_lid];
+    Cell prev = m_cells[m_infos[local_id].m_previous_lid];
     return DirCell(next,prev);
   }
 
@@ -417,7 +417,7 @@ class ARCANE_CARTESIANMESH_EXPORT CellDirectionMng
   SharedArray<ItemDirectionInfo> m_infos;
   eMeshDirection m_direction;
   Impl* m_p;
-  ItemInternalList m_items;
+  CellInfoListView m_cells;
   Int32 m_nodes_indirection[MAX_NB_NODE];
   Int32 m_next_face_index;
   Int32 m_previous_face_index;

--- a/arcane/ceapart/src/arcane/cartesianmesh/FaceDirectionMng.cc
+++ b/arcane/ceapart/src/arcane/cartesianmesh/FaceDirectionMng.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* FaceDirectionMng.cc                                         (C) 2000-2020 */
+/* FaceDirectionMng.cc                                         (C) 2000-2022 */
 /*                                                                           */
 /* Infos sur les faces d'une direction X Y ou Z d'un maillage structuré.     */
 /*---------------------------------------------------------------------------*/
@@ -51,6 +51,7 @@ class FaceDirectionMng::Impl
 FaceDirectionMng::
 FaceDirectionMng()
 : m_direction(MD_DirInvalid)
+, m_cells(nullptr)
 , m_p (nullptr)
 {
 }
@@ -96,7 +97,9 @@ void FaceDirectionMng::
 _internalComputeInfos(const CellDirectionMng& cell_dm,const VariableCellReal3& cells_center,
                       const VariableFaceReal3& faces_center)
 {
-  IItemFamily* face_family = m_p->m_cartesian_mesh->mesh()->faceFamily();
+  IMesh* mesh = m_p->m_cartesian_mesh->mesh();
+  IItemFamily* face_family = mesh->faceFamily();
+  IItemFamily* cell_family = mesh->cellFamily();
   int dir = (int)m_direction;
   String base_group_name = String("Direction")+dir;
   if (m_p->m_patch_index>=0)
@@ -148,6 +151,7 @@ _internalComputeInfos(const CellDirectionMng& cell_dm,const VariableCellReal3& c
   m_p->m_inner_all_items = face_family->createGroup(String("AllInner")+base_group_name,inner_lids,true);
   m_p->m_outer_all_items = face_family->createGroup(String("AllOuter")+base_group_name,outer_lids,true);
   m_p->m_all_items = all_faces;
+  m_cells = CellInfoListView(cell_family);
 
   _computeCellInfos(cell_dm,cells_center,faces_center);
 }
@@ -249,14 +253,10 @@ _computeCellInfos(const CellDirectionMng& cell_dm,const VariableCellReal3& cells
           front_cell = Cell();
       }
     }
-    ItemInternal* front_cell_i = front_cell.internal();
-    ItemInternal* back_cell_i = back_cell.internal();
-    ARCANE_CHECK_POINTER(back_cell_i);
-    ARCANE_CHECK_POINTER(front_cell_i);
     if (is_inverse)
-      m_infos[face_lid] = ItemDirectionInfo(back_cell_i,front_cell_i);
+      m_infos[face_lid] = ItemDirectionInfo(back_cell.localId(),front_cell.localId());
     else
-      m_infos[face_lid] = ItemDirectionInfo(front_cell_i,back_cell_i);
+      m_infos[face_lid] = ItemDirectionInfo(front_cell.localId(),back_cell.localId());
   }
 }
 

--- a/arcane/ceapart/src/arcane/cartesianmesh/FaceDirectionMng.h
+++ b/arcane/ceapart/src/arcane/cartesianmesh/FaceDirectionMng.h
@@ -79,19 +79,21 @@ class ARCANE_CARTESIANMESH_EXPORT FaceDirectionMng
      * à nullptr.
      */
     ItemDirectionInfo()
-    : m_next_item(nullptr), m_previous_item(nullptr){}
-    ItemDirectionInfo(ItemInternal* next,ItemInternal* prev)
-    : m_next_item(next), m_previous_item(prev){}
+    : m_next_lid(NULL_ITEM_LOCAL_ID), m_previous_lid(NULL_ITEM_LOCAL_ID){}
+    ItemDirectionInfo(Int32 next_lid,Int32 prev_lid)
+    : m_next_lid(next_lid), m_previous_lid(prev_lid){}
    public:
     //! entité après l'entité courante dans la direction
-    ItemInternal* m_next_item;
+    Int32 m_next_lid;
     //! entité avant l'entité courante dans la direction
-    ItemInternal* m_previous_item;
+    Int32 m_previous_lid;
   };
  public:
   
   //! Créé une instance vide. L'instance n'est pas valide tant que init() n'a pas été appelé.
   FaceDirectionMng();
+  FaceDirectionMng(const FaceDirectionMng& rhs) = default;
+  FaceDirectionMng& operator=(const FaceDirectionMng& rhs) = default;
   ~FaceDirectionMng();
 
   //! Face direction correspondant à la face \a f.
@@ -154,8 +156,8 @@ class ARCANE_CARTESIANMESH_EXPORT FaceDirectionMng
   //! Face direction correspondant à la face de numéro local \a local_id
   DirFace _face(Int32 local_id) const
   {
-    Cell next = Cell(m_infos[local_id].m_next_item);
-    Cell prev = Cell(m_infos[local_id].m_previous_item);
+    Cell next = m_cells[m_infos[local_id].m_next_lid];
+    Cell prev = m_cells[m_infos[local_id].m_previous_lid];
     return DirFace(next,prev);
   }
 
@@ -187,6 +189,7 @@ class ARCANE_CARTESIANMESH_EXPORT FaceDirectionMng
 
   SharedArray<ItemDirectionInfo> m_infos;
   eMeshDirection m_direction;
+  CellInfoListView m_cells;
   Impl* m_p;
 
   void _computeCellInfos(const CellDirectionMng& cell_dm,

--- a/arcane/ceapart/src/arcane/cartesianmesh/NodeDirectionMng.h
+++ b/arcane/ceapart/src/arcane/cartesianmesh/NodeDirectionMng.h
@@ -60,7 +60,7 @@ class ARCANE_CARTESIANMESH_EXPORT DirNode
   };
  private:
   // Seul NodeDirectionMng à le droit de construire un DirNode.
-  DirNode(ItemInternal* current,Node next,Node prev,DirNodeCellIndex idx)
+  DirNode(Node current,Node next,Node prev,DirNodeCellIndex idx)
   : m_current(current), m_previous(prev), m_next(next), m_cell_index(idx) {}
  public:
   //! Maille avant
@@ -88,7 +88,7 @@ class ARCANE_CARTESIANMESH_EXPORT DirNode
   CellLocalId cellId(Int32 position) const
   {
     Int32 x = cellIndex(position);
-    return (x==NULL_CELL) ? CellLocalId(NULL_ITEM_LOCAL_ID) : CellLocalId(m_current->cellLocalId(x));
+    return (x==NULL_CELL) ? CellLocalId(NULL_ITEM_LOCAL_ID) : CellLocalId(m_current.cellId(x));
   }
   /*!
    * \brief Maille en fonction de sa position par rapport à ce noeud.
@@ -99,7 +99,7 @@ class ARCANE_CARTESIANMESH_EXPORT DirNode
   Cell cell(Int32 position) const
   {
     Int32 x = cellIndex(position);
-    return (x==NULL_CELL) ? Cell() : Cell(m_current->internalCell(x));
+    return (x==NULL_CELL) ? Cell() : Cell(m_current.cell(x));
   }
 
   //! Noeud devant à gauche dans la direction
@@ -139,7 +139,8 @@ class ARCANE_CARTESIANMESH_EXPORT DirNode
   CellLocalId topPreviousLeftCellId() const { return cellId(CNP_TopPreviousLeft); }
 
  private:
-  ItemInternal* m_current;
+
+  Node m_current;
   Node m_previous;
   Node m_next;
   DirNodeCellIndex m_cell_index;
@@ -171,14 +172,14 @@ class ARCANE_CARTESIANMESH_EXPORT NodeDirectionMng
      * à nullptr.
      */
     ItemDirectionInfo()
-    : m_next_item(nullptr), m_previous_item(nullptr){}
-    ItemDirectionInfo(ItemInternal* next,ItemInternal* prev)
-    : m_next_item(next), m_previous_item(prev){}
+    : m_next_lid(NULL_ITEM_LOCAL_ID), m_previous_lid(NULL_ITEM_LOCAL_ID){}
+    ItemDirectionInfo(Int32 next_lid,Int32 prev_lid)
+    : m_next_lid(next_lid), m_previous_lid(prev_lid){}
    public:
     //! entité après l'entité courante dans la direction
-    ItemInternal* m_next_item;
+    Int32 m_next_lid;
     //! entité avant l'entité courante dans la direction
-    ItemInternal* m_previous_item;
+    Int32 m_previous_lid;
    public:
     void setCellIndexes(IndexType idx[8])
     {
@@ -278,7 +279,7 @@ class ARCANE_CARTESIANMESH_EXPORT NodeDirectionMng
 
   SharedArray<ItemDirectionInfo> m_infos;
   eMeshDirection m_direction;
-  ItemInternalList m_nodes;
+  NodeInfoListView m_nodes;
   Impl* m_p;
 
  private:
@@ -286,8 +287,8 @@ class ARCANE_CARTESIANMESH_EXPORT NodeDirectionMng
   //! Noeud direction correspondant au noeud de numéro local \a local_id
   DirNode _node(Int32 local_id) const
   {
-    Node next = Node(m_infos[local_id].m_next_item);
-    Node prev = Node(m_infos[local_id].m_previous_item);
+    Node next = m_nodes[m_infos[local_id].m_next_lid];
+    Node prev = m_nodes[m_infos[local_id].m_previous_lid];
     return DirNode(m_nodes[local_id],next,prev,m_infos[local_id].m_cell_index);
   }
 


### PR DESCRIPTION
This will reduce memory usage for some structures. We use `localId()` instead (which are of type `Int32`).