### PR TITLE
Optimize and cleanup 'ItemEnumerator'

### DIFF
--- a/arcane/src/arcane/Item.h
+++ b/arcane/src/arcane/Item.h
@@ -84,6 +84,8 @@ class ARCANE_CORE_EXPORT Item
   friend class ItemVectorView;
   friend class ItemVectorViewConstIterator;
   friend class SimdItem;
+  friend class SimdItemEnumeratorBase;
+  template<typename ItemType> friend class ItemEnumeratorBaseT;
 
  public:
 

--- a/arcane/src/arcane/Item.h
+++ b/arcane/src/arcane/Item.h
@@ -80,7 +80,7 @@ namespace Arcane
 class ARCANE_CORE_EXPORT Item
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<Item>;
+  friend class ItemEnumeratorBaseT<Item>;
   friend class ItemVectorView;
   friend class ItemVectorViewConstIterator;
   friend class SimdItem;
@@ -502,7 +502,7 @@ class ARCANE_CORE_EXPORT Node
 : public Item
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<Node>;
+  friend class ItemEnumeratorBaseT<Node>;
   friend class ItemVectorViewT<Node>;
   friend class ItemVectorViewConstIteratorT<Node>;
   friend class SimdItemT<Node>;
@@ -646,7 +646,7 @@ class ARCANE_CORE_EXPORT ItemWithNodes
 : public Item
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<ItemWithNodes>;
+  friend class ItemEnumeratorBaseT<ItemWithNodes>;
   friend class ItemVectorViewT<ItemWithNodes>;
   friend class ItemVectorViewConstIteratorT<ItemWithNodes>;
   friend class SimdItemT<ItemWithNodes>;
@@ -725,7 +725,7 @@ class ARCANE_CORE_EXPORT Edge
 : public ItemWithNodes
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<Edge>;
+  friend class ItemEnumeratorBaseT<Edge>;
   friend class ItemVectorViewT<Edge>;
   friend class ItemVectorViewConstIteratorT<Edge>;
   friend class SimdItemT<Edge>;
@@ -853,7 +853,7 @@ class ARCANE_CORE_EXPORT Face
 : public ItemWithNodes
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<Face>;
+  friend class ItemEnumeratorBaseT<Face>;
   friend class ItemVectorViewT<Face>;
   friend class ItemVectorViewConstIteratorT<Face>;
   friend class SimdItemT<Face>;
@@ -1093,7 +1093,7 @@ class ARCANE_CORE_EXPORT Cell
 : public ItemWithNodes
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<Cell>;
+  friend class ItemEnumeratorBaseT<Cell>;
   friend class ItemVectorViewT<Cell>;
   friend class ItemVectorViewConstIteratorT<Cell>;
   friend class SimdItemT<Cell>;
@@ -1288,7 +1288,7 @@ class Particle
 : public Item
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<Particle>;
+  friend class ItemEnumeratorBaseT<Particle>;
   friend class ItemVectorViewT<Particle>;
   friend class ItemVectorViewConstIteratorT<Particle>;
   friend class SimdItemT<Particle>;
@@ -1388,7 +1388,7 @@ class DoF
 : public Item
 {
   // Pour accéder aux constructeurs privés
-  friend class ItemEnumeratorBaseV3T<DoF>;
+  friend class ItemEnumeratorBaseT<DoF>;
   friend class ItemVectorViewT<DoF>;
   friend class ItemVectorViewConstIteratorT<DoF>;
   friend class SimdItemT<DoF>;

--- a/arcane/src/arcane/ItemEnumerator.h
+++ b/arcane/src/arcane/ItemEnumerator.h
@@ -56,13 +56,13 @@ class ItemEnumerator
   //   template<class T> friend class ItemEnumeratorBase;
   // mais cela ne fonctionne pas avec GCC 8. On fait donc la spécialisation
   // à la main
-  friend class ItemEnumeratorBaseV3T<Node>;
-  friend class ItemEnumeratorBaseV3T<ItemWithNodes>;
-  friend class ItemEnumeratorBaseV3T<Edge>;
-  friend class ItemEnumeratorBaseV3T<Face>;
-  friend class ItemEnumeratorBaseV3T<Cell>;
-  friend class ItemEnumeratorBaseV3T<Particle>;
-  friend class ItemEnumeratorBaseV3T<DoF>;
+  friend class ItemEnumeratorBaseT<Node>;
+  friend class ItemEnumeratorBaseT<ItemWithNodes>;
+  friend class ItemEnumeratorBaseT<Edge>;
+  friend class ItemEnumeratorBaseT<Face>;
+  friend class ItemEnumeratorBaseT<Cell>;
+  friend class ItemEnumeratorBaseT<Particle>;
+  friend class ItemEnumeratorBaseT<DoF>;
 
  public:
 
@@ -111,8 +111,8 @@ class ItemEnumerator
 /*---------------------------------------------------------------------------*/
 
 //! Constructeur seulement utilisé par fromItemEnumerator()
-inline ItemEnumeratorBaseV3::
-ItemEnumeratorBaseV3(const ItemEnumerator& rhs,bool)
+inline ItemEnumeratorBase::
+ItemEnumeratorBase(const ItemEnumerator& rhs,bool)
 : m_shared_info(rhs.m_shared_info)
 , m_local_ids(rhs.unguardedLocalIds())
 , m_index(rhs.index())
@@ -125,17 +125,17 @@ ItemEnumeratorBaseV3(const ItemEnumerator& rhs,bool)
 /*---------------------------------------------------------------------------*/
 
 //! Constructeur seulement utilisé par fromItemEnumerator()
-template<typename ItemType> inline ItemEnumeratorBaseV3T<ItemType>::
-ItemEnumeratorBaseV3T(const ItemEnumerator& rhs,bool v)
-: ItemEnumeratorBaseV3(rhs,v)
+template<typename ItemType> inline ItemEnumeratorBaseT<ItemType>::
+ItemEnumeratorBaseT(const ItemEnumerator& rhs,bool v)
+: ItemEnumeratorBase(rhs,v)
 {
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-inline ItemEnumeratorBaseV3::
-ItemEnumeratorBaseV3(const ItemEnumerator& rhs)
+inline ItemEnumeratorBase::
+ItemEnumeratorBase(const ItemEnumerator& rhs)
 : m_shared_info(rhs.m_shared_info)
 , m_local_ids(rhs.unguardedLocalIds())
 , m_index(rhs.index())
@@ -147,25 +147,25 @@ ItemEnumeratorBaseV3(const ItemEnumerator& rhs)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename ItemType> inline ItemEnumeratorBaseV3T<ItemType>::
-ItemEnumeratorBaseV3T(const ItemEnumerator& rhs)
-: ItemEnumeratorBaseV3(rhs)
+template<typename ItemType> inline ItemEnumeratorBaseT<ItemType>::
+ItemEnumeratorBaseT(const ItemEnumerator& rhs)
+: ItemEnumeratorBase(rhs)
 {
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename ItemType> inline ItemEnumeratorBaseV3T<ItemType>::
-ItemEnumeratorBaseV3T(const ItemInternalEnumerator& rhs)
-: ItemEnumeratorBaseV3T(ItemEnumerator(rhs))
+template<typename ItemType> inline ItemEnumeratorBaseT<ItemType>::
+ItemEnumeratorBaseT(const ItemInternalEnumerator& rhs)
+: ItemEnumeratorBaseT(ItemEnumerator(rhs))
 {
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename ItemType> inline ItemEnumerator ItemEnumeratorBaseV3T<ItemType>::
+template<typename ItemType> inline ItemEnumerator ItemEnumeratorBaseT<ItemType>::
 toItemEnumerator() const
 {
   return ItemEnumerator(m_shared_info,m_local_ids,m_index,m_count,m_group_impl,m_item_for_operator_arrow);

--- a/arcane/src/arcane/ItemEnumerator.h
+++ b/arcane/src/arcane/ItemEnumerator.h
@@ -113,8 +113,7 @@ class ItemEnumerator
 //! Constructeur seulement utilisé par fromItemEnumerator()
 inline ItemEnumeratorBase::
 ItemEnumeratorBase(const ItemEnumerator& rhs,bool)
-: m_shared_info(rhs.m_shared_info)
-, m_local_ids(rhs.unguardedLocalIds())
+: m_local_ids(rhs.unguardedLocalIds())
 , m_index(rhs.index())
 , m_count(rhs.count())
 , m_group_impl(rhs.group())
@@ -128,6 +127,7 @@ ItemEnumeratorBase(const ItemEnumerator& rhs,bool)
 template<typename ItemType> inline ItemEnumeratorBaseT<ItemType>::
 ItemEnumeratorBaseT(const ItemEnumerator& rhs,bool v)
 : ItemEnumeratorBase(rhs,v)
+, m_shared_info(rhs.m_shared_info)
 {
 }
 
@@ -136,8 +136,7 @@ ItemEnumeratorBaseT(const ItemEnumerator& rhs,bool v)
 
 inline ItemEnumeratorBase::
 ItemEnumeratorBase(const ItemEnumerator& rhs)
-: m_shared_info(rhs.m_shared_info)
-, m_local_ids(rhs.unguardedLocalIds())
+: m_local_ids(rhs.unguardedLocalIds())
 , m_index(rhs.index())
 , m_count(rhs.count())
 , m_group_impl(rhs.group())
@@ -150,6 +149,7 @@ ItemEnumeratorBase(const ItemEnumerator& rhs)
 template<typename ItemType> inline ItemEnumeratorBaseT<ItemType>::
 ItemEnumeratorBaseT(const ItemEnumerator& rhs)
 : ItemEnumeratorBase(rhs)
+, m_shared_info(rhs.m_shared_info)
 {
 }
 

--- a/arcane/src/arcane/ItemEnumerator.h
+++ b/arcane/src/arcane/ItemEnumerator.h
@@ -72,7 +72,7 @@ class ItemEnumerator
  public:
 
   ItemEnumerator() = default;
-  ItemEnumerator(const ItemInternalVectorView& view) : BaseClass(view){}
+  ItemEnumerator(const ItemInternalVectorView& view) : BaseClass(view,nullptr){}
   ItemEnumerator(const ItemInternalEnumerator& rhs) : BaseClass(rhs,true){}
 
   // TODO: make deprecated
@@ -99,9 +99,9 @@ class ItemEnumerator
 
  private:
 
-  ItemEnumerator(ItemSharedInfo* shared_info,const Int32* local_ids,Int32 index,Int32 n,
+  ItemEnumerator(const Int32* local_ids,Int32 index,Int32 n,
                  const ItemGroupImpl* agroup,Item item_base)
-  : BaseClass(shared_info,local_ids,index,n,agroup,item_base){}
+  : BaseClass(local_ids,index,n,agroup,item_base){}
 };
 
 /*---------------------------------------------------------------------------*/
@@ -127,7 +127,7 @@ ItemEnumeratorBase(const ItemEnumerator& rhs,bool)
 template<typename ItemType> inline ItemEnumeratorBaseT<ItemType>::
 ItemEnumeratorBaseT(const ItemEnumerator& rhs,bool v)
 : ItemEnumeratorBase(rhs,v)
-, m_shared_info(rhs.m_shared_info)
+, m_item(rhs.m_item)
 {
 }
 
@@ -149,7 +149,7 @@ ItemEnumeratorBase(const ItemEnumerator& rhs)
 template<typename ItemType> inline ItemEnumeratorBaseT<ItemType>::
 ItemEnumeratorBaseT(const ItemEnumerator& rhs)
 : ItemEnumeratorBase(rhs)
-, m_shared_info(rhs.m_shared_info)
+, m_item(rhs.m_item)
 {
 }
 
@@ -168,7 +168,7 @@ ItemEnumeratorBaseT(const ItemInternalEnumerator& rhs)
 template<typename ItemType> inline ItemEnumerator ItemEnumeratorBaseT<ItemType>::
 toItemEnumerator() const
 {
-  return ItemEnumerator(m_shared_info,m_local_ids,m_index,m_count,m_group_impl,m_item_for_operator_arrow);
+  return ItemEnumerator(m_local_ids,m_index,m_count,m_group_impl,m_item);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemEnumeratorBase.h
+++ b/arcane/src/arcane/ItemEnumeratorBase.h
@@ -37,7 +37,7 @@ class ItemGroupImpl;
  * Les instances de cette classes sont créées soit via ItemEnumerator, soit
  * via ItemEnumeratorT.
  */
-class ItemEnumeratorBaseV3
+class ItemEnumeratorBase
 {
  private:
 
@@ -46,22 +46,22 @@ class ItemEnumeratorBaseV3
 
  protected:
 
-  ItemEnumeratorBaseV3()
+  ItemEnumeratorBase()
   : m_local_ids(nullptr), m_index(0), m_count(0), m_group_impl(nullptr) { }
-  ItemEnumeratorBaseV3(const ItemInternalPtr* items,const Int32* local_ids,Integer n, const ItemGroupImpl * agroup = nullptr)
+  ItemEnumeratorBase(const ItemInternalPtr* items,const Int32* local_ids,Integer n, const ItemGroupImpl * agroup = nullptr)
   : m_local_ids(local_ids), m_index(0), m_count(n), m_group_impl(agroup) { _init(items); }
-  ItemEnumeratorBaseV3(ItemSharedInfo* shared_info,const Int32ConstArrayView& local_ids)
+  ItemEnumeratorBase(ItemSharedInfo* shared_info,const Int32ConstArrayView& local_ids)
   : m_shared_info(shared_info), m_local_ids(local_ids.data()), m_index(0), m_count(local_ids.size()), m_group_impl(nullptr) { }
-  ItemEnumeratorBaseV3(const ItemInternalArrayView& items,const Int32ConstArrayView& local_ids, const ItemGroupImpl * agroup = nullptr)
+  ItemEnumeratorBase(const ItemInternalArrayView& items,const Int32ConstArrayView& local_ids, const ItemGroupImpl * agroup = nullptr)
   : m_local_ids(local_ids.data()), m_index(0), m_count(local_ids.size()), m_group_impl(agroup) { _init(items.data()); }
-  ItemEnumeratorBaseV3(const ItemInternalVectorView& view, const ItemGroupImpl* agroup = nullptr)
+  ItemEnumeratorBase(const ItemInternalVectorView& view, const ItemGroupImpl* agroup = nullptr)
   : m_shared_info(view.m_shared_info), m_local_ids(view.localIds().data()),
     m_index(0), m_count(view.size()), m_group_impl(agroup) { }
-  ItemEnumeratorBaseV3(const ItemVectorView& rhs)
-  : ItemEnumeratorBaseV3((const ItemInternalVectorView&)rhs) {}
+  ItemEnumeratorBase(const ItemVectorView& rhs)
+  : ItemEnumeratorBase((const ItemInternalVectorView&)rhs) {}
 
-  ItemEnumeratorBaseV3(const ItemEnumerator& rhs);
-  ItemEnumeratorBaseV3(const ItemInternalEnumerator& rhs);
+  ItemEnumeratorBase(const ItemEnumerator& rhs);
+  ItemEnumeratorBase(const ItemInternalEnumerator& rhs);
 
  public:
 
@@ -122,9 +122,9 @@ class ItemEnumeratorBaseV3
  protected:
 
   //! Constructeur seulement utilisé par fromItemEnumerator()
-  ItemEnumeratorBaseV3(const ItemEnumerator& rhs,bool);
+  ItemEnumeratorBase(const ItemEnumerator& rhs,bool);
 
-  ItemEnumeratorBaseV3(ItemSharedInfo* shared_info,const Int32* local_ids,Int32 index,Int32 n,
+  ItemEnumeratorBase(ItemSharedInfo* shared_info,const Int32* local_ids,Int32 index,Int32 n,
                        const ItemGroupImpl * agroup)
   : m_shared_info(shared_info), m_local_ids(local_ids), m_index(index), m_count(n), m_group_impl(agroup)
   {
@@ -147,34 +147,34 @@ class ItemEnumeratorBaseV3
  * via ItemEnumeratorT.
  */
 template<typename ItemType>
-class ItemEnumeratorBaseV3T
-: public ItemEnumeratorBaseV3
+class ItemEnumeratorBaseT
+: public ItemEnumeratorBase
 {
  private:
 
   using ItemInternalPtr = ItemInternal*;
   using LocalIdType = typename ItemType::LocalIdType;
-  using BaseClass = ItemEnumeratorBaseV3;
+  using BaseClass = ItemEnumeratorBase;
 
  protected:
 
-  ItemEnumeratorBaseV3T()
+  ItemEnumeratorBaseT()
   : BaseClass() { }
-  ItemEnumeratorBaseV3T(const ItemInternalPtr* items,const Int32* local_ids,Integer n, const ItemGroupImpl* agroup = nullptr)
+  ItemEnumeratorBaseT(const ItemInternalPtr* items,const Int32* local_ids,Integer n, const ItemGroupImpl* agroup = nullptr)
   : BaseClass(items,local_ids,n,agroup) {}
-  ItemEnumeratorBaseV3T(ItemSharedInfo* shared_info,const Int32ConstArrayView& local_ids)
+  ItemEnumeratorBaseT(ItemSharedInfo* shared_info,const Int32ConstArrayView& local_ids)
   : BaseClass(shared_info,local_ids){}
-  ItemEnumeratorBaseV3T(const ItemInternalArrayView& items,const Int32ConstArrayView& local_ids, const ItemGroupImpl * agroup = nullptr)
+  ItemEnumeratorBaseT(const ItemInternalArrayView& items,const Int32ConstArrayView& local_ids, const ItemGroupImpl * agroup = nullptr)
   : BaseClass(items,local_ids,agroup){}
-  ItemEnumeratorBaseV3T(const ItemInternalVectorView& view, const ItemGroupImpl* agroup = nullptr)
+  ItemEnumeratorBaseT(const ItemInternalVectorView& view, const ItemGroupImpl* agroup = nullptr)
   : BaseClass(view,agroup) {}
-  ItemEnumeratorBaseV3T(const ItemVectorView& rhs)
-  : ItemEnumeratorBaseV3T((const ItemInternalVectorView&)rhs) {}
-  ItemEnumeratorBaseV3T(const ItemVectorViewT<ItemType>& rhs)
-  : ItemEnumeratorBaseV3T((const ItemInternalVectorView&)rhs) {}
+  ItemEnumeratorBaseT(const ItemVectorView& rhs)
+  : ItemEnumeratorBaseT((const ItemInternalVectorView&)rhs) {}
+  ItemEnumeratorBaseT(const ItemVectorViewT<ItemType>& rhs)
+  : ItemEnumeratorBaseT((const ItemInternalVectorView&)rhs) {}
 
-  ItemEnumeratorBaseV3T(const ItemEnumerator& rhs);
-  ItemEnumeratorBaseV3T(const ItemInternalEnumerator& rhs);
+  ItemEnumeratorBaseT(const ItemEnumerator& rhs);
+  ItemEnumeratorBaseT(const ItemInternalEnumerator& rhs);
 
  public:
 
@@ -187,16 +187,16 @@ class ItemEnumeratorBaseV3T
 
  protected:
 
-  mutable ItemType m_item_for_operator_arrow;
+  mutable ItemType m_item_for_operator_arrow = ItemType(NULL_ITEM_LOCAL_ID,nullptr);
 
  protected:
 
   //! Constructeur seulement utilisé par fromItemEnumerator()
-  ItemEnumeratorBaseV3T(const ItemEnumerator& rhs,bool);
+  ItemEnumeratorBaseT(const ItemEnumerator& rhs,bool);
 
-  ItemEnumeratorBaseV3T(ItemSharedInfo* shared_info,const Int32* local_ids,Int32 index,Int32 n,
+  ItemEnumeratorBaseT(ItemSharedInfo* shared_info,const Int32* local_ids,Int32 index,Int32 n,
                         const ItemGroupImpl* agroup,Item item_base)
-  : ItemEnumeratorBaseV3(shared_info,local_ids,index,n,agroup), m_item_for_operator_arrow(item_base)
+  : ItemEnumeratorBase(shared_info,local_ids,index,n,agroup), m_item_for_operator_arrow(item_base)
   {
   }
 };

--- a/arcane/src/arcane/ItemInternalVectorView.h
+++ b/arcane/src/arcane/ItemInternalVectorView.h
@@ -127,6 +127,7 @@ class ARCANE_CORE_EXPORT ItemInternalVectorView
   friend class impl::ItemBase;
   friend class ItemEnumeratorBase;
   friend class SimdItemEnumeratorBase;
+  template<typename T> friend class ItemEnumeratorBaseT;
   using const_iterator = ItemInternalVectorViewConstIterator;
 
  public:

--- a/arcane/src/arcane/ItemInternalVectorView.h
+++ b/arcane/src/arcane/ItemInternalVectorView.h
@@ -125,7 +125,7 @@ class ARCANE_CORE_EXPORT ItemInternalVectorView
   friend class ItemVectorView;
   friend class ItemInternalConnectivityList;
   friend class impl::ItemBase;
-  friend class ItemEnumeratorBaseV3;
+  friend class ItemEnumeratorBase;
   friend class SimdItemEnumeratorBase;
   using const_iterator = ItemInternalVectorViewConstIterator;
 

--- a/arcane/src/arcane/ItemSharedInfo.h
+++ b/arcane/src/arcane/ItemSharedInfo.h
@@ -63,7 +63,7 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   friend class ItemInternalVectorView;
   friend class ItemVectorViewConstIterator;
   friend class ItemVectorView;
-  friend class ItemEnumeratorBaseV3;
+  friend class ItemEnumeratorBase;
   friend class ItemCompatibility;
   friend class SimdItemBase;
   friend class SimdItemEnumeratorBase;

--- a/arcane/src/arcane/ItemTypes.h
+++ b/arcane/src/arcane/ItemTypes.h
@@ -168,9 +168,7 @@ class ItemEnumeratorT;
 /*---------------------------------------------------------------------------*/
 
 template<typename ItemType>
-class ItemEnumeratorBaseV3T;
-
-template<typename ItemType> using ItemEnumeratorBaseT = ItemEnumeratorBaseV3T<ItemType>;
+class ItemEnumeratorBaseT;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemVectorView.h
+++ b/arcane/src/arcane/ItemVectorView.h
@@ -32,7 +32,18 @@ class ItemVectorView;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
+/*!
+ * \internal
+ * \brief Itérateur pour la classe ItemVectorView.
+ *
+ * Cette classe est interne à Arcane. Elle s'utilise via le for-range:
+ *
+ * \code
+ * ItemVectorView view;
+ * for( Item item : view )
+ *    ;
+ * \endcode
+ */
 class ItemVectorViewConstIterator
 {
  protected:
@@ -82,9 +93,10 @@ class ItemVectorViewConstIterator
   {
     return lhs.m_index<=rhs.m_index;
   }
+  //! Compare les indices d'itération de deux instances
   friend bool operator==(const ThatClass& lhs,const ThatClass& rhs)
   {
-    return lhs.m_shared_info==rhs.m_shared_info && lhs.m_local_ids==rhs.m_local_ids && lhs.m_index==rhs.m_index;
+    return lhs.m_index==rhs.m_index;
   }
   friend bool operator!=(const ThatClass& lhs,const ThatClass& rhs)
   {

--- a/arcane/src/arcane/SimdItem.h
+++ b/arcane/src/arcane/SimdItem.h
@@ -384,7 +384,7 @@ class ARCANE_CORE_EXPORT SimdItemEnumeratorBase
   SimdItemEnumeratorBase(const ItemInternalVectorView& view)
   : SimdEnumeratorBase(view.localIds()), m_shared_info(view.m_shared_info) {}
   SimdItemEnumeratorBase(const ItemEnumerator& rhs)
-  : SimdEnumeratorBase(rhs.unguardedLocalIds(),rhs.count()), m_shared_info(rhs.m_shared_info) {}
+  : SimdEnumeratorBase(rhs.unguardedLocalIds(),rhs.count()), m_shared_info(rhs.m_item.m_shared_info) {}
 
   // TODO: rendre obsolète
   SimdItemEnumeratorBase(const ItemInternalPtr* items,const Int32* local_ids,Integer n)


### PR DESCRIPTION
- Rename `ItemEnumeratorBaseV3` to `ItemEnumeratorBase`
- Remove the field 'ItemSharedInfo* m_shared_info` which is redondant with the `Item m_item` field.