### PR TITLE
Use a typename instead of an int for extents in classes MDSpan and NumArray.

### DIFF
--- a/arcane/src/arcane/utils/UtilsTypes.h
+++ b/arcane/src/arcane/utils/UtilsTypes.h
@@ -224,11 +224,14 @@ class MDDim
   static constexpr int rank() { return RankValue; }
 };
 
+// Ces quatres macros pourront être supprimées après la 3.8
+
 // A définir lorsqu'on voudra que le rang des classes NumArray et associées
 // soit spécifier par une classe au lieu d'un entier
-//#define ARCANE_USE_TYPE_FOR_EXTENT
-
-#ifdef ARCANE_USE_TYPE_FOR_EXTENT
+#define ARCANE_USE_TYPE_FOR_EXTENT
+#define A_MDRANK_TYPE(rank_name) typename rank_name
+#define A_MDRANK_RANK_VALUE(rank_name) (rank_name :: rank())
+#define A_MDDIM(rank_value) MDDim< rank_value >
 
 //! Constante pour un tableau dynamique de rang 0
 using MDDim0 = MDDim<0>;
@@ -241,28 +244,6 @@ using MDDim3 = MDDim<3>;
 //! Constante pour un tableau dynamique de rang 4
 using MDDim4 = MDDim<4>;
 
-#define A_MDRANK_TYPE(rank_name) typename rank_name
-#define A_MDRANK_RANK_VALUE(rank_name) (rank_name :: rank())
-#define A_MDDIM(rank_value) MDDim< rank_value >
-
-#else
-
-//! Constante pour un tableau de rang 0
-constexpr int MDDim0 = 0;
-//! Constante pour un tableau de rang 1
-constexpr int MDDim1 = 1;
-//! Constante pour un tableau de rang 2
-constexpr int MDDim2 = 2;
-//! Constante pour un tableau de rang 3
-constexpr int MDDim3 = 3;
-//! Constante pour un tableau de rang 4
-constexpr int MDDim4 = 4;
-
-#define A_MDRANK_TYPE(rank_name) int rank_name
-#define A_MDRANK_RANK_VALUE(rank_name) (rank_name)
-#define A_MDDIM(rank_value) rank_value
-
-#endif
 
 enum class eMemoryRessource;
 template<A_MDRANK_TYPE(RankValue)> class DefaultLayout;


### PR DESCRIPTION
The use of an `int` to specify the rank was deprecated in version 3.7 of Arcane.

Using a type to specify the extents will allows the use of static extents for example.