### PR TITLE
Remove usage of compatibility macros for Array extents

### DIFF
--- a/arcane/src/arcane/accelerator/NumArrayViews.h
+++ b/arcane/src/arcane/accelerator/NumArrayViews.h
@@ -34,9 +34,9 @@ namespace Arcane::Accelerator
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType>
+template<typename DataType,typename ExtentType,typename LayoutType>
 class NumArrayViewSetter;
-template<typename Accessor,A_MDRANK_TYPE(N),typename LayoutType>
+template<typename Accessor,typename ExtentType,typename LayoutType>
 class NumArrayView;
 
 /*---------------------------------------------------------------------------*/
@@ -220,11 +220,11 @@ class NumArrayView<Accessor,MDDim4,LayoutType>
 /*!
  * \brief Vue en écriture.
  */
-template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType> auto
-viewOut(RunCommand& command,NumArray<DataType,N,LayoutType>& var)
+template<typename DataType,typename ExtentType,typename LayoutType> auto
+viewOut(RunCommand& command,NumArray<DataType,ExtentType,LayoutType>& var)
 {
   using Accessor = DataViewSetter<DataType>;
-  return NumArrayView<Accessor,N,LayoutType>(command,var.span());
+  return NumArrayView<Accessor,ExtentType,LayoutType>(command,var.span());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -233,11 +233,11 @@ viewOut(RunCommand& command,NumArray<DataType,N,LayoutType>& var)
 /*!
  * \brief Vue en lecture/écriture.
  */
-template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType> auto
-viewInOut(RunCommand& command,NumArray<DataType,N,LayoutType>& v)
+template<typename DataType,typename ExtentType,typename LayoutType> auto
+viewInOut(RunCommand& command,NumArray<DataType,ExtentType,LayoutType>& v)
 {
   using Accessor = DataViewGetterSetter<DataType>;
-  return NumArrayView<Accessor,N,LayoutType>(command,v.span());
+  return NumArrayView<Accessor,ExtentType,LayoutType>(command,v.span());
 }
 
 /*----------------------------------------------1-----------------------------*/
@@ -245,11 +245,11 @@ viewInOut(RunCommand& command,NumArray<DataType,N,LayoutType>& v)
 /*!
  * \brief Vue en lecture.
  */
-template<typename DataType,A_MDRANK_TYPE(N),typename LayoutType> auto
-viewIn(RunCommand& command,const NumArray<DataType,N,LayoutType>& v)
+template<typename DataType,typename ExtentType,typename LayoutType> auto
+viewIn(RunCommand& command,const NumArray<DataType,ExtentType,LayoutType>& v)
 {
   using Accessor = DataViewGetter<DataType>;
-  return NumArrayView<Accessor,N,LayoutType>(command,v.constSpan());
+  return NumArrayView<Accessor,ExtentType,LayoutType>(command,v.constSpan());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/RunCommandLoop.h
+++ b/arcane/src/arcane/accelerator/RunCommandLoop.h
@@ -93,7 +93,7 @@ _applyGenericLoop(RunCommand& command,LoopBoundType<N> bounds,const Lambda& func
 
 //! Applique la lambda \a func sur l'intervalle d'itération donnée par \a bounds
 template<int N,typename Lambda> void
-run(RunCommand& command,ArrayBounds<A_MDDIM(N)> bounds,const Lambda& func)
+run(RunCommand& command,ArrayBounds<MDDim<N>> bounds,const Lambda& func)
 {
   impl::_applyGenericLoop(command,SimpleForLoopRanges(bounds),func);
 }
@@ -134,7 +134,7 @@ class ArrayBoundRunCommand
 };
 
 template<int N> ArrayBoundRunCommand<N,SimpleForLoopRanges<N>>
-operator<<(RunCommand& command,const ArrayBounds<A_MDDIM(N)>& bounds)
+operator<<(RunCommand& command,const ArrayBounds<MDDim<N>>& bounds)
 {
   return {command,bounds};
 }
@@ -171,7 +171,7 @@ void operator<<(ArrayBoundRunCommand<N,ForLoopBoundType<N>>&& nr,const Lambda& f
 
 //! Boucle sur accélérateur
 #define RUNCOMMAND_LOOPN(iter_name, N, ...)                           \
-  A_FUNCINFO << ArrayBounds<A_MDDIM(N)>(__VA_ARGS__) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<N> iter_name )
+  A_FUNCINFO << ArrayBounds<MDDim<N>>(__VA_ARGS__) << [=] ARCCORE_HOST_DEVICE (ArrayBoundsIndex<N> iter_name )
 
 //! Boucle sur accélérateur
 #define RUNCOMMAND_LOOP1(iter_name, x1)                             \

--- a/arcane/src/arcane/impl/NumArrayData.cc
+++ b/arcane/src/arcane/impl/NumArrayData.cc
@@ -66,10 +66,10 @@ class INumArrayDataT
  public:
 
   //! Vue constante sur la donnée
-  virtual MDSpan<const DataType,A_MDDIM(RankValue)> view() const = 0;
+  virtual MDSpan<const DataType,MDDim<RankValue>> view() const = 0;
 
   //! Vue sur la donnée
-  virtual MDSpan<DataType,A_MDDIM(RankValue)> view() = 0;
+  virtual MDSpan<DataType,MDDim<RankValue>> view() = 0;
 
   //! Clone la donnée
   virtual Ref<ThatClass> cloneTrueRef() = 0;
@@ -111,10 +111,8 @@ class NumArrayDataT
   eDataType dataType() const override { return DataTypeTraitsT<DataType>::type(); }
   void serialize(ISerializer* sbuf, IDataOperation* operation) override;
   void serialize(ISerializer* sbuf, Int32ConstArrayView ids, IDataOperation* operation) override;
-  //NumArray<DataType,RankValue>& value() override { return m_value; }
-  //const NumArray<DataType,RankValue>& value() const override { return m_value; }
-  MDSpan<DataType,A_MDDIM(RankValue)> view() override { return m_value.span(); }
-  MDSpan<const DataType,A_MDDIM(RankValue)> view() const override { return m_value.span(); }
+  MDSpan<DataType,MDDim<RankValue>> view() override { return m_value.span(); }
+  MDSpan<const DataType,MDDim<RankValue>> view() const override { return m_value.span(); }
   void resize(Integer new_size) override;
   IData* clone() override { return _cloneTrue(); }
   IData* cloneEmpty() override { return _cloneTrueEmpty(); };
@@ -169,7 +167,7 @@ class NumArrayDataT
 
  private:
 
-  NumArray<DataType,A_MDDIM(RankValue)> m_value; //!< Donnée
+  NumArray<DataType,MDDim<RankValue>> m_value; //!< Donnée
   ITraceMng* m_trace;
   ArrayShape m_shape;
 
@@ -371,7 +369,7 @@ allocateBufferForSerializedData(ISerializedData* sdata)
   std::array<Int32,RankValue> numarray_extents;
   for( Int32 i=0; i<RankValue; ++i )
     numarray_extents[i] = CheckedConvert::toInt32(sdata_extents[i]);
-  auto extents = ArrayExtents<A_MDDIM(RankValue)>::fromSpan(numarray_extents);
+  auto extents = ArrayExtents<MDDim<RankValue>>::fromSpan(numarray_extents);
   m_value.resize(extents);
 
   Byte* byte_data = reinterpret_cast<Byte*>(m_value.to1DSpan().data());
@@ -435,7 +433,7 @@ serialize(ISerializer* sbuf,IDataOperation* operation)
     case ISerializer::ReadReplace:
       {
         //m_trace->info() << "READ REPLACE count=" << count << " dim2_size=" << dim2_size;
-        m_value.resize(ArrayExtents<A_MDDIM(RankValue)>::fromSpan(extents_span));
+        m_value.resize(ArrayExtents<MDDim<RankValue>>::fromSpan(extents_span));
         if (operation)
           ARCANE_THROW(NotImplementedException,"serialize(ReadReplace) with IDataOperation");
         BasicType* bt = reinterpret_cast<BasicType*>(m_value.to1DSpan().data());

--- a/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
@@ -79,7 +79,7 @@ class NumArrayUnitTest
   }
 
   template <int Rank,typename LayoutType> double
-  _doSum(const NumArray<double, A_MDDIM(Rank), LayoutType>& values, ArrayBounds<A_MDDIM(Rank)> bounds)
+  _doSum(const NumArray<double, MDDim<Rank>, LayoutType>& values, ArrayBounds<MDDim<Rank>> bounds)
   {
     double total = 0.0;
     SimpleForLoopRanges<Rank> lb(bounds);

--- a/arcane/src/arcane/utils/ArrayBounds.h
+++ b/arcane/src/arcane/utils/ArrayBounds.h
@@ -43,24 +43,24 @@ constexpr T fastmod(T a , T b)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<A_MDRANK_TYPE(RankValue)>
+template<typename ExtentType>
 class ArrayBoundsBase
-: private ArrayExtents<RankValue>
+: private ArrayExtents<ExtentType>
 {
  public:
-  using ArrayExtents<RankValue>::extent;
+  using ArrayExtents<ExtentType>::extent;
  public:
   constexpr ArrayBoundsBase() : m_nb_element(0) {}
  public:
   ARCCORE_HOST_DEVICE constexpr Int64 nbElement() const { return m_nb_element; }
-  ARCCORE_HOST_DEVICE constexpr std::array<Int32,A_MDRANK_RANK_VALUE(RankValue)> asStdArray() const { return ArrayExtents<RankValue>::asStdArray(); }
+  ARCCORE_HOST_DEVICE constexpr std::array<Int32,ExtentType::rank()> asStdArray() const { return ArrayExtents<ExtentType>::asStdArray(); }
  protected:
   constexpr void _computeNbElement()
   {
     m_nb_element = this->totalNbElement();
   }
  protected:
-  using ArrayExtents<RankValue>::m_extents;
+  using ArrayExtents<ExtentType>::m_extents;
   Int64 m_nb_element;
 };
 

--- a/arcane/src/arcane/utils/ArrayExtents.h
+++ b/arcane/src/arcane/utils/ArrayExtents.h
@@ -178,22 +178,18 @@ class ArrayExtentsBase<MDDim0>
 /*!
  * \brief Classe pour conserver le nombre d'éléments dans chaque dimension.
  */
-template<A_MDRANK_TYPE(RankValue)>
+template<typename ExtentType>
 class ArrayExtentsBase
 {
-#ifdef ARCANE_USE_TYPE_FOR_EXTENT
-  using ArrayExtentsPreviousRank = ArrayExtentsBase<MDDim<RankValue::rank()-1>>;
-#else
-  using ArrayExtentsPreviousRank = ArrayExtentsBase<RankValue-1>;
-#endif
+  using ArrayExtentsPreviousRank = ArrayExtentsBase<MDDim<ExtentType::rank()-1>>;
 
  public:
   ARCCORE_HOST_DEVICE constexpr ArrayExtentsBase()
-  : m_extents(detail::ArrayExtentsTraits<A_MDRANK_RANK_VALUE(RankValue)>::extendsInitHelper()) { }
+  : m_extents(detail::ArrayExtentsTraits<ExtentType::rank()>::extendsInitHelper()) { }
  protected:
   explicit ARCCORE_HOST_DEVICE ArrayExtentsBase(SmallSpan<const Int32> extents)
   {
-    auto nb_rank = A_MDRANK_RANK_VALUE(RankValue);
+    auto nb_rank = ExtentType::rank();
     Integer n = extents.size();
     Integer vn = math::min(n,nb_rank);
     for( int i=0; i<vn; ++i )
@@ -207,30 +203,30 @@ class ArrayExtentsBase
   //! Positionne à \a v le nombre d'éléments de la i-ème dimension
   ARCCORE_HOST_DEVICE void setExtent(int i,Int32 v) { m_extents[i] = v; }
   ARCCORE_HOST_DEVICE Int32 operator()(int i) const { return m_extents[i]; }
-  ARCCORE_HOST_DEVICE SmallSpan<const Int32> asSpan() const { return { m_extents.data(), A_MDRANK_RANK_VALUE(RankValue) }; }
-  ARCCORE_HOST_DEVICE std::array<Int32,A_MDRANK_RANK_VALUE(RankValue)> asStdArray() const { return m_extents; }
+  ARCCORE_HOST_DEVICE SmallSpan<const Int32> asSpan() const { return { m_extents.data(), ExtentType::rank() }; }
+  ARCCORE_HOST_DEVICE std::array<Int32,ExtentType::rank()> asStdArray() const { return m_extents; }
   //! Nombre total d'eléments
   ARCCORE_HOST_DEVICE constexpr Int64 totalNbElement() const
   {
     Int64 nb_element = 1;
-    for (int i=0; i<A_MDRANK_RANK_VALUE(RankValue); i++)
+    for (int i=0; i<ExtentType::rank(); i++)
       nb_element *= m_extents[i];
     return nb_element;
   }
   // Instance contenant les dimensions après la première
   ARCCORE_HOST_DEVICE ArrayExtentsPreviousRank removeFirstExtent() const
   {
-    return ArrayExtentsPreviousRank::fromSpan({m_extents.data()+1,A_MDRANK_RANK_VALUE(RankValue)-1});
+    return ArrayExtentsPreviousRank::fromSpan({m_extents.data()+1,ExtentType::rank()-1});
   }
   /*!
    * \brief Construit une instance à partir des valeurs données dans \a extents.
    */
-  ARCCORE_HOST_DEVICE static ArrayExtentsBase<RankValue> fromSpan(SmallSpan<const Int32> extents)
+  ARCCORE_HOST_DEVICE static ArrayExtentsBase<ExtentType> fromSpan(SmallSpan<const Int32> extents)
   {
-    return ArrayExtentsBase<RankValue>(extents);
+    return ArrayExtentsBase<ExtentType>(extents);
   }
  protected:
-  std::array<Int32,A_MDRANK_RANK_VALUE(RankValue)> m_extents;
+  std::array<Int32,ExtentType::rank()> m_extents;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ArrayLayout.h
+++ b/arcane/src/arcane/utils/ArrayLayout.h
@@ -78,8 +78,8 @@ class ArrayLayout3
 /*---------------------------------------------------------------------------*/
 // Layout par défaut pour chaque dimension
 
-template<A_MDRANK_TYPE(RankValue)> class RightLayout;
-template<A_MDRANK_TYPE(RankValue)> class LeftLayout;
+template<typename ExtentType> class RightLayout;
+template<typename ExtentType> class LeftLayout;
 
 template<> class RightLayout<MDDim2> : public ArrayLayout2<0,1> {};
 template<> class RightLayout<MDDim3> : public ArrayLayout3<0,1,2> {};

--- a/arcane/src/arcane/utils/ForLoopRanges.h
+++ b/arcane/src/arcane/utils/ForLoopRanges.h
@@ -57,7 +57,7 @@ class SimpleForLoopRanges
 {
   friend class ComplexForLoopRanges<N>;
  public:
-  using ArrayBoundsType = ArrayBounds<A_MDDIM(N)>;
+  using ArrayBoundsType = ArrayBounds<MDDim<N>>;
   using ArrayBoundsIndexType = ArrayBoundsIndex<N>;
  public:
   typedef typename ArrayBoundsType::IndexType IndexType;
@@ -86,7 +86,7 @@ template <int N>
 class ComplexForLoopRanges
 {
  public:
-  using ArrayBoundsType = ArrayBounds<A_MDDIM(N)>;
+  using ArrayBoundsType = ArrayBounds<MDDim<N>>;
   using ArrayBoundsIndexType = ArrayBoundsIndex<N>;
  public:
   typedef typename ArrayBoundsType::IndexType IndexType;

--- a/arcane/src/arcane/utils/UtilsTypes.h
+++ b/arcane/src/arcane/utils/UtilsTypes.h
@@ -244,25 +244,24 @@ using MDDim3 = MDDim<3>;
 //! Constante pour un tableau dynamique de rang 4
 using MDDim4 = MDDim<4>;
 
-
 enum class eMemoryRessource;
-template<A_MDRANK_TYPE(RankValue)> class DefaultLayout;
+template<typename ExtentType> class DefaultLayout;
 class IMemoryRessourceMng;
-template<typename DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
+template<typename DataType,typename ExtentType,typename LayoutType = DefaultLayout<ExtentType> >
 class MDSpanBase;
-template<class DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
+template<class DataType,typename ExtentType,typename LayoutType = DefaultLayout<ExtentType> >
 class MDSpan;
-template<typename DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
+template<typename DataType,typename ExtentType,typename LayoutType = DefaultLayout<ExtentType> >
 class NumArrayBase;
-template<class DataType,A_MDRANK_TYPE(RankValue),typename LayoutType = DefaultLayout<RankValue> >
+template<class DataType,typename ExtentType,typename LayoutType = DefaultLayout<ExtentType> >
 class NumArray;
-template<A_MDRANK_TYPE(RankValue)> class ArrayBounds;
+template<typename ExtentType> class ArrayBounds;
 template<int RankValue> class ArrayBoundsIndexBase;
 template<int RankValue> class ArrayBoundsIndex;
-template<A_MDRANK_TYPE(RankValue)> class ArrayExtentsBase;
-template<A_MDRANK_TYPE(RankValue)> class ArrayExtents;
+template<typename ExtentType> class ArrayExtentsBase;
+template<typename ExtentType> class ArrayExtents;
 template<int RankValue> class ArrayStridesBase;
-template<A_MDRANK_TYPE(RankValue),typename LayoutType> class ArrayExtentsWithOffset;
+template<typename ExtentType,typename LayoutType> class ArrayExtentsWithOffset;
 class ForLoopRange;
 template<int RankValue> class SimpleForLoopRanges;
 template<int RankValue> class ComplexForLoopRanges;


### PR DESCRIPTION
These macros have been added for compatibility with Arcane before 3.7 when the rank of `NumArray` and `MDSpan` classes was an `Int32`.
