### PR TITLE
Fix saving of mesh properties before a checkpoint

### DIFF
--- a/arcane/src/arcane/impl/SubDomain.cc
+++ b/arcane/src/arcane/impl/SubDomain.cc
@@ -165,10 +165,9 @@ class SubDomain
    public:
     void init()
     {
-      IVariableMng* vm = m_sub_domain->variableMng();
       m_observers.addObserver(this,
                               &PropertyMngCheckpoint::_notifyWrite,
-                              vm->writeObservable());
+                              m_property_values.variable()->writeObservable());
       m_observers.addObserver(this,
                               &PropertyMngCheckpoint::_notifyRead,
                               m_property_values.variable()->readObservable());

--- a/arcane/src/arcane/impl/VariableMng.cc
+++ b/arcane/src/arcane/impl/VariableMng.cc
@@ -1125,14 +1125,25 @@ _writeVariables(IDataWriter* writer,const VariableCollection& vars,bool use_hash
 
   m_write_observable->notifyAllObservers();
   writer->beginWrite(vars);
+
+  // Appelle la notification de l'écriture des variables
+  // Il faut le faire avant de positionner les méta-données
+  // car cela autorise de changer la valeur de la variable
+  // lors de cet appel.
+  for( VariableCollection::Enumerator i(vars); ++i; ){
+    IVariable* var = *i;
+    if (var->isUsed())
+      var->notifyBeginWrite();
+  }
+
   String meta_data = _generateMetaData(vars,use_hash);
   writer->setMetaData(meta_data);
+
   for( VariableCollection::Enumerator i(vars); ++i; ){
     IVariable* var = *i;
     if (!var->isUsed())
       continue;
     try{
-      var->notifyBeginWrite();
       writer->write(var,var->data());
     }
     catch(const Exception& ex)

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -336,13 +336,6 @@ build()
   m_observer_pool.addObserver(this,
                               &DynamicMesh::_readFromDump,
                               vm->readObservable());
-  IPropertyMng* pm = subDomain()->propertyMng();
-  m_observer_pool.addObserver(this,
-                              &DynamicMesh::_saveProperties,
-                              pm->writeObservable());
-  m_observer_pool.addObserver(this,
-                              &DynamicMesh::_loadProperties,
-                              pm->readObservable());
 
   m_mesh_builder = new DynamicMeshIncrementalBuilder(this);
   m_mesh_checker = new DynamicMeshChecker(this);
@@ -1319,6 +1312,8 @@ _prepareForDump()
   info(4) << "DynamicMesh::prepareForDump() name=" << name()
           << " need_compact?=" << m_need_compact
           << " want_dump?=" << want_dump;
+
+  _saveProperties();
 
   // Si le maillage n'est pas sauvé, ne fait rien. Cela évite de compacter
   // et trier le maillage ce qui n'est pas souhaitable si les propriétés
@@ -2574,6 +2569,8 @@ setEstimatedCells(Integer nb_cell0)
 void DynamicMesh::
 _readFromDump()
 {
+  _loadProperties();
+
   // Ne fais rien sur un maillage pas encore alloué.
   if (m_mesh_dimension()<0)
     return;

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -943,7 +943,7 @@ _checkNeedEndUpdate() const
 void ItemFamily::
 prepareForDump()
 {
-  info(4) << "ItemFamily::prepareFromDump(): " << fullName()
+  info(4) << "ItemFamily::prepareForDump(): " << fullName()
           << " need=" << m_need_prepare_dump
           << " item-need=" << m_item_need_prepare_dump
           << " m_item_shared_infos->hasChanged()=" << m_item_shared_infos->hasChanged()
@@ -953,6 +953,7 @@ prepareForDump()
     auto* p = m_properties;
     p->setInt32("dump-version",0x0307);
     p->setInt32("nb-item",m_infos.nbItem());
+    p->setInt32("current-change-id",m_current_id);
   }
 
   // TODO: ajoute flag vérification si nécessaire
@@ -1080,6 +1081,11 @@ readFromDump()
     if (dump_version>=0x0307){
       use_type_variable = true;
       nb_item = p->getInt32("nb-item");
+      Int32 cid = p->getInt32("current-change-id");
+      Int32 expected_cid = m_internal_variables->m_current_id();
+      if (cid!=expected_cid)
+        ARCANE_FATAL("Bad value for current id mesh={0} id={1} expected={2}",
+                     fullName(),cid,expected_cid);
     }
   }
 
@@ -1184,7 +1190,6 @@ readFromDump()
       Integer shared_data_index = items_shared_data_index[i];
       ItemSharedInfoWithType* isi = item_shared_infos[shared_data_index];
       Int64 uid = m_items_unique_id_view[i];
-      info() << "ALLOC ONE i=" << i << " uid=" << uid;
       ItemInternal* item = m_infos.allocOne(uid);
       item->setSharedInfo(isi->sharedInfo(),isi->itemTypeId());
     }


### PR DESCRIPTION
In `ItemFamily`, the values of the properties where saved before the call to `_prepareForDump()` but this call modify properties. So the last modification was not taken into account.