### PR TITLE
Add support to change number of threads per block

### DIFF
--- a/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
@@ -116,7 +116,9 @@ _internalStreamImpl()
 auto RunCommandLaunchInfo::
 computeThreadBlockInfo(Int64 full_size) const -> ThreadBlockInfo
 {
-  int threads_per_block = 256;
+  int threads_per_block = m_command.nbThreadPerBlock();
+  if (threads_per_block<=0)
+    threads_per_block = 256;
   Int64 big_b = (full_size + threads_per_block - 1) / threads_per_block;
   int blocks_per_grid = CheckedConvert::toInt32(big_b);
   return { blocks_per_grid, threads_per_block };

--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -203,6 +203,8 @@ class RunCommandImpl
   RunQueueImpl* m_queue;
   TraceInfo m_trace_info;
   String m_kernel_name;
+  Int32 m_nb_thread_per_block = 0;
+
   // NOTE: cette pile gère la mémoire associé à un seul runtime
   // Si on souhaite un jour supporté plusieurs runtimes il faudra une pile
   // par runtime. On peut éventuellement limiter cela si on est sur
@@ -273,6 +275,7 @@ reset()
 {
   m_kernel_name = String();
   m_trace_info = TraceInfo();
+  m_nb_thread_per_block = 0;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -347,6 +350,15 @@ kernelName() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+Int32 RunCommand::
+nbThreadPerBlock() const
+{
+  return m_p->m_nb_thread_per_block;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 RunCommand& RunCommand::
 addTraceInfo(const TraceInfo& ti)
 {
@@ -361,6 +373,20 @@ RunCommand& RunCommand::
 addKernelName(const String& v)
 {
   m_p->m_kernel_name = v;
+  return *this;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+RunCommand& RunCommand::
+addNbThreadPerBlock(Int32 v)
+{
+  if (v<0)
+    v = 0;
+  if (v>0 && v<32)
+    v = 32;
+  m_p->m_nb_thread_per_block = v;
   return *this;
 }
 

--- a/arcane/src/arcane/accelerator/core/RunCommand.h
+++ b/arcane/src/arcane/accelerator/core/RunCommand.h
@@ -40,16 +40,49 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
  public:
 
   RunCommand(RunQueue& run_queue);
-  RunCommand(const RunCommand&) = delete;
-  RunCommand& operator=(const RunCommand&) = delete;
   ~RunCommand();
 
  public:
 
+  RunCommand(const RunCommand&) = delete;
+  RunCommand& operator=(const RunCommand&) = delete;
+
+ public:
+
+  /*!
+   * \brief Positionne le informations de trace.
+   *
+   * Ces informations sont utilisées pour les traces ou pour le débug.
+   * Les macros RUNCOMMAND_LOOP ou RUNCOMMAND_ENUMERATE appellent
+   * automatiquement cette méthode.
+   */
   RunCommand& addTraceInfo(const TraceInfo& ti);
+
+  /*!
+   * \brief Positionne le nom du noyau.
+   *
+   * Ce nom est utilisé pour les traces ou pour le débug.
+   */
   RunCommand& addKernelName(const String& v);
+
+  /*!
+   * \brief Positionne le nombre de thread par bloc pour les accélérateurs.
+   *
+   * Si la valeur \a v est nulle, le choix par défaut est utilisé.
+   * Si la valeur \a v est positive, sa valeur minimale valide dépend
+   * de l'accélérateur. En général c'est au moins 32.
+   */
+  RunCommand& addNbThreadPerBlock(Int32 v);
+
+  //! Informations pour les traces
   const TraceInfo& traceInfo() const;
+
+  //! Nom du noyau
   const String& kernelName() const;
+
+  //! Nombre de threads par bloc ou 0 pour la valeur par défaut
+  Int32 nbThreadPerBlock() const;
+
   friend ARCANE_ACCELERATOR_CORE_EXPORT RunCommand& operator<<(RunCommand& command,const TraceInfo& trace_info);
 
  private:

--- a/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
@@ -188,6 +188,9 @@ _executeTest1(eMemoryRessource mem_kind)
     {
       auto command = makeCommand(queue);
       auto out_t1 = viewOut(command, t1);
+      command.addNbThreadPerBlock(128);
+      if (command.nbThreadPerBlock()!=128)
+        ARCANE_FATAL("Bad number of thread per block (v={0} expected=128)",command.nbThreadPerBlock());
 
       command << RUNCOMMAND_LOOP1(iter, n1)
       {


### PR DESCRIPTION
The added method `RunCommand::addNbThreadPerBlock()` allows to change the number of thread per block for a given command.