### PR TITLE
Remove usage of virtual (CPU) timer

### DIFF
--- a/arcane/src/arcane/EntryPoint.cc
+++ b/arcane/src/arcane/EntryPoint.cc
@@ -48,7 +48,6 @@ EntryPoint::
 EntryPoint(const EntryPointBuildInfo& bi)
 : m_sub_domain(bi.module()->subDomain())
 , m_caller(bi.caller())
-, m_cpu_timer(new Timer(m_sub_domain, bi.name(), Timer::TimerVirtual))
 , m_elapsed_timer(new Timer(m_sub_domain, bi.name(), Timer::TimerReal))
 , m_name(bi.name())
 , m_module(bi.module())
@@ -88,7 +87,6 @@ create(const EntryPointBuildInfo& bi)
 EntryPoint::
 ~EntryPoint()
 {
-  delete m_cpu_timer;
   delete m_elapsed_timer;
   //FIXME ceci ne doit pas etre detruit si on passe par le wrapper C#
   if (m_is_destroy_caller)
@@ -141,7 +139,6 @@ executeEntryPoint()
   Trace::Setter mclass(m_sub_domain->traceMng(), m_module->name());
 
   {
-    Timer::Sentry ts_cpu(m_cpu_timer);
     Timer::Sentry ts_elapsed(m_elapsed_timer);
     Timer::Action ts_action1(m_sub_domain, m_module->name());
     Timer::Phase ts_phase(m_sub_domain, TP_Computation);
@@ -158,7 +155,7 @@ executeEntryPoint()
 Real EntryPoint::
 lastCPUTime() const
 {
-  return m_cpu_timer->lastActivationTime();
+  return m_elapsed_timer->lastActivationTime();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -167,7 +164,7 @@ lastCPUTime() const
 Real EntryPoint::
 totalCPUTime() const
 {
-  return m_cpu_timer->totalTime();
+  return m_elapsed_timer->totalTime();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -192,10 +189,8 @@ totalElapsedTime() const
 /*---------------------------------------------------------------------------*/
 
 Real EntryPoint::
-totalTime(Timer::eTimerType type) const
+totalTime(Timer::eTimerType) const
 {
-  if (type == Timer::TimerVirtual)
-    return totalCPUTime();
   return totalElapsedTime();
 }
 
@@ -203,10 +198,8 @@ totalTime(Timer::eTimerType type) const
 /*---------------------------------------------------------------------------*/
 
 Real EntryPoint::
-lastTime(Timer::eTimerType type) const
+lastTime(Timer::eTimerType) const
 {
-  if (type == Timer::TimerVirtual)
-    return lastCPUTime();
   return lastElapsedTime();
 }
 

--- a/arcane/src/arcane/EntryPoint.h
+++ b/arcane/src/arcane/EntryPoint.h
@@ -123,17 +123,16 @@ class ARCANE_CORE_EXPORT EntryPoint
 
  private:
 
-  ISubDomain* m_sub_domain; //!< Gestionnaire de sous-domaine
-  IFunctor* m_caller; //!< Point d'appel
-  Timer* m_cpu_timer; //!< Timer CPU du point d'entrée
-  Timer* m_elapsed_timer; //!< Timer horloge du point d'entrée
+  ISubDomain* m_sub_domain = nullptr; //!< Gestionnaire de sous-domaine
+  IFunctor* m_caller = nullptr; //!< Point d'appel
+  Timer* m_elapsed_timer = nullptr; //!< Timer horloge du point d'entrée
   String m_name; //!< Nom du point d'entrée
   String m_full_name; //!< Nom du point d'entrée
-  IModule* m_module; //!< Module associé
+  IModule* m_module = nullptr; //!< Module associé
   String m_where; //!< Endroit de l'appel
-  int m_property; //!< Propriétés du point d'entrée
-  Integer m_nb_call; //!< Nombre de fois que le point d'entrée a été exécuté
-  bool m_is_destroy_caller; //!< Indique si on doit détruire le functor d'appel.
+  int m_property = 0; //!< Propriétés du point d'entrée
+  Integer m_nb_call = 0; //!< Nombre de fois que le point d'entrée a été exécuté
+  bool m_is_destroy_caller = false; //!< Indique si on doit détruire le functor d'appel.
 
  private:
 

--- a/arcane/src/arcane/IEntryPoint.h
+++ b/arcane/src/arcane/IEntryPoint.h
@@ -107,16 +107,16 @@ class ARCANE_CORE_EXPORT IEntryPoint
   /*!
    * \brief Consommation CPU totale passé dans ce point d'entrée en (en milli-s).
    *
-   * La résolution de cette méthode est assez faible. Il est en préférable d'utiliser
-   * le temps réel totalElapsedTime().
+   * \note depuis la version 3.6 de Arcane, cette méthode renvoie la même valeur
+   * que totalElapsedTime().
    */
   virtual Real totalCPUTime() const = 0;
 
   /*!
    * \brief Consommation CPU de la dernière itération (en milli-s).
    *
-   * La résolution de cette méthode est assez faible. Il est en préférable d'utiliser
-   * le temps réel elapsedTime().
+   * \note depuis la version 3.6 de Arcane, cette méthode renvoie la même valeur
+   * que lastElapsedTime().
    */
   virtual Real lastCPUTime() const = 0;
 
@@ -126,11 +126,19 @@ class ARCANE_CORE_EXPORT IEntryPoint
   //! Temps d'exécution (temps horloge) de la dernière itération (en milli-s).
   virtual Real lastElapsedTime() const = 0;
 
-  //! Temps total associé au timer \a type.
-  virtual Real totalTime(Timer::eTimerType type) const = 0;
+  /*!
+   * \brief Retourne totalElapsedTime().
+   * \deprecated Utiliser totalElapsedTime() à la place
+   */
+  ARCANE_DEPRECATED_REASON("Y2022: Use totalElapsedTime() instead")
+  virtual Real totalTime(Timer::eTimerType) const = 0;
 
-  //! Temps d'exécution de la dernière itération associé au timer \a type.
-  virtual Real lastTime(Timer::eTimerType type) const = 0;
+  /*!
+   * \brief Retourne lastElapsedTime().
+   * \deprecated Utiliser lastElapsedTime() à la place
+   */
+  ARCANE_DEPRECATED_REASON("Y2022: Use lastElapsedTime() instead")
+  virtual Real lastTime(Timer::eTimerType) const = 0;
 
   //! Retourne le nombre de fois que le point d'entrée a été exécuté
   virtual Integer nbCall() const = 0;

--- a/arcane/src/arcane/impl/TimerMng.cc
+++ b/arcane/src/arcane/impl/TimerMng.cc
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TimerMng.cc                                                 (C) 2000-2019 */
+/* TimerMng.cc                                                 (C) 2000-2022 */
 /*                                                                           */
 /* Implémentation d'un gestionnaire de timer.                                */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/ArcanePrecomp.h"
+#include "arcane/impl/TimerMng.h"
 
 #include "arcane/utils/Iterator.h"
 #include "arcane/utils/FatalErrorException.h"
@@ -24,30 +24,13 @@
 #include "arcane/ISubDomain.h"
 #include "arcane/IMainFactory.h"
 
-#include "arcane/impl/TimerMng.h"
-
-#ifdef ARCANE_OS_WIN32
-#include <windows.h>
-#define ARCANE_TIMER_USE_CLOCK
-#else
-#include <sys/time.h>
-#endif
-#include <time.h>
-#include <errno.h>
-
 #include <algorithm>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-#ifdef ARCANE_TIMER_USE_CLOCK
-static clock_t current_clock_value = 0;
-#endif
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -55,14 +38,11 @@ static clock_t current_clock_value = 0;
 TimerMng::
 TimerMng(ITraceMng* trace)
 : TraceAccessor(trace)
-, m_nb_timer(0)
 {
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-TimerMng::~TimerMng() = default;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -70,11 +50,7 @@ TimerMng::~TimerMng() = default;
 void TimerMng::
 beginTimer(Timer* timer)
 {
-  if (timer->type()==Timer::TimerVirtual){
-    if (m_nb_timer.fetch_add(1)==0)
-      _setVirtualTime();
-  }
-  Real tvalue = _getTime(timer);
+  Real tvalue = _getRealTime();
   timer->_setStartTime(tvalue);
 }
 
@@ -84,7 +60,7 @@ beginTimer(Timer* timer)
 Real TimerMng::
 getTime(Timer* timer)
 {
-  Real tvalue = _getTime(timer);
+  Real tvalue = _getRealTime();
   Real active_value = tvalue - timer->_startTime();
   return active_value;
 }
@@ -95,9 +71,7 @@ getTime(Timer* timer)
 Real TimerMng::
 endTimer(Timer* timer)
 {
-  Real tvalue = _getTime(timer);
-  if (timer->type()==Timer::TimerVirtual)
-    --m_nb_timer;
+  Real tvalue = _getRealTime();
   Real active_value = tvalue - timer->_startTime();
   return active_value;
 }
@@ -116,15 +90,9 @@ hasTimer(Timer* timer)
 /*---------------------------------------------------------------------------*/
 
 Real TimerMng::
-_getTime(Timer* t)
+_getRealTime()
 {
-  switch(t->type()){
-   case Timer::TimerVirtual:
-     return _getVirtualTime();
-   case Timer::TimerReal:
-     return _getRealTime();
-  }
-  return 0.0;
+  return platform::getRealTime();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -143,66 +111,7 @@ _errorInTimer(const String& msg,int retcode)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void TimerMng::
-_setVirtualTime()
-{
-#ifdef ARCANE_TIMER_USE_CLOCK
-	current_clock_value = ::clock();
-#else
-	struct itimerval time_val;
-  struct itimerval otime_val;
-  time_val.it_value.tv_sec = 5000000;
-  time_val.it_value.tv_usec = 0;
-  time_val.it_interval.tv_sec = 0;
-  time_val.it_interval.tv_usec = 0;
-  int r = ::setitimer(ITIMER_VIRTUAL,&time_val,&otime_val);
-  if (r!=0)
-    _errorInTimer("setitimer()",r);
-#endif
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Real TimerMng::
-_getVirtualTime()
-{
-#ifdef ARCANE_TIMER_USE_CLOCK
-	clock_t cv = ::clock();
-	Real diffv = static_cast<Real>(cv-current_clock_value);
-	return diffv / CLOCKS_PER_SEC;
-#else
-	struct itimerval time_val;
-  int r = ::getitimer(ITIMER_VIRTUAL,&time_val);
-  if (r!=0)
-    _errorInTimer("getitimer()",r);
-  double v = ((double)time_val.it_value.tv_sec) * 1.0
-    + ((double)time_val.it_value.tv_usec) * 1e-6;
-  return (5000000. - v);
-#endif
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void TimerMng::
-_setRealTime()
-{
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Real TimerMng::
-_getRealTime()
-{
-  return platform::getRealTime();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_END_NAMESPACE
+} // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/TimerMng.h
+++ b/arcane/src/arcane/impl/TimerMng.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TimerMng.h                                                  (C) 2000-2019 */
+/* TimerMng.h                                                  (C) 2000-2022 */
 /*                                                                           */
 /* Implémentation d'un gestionnaire de timer.                                */
 /*---------------------------------------------------------------------------*/
@@ -44,10 +44,6 @@ class ARCANE_IMPL_EXPORT TimerMng
 
  public:
 
-  ~TimerMng() override;
-
- public:
-
   void beginTimer(Timer* timer) override;
   Real endTimer(Timer* timer) override;
   Real getTime(Timer* timer) override;
@@ -59,21 +55,11 @@ class ARCANE_IMPL_EXPORT TimerMng
   virtual Real _getRealTime();
 
   //! Positionne un timer réel
-  virtual void _setRealTime();
+  virtual void _setRealTime() {}
   
  private:
 
-  std::atomic<Int64> m_nb_timer;
-
- private:
-
   void _errorInTimer(const String& msg,int retcode);
-
-  void _setVirtualTime();
-  Real _getVirtualTime();
-
-  void _setTime(Timer*);
-  Real _getTime(Timer*);
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Use only the wall clock to measure time.

The virtual time is not very accurate and does not really work when using multi-threading