### PR TITLE
Add template parameter for extent in 'Span' and 'Span2' classes

### DIFF
--- a/arccore/src/base/arccore/base/ArrayView.h
+++ b/arccore/src/base/arccore/base/ArrayView.h
@@ -16,6 +16,7 @@
 
 #include "arccore/base/ArrayRange.h"
 #include "arccore/base/ArrayViewCommon.h"
+#include "arccore/base/BaseTypes.h"
 
 #include <cstddef>
 #include <array>
@@ -32,9 +33,6 @@ namespace Arccore
 template<typename T> class ConstArrayView;
 template<typename T> class ConstIterT;
 template<typename T> class IterT;
-template<typename T> class Span;
-template<typename T> class SmallSpan;
-
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/BaseTypes.h
+++ b/arccore/src/base/arccore/base/BaseTypes.h
@@ -50,6 +50,9 @@ typedef unsigned short UInt16;
 //! Type d'un réel simple précision
 typedef float Single;
 
+//! Indique que la dimension d'un tableau est dynamique
+inline constexpr Int32 DynExtent = -1;
+
 template<typename T> class ConstArrayView;
 template<typename T> class ArrayView;
 template<typename T> class ConstArray2View;
@@ -59,12 +62,12 @@ template<typename T> class Array3View;
 template<typename T> class ConstArray4View;
 template<typename T> class Array4View;
 template<class DataType> class CoreArray;
-template<typename T,typename SizeType> class SpanImpl;
-template<typename T> class Span;
-template<typename T> class SmallSpan;
-template<typename T,typename SizeType> class Span2Impl;
-template<typename T> class Span2;
-template<typename T> class SmallSpan2;
+template<typename T,typename SizeType,SizeType Extent = -1> class SpanImpl;
+template<typename T,Int64 Extent = DynExtent> class Span;
+template<typename T,Int32 Extent = DynExtent> class SmallSpan;
+template<typename T,typename SizeType, SizeType Extent1 = DynExtent, SizeType Extent2= DynExtent> class Span2Impl;
+template<typename T, Int64 Extent1 = DynExtent, Int64 Extent2 = DynExtent> class Span2;
+template<typename T, Int32 Extent1 = DynExtent, Int32 Extent2 = DynExtent> class SmallSpan2;
 
 class StringImpl;
 class String;

--- a/arccore/src/base/arccore/base/Span.h
+++ b/arccore/src/base/arccore/base/Span.h
@@ -57,12 +57,12 @@ class ViewTypeT<const T>
  * type utilisé pour conserver le nombre d'éléments du tableau. Cela peut
  * être 'Int32' ou 'Int64'.
 */
-template<typename T,typename SizeType>
+template<typename T,typename SizeType,SizeType Extent>
 class SpanImpl
 {
  public:
 
-  using ThatClass = SpanImpl<T,SizeType>;
+  using ThatClass = SpanImpl<T,SizeType,Extent>;
   using size_type = SizeType;
   using ElementType = T;
   using element_type = ElementType;
@@ -402,14 +402,14 @@ class SpanImpl
  peut donc dépasser 2Go. Elle est concue pour être similaire à la classe
  std::span du C++20.
 */
-template<typename T>
+template<typename T,Int64 Extent>
 class Span
-: public SpanImpl<T,Int64>
+: public SpanImpl<T,Int64,Extent>
 {
  public:
 
-  using ThatClass = Span<T>;
-  using BaseClass = SpanImpl<T,Int64>;
+  using ThatClass = Span<T,Extent>;
+  using BaseClass = SpanImpl<T,Int64,Extent>;
   using size_type = Int64;
   using value_type = typename BaseClass::value_type;
   using pointer = typename BaseClass::pointer;
@@ -508,14 +508,14 @@ class Span
  * type \a T de la même manière qu'un tableau C standard. Elle est similaire à
  * Span à ceci près que le nombre d'éléments est stocké sur un 'Int32'.
  */
-template<typename T>
+template<typename T,Int32 Extent>
 class SmallSpan
-: public SpanImpl<T,Int32>
+: public SpanImpl<T,Int32,Extent>
 {
  public:
 
-  using ThatClass = SmallSpan<T>;
-  using BaseClass = SpanImpl<T,Int32>;
+  using ThatClass = SmallSpan<T,Extent>;
+  using BaseClass = SpanImpl<T,Int32,Extent>;
   using size_type = Int32;
   using value_type = typename BaseClass::value_type;
   using pointer = typename BaseClass::pointer;

--- a/arccore/src/base/arccore/base/Span2.h
+++ b/arccore/src/base/arccore/base/Span2.h
@@ -59,7 +59,7 @@ class View2TypeT<const T>
  * type utilisé pour conserver le nombre d'éléments du tableau. Cela peut
  * être 'Int32' ou 'Int64'.
  */
-template<typename T,typename SizeType>
+template<typename T,typename SizeType,SizeType Extent1,SizeType Extent2>
 class Span2Impl
 {
  public:
@@ -198,16 +198,16 @@ class Span2Impl
  * Comme toute vue, une instance de cette classe n'est valide que tant
  * que le conteneur dont elle est issue ne change pas de nombre d'éléments.
  */
-template<class T>
+template<class T,Int32 Extent1,Int32 Extent2>
 class SmallSpan2
-: public Span2Impl<T,Int32>
+: public Span2Impl<T,Int32,Extent1,Extent2>
 {
   friend class Span2<T>;
 
  public:
 
-  using ThatClass = SmallSpan2<T>;
-  using BaseClass = Span2Impl<T,Int32>;
+  using ThatClass = SmallSpan2<T,Extent1,Extent2>;
+  using BaseClass = Span2Impl<T,Int32,Extent1,Extent2>;
   using size_type = Int32;
   using value_type = typename BaseClass::value_type;
   using pointer = typename BaseClass::pointer;
@@ -266,14 +266,14 @@ class SmallSpan2
  * Comme toute vue, une instance de cette classe n'est valide que tant
  * que le conteneur dont elle est issue ne change pas de nombre d'éléments.
  */
-template<class T>
+template<class T,Int64 Extent1,Int64 Extent2>
 class Span2
-: public Span2Impl<T,Int64>
+: public Span2Impl<T,Int64,Extent1,Extent2>
 {
  public:
 
-  using ThatClass = Span2<T>;
-  using BaseClass = Span2Impl<T,Int64>;
+  using ThatClass = Span2<T,Extent1,Extent2>;
+  using BaseClass = Span2Impl<T,Int64,Extent1,Extent2>;
   using size_type = Int64;
   using value_type = typename BaseClass::value_type;
   using pointer = typename BaseClass::pointer;


### PR DESCRIPTION
This will allow us to add static extent to these classes and have the same behavior than `std::span`