### PR TITLE
Add partial support for 3D cartesian mesh refinement

### DIFF
--- a/arcane/ceapart/src/arcane/cartesianmesh/ICartesianMesh.h
+++ b/arcane/ceapart/src/arcane/cartesianmesh/ICartesianMesh.h
@@ -127,6 +127,20 @@ class ARCANE_CARTESIANMESH_EXPORT ICartesianMesh
   virtual void refinePatch2D(Real2 position, Real2 length) = 0;
 
   /*!
+   * \brief Raffine en 3D un bloc du maillage cartésien.
+   *
+   * Cette méthode ne peut être appelée que si le maillage est un maillage
+   * AMR (IMesh::isAmrActivated()==true).
+   *
+   * Les mailles dont les positions des centres sont comprises entre
+   * \a position et \a (position+length) sont raffinées et les informations
+   * de connectivité correspondantes sont mises à jour.
+   *
+   * Cette opération est collective.
+   */
+  virtual void refinePatch3D(Real3 position, Real3 length) = 0;
+
+  /*!
    * \brief Renumérote les uniqueId() des entités.
    *
    * Suivant les valeurs de \a v, on renumérote les uniqueId() des faces et/ou 

--- a/arcane/ceapart/src/arcane/tests/AMRCartesianMeshTester.axl
+++ b/arcane/ceapart/src/arcane/tests/AMRCartesianMeshTester.axl
@@ -8,10 +8,13 @@
   </description>
 
  <options>
-   <simple name="nb-refine" type="integer" />
-   <complex name="refinement" type="Refinement" minOccurs="0" maxOccurs="unbounded">
+   <complex name="refinement-2d" type="Refinement2D" minOccurs="0" maxOccurs="unbounded">
      <simple name="position" type="real2" />
      <simple name="length" type="real2" />
+   </complex>
+   <complex name="refinement-3d" type="Refinement3D" minOccurs="0" maxOccurs="unbounded">
+     <simple name="position" type="real3" />
+     <simple name="length" type="real3" />
    </complex>
    <service-instance name = "post-processor"
                      type = "Arcane::IPostProcessorWriter"

--- a/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.h
+++ b/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CartesianMeshTestUtils.cc                                   (C) 2000-2021 */
+/* CartesianMeshTestUtils.cc                                   (C) 2000-2022 */
 /*                                                                           */
 /* Fonctions utilitaires pour les tests de 'CartesianMesh'.                  */
 /*---------------------------------------------------------------------------*/
@@ -45,7 +45,7 @@ class CartesianMeshTestUtils
 
  public:
 
-  void testAll();
+  void testAll(bool is_amr);
 
  public:
 
@@ -61,6 +61,7 @@ class CartesianMeshTestUtils
   VariableFaceReal3 m_face_center;
   VariableNodeReal m_node_density; 
   Integer m_nb_print = 100;
+  bool m_is_amr = false;
 
  private:
 

--- a/arcane/ceapart/src/arcane/tests/CartesianMeshTesterModule.cc
+++ b/arcane/ceapart/src/arcane/tests/CartesianMeshTesterModule.cc
@@ -401,7 +401,7 @@ init()
     info() << "NB_BOUNDARY1=" << nb_boundary1 << " NB_BOUNDARY2=" << nb_boundary2;
   }
 
-  m_utils->testAll();
+  m_utils->testAll(false);
   m_utils_v2->testAll();
   _checkFaceUniqueIdsAreContiguous();
   _testXmlInfos();

--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -106,7 +106,9 @@ if (Lima_FOUND)
 endif()
 ARCANE_ADD_TEST_SEQUENTIAL(adiadvection-1 testAdiAdvection-1.arc "-m 20")
 arcane_add_test(amr-cartesian2D-1 testAMRCartesianMesh2D-1.arc "-m 20")
+arcane_add_test(amr-cartesian3D-1 testAMRCartesianMesh3D-1.arc "-m 20")
 arcane_add_test(amr-checkpoint-cartesian2D-1 testAMRCartesianMesh2D-1.arc -c 3 -m 5)
+arcane_add_test(amr-checkpoint-cartesian3D-1 testAMRCartesianMesh3D-1.arc -c 3 -m 5)
 
 # Tests sur le renumérotation des faces en cartésien
 # L'idéal est d'avoir pas mal de sous-domaines pour être sur que le

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-1.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-1.arc
@@ -3,7 +3,7 @@
  <arcane>
   <titre>Test CartesianMesh</titre>
 
-  <description>Test des maillages cartesiens AMR 2D</description>
+  <description>Test des maillages cartesiens AMR 3D</description>
 
   <boucle-en-temps>AMRCartesianMeshTestLoop</boucle-en-temps>
 
@@ -21,17 +21,17 @@
     <variable>NodeDensity</variable>
     <groupe>AllCells</groupe>
     <groupe>AllNodes</groupe>
-    <groupe>AllFacesDirection0</groupe>
-    <groupe>AllFacesDirection1</groupe>
+    <groupe>AMRPatchCells0</groupe>
+    <groupe>AMRPatchCells1</groupe>
+    <groupe>AMRPatchCells2</groupe>
    </depouillement>
  </arcane-post-traitement>
- 
- 
+
  <maillage amr="true">
    <meshgenerator>
      <cartesian>
-       <nsd>2 2</nsd>
-       <origine>0.0 0.0</origine>
+       <nsd>2 2 1</nsd>
+       <origine>0.0 0.0 0.0</origine>
        <lx nx='2' prx='1.0'>2.0</lx>
        <lx nx='4' prx='1.2'>3.0</lx>
        <lx nx='5' prx='1.3'>3.0</lx>
@@ -40,31 +40,29 @@
        <ly ny='2' pry='1.0'>2.0</ly>
        <ly ny='3' pry='1.1'>4.0</ly>
        <ly ny='4' pry='1.3'>5.0</ly>
+
+       <lz nz='8' prz='1.0'>2.0</lz>
      </cartesian>
    </meshgenerator>
  </maillage>
 
  <a-m-r-cartesian-mesh-tester>
-   <refinement-2d>
-     <position>1.0 2.0</position>
-     <length>1.0 2.0</length>
-   </refinement-2d>
-   <refinement-2d>
-     <position>1.4 3.0</position>
-     <length>0.5 1.0</length>
-   </refinement-2d>
-   <refinement-2d>
-     <position>4.0 5.0</position>
-     <length>3.0 4.0</length>
-   </refinement-2d>
-   <refinement-2d>
-     <position>5.0 7.0</position>
-     <length>2.0 2.0</length>
-   </refinement-2d>
-   <expected-number-of-cells-in-patchs>153 8 4 80 128</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>eef03075d1b1d32b63c9014bc567704e</nodes-uid-hash>
-   <faces-uid-hash>6d1b4ec0963f467f704c08f3f50dbd73</faces-uid-hash>
-   <cells-uid-hash>a577cb5e34dcbac51cec397ff7cb684e</cells-uid-hash>
+   <refinement-3d>
+     <position>1.0 2.0 -0.1</position>
+     <length>2.0 4.0 0.5</length>
+   </refinement-3d>
+   <refinement-3d>
+     <position>1.4 3.0 0.3</position>
+     <length>0.5 1.0 1.0</length>
+   </refinement-3d>
+   <!-- <refinement-3d>
+     <position>4.0 5.0 0.2</position>
+     <length>3.0 4.0 0.8</length>
+   </refinement-3d> -->
+   <expected-number-of-cells-in-patchs>1224 144 40</expected-number-of-cells-in-patchs>
+   <nodes-uid-hash></nodes-uid-hash>
+   <faces-uid-hash></faces-uid-hash>
+   <cells-uid-hash></cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>


### PR DESCRIPTION
The renumbering part (to have same `uniqueId()` between sequential and parallel execution) is not yet implemented.