### PR TITLE
In Gihub CI, use 'action/cache@v3' instead of 'action/cache@v2'

### DIFF
--- a/.github/workflows/build_tests_all.yml
+++ b/.github/workflows/build_tests_all.yml
@@ -102,7 +102,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_aio-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -223,7 +223,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_split-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -447,7 +447,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_cuda-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/build_tests_debug.yml
+++ b/.github/workflows/build_tests_debug.yml
@@ -98,7 +98,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_aio-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -219,7 +219,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_split-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -443,7 +443,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_cuda-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/build_tests_rand.yml
+++ b/.github/workflows/build_tests_rand.yml
@@ -104,7 +104,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_rand-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/build_tests_release.yml
+++ b/.github/workflows/build_tests_release.yml
@@ -104,7 +104,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_aio-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -227,7 +227,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_split-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -453,7 +453,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo_name}}_${{matrix.type}}_cuda-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
 
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: codecov-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -96,7 +96,7 @@ jobs:
           dotnet-version: '6.0.x'
 
       - name: Get cache for 'ccache' tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: framework-ccache1-${{matrix.os}}-${{ github.run_number }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -61,7 +61,7 @@ jobs:
           echo "::set-output name=md5::$(cat coverity-tool/md5-new)"
 
       - name: Restore cached files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         # Disabled for `act`
         if: ${{ !env.ACT }}
         with:

--- a/.github/workflows/ifpen_el7_foss-2018b.yml
+++ b/.github/workflows/ifpen_el7_foss-2018b.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arccore-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -285,7 +285,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arcane-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -355,7 +355,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alien-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -450,7 +450,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alienlegacy-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/ifpen_el7_gimkl-2018b.yml
+++ b/.github/workflows/ifpen_el7_gimkl-2018b.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arccore-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -285,7 +285,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arcane-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -355,7 +355,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alien-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -450,7 +450,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alienlegacy-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/ifpen_el8_foss-2018b.yml
+++ b/.github/workflows/ifpen_el8_foss-2018b.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arccore-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -285,7 +285,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arcane-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -355,7 +355,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alien-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -450,7 +450,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alienlegacy-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}

--- a/.github/workflows/ifpen_el8_gimkl-2018b.yml
+++ b/.github/workflows/ifpen_el8_gimkl-2018b.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arccore-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -285,7 +285,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-arcane-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -355,7 +355,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alien-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}
@@ -450,7 +450,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=date::$(/bin/date -u '+%Y%m%d%H%M%S')"
       - name: Get cache for ccache tool
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
           key: ${{ env.CC_KEY_PREFIX }}-alienlegacy-${{ env.CM_BUILD_TYPE }}-${{ steps.get-date.outputs.date }}-${{ github.run_number }}


### PR DESCRIPTION
`action/cache@v2` is deprecated because it uses `node` version 12 which is deprecated.
