### PR TITLE
Remove base class 'ItemBase' from Item and simplify some methods

### DIFF
--- a/arcane/src/arcane/Item.cc
+++ b/arcane/src/arcane/Item.cc
@@ -5,17 +5,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Item.cc                                                     (C) 2000-2021 */
+/* Item.cc                                                     (C) 2000-2022 */
 /*                                                                           */
 /* Classe de base d'un élément du maillage.                                  */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arcane/Item.h"
+
 #include "arcane/utils/Iostream.h"
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/NotSupportedException.h"
+#include "arcane/utils/ITraceMng.h"
 
-#include "arcane/Item.h"
 #include "arcane/ItemCompare.h"
 #include "arcane/ItemPrinter.h"
 #include "arcane/MeshItemInternalList.h"
@@ -26,6 +28,10 @@
 
 namespace Arcane
 {
+
+int Item::m_nb_created_from_internal = 0;
+int Item::m_nb_created_from_internalptr = 0;
+int Item::m_nb_set_from_internal = 0;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -73,6 +79,28 @@ _badConversion(eItemKind k1,eItemKind k2) const
 {
   ARCANE_FATAL("Can not convert connectivity view ({0},{1}) to ({2},{3})",
                m_source_kind,m_target_kind,k1,k2);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void Item::
+dumpStats(ITraceMng* tm)
+{
+  tm->info() << "ItemStats: nb_created_from_internal = " << m_nb_created_from_internal;
+  tm->info() << "ItemStats: nb_created_from_internalptr = " << m_nb_created_from_internalptr;
+  tm->info() << "ItemStats: nb_set_from_internal = " << m_nb_set_from_internal;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void Item::
+resetStats()
+{
+  m_nb_created_from_internal = 0;
+  m_nb_created_from_internalptr = 0;
+  m_nb_set_from_internal = 0;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/Item.h
+++ b/arcane/src/arcane/Item.h
@@ -68,7 +68,6 @@ namespace Arcane
  et les opérations de comparaisons ne sont valides sur l'entité nulle.
  */
 class ARCANE_CORE_EXPORT Item
-: protected impl::ItemBase
 {
   // Pour accéder aux constructeurs privés
   friend class ItemEnumeratorBaseV3T<Item>;
@@ -142,7 +141,7 @@ class ARCANE_CORE_EXPORT Item
 
   //! Constructeur réservé pour les énumérateurs
   Item(Int32 local_id,ItemSharedInfo* shared_info)
-  : ItemBase(local_id,shared_info) {}
+  : m_shared_info(shared_info), m_local_id(local_id) {}
 
  public:
 
@@ -150,15 +149,18 @@ class ARCANE_CORE_EXPORT Item
   Item() = default;
 
   //! Construit une référence à l'entité \a internal
-  Item(ItemInternal* ainternal) : ItemBase(ainternal) {}
+  Item(ItemInternal* ainternal)
+  : m_shared_info(ainternal->m_shared_info)
+  , m_local_id(ainternal->m_local_id) {}
 
   // NOTE: Pour le constructeur suivant; il est indispensable d'utiliser
   // const& pour éviter une ambiguité avec le constructeur par recopie
   //! Construit une référence à l'entité \a abase
-  Item(const ItemBase& abase) : ItemBase(abase) {}
+  Item(const ItemBase& abase) : m_shared_info(abase.m_shared_info), m_local_id(abase.m_local_id) {}
 
   //! Construit une référence à l'entité \a internal
-  Item(const ItemInternalPtr* internals,Int32 local_id) : ItemBase(internals[local_id]) {}
+  Item(const ItemInternalPtr* internals,Int32 local_id)
+  : Item(local_id,internals[local_id]->m_shared_info) {}
 
   //! Opérateur de copie
   Item& operator=(ItemInternal* ainternal)
@@ -179,22 +181,32 @@ class ARCANE_CORE_EXPORT Item
   ItemLocalId itemLocalId() const { return ItemLocalId{ m_local_id }; }
 
   //! Identifiant unique sur tous les domaines
-  ItemUniqueId uniqueId() const { return ItemBase::uniqueId(); }
+  ItemUniqueId uniqueId() const
+  {
+#ifdef ARCANE_CHECK
+    if (m_local_id!=NULL_ITEM_LOCAL_ID)
+      arcaneCheckAt((Integer)m_local_id,m_shared_info->m_unique_ids.size());
+#endif
+    // Ne pas utiliser l'accesseur normal car ce tableau peut etre utilise pour la maille
+    // nulle et dans ce cas m_local_id vaut NULL_ITEM_LOCAL_ID (qui est negatif)
+    // ce qui provoque une exception pour debordement de tableau.
+    return ItemUniqueId(m_shared_info->m_unique_ids.data()[m_local_id]);
+  }
 
   //! Numéro du sous-domaine propriétaire de l'entité
-  Int32 owner() const { return ItemBase::owner(); }
+  Int32 owner() const { return m_shared_info->_ownerV2(m_local_id); }
 
   //! Type de l'entité
-  Int16 type() const { return ItemBase::typeId(); }
+  Int16 type() const { return m_shared_info->_typeId(m_local_id); }
 
   //! Type de l'entité
-  ItemTypeId itemTypeId() const { return ItemBase::itemTypeId(); }
+  ItemTypeId itemTypeId() const { return ItemTypeId(type()); }
 
   //! Genre de l'entité
-  eItemKind kind() const { return ItemBase::kind(); }
+  eItemKind kind() const { return m_shared_info->m_item_kind; }
 
   //! \a true si l'entité est appartient au sous-domaine
-  bool isOwn() const { return ItemBase::isOwn(); }
+  bool isOwn() const { return (_flags() & ItemFlags::II_Own)!=0; }
 
   /*!
    * \brief Vrai si l'entité est partagé d'autres sous-domaines.
@@ -206,7 +218,7 @@ class ARCANE_CORE_EXPORT Item
    * Cette méthode n'est pertinente que si les informations de connectivité
    * ont été calculées (par un appel à IItemFamily::computeSynchronizeInfos()).
    */
-  bool isShared() const { return ItemBase::isShared(); }
+  bool isShared() const { return (_flags() & ItemFlags::II_Shared)!=0; }
 
   //! Converti l'entité en le genre \a ItemWithNodes.
   inline ItemWithNodes toItemWithNodes() const;
@@ -224,13 +236,13 @@ class ARCANE_CORE_EXPORT Item
   inline DoF toDoF() const;
 
   //! Nombre de parents
-  Int32 nbParent() const { return ItemBase::nbParent(); }
+  Int32 nbParent() const { return _nbParent(); }
 
   //! i-ème parent
-  Item parent(Int32 i) const { return ItemBase::parentBase(i); }
+  Item parent(Int32 i) const { return m_shared_info->_parentV2(m_local_id,i); }
 
   //! premier parent
-  Item parent() const { return ItemBase::parentBase(0); }
+  Item parent() const { return m_shared_info->_parentV2(m_local_id,0); }
 
  public:
 
@@ -286,7 +298,12 @@ class ARCANE_CORE_EXPORT Item
    * \warning La partie interne de l'entité ne doit être modifiée que
    * par ceux qui savent ce qu'ils font.
    */
-  ItemInternal* internal() const { return ItemBase::itemInternal(); }
+  ItemInternal* internal() const
+  {
+    if (m_local_id!=NULL_ITEM_LOCAL_ID)
+      return m_shared_info->m_items_internal[m_local_id];
+    return ItemInternal::nullItem();
+  }
 
   /*!
    * \brief Infos sur le type de l'entité.
@@ -295,7 +312,7 @@ class ARCANE_CORE_EXPORT Item
    * un type donné d'entité , comme par exemple les numérotations locales
    * de ces faces ou de ses arêtes.
    */
-  const ItemTypeInfo* typeInfo() const { return ItemBase::typeInfo(); }
+  const ItemTypeInfo* typeInfo() const { return m_shared_info->typeInfoFromId(type()); }
 
  public:
 
@@ -305,9 +322,20 @@ class ARCANE_CORE_EXPORT Item
   ARCANE_DEPRECATED_REASON("Y2022: Do not use this operator. Use operator '.' instead")
   const Item* operator->() const { return this; }
 
+ private:
+
+  //! Infos partagées entre toutes les entités ayant les mêmes caractéristiques
+  ItemSharedInfo* m_shared_info = ItemSharedInfo::nullItemSharedInfoPointer;
+
  protected:
 
-  using ItemBase::m_local_id;
+  /*!
+   * \brief Numéro local (au sous-domaine) de l'entité.
+   *
+   * Pour des raisons de performance, le numéro local doit être
+   * le premier champs de la classe.
+   */
+  Int32 m_local_id = NULL_ITEM_LOCAL_ID;
 
  protected:
 
@@ -324,6 +352,70 @@ class ARCANE_CORE_EXPORT Item
   void _set(const Item& rhs)
   {
     _setFromInternal(rhs);
+  }
+
+ protected:
+
+  //! Flags de l'entité
+  Int32 _flags() const { return m_shared_info->_flagsV2(m_local_id); }
+  //! Nombre de noeuds de l'entité
+  Integer _nbNode() const { return _connectivity()->_nbNodeV2(m_local_id); }
+  //! Nombre d'arêtes de l'entité ou nombre d'arêtes connectés à l'entités (pour les noeuds)
+  Integer _nbEdge() const { return _connectivity()->_nbEdgeV2(m_local_id); }
+  //! Nombre de faces de l'entité ou nombre de faces connectés à l'entités (pour les noeuds et arêtes)
+  Integer _nbFace() const { return _connectivity()->_nbFaceV2(m_local_id); }
+  //! Nombre de mailles connectées à l'entité (pour les noeuds, arêtes et faces)
+  Integer _nbCell() const { return _connectivity()->_nbCellV2(m_local_id); }
+  //! Nombre de parent
+  Int32 _nbHParent() const { return _connectivity()->_nbHParentV2(m_local_id); }
+  //! Nombre d' enfants
+  Int32 _nbHChildren() const { return _connectivity()->_nbHChildrenV2(m_local_id); }
+  //! Nombre de parent
+  Integer _nbParent() const { return m_shared_info->nbParent(); }
+  Int32 _nodeId(Integer index) const { return _connectivity()->_nodeLocalIdV2(m_local_id,index); }
+  Int32 _edgeId(Integer index) const { return _connectivity()->_edgeLocalIdV2(m_local_id,index); }
+  Int32 _faceId(Integer index) const { return _connectivity()->_faceLocalIdV2(m_local_id,index); }
+  Int32 _cellId(Integer index) const { return _connectivity()->_cellLocalIdV2(m_local_id,index); }
+  Int32 _hParentId(Int32 index) const { return _connectivity()->_hParentLocalIdV2(m_local_id,index); }
+  Int32 _hChildId(Int32 index) const { return _connectivity()->_hChildLocalIdV2(m_local_id,index); }
+  ItemInternalVectorView _internalNodes() const { return _connectivity()->nodesV2(m_local_id); }
+  ItemInternalVectorView _internalEdges() const { return _connectivity()->edgesV2(m_local_id); }
+  ItemInternalVectorView _internalFaces() const { return _connectivity()->facesV2(m_local_id); }
+  ItemInternalVectorView _internalCells() const { return _connectivity()->cellsV2(m_local_id); }
+  Int32ConstArrayView _nodeIds() const { return _connectivity()->nodeLocalIdsV2(m_local_id); }
+  Int32ConstArrayView _edgeIds() const { return _connectivity()->edgeLocalIdsV2(m_local_id); }
+  Int32ConstArrayView _faceIds() const { return _connectivity()->faceLocalIdsV2(m_local_id); }
+  Int32ConstArrayView _cellIds() const { return _connectivity()->cellLocalIdsV2(m_local_id); }
+  //TODO: A remplacer par le vrai type
+  ItemBase _nodeBase(Int32 index) const { return _connectivity()->nodeBase(m_local_id,index); }
+  ItemBase _edgeBase(Int32 index) const { return _connectivity()->edgeBase(m_local_id,index); }
+  ItemBase _faceBase(Int32 index) const { return _connectivity()->faceBase(m_local_id,index); }
+  ItemBase _cellBase(Int32 index) const { return _connectivity()->cellBase(m_local_id,index); }
+  ItemBase _hParentBase(Int32 index) const { return _connectivity()->hParentBase(m_local_id,index); }
+  ItemBase _hChildBase(Int32 index) const { return _connectivity()->hChildBase(m_local_id,index); }
+  inline ItemBase _parentBase(Int32 index) const;
+  ItemBase _toItemBase() const { return ItemBase(m_local_id,m_shared_info); }
+
+ private:
+
+  ItemInternalConnectivityList* _connectivity() const
+  {
+    return m_shared_info->m_connectivity;
+  }
+  void _setFromInternal(ItemBase* rhs)
+  {
+    m_local_id = rhs->m_local_id;
+    m_shared_info = rhs->m_shared_info;
+  }
+  void _setFromInternal(const ItemBase& rhs)
+  {
+    m_local_id = rhs.m_local_id;
+    m_shared_info = rhs.m_shared_info;
+  }
+  void _setFromInternal(const Item& rhs)
+  {
+    m_local_id = rhs.m_local_id;
+    m_shared_info = rhs.m_shared_info;
   }
 };
 
@@ -457,13 +549,13 @@ class ARCANE_CORE_EXPORT Node
   NodeLocalId itemLocalId() const { return NodeLocalId{ m_local_id }; }
 
   //! Nombre d'arêtes connectées au noeud
-  Int32 nbEdge() const { return ItemBase::nbEdge(); }
+  Int32 nbEdge() const { return _nbEdge(); }
 
   //! Nombre de faces connectées au noeud
-  Int32 nbFace() const { return ItemBase::nbFace(); }
+  Int32 nbFace() const { return _nbFace(); }
 
   //! Nombre de mailles connectées au noeud
-  Int32 nbCell() const { return ItemBase::nbCell(); }
+  Int32 nbCell() const { return _nbCell(); }
 
   //! i-ème arête du noeud
   inline Edge edge(Int32 i) const;
@@ -475,39 +567,39 @@ class ARCANE_CORE_EXPORT Node
   inline Cell cell(Int32 i) const;
 
   //! i-ème arête du noeud
-  EdgeLocalId edgeId(Int32 i) const { return EdgeLocalId(ItemBase::edgeId(i)); }
+  EdgeLocalId edgeId(Int32 i) const { return EdgeLocalId(_edgeId(i)); }
 
   //! i-ème face du noeud
-  FaceLocalId faceId(Int32 i) const { return FaceLocalId(ItemBase::faceId(i)); }
+  FaceLocalId faceId(Int32 i) const { return FaceLocalId(_faceId(i)); }
 
   //! i-ème maille du noeud
-  CellLocalId cellId(Int32 i) const { return CellLocalId(ItemBase::cellId(i)); }
+  CellLocalId cellId(Int32 i) const { return CellLocalId(_cellId(i)); }
 
   //! Liste des arêtes du noeud
-  EdgeVectorView edges() const { return ItemBase::internalEdges(); }
+  EdgeVectorView edges() const { return _internalEdges(); }
 
   //! Liste des faces du noeud
-  FaceVectorView faces() const { return ItemBase::internalFaces(); }
+  FaceVectorView faces() const { return _internalFaces(); }
 
   //! Liste des mailles du noeud
-  CellVectorView cells() const { return ItemBase::internalCells(); }
+  CellVectorView cells() const { return _internalCells(); }
 
   //! Liste des arêtes du noeud
   EdgeLocalIdView edgeIds() const
   {
-    return EdgeLocalIdView::fromIds(ItemBase::edgeIds());
+    return EdgeLocalIdView::fromIds(_edgeIds());
   }
 
   //! Liste des faces du noeud
   FaceLocalIdView faceIds() const
   {
-    return FaceLocalIdView::fromIds(ItemBase::faceIds());
+    return FaceLocalIdView::fromIds(_faceIds());
   }
 
   //! Liste des mailles du noeud
   CellLocalIdView cellIds() const
   {
-    return CellLocalIdView::fromIds(ItemBase::cellIds());
+    return CellLocalIdView::fromIds(_cellIds());
   }
 
   // AMR
@@ -515,7 +607,7 @@ class ARCANE_CORE_EXPORT Node
   //! Enumére les mailles connectées au noeud
   CellVectorView _internalActiveCells(Int32Array& local_ids) const
   {
-    return ItemBase::_internalActiveCells(local_ids);
+    return _toItemBase()._internalActiveCells(local_ids);
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: Do not use this operator. Use operator '.' instead")
@@ -579,24 +671,24 @@ class ARCANE_CORE_EXPORT ItemWithNodes
  public:
 
   //! Nombre de noeuds de l'entité
-  Int32 nbNode() const { return ItemBase::nbNode(); }
+  Int32 nbNode() const { return _nbNode(); }
 
   //! i-ème noeud de l'entité
-  Node node(Int32 i) const { return Node(ItemBase::nodeBase(i)); }
+  Node node(Int32 i) const { return Node(_nodeBase(i)); }
 
   //! Liste des noeuds de l'entité
-  NodeVectorView nodes() const { return ItemBase::internalNodes(); }
+  NodeVectorView nodes() const { return _internalNodes(); }
 
   //! Liste des noeuds de l'entité
   NodeLocalIdView nodeIds() const
   {
-    return NodeLocalIdView::fromIds(ItemBase::nodeIds());
+    return NodeLocalIdView::fromIds(_nodeIds());
   }
 
   //! i-ème noeud de l'entité.
   NodeLocalId nodeId(Int32 index) const
   {
-    return NodeLocalId(ItemBase::nodeId(index));
+    return NodeLocalId(_nodeId(index));
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: Do not use this operator. Use operator '.' instead")
@@ -689,39 +781,39 @@ class ARCANE_CORE_EXPORT Edge
   Int32 nbNode() const { return 2; }
 
   //! Nombre de faces connectées à l'arête
-  Int32 nbFace() const { return ItemBase::nbFace(); }
+  Int32 nbFace() const { return _nbFace(); }
 
   //! Nombre de mailles connectées à l'arête
-  Int32 nbCell() const { return ItemBase::nbCell(); }
+  Int32 nbCell() const { return _nbCell(); }
 
   //! i-ème maille de l'arête
   inline Cell cell(Int32 i) const;
 
   //! Liste des mailles de l'arête
-  CellVectorView cells() const { return ItemBase::internalCells(); }
+  CellVectorView cells() const { return _internalCells(); }
 
   //! i-ème maille de l'arête
-  CellLocalId cellId(Int32 i) const { return CellLocalId(ItemBase::cellId(i)); }
+  CellLocalId cellId(Int32 i) const { return CellLocalId(_cellId(i)); }
 
   //! Liste des mailles de l'arête
   CellLocalIdView cellIds() const
   {
-    return CellLocalIdView::fromIds(ItemBase::cellIds());
+    return CellLocalIdView::fromIds(_cellIds());
   }
 
   //! i-ème face de l'arête
   inline Face face(Int32 i) const;
 
   //! Liste des faces de l'arête
-  FaceVectorView faces() const { return ItemBase::internalFaces(); }
+  FaceVectorView faces() const { return _internalFaces(); }
 
   //! i-ème face de l'arête
-  FaceLocalId faceId(Int32 i) const { return FaceLocalId(ItemBase::faceId(i)); }
+  FaceLocalId faceId(Int32 i) const { return FaceLocalId(_faceId(i)); }
 
   //! Liste des faces de l'arête
   FaceLocalIdView faceIds() const
   {
-    return FaceLocalIdView::fromIds(ItemBase::faceIds());
+    return FaceLocalIdView::fromIds(_faceIds());
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: Do not use this operator. Use operator '.' instead")
@@ -811,21 +903,21 @@ class ARCANE_CORE_EXPORT Face
   FaceLocalId itemLocalId() const { return FaceLocalId{ m_local_id }; }
 
   //! Nombre de mailles de la face (1 ou 2)
-  Int32 nbCell() const { return ItemBase::nbCell(); }
+  Int32 nbCell() const { return _nbCell(); }
 
   //! i-ème maille de la face
   inline Cell cell(Int32 i) const;
 
   //! Liste des mailles de la face
-  CellVectorView cells() const { return ItemBase::internalCells(); }
+  CellVectorView cells() const { return _internalCells(); }
 
   //! i-ème maille de la face
-  CellLocalId cellId(Int32 i) const { return CellLocalId(ItemBase::cellId(i)); }
+  CellLocalId cellId(Int32 i) const { return CellLocalId(_cellId(i)); }
 
   //! Liste des mailles de la face
   CellLocalIdView cellIds() const
   {
-    return CellLocalIdView::fromIds(ItemBase::cellIds());
+    return CellLocalIdView::fromIds(_cellIds());
   }
 
   /*!
@@ -833,18 +925,18 @@ class ARCANE_CORE_EXPORT Face
    *
    * \warning Une face au bord du sous-domaine n'est pas nécessairement au bord du maillage global.
    */
-  bool isSubDomainBoundary() const { return ItemBase::isBoundary(); }
+  bool isSubDomainBoundary() const { return (_flags() & ItemFlags::II_Boundary)!=0; }
 
   /*!
    * \a true si la face est au bord du sous-domaine.
    * \deprecated Utiliser isSubDomainBoundary() à la place.
    */
-  ARCANE_DEPRECATED_118 bool isBoundary() const { return ItemBase::isBoundary(); }
+  ARCANE_DEPRECATED_118 bool isBoundary() const { return isSubDomainBoundary(); }
 
   //! Indique si la face est au bord t orientée vers l'extérieur.
   bool isSubDomainBoundaryOutside() const
   {
-    return isSubDomainBoundary() && (ItemBase::flags() & ItemFlags::II_HasBackCell);
+    return isSubDomainBoundary() && (_flags() & ItemFlags::II_HasBackCell);
   }
 
   /*!
@@ -864,13 +956,13 @@ class ARCANE_CORE_EXPORT Face
   inline Cell backCell() const;
 
   //! Maille derrière la face (maille nulle si aucune)
-  CellLocalId backCellId() const { return CellLocalId{ItemBase::backCellId()}; }
+  CellLocalId backCellId() const { return CellLocalId(_toItemBase().backCellId()); }
 
   //! Maille devant la face (maille nulle si aucune)
   inline Cell frontCell() const;
 
   //! Maille devant la face (maille nulle si aucune)
-  CellLocalId frontCellId() const { return CellLocalId{ItemBase::frontCellId()}; }
+  CellLocalId frontCellId() const { return CellLocalId(_toItemBase().frontCellId()); }
 
   /*!
    * \brief Maille opposée de cette face à la maille \a cell.
@@ -898,13 +990,13 @@ class ARCANE_CORE_EXPORT Face
    *
    * \sa ITiedInterface
    */
-  Face masterFace() const { return ItemBase::masterFace(); }
+  Face masterFace() const { return _toItemBase().masterFace(); }
 
   //! \a true s'il s'agit de la face maître d'une interface
-  bool isMasterFace() const { return ItemBase::isMasterFace(); }
+  bool isMasterFace() const { return _toItemBase().isMasterFace(); }
 
   //! \a true s'il s'agit d'une face esclave d'une interface
-  bool isSlaveFace() const { return ItemBase::isSlaveFace(); }
+  bool isSlaveFace() const { return _toItemBase().isSlaveFace(); }
 
   //! \a true s'il s'agit d'une face esclave ou maître d'une interface
   bool isTiedFace() const { return isSlaveFace() || isMasterFace(); }
@@ -917,29 +1009,29 @@ class ARCANE_CORE_EXPORT Face
    */
   FaceVectorView slaveFaces() const
   {
-    if (ItemBase::isMasterFace())
-      return ItemBase::internalFaces();
+    if (_toItemBase().isMasterFace())
+      return _internalFaces();
     return FaceVectorView();
   }
 
  public:
 
   //! Nombre d'arêtes de la face
-  Int32 nbEdge() const { return ItemBase::nbEdge(); }
+  Int32 nbEdge() const { return _nbEdge(); }
 
   //! i-ème arête de la face
-  Edge edge(Int32 i) const { return Edge(ItemBase::edgeBase(i)); }
+  Edge edge(Int32 i) const { return Edge(_edgeBase(i)); }
 
   //! Liste des arêtes de la face
-  EdgeVectorView edges() const { return ItemBase::internalEdges(); }
+  EdgeVectorView edges() const { return _internalEdges(); }
 
   //! i-ème arête de la face
-  EdgeLocalId edgeId(Int32 i) const { return EdgeLocalId(ItemBase::edgeId(i)); }
+  EdgeLocalId edgeId(Int32 i) const { return EdgeLocalId(_edgeId(i)); }
 
   //! Liste des arêtes de la face
   EdgeLocalIdView edgeIds() const
   {
-    return EdgeLocalIdView::fromIds(ItemBase::edgeIds());
+    return EdgeLocalIdView::fromIds(_edgeIds());
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: Do not use this operator. Use operator '.' instead")
@@ -1048,39 +1140,39 @@ class ARCANE_CORE_EXPORT Cell
   CellLocalId itemLocalId() const { return CellLocalId{ m_local_id }; }
 
   //! Nombre de faces de la maille
-  Int32 nbFace() const { return ItemBase::nbFace(); }
+  Int32 nbFace() const { return _nbFace(); }
 
   //! i-ème face de la maille
-  Face face(Int32 i) const { return Face(ItemBase::faceBase(i)); }
+  Face face(Int32 i) const { return Face(_faceBase(i)); }
 
   //! Liste des faces de la maille
-  FaceVectorView faces() const { return ItemBase::internalFaces(); }
+  FaceVectorView faces() const { return _internalFaces(); }
 
   //! i-ème face de la maille
-  FaceLocalId faceId(Int32 i) const { return FaceLocalId(ItemBase::faceId(i)); }
+  FaceLocalId faceId(Int32 i) const { return FaceLocalId(_faceId(i)); }
 
   //! Liste des faces de la maille
   FaceLocalIdView faceIds() const
   {
-    return FaceLocalIdView::fromIds(ItemBase::faceIds());
+    return FaceLocalIdView::fromIds(_faceIds());
   }
 
   //! Nombre d'arêtes de la maille
-  Int32 nbEdge() const { return ItemBase::nbEdge(); }
+  Int32 nbEdge() const { return _nbEdge(); }
 
   //! i-ème arête de la maille
-  Edge edge(Int32 i) const { return Edge(ItemBase::edgeBase(i)); }
+  Edge edge(Int32 i) const { return Edge(_edgeBase(i)); }
 
   //! i-ème arête de la maille
-  EdgeLocalId edgeId(Int32 i) const { return EdgeLocalId(ItemBase::edgeId(i)); }
+  EdgeLocalId edgeId(Int32 i) const { return EdgeLocalId(_edgeId(i)); }
 
   //! Liste des arêtes de la maille
-  EdgeVectorView edges() const { return ItemBase::internalEdges(); }
+  EdgeVectorView edges() const { return _internalEdges(); }
 
   //! Liste des arêtes de la maille
   EdgeLocalIdView edgeIds() const
   {
-    return EdgeLocalIdView::fromIds(ItemBase::edgeIds());
+    return EdgeLocalIdView::fromIds(_edgeIds());
   }
 
   //! AMR
@@ -1089,44 +1181,53 @@ class ARCANE_CORE_EXPORT Cell
   //! Une fusion des deux notions est envisageable dans un deuxième temps
   //! dans un premier temps, les appelations, pour l'amr, sont en français i.e. parent -> pere et child -> enfant
   //! un seul parent
-  Cell hParent() const { return Cell(ItemBase::hParentBase(0)); }
+  Cell hParent() const { return Cell(_hParentBase(0)); }
 
-  Int32 nbHChildren() const { return ItemBase::nbHChildren(); }
+  Int32 nbHChildren() const { return _nbHChildren(); }
 
   //! i-ème enfant
-  Cell hChild(Int32 i) const { return Cell(ItemBase::hChildBase(i)); }
+  Cell hChild(Int32 i) const { return Cell(_hChildBase(i)); }
 
   //! parent de niveau 0
-  Cell topHParent() const { return Cell(ItemBase::topHParentBase()); }
+  Cell topHParent() const { return Cell(_toItemBase().topHParentBase()); }
 
   /*!
    * \returns \p true si l'item est actif (i.e. n'a pas de
    * descendants actifs), \p false  sinon. Notez qu'il suffit de vérifier
    * le premier enfant seulement. Renvoie toujours \p true si l'AMR est désactivé.
    */
-  bool isActive() const { return ItemBase::isActive(); }
+  bool isActive() const { return _toItemBase().isActive(); }
 
-  bool isSubactive() const { return ItemBase::isSubactive(); }
+  bool isSubactive() const { return _toItemBase().isSubactive(); }
 
   /*!
    * \returns \p true si l'item est un ancetre (i.e. a un
    * enfant actif ou un enfant ancetre), \p false sinon.
    * Renvoie toujours \p false si l'AMR est désactivé.
    */
-  bool isAncestor() const { return ItemBase::isAncestor(); }
+  bool isAncestor() const { return _toItemBase().isAncestor(); }
 
   /*!
    * \returns \p true si l'item a des enfants (actifs ou non),
    * \p false  sinon. Renvoie toujours \p false si l'AMR est désactivé.
    */
-  bool hasHChildren() const { return ItemBase::hasHChildren(); }
+  bool hasHChildren() const { return _toItemBase().hasHChildren(); }
 
   /*!
    * \returns le niveau de raffinement de l'item courant.  Si l'item
    * parent est \p NULL donc par convention il est au niveau 0,
    * sinon il est simplement au niveau superieur que celui de son parent.
    */
-  Int32 level() const { return ItemBase::level(); }
+  Int32 level() const
+  {
+    //! si je n'ai pas de parent donc j'ai été crée
+    //! directement à partir d'un fichier ou par l'utilisateur,
+    //! donc je suis un item de niveau 0
+    if (this->_nbHParent() == 0)
+      return 0;
+    //! sinon je suis au niveau supérieur que celui de mon parent
+    return (this->_hParentBase(0).level() + 1);
+  }
 
   /*!
    * \returns le rang de l'enfant \p (iitem).
@@ -1135,7 +1236,7 @@ class ARCANE_CORE_EXPORT Cell
    */
   Int32 whichChildAmI(const ItemInternal* iitem) const
   {
-    return ItemBase::whichChildAmI(iitem->localId());
+    return _toItemBase().whichChildAmI(iitem->localId());
   }
 
   /*!
@@ -1145,7 +1246,7 @@ class ARCANE_CORE_EXPORT Cell
    */
   Int32 whichChildAmI(CellLocalId local_id) const
   {
-    return ItemBase::whichChildAmI(local_id);
+    return _toItemBase().whichChildAmI(local_id);
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: Do not use this operator. Use operator '.' instead")
@@ -1219,13 +1320,13 @@ class Particle
    * Il faut appeler setCell() avant d'appeler cette fonction.
    * \precondition hasCell() doit être vrai.
    */
-  Cell cell() const { return Cell(ItemBase::cellBase(0)); }
+  Cell cell() const { return Cell(_cellBase(0)); }
 
   //! Maille connectée à la particule
-  CellLocalId cellId() const { return CellLocalId(ItemBase::cellId(0)); }
+  CellLocalId cellId() const { return CellLocalId(_cellId(0)); }
 
   //! Vrai si la particule est dans une maille du maillage
-  bool hasCell() const { return (ItemBase::cellId(0)!=NULL_ITEM_LOCAL_ID); }
+  bool hasCell() const { return (_cellId(0)!=NULL_ITEM_LOCAL_ID); }
 
   /*!
    * \brief Maille à laquelle appartient la particule ou maille nulle.
@@ -1234,10 +1335,10 @@ class Particle
    */
   Cell cellOrNull() const
   {
-    Int32 cell_local_id = ItemBase::cellId(0);
+    Int32 cell_local_id = _cellId(0);
     if (cell_local_id==NULL_ITEM_LOCAL_ID)
       return Cell();
-    return Cell(ItemBase::cellBase(0));
+    return Cell(_cellBase(0));
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: Do not use this operator. Use operator '.' instead")
@@ -1325,19 +1426,19 @@ class DoF
 inline Edge Node::
 edge(Int32 i) const
 {
-  return Edge(ItemBase::edgeBase(i));
+  return Edge(_edgeBase(i));
 }
 
 inline Face Node::
 face(Int32 i) const
 {
-  return Face(ItemBase::faceBase(i));
+  return Face(_faceBase(i));
 }
 
 inline Cell Node::
 cell(Int32 i) const
 {
-  return Cell(ItemBase::cellBase(i));
+  return Cell(_cellBase(i));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1346,13 +1447,13 @@ cell(Int32 i) const
 inline Face Edge::
 face(Int32 i) const
 {
-  return Face(ItemBase::faceBase(i));
+  return Face(_faceBase(i));
 }
 
 inline Cell Edge::
 cell(Int32 i) const
 {
-  return Cell(ItemBase::cellBase(i));
+  return Cell(_cellBase(i));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1361,19 +1462,19 @@ cell(Int32 i) const
 inline Cell Face::
 boundaryCell() const
 {
-  return Cell(ItemBase::boundaryCell());
+  return Cell(_toItemBase().boundaryCell());
 }
 
 inline Cell Face::
 backCell() const
 {
-  return Cell(ItemBase::backCell());
+  return Cell(_toItemBase().backCell());
 }
 
 inline Cell Face::
 frontCell() const
 {
-  return Cell(ItemBase::frontCell());
+  return Cell(_toItemBase().frontCell());
 }
 
 inline Cell Face::
@@ -1386,7 +1487,7 @@ oppositeCell(Cell cell) const
 inline Cell Face::
 cell(Int32 i) const
 {
-  return Cell(ItemBase::cellBase(i));
+  return Cell(_cellBase(i));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemEnumerator.h
+++ b/arcane/src/arcane/ItemEnumerator.h
@@ -100,7 +100,7 @@ class ItemEnumerator
  private:
 
   ItemEnumerator(ItemSharedInfo* shared_info,const Int32* local_ids,Int32 index,Int32 n,
-                 const ItemGroupImpl* agroup,impl::ItemBase item_base)
+                 const ItemGroupImpl* agroup,Item item_base)
   : BaseClass(shared_info,local_ids,index,n,agroup,item_base){}
 };
 

--- a/arcane/src/arcane/ItemEnumeratorBase.h
+++ b/arcane/src/arcane/ItemEnumeratorBase.h
@@ -195,7 +195,7 @@ class ItemEnumeratorBaseV3T
   ItemEnumeratorBaseV3T(const ItemEnumerator& rhs,bool);
 
   ItemEnumeratorBaseV3T(ItemSharedInfo* shared_info,const Int32* local_ids,Int32 index,Int32 n,
-                        const ItemGroupImpl* agroup,impl::ItemBase item_base)
+                        const ItemGroupImpl* agroup,Item item_base)
   : ItemEnumeratorBaseV3(shared_info,local_ids,index,n,agroup), m_item_for_operator_arrow(item_base)
   {
   }

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -54,6 +54,7 @@ class ItemInternalConnectivityList;
 class ARCANE_CORE_EXPORT ItemSharedInfo
 {
   friend class impl::ItemBase;
+  friend class Item;
   friend class ItemInternal;
   friend class ItemInfoListView;
   friend class mesh::ItemFamily;

--- a/arcane/src/arcane/impl/TimeLoopMng.cc
+++ b/arcane/src/arcane/impl/TimeLoopMng.cc
@@ -1631,6 +1631,8 @@ _dumpTimeInfos(JSONWriter& json_writer)
       ps->dumpJSON(json_writer);
     }
   }
+
+  Item::dumpStats(traceMng());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1802,6 +1804,7 @@ doComputeLoop(Integer max_loop)
   try{
     if (ps)
       ps->initialize();
+    Item::resetStats();
     // Désactive le profiling si demande spécifique
     if (want_specific_profiling)
       ps = nullptr;


### PR DESCRIPTION
The class `Item` now directly use the `ItemSharedInfo` instance.