### PR TITLE
Remove specialization for 'NumArray' and 'MDSpan'

### DIFF
--- a/arcane/src/arcane/utils/ArrayExtentsValue.h
+++ b/arcane/src/arcane/utils/ArrayExtentsValue.h
@@ -129,7 +129,7 @@ class ArrayExtentsValue<X0>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
   {
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
@@ -218,7 +218,7 @@ class ArrayExtentsValue<X0,X1>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
   {
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
@@ -321,7 +321,7 @@ class ArrayExtentsValue<X0,X1,X2>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
   {
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
@@ -438,7 +438,7 @@ class ArrayExtentsValue<X0,X1,X2,X3>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
   {
     Int32 i = 0;
     if constexpr (X0 == DynExtent)

--- a/arcane/src/arcane/utils/ArrayExtentsValue.h
+++ b/arcane/src/arcane/utils/ArrayExtentsValue.h
@@ -129,8 +129,9 @@ class ArrayExtentsValue<X0>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
   {
+    ARCANE_UNUSED(dims);
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       m_extent0.v = dims[i++];
@@ -141,8 +142,9 @@ class ArrayExtentsValue<X0>
     return {};
   }
 
-  ARCCORE_HOST_DEVICE void _checkIndex([[maybe_unused]] IndexType idx) const
+  ARCCORE_HOST_DEVICE void _checkIndex(IndexType idx) const
   {
+    ARCANE_UNUSED(idx);
     ARCCORE_CHECK_AT(idx.id0(), m_extent0.v);
   }
 
@@ -218,8 +220,9 @@ class ArrayExtentsValue<X0,X1>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
   {
+    ARCANE_UNUSED(dims);
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       m_extent0.v = dims[i++];
@@ -232,8 +235,9 @@ class ArrayExtentsValue<X0,X1>
     return { m_extent1.v };
   }
 
-  ARCCORE_HOST_DEVICE void _checkIndex([[maybe_unused]] IndexType idx) const
+  ARCCORE_HOST_DEVICE void _checkIndex(IndexType idx) const
   {
+    ARCANE_UNUSED(idx);
     ARCCORE_CHECK_AT(idx.id0(), m_extent0.v);
     ARCCORE_CHECK_AT(idx.id1(), m_extent1.v);
   }
@@ -321,8 +325,9 @@ class ArrayExtentsValue<X0,X1,X2>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
   {
+    ARCANE_UNUSED(dims);
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       m_extent0.v = dims[i++];
@@ -337,8 +342,9 @@ class ArrayExtentsValue<X0,X1,X2>
     return { m_extent1.v, m_extent2.v };
   }
 
-  ARCCORE_HOST_DEVICE void _checkIndex([[maybe_unused]] IndexType idx) const
+  ARCCORE_HOST_DEVICE void _checkIndex(IndexType idx) const
   {
+    ARCANE_UNUSED(idx);
     ARCCORE_CHECK_AT(idx.id0(), m_extent0.v);
     ARCCORE_CHECK_AT(idx.id1(), m_extent1.v);
     ARCCORE_CHECK_AT(idx.id2(), m_extent2.v);
@@ -438,8 +444,9 @@ class ArrayExtentsValue<X0,X1,X2,X3>
   }
 
   //! Construit une instance avec les N valeurs dynamiques.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DimsType dims)
+  ARCCORE_HOST_DEVICE ArrayExtentsValue(DimsType dims)
   {
+    ARCANE_UNUSED(dims);
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       m_extent0.v = dims[i++];
@@ -456,8 +463,9 @@ class ArrayExtentsValue<X0,X1,X2,X3>
     return { m_extent1.v, m_extent2.v, m_extent3.v };
   }
 
-  ARCCORE_HOST_DEVICE void _checkIndex([[maybe_unused]] IndexType idx) const
+  ARCCORE_HOST_DEVICE void _checkIndex(IndexType idx) const
   {
+    ARCANE_UNUSED(idx);
     ARCCORE_CHECK_AT(idx.id0(), m_extent0.v);
     ARCCORE_CHECK_AT(idx.id1(), m_extent1.v);
     ARCCORE_CHECK_AT(idx.id2(), m_extent2.v);

--- a/arcane/src/arcane/utils/MDSpan.h
+++ b/arcane/src/arcane/utils/MDSpan.h
@@ -63,6 +63,7 @@ class MDSpanBase
   using ExtentsType = ExtentType;
   using IndexType = typename ExtentsType::IndexType;
   using ArrayExtentsWithOffsetType = ArrayExtentsWithOffset<ExtentType, LayoutType>;
+  using DimsType = typename ExtentType::DimsType;
   // Pour compatibilité. A supprimer pour cohérence avec les autres 'using'
   using ArrayBoundsIndexType = typename ExtentsType::IndexType;
 
@@ -74,6 +75,10 @@ class MDSpanBase
   , m_extents(extents)
   {
   }
+  constexpr ARCCORE_HOST_DEVICE MDSpanBase(DataType* ptr, const DimsType& dims)
+  : m_ptr(ptr)
+  , m_extents(dims)
+  {}
   // Constructeur MDSpan<const T> à partir d'un MDSpan<T>
   template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
   constexpr ARCCORE_HOST_DEVICE MDSpanBase(const MDSpanBase<X, ExtentType>& rhs)
@@ -158,6 +163,7 @@ class MDSpanIntermediate<DataType, 1, ExtentType, LayoutType>
   using BaseClass::ptrAt;
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
+  using DimsType = typename ExtentType::DimsType;
 
  public:
 
@@ -165,6 +171,14 @@ class MDSpanIntermediate<DataType, 1, ExtentType, LayoutType>
   MDSpanIntermediate() = default;
   constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
+  {}
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, const DimsType& dims)
+  : BaseClass(ptr, dims)
+  {
+  }
+  template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(const MDSpan<X, ExtentsType>& rhs)
+  : BaseClass(rhs)
   {}
 
  public:
@@ -213,6 +227,7 @@ class MDSpanIntermediate<DataType, 2, ExtentType, LayoutType>
   using BaseClass::ptrAt;
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
+  using DimsType = typename ExtentType::DimsType;
 
  protected:
 
@@ -220,6 +235,14 @@ class MDSpanIntermediate<DataType, 2, ExtentType, LayoutType>
   MDSpanIntermediate() = default;
   constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
+  {}
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, const DimsType& dims)
+  : BaseClass(ptr, dims)
+  {
+  }
+  template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(const MDSpan<X, ExtentsType>& rhs)
+  : BaseClass(rhs)
   {}
 
  public:
@@ -275,16 +298,21 @@ class MDSpanIntermediate<DataType, 3, ExtentType, LayoutType>
   using BaseClass::ptrAt;
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
+  using DimsType = typename ExtentType::DimsType;
 
  protected:
 
   //! Construit une vue vide
   MDSpanIntermediate() = default;
-  ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
   {}
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, const DimsType& dims)
+  : BaseClass(ptr, dims)
+  {
+  }
   template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
-  ARCCORE_HOST_DEVICE MDSpanIntermediate(const MDSpan<X, ExtentsType>& rhs)
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(const MDSpan<X, ExtentsType>& rhs)
   : BaseClass(rhs)
   {}
 
@@ -340,6 +368,7 @@ class MDSpanIntermediate<DataType, 4, ExtentType, LayoutType>
   using BaseClass::ptrAt;
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
+  using DimsType = typename ExtentType::DimsType;
 
  protected:
 
@@ -348,6 +377,10 @@ class MDSpanIntermediate<DataType, 4, ExtentType, LayoutType>
   constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
   {}
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, const DimsType& dims)
+  : BaseClass(ptr, dims)
+  {
+  }
   template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
   constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(const MDSpan<X, ExtentType>& rhs)
   : BaseClass(rhs)
@@ -431,6 +464,7 @@ class MDSpan
   using BaseClass::ptrAt;
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
+  using DimsType = typename ExtentType::DimsType;
 
  public:
 
@@ -439,6 +473,10 @@ class MDSpan
   constexpr ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
   {}
+  constexpr ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, const DimsType& dims)
+  : BaseClass(ptr, dims)
+  {
+  }
   template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
   constexpr ARCCORE_HOST_DEVICE MDSpan(const MDSpan<X, ExtentsType>& rhs)
   : BaseClass(rhs)

--- a/arcane/src/arcane/utils/MDSpan.h
+++ b/arcane/src/arcane/utils/MDSpan.h
@@ -33,6 +33,10 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+//! Spécialisation intérmédiaire
+template <typename DataType, int Rank, typename ExtentType, typename LayoutType>
+class MDSpanIntermediate;
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
@@ -43,14 +47,8 @@ namespace Arcane
  * Cette classe s'inspire la classe std::mdspan en cours de définition
  * (voir http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0009r12.html)
  *
- * Cette classe est utilisée pour gérer les vues sur les tableaux des types
- * numériques qui sont accessibles sur accélérateur. \a RankValue est le
- * rang du tableau (nombre de dimensions) et \a DataType le type de données
- * associé.
- *
- * En général cette classe n'est pas utilisée directement mais par l'intermédiaire
- * d'une de ses spécialisations suivant le rang comme MDSpan<DataType,1>,
- * MDSpan<DataType,2>, MDSpan<DataType,3> ou MDSpan<DataType,4>.
+ * Cette classe ne doit pas être utilisée directement. Il faut utiliser MDSpan
+ * à la place.
  */
 template <typename DataType, typename ExtentType, typename LayoutType>
 class MDSpanBase
@@ -71,20 +69,22 @@ class MDSpanBase
  public:
 
   MDSpanBase() = default;
-  ARCCORE_HOST_DEVICE MDSpanBase(DataType* ptr, ArrayExtentsWithOffsetType extents)
+  constexpr ARCCORE_HOST_DEVICE MDSpanBase(DataType* ptr, ArrayExtentsWithOffsetType extents)
   : m_ptr(ptr)
   , m_extents(extents)
   {
   }
   // Constructeur MDSpan<const T> à partir d'un MDSpan<T>
-  template<typename X,typename = std::enable_if_t<std::is_same_v<X,UnqualifiedValueType>>>
-  ARCCORE_HOST_DEVICE MDSpanBase(const MDSpanBase<X,ExtentType>& rhs)
-  : m_ptr(rhs.m_ptr), m_extents(rhs.m_extents){}
+  template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
+  constexpr ARCCORE_HOST_DEVICE MDSpanBase(const MDSpanBase<X, ExtentType>& rhs)
+  : m_ptr(rhs.m_ptr)
+  , m_extents(rhs.m_extents)
+  {}
 
  public:
 
-  ARCCORE_HOST_DEVICE DataType* _internalData() { return m_ptr; }
-  ARCCORE_HOST_DEVICE const DataType* _internalData() const { return m_ptr; }
+  constexpr ARCCORE_HOST_DEVICE DataType* _internalData() { return m_ptr; }
+  constexpr ARCCORE_HOST_DEVICE const DataType* _internalData() const { return m_ptr; }
 
  public:
 
@@ -99,26 +99,31 @@ class MDSpanBase
 
  public:
 
-  ARCCORE_HOST_DEVICE Int64 offset(IndexType idx) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(IndexType idx) const
   {
     return m_extents.offset(idx);
   }
   //! Valeur pour l'élément \a i
-  ARCCORE_HOST_DEVICE DataType& operator()(IndexType idx) const
+  constexpr ARCCORE_HOST_DEVICE DataType& operator()(IndexType idx) const
   {
     return m_ptr[offset(idx)];
   }
   //! Pointeur sur la valeur pour l'élément \a i
-  ARCCORE_HOST_DEVICE DataType* ptrAt(IndexType idx) const
+  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(IndexType idx) const
   {
     return m_ptr + offset(idx);
   }
 
  public:
 
-  ARCCORE_HOST_DEVICE MDSpanBase<const DataType,ExtentType> constSpan() const
-  { return MDSpanBase<const DataType,ExtentType>(m_ptr,m_extents); }
-  ARCCORE_HOST_DEVICE Span<DataType> to1DSpan() const { return { m_ptr, m_extents.totalNbElement() }; }
+  constexpr ARCCORE_HOST_DEVICE MDSpanBase<const DataType, ExtentType> constSpan() const
+  {
+    return MDSpanBase<const DataType, ExtentType>(m_ptr, m_extents);
+  }
+  constexpr ARCCORE_HOST_DEVICE Span<DataType> to1DSpan() const
+  {
+    return { m_ptr, m_extents.totalNbElement() };
+  }
 
  protected:
 
@@ -132,13 +137,15 @@ class MDSpanBase
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Vue multi-dimensionnelle à 1 dimension.
+ * \brief Spécialisation d'une vue multi-dimensionnelle à 1 dimension.
  */
-template <int X0, class DataType, typename LayoutType>
-class MDSpan<DataType, ExtentsV<X0>, LayoutType>
-: public MDSpanBase<DataType, ExtentsV<X0>, LayoutType>
+template <typename DataType, typename ExtentType, typename LayoutType>
+class MDSpanIntermediate<DataType, 1, ExtentType, LayoutType>
+: public MDSpanBase<DataType, ExtentType, LayoutType>
 {
-  using ExtentsType = ExtentsV<X0>;
+ protected:
+
+  using ExtentsType = ExtentType;
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
   friend class NumArrayBase<UnqualifiedValueType, ExtentsType, LayoutType>;
   using BaseClass = MDSpanBase<DataType, ExtentsType, LayoutType>;
@@ -155,8 +162,8 @@ class MDSpan<DataType, ExtentsV<X0>, LayoutType>
  public:
 
   //! Construit une vue vide
-  MDSpan() = default;
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
+  MDSpanIntermediate() = default;
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
   {}
 
@@ -167,36 +174,33 @@ class MDSpan<DataType, ExtentsV<X0>, LayoutType>
 
  public:
 
-  ARCCORE_HOST_DEVICE Int64 offset(Int32 i) const { return m_extents.offset(i); }
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i) const { return m_extents.offset(i); }
   //! Valeur pour l'élément \a i
-  ARCCORE_HOST_DEVICE DataType& operator()(Int32 i) const { return m_ptr[offset(i)]; }
+  constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i) const { return m_ptr[offset(i)]; }
   //! Pointeur sur la valeur pour l'élément \a i
-  ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i) const { return m_ptr+offset(i); }
+  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i) const { return m_ptr + offset(i); }
   //! Valeur pour l'élément \a i
-  ARCCORE_HOST_DEVICE DataType operator[](Int32 i) const { return m_ptr[offset(i)]; }
+  constexpr ARCCORE_HOST_DEVICE DataType operator[](Int32 i) const { return m_ptr[offset(i)]; }
   //! Valeur pour l'élément \a i et la composante \a a
-  template<typename X = DataType,typename SubType = typename NumericTraitsT<X>::SubscriptType >
-  ARCCORE_HOST_DEVICE SubType operator()(Int32 i,Int32 a) const { return m_ptr[offset(i)][a]; }
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  constexpr ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 a) const { return m_ptr[offset(i)][a]; }
   //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template<typename X = DataType,typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type >
-  ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i,Int32 a,Int32 b) const { return m_ptr[offset(i)][a][b]; }
-
- public:
-
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,ExtentsType,LayoutType> constSpan() const
-  { return MDSpan<const DataType,ExtentsType,LayoutType>(m_ptr,m_extents); }
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  constexpr ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 a, Int32 b) const { return m_ptr[offset(i)][a][b]; }
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Vue multi-dimensionnelle à 2 dimensions.
+ * \brief Spécialisation d'une vue multi-dimensionnelle à 2 dimensions.
  */
-template <int X0, int X1, class DataType, typename LayoutType>
-class MDSpan<DataType, ExtentsV<X0, X1>, LayoutType>
-: public MDSpanBase<DataType, ExtentsV<X0, X1>, LayoutType>
+template <typename DataType, typename ExtentType, typename LayoutType>
+class MDSpanIntermediate<DataType, 2, ExtentType, LayoutType>
+: public MDSpanBase<DataType, ExtentType, LayoutType>
 {
-  using ExtentsType = ExtentsV<X0, X1>;
+ protected:
+
+  using ExtentsType = ExtentType;
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
   friend class NumArrayBase<UnqualifiedValueType, ExtentsType, LayoutType>;
   using BaseClass = MDSpanBase<DataType, ExtentsType, LayoutType>;
@@ -210,11 +214,11 @@ class MDSpan<DataType, ExtentsV<X0, X1>, LayoutType>
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
 
- public:
+ protected:
 
   //! Construit un tableau vide
-  MDSpan() = default;
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
+  MDSpanIntermediate() = default;
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
   {}
 
@@ -227,36 +231,37 @@ class MDSpan<DataType, ExtentsV<X0, X1>, LayoutType>
 
  public:
 
-  ARCCORE_HOST_DEVICE Int64 offset(Int32 i,Int32 j) const { return m_extents.offset(i,j); }
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j) const { return m_extents.offset(i, j); }
   //! Valeur pour l'élément \a i,j
-  ARCCORE_HOST_DEVICE DataType& operator()(Int32 i,Int32 j) const { return m_ptr[offset(i,j)]; }
+  constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j) const { return m_ptr[offset(i, j)]; }
   //! Pointeur sur la valeur pour l'élément \a i,j
-  ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i,Int32 j) const { return m_ptr + offset(i,j); }
+  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j) const { return m_ptr + offset(i, j); }
   //! Valeur pour l'élément \a i et la composante \a a
-  template<typename X = DataType,typename SubType = typename NumericTraitsT<X>::SubscriptType >
-  ARCCORE_HOST_DEVICE SubType operator()(Int32 i,Int32 j,Int32 a) const { return m_ptr[offset(i,j)][a]; }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template<typename X = DataType,typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type >
-  ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i,Int32 j,Int32 a,Int32 b) const { return m_ptr[offset(i,j)][a][b]; }
-
- public:
-
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,ExtentsType,LayoutType> constSpan() const
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  constexpr ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 j, Int32 a) const
   {
-    return MDSpan<const DataType,ExtentsType,LayoutType>(m_ptr,m_extents);
+    return m_ptr[offset(i, j)][a];
+  }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  constexpr ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 j, Int32 a, Int32 b) const
+  {
+    return m_ptr[offset(i, j)][a][b];
   }
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Vue multi-dimensionnelle à 3 dimensions.
+ * \brief Spécialisation d'une vue multi-dimensionnelle à 3 dimensions.
  */
-template <int X0, int X1, int X2, class DataType, typename LayoutType>
-class MDSpan<DataType, ExtentsV<X0, X1, X2>, LayoutType>
-: public MDSpanBase<DataType, ExtentsV<X0, X1, X2>, LayoutType>
+template <typename DataType, typename ExtentType, typename LayoutType>
+class MDSpanIntermediate<DataType, 3, ExtentType, LayoutType>
+: public MDSpanBase<DataType, ExtentType, LayoutType>
 {
-  using ExtentsType = ExtentsV<X0, X1, X2>;
+ protected:
+
+  using ExtentsType = ExtentType;
   using UnqualifiedValueType = std::remove_cv_t<DataType>;
   friend class NumArrayBase<UnqualifiedValueType, ExtentsType, LayoutType>;
   using BaseClass = MDSpanBase<DataType, ExtentsType, LayoutType>;
@@ -271,15 +276,15 @@ class MDSpan<DataType, ExtentsV<X0, X1, X2>, LayoutType>
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
 
- public:
+ protected:
 
   //! Construit une vue vide
-  MDSpan() = default;
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
+  MDSpanIntermediate() = default;
+  ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
   {}
   template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
-  ARCCORE_HOST_DEVICE MDSpan(const MDSpan<X, ExtentsType>& rhs)
+  ARCCORE_HOST_DEVICE MDSpanIntermediate(const MDSpan<X, ExtentsType>& rhs)
   : BaseClass(rhs)
   {}
 
@@ -294,27 +299,22 @@ class MDSpan<DataType, ExtentsV<X0, X1, X2>, LayoutType>
 
  public:
 
-  ARCCORE_HOST_DEVICE Int64 offset(Int32 i,Int32 j,Int32 k) const { return m_extents.offset(i,j,k); }
+  ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j, Int32 k) const { return m_extents.offset(i, j, k); }
   //! Valeur pour l'élément \a i,j,k
-  ARCCORE_HOST_DEVICE DataType& operator()(Int32 i,Int32 j,Int32 k) const { return m_ptr[offset(i,j,k)]; }
+  ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j, Int32 k) const { return m_ptr[offset(i, j, k)]; }
   //! Pointeur sur la valeur pour l'élément \a i,j,k
-  ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i,Int32 j,Int32 k) const { return m_ptr+offset(i,j,k); }
+  ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j, Int32 k) const { return m_ptr + offset(i, j, k); }
   //! Valeur pour l'élément \a i et la composante \a a
-  template<typename X = DataType,typename SubType = typename NumericTraitsT<X>::SubscriptType >
-  ARCCORE_HOST_DEVICE SubType operator()(Int32 i,Int32 j,Int32 k,Int32 a) const
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 j, Int32 k, Int32 a) const
   {
-    return m_ptr[offset(i,j,k)][a];
+    return m_ptr[offset(i, j, k)][a];
   }
   //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template<typename X = DataType,typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type >
-  ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i,Int32 j,Int32 k,Int32 a,Int32 b) const
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) const
   {
-    return m_ptr[offset(i,j,k)][a][b];
-  }
- public:
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,ExtentsType,LayoutType> constSpan() const
-  {
-    return MDSpan<const DataType,ExtentsType,LayoutType>(m_ptr,m_extents);
+    return m_ptr[offset(i, j, k)][a][b];
   }
 };
 
@@ -323,16 +323,16 @@ class MDSpan<DataType, ExtentsV<X0, X1, X2>, LayoutType>
 /*!
  * \brief Vue multi-dimensionnelle à 4 dimensions.
  */
-template <int X0, int X1, int X2, int X3, class DataType, typename LayoutType>
-class MDSpan<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
-: public MDSpanBase<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
+template <typename DataType, typename ExtentType, typename LayoutType>
+class MDSpanIntermediate<DataType, 4, ExtentType, LayoutType>
+: public MDSpanBase<DataType, ExtentType, LayoutType>
 {
-  using ExtentsType = ExtentsV<X0, X1, X2, X3>;
-  using UnqualifiedValueType = std::remove_cv_t<DataType>;
-  friend class NumArrayBase<UnqualifiedValueType, ExtentsType, LayoutType>;
-  using BaseClass = MDSpanBase<DataType, ExtentsType, LayoutType>;
+ protected:
+
+  using BaseClass = MDSpanBase<DataType, ExtentType, LayoutType>;
   using BaseClass::m_extents;
   using BaseClass::m_ptr;
+  using UnqualifiedValueType = std::remove_cv_t<DataType>;
 
  public:
 
@@ -341,12 +341,16 @@ class MDSpan<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
   using BaseClass::operator();
   using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
 
- public:
+ protected:
 
   //! Construit une vue vide
-  MDSpan() = default;
-  ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
+  MDSpanIntermediate() = default;
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
   : BaseClass(ptr, extents_and_offset)
+  {}
+  template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
+  constexpr ARCCORE_HOST_DEVICE MDSpanIntermediate(const MDSpan<X, ExtentType>& rhs)
+  : BaseClass(rhs)
   {}
 
  public:
@@ -362,41 +366,89 @@ class MDSpan<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
 
  public:
 
-  ARCCORE_HOST_DEVICE Int64 offset(Int32 i,Int32 j,Int32 k,Int32 l) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j, Int32 k, Int32 l) const
   {
-    return m_extents.offset(i,j,k,l);
+    return m_extents.offset(i, j, k, l);
   }
 
  public:
 
   //! Valeur pour l'élément \a i,j,k,l
-  ARCCORE_HOST_DEVICE DataType& operator()(Int32 i,Int32 j,Int32 k,Int32 l) const
+  constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j, Int32 k, Int32 l) const
   {
-    return m_ptr[offset(i,j,k,l)];
+    return m_ptr[offset(i, j, k, l)];
   }
   //! Pointeur sur la valeur pour l'élément \a i,j,k
-  ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i,Int32 j,Int32 k,Int32 l) const
+  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j, Int32 k, Int32 l) const
   {
-    return m_ptr + offset(i,j,k,l);
+    return m_ptr + offset(i, j, k, l);
   }
   //! Valeur pour l'élément \a i et la composante \a a
-  template<typename X = DataType,typename SubType = typename NumericTraitsT<X>::SubscriptType >
-  ARCCORE_HOST_DEVICE SubType operator()(Int32 i,Int32 j,Int32 k,Int32 l,Int32 a) const
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  constexpr ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) const
   {
-    return m_ptr[offset(i,j,k,l)][a];
+    return m_ptr[offset(i, j, k, l)][a];
   }
   //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template<typename X = DataType,typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type >
-  ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i,Int32 j,Int32 k,Int32 l,Int32 a,Int32 b) const
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  constexpr ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) const
   {
-    return m_ptr[offset(i,j,k,l)][a][b];
+    return m_ptr[offset(i, j, k, l)][a][b];
   }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Vues sur des tableaux multi-dimensionnels.
+ *
+ * \warning API en cours de définition.
+ *
+ * Cette classe s'inspire la classe std::mdspan en cours de définition
+ * (voir http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0009r12.html)
+ *
+ * Cette classe est utilisée pour gérer les vues sur les tableaux tels que
+ * NumArray. Les méthodes de cette classe sont accessibles sur accélérateur.
+ *
+ */
+template <typename DataType, typename ExtentType, typename LayoutType>
+class MDSpan
+: public MDSpanIntermediate<DataType, ExtentType::rank(), ExtentType, LayoutType>
+{
+  using ExtentsType = ExtentType;
+  using UnqualifiedValueType = std::remove_cv_t<DataType>;
+  friend class NumArrayBase<UnqualifiedValueType, ExtentsType, LayoutType>;
+  using BaseClass = MDSpanIntermediate<DataType, ExtentType::rank(), ExtentsType, LayoutType>;
+  using BaseClass::m_extents;
+  using BaseClass::m_ptr;
 
  public:
 
-  ARCCORE_HOST_DEVICE MDSpan<const DataType,ExtentsType,LayoutType> constSpan() const
+  using BaseClass::offset;
+  using BaseClass::ptrAt;
+  using BaseClass::operator();
+  using ArrayExtentsWithOffsetType = typename BaseClass::ArrayExtentsWithOffsetType;
+
+ public:
+
+  //! Construit une vue vide
+  MDSpan() = default;
+  constexpr ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents_and_offset)
+  : BaseClass(ptr, extents_and_offset)
+  {}
+  template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
+  constexpr ARCCORE_HOST_DEVICE MDSpan(const MDSpan<X, ExtentsType>& rhs)
+  : BaseClass(rhs)
+  {}
+
+ public:
+
+  ARCCORE_HOST_DEVICE MDSpan<const DataType, ExtentsType, LayoutType> constSpan() const
   {
-    return MDSpan<const DataType,ExtentsType,LayoutType>(m_ptr,m_extents);
+    return MDSpan<const DataType, ExtentsType, LayoutType>(m_ptr, m_extents);
   }
 };
 

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -682,6 +682,9 @@ class NumArray<DataType, ExtentsV<X0>, LayoutType>
   template <typename X>
   using is_fully_dynamic = std::enable_if_t<X::is_full_dynamic(), int>;
 
+  template <typename X>
+  using is_full_dynamic_and_rank1 = std::enable_if_t<X::is_full_dynamic() && (X::rank() == 1), int>;
+
  public:
 
   //! Construit un tableau vide
@@ -697,32 +700,32 @@ class NumArray<DataType, ExtentsV<X0>, LayoutType>
   {
   }
   //! Construit un tableau
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 1, void>>
   explicit NumArray(Int32 dim1_size)
   : BaseClass(DimsType(dim1_size))
   {
   }
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 1, void>>
   NumArray(Int32 dim1_size, eMemoryRessource r)
   : BaseClass(DimsType(dim1_size), r)
   {
   }
   //! Construit un tableau à partir de valeurs prédéfinies
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = is_full_dynamic_and_rank1<X>>
   NumArray(Int32 dim1_size, std::initializer_list<DataType> alist)
   : NumArray(dim1_size)
   {
     this->m_data.copyInitializerList(alist);
   }
   //! Construit une instance à partir d'une vue
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = is_full_dynamic_and_rank1<X>>
   NumArray(SmallSpan<const DataType> v)
   : NumArray(v.size())
   {
     this->m_data.copy(v);
   }
   //! Construit une instance à partir d'une vue
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = is_full_dynamic_and_rank1<X>>
   NumArray(Span<const DataType> v)
   : NumArray(arcaneCheckArraySize(v.size()))
   {
@@ -740,7 +743,7 @@ class NumArray<DataType, ExtentsV<X0>, LayoutType>
    * \warning Les valeurs actuelles ne sont pas conservées lors de cette opération
    * et les nouvelles valeurs ne sont pas initialisées.
    */
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 1, void>>
   void resize(Int32 dim1_size)
   {
     this->resize(DimsType(dim1_size));
@@ -773,7 +776,7 @@ class NumArray<DataType, ExtentsV<X0, X1>, LayoutType>
   using BaseClass::m_span;
 
   template <typename X>
-  using is_fully_dynamic = std::enable_if_t<X::is_full_dynamic(), int>;
+  using is_full_dynamic_and_rank2 = std::enable_if_t<X::is_full_dynamic() && (X::rank() == 2), int>;
 
  public:
 
@@ -791,12 +794,12 @@ class NumArray<DataType, ExtentsV<X0, X1>, LayoutType>
   }
 
   //! Construit un tableau
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 2, void>>
   NumArray(Int32 dim1_size, Int32 dim2_size)
   : BaseClass(DimsType(dim1_size, dim2_size))
   {
   }
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 2, void>>
   NumArray(Int32 dim1_size, Int32 dim2_size, eMemoryRessource r)
   : BaseClass(DimsType(dim1_size, dim2_size), r)
   {
@@ -807,7 +810,7 @@ class NumArray<DataType, ExtentsV<X0, X1>, LayoutType>
    * Les valeurs sont rangées de manière contigues en mémoire donc
    * la liste \a alist doit avoir un layout qui correspond à celui de cette classe.
    */
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = is_full_dynamic_and_rank2<X>>
   NumArray(Int32 dim1_size, Int32 dim2_size, std::initializer_list<DataType> alist)
   : NumArray(dim1_size, dim2_size)
   {
@@ -820,7 +823,7 @@ class NumArray<DataType, ExtentsV<X0, X1>, LayoutType>
 
  public:
 
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 2, void>>
   void resize(Int32 dim1_size, Int32 dim2_size)
   {
     this->resize(DimsType(dim1_size, dim2_size));
@@ -871,12 +874,12 @@ class NumArray<DataType, ExtentsV<X0, X1, X2>, LayoutType>
   explicit NumArray(eMemoryRessource r)
   : BaseClass(r)
   {}
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 3, void>>
   NumArray(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size)
   : BaseClass(DimsType(dim1_size, dim2_size, dim3_size))
   {
   }
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 3, void>>
   NumArray(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, eMemoryRessource r)
   : BaseClass(DimsType(dim1_size, dim2_size, dim3_size), r)
   {
@@ -889,7 +892,7 @@ class NumArray<DataType, ExtentsV<X0, X1, X2>, LayoutType>
 
  public:
 
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 3, void>>
   void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size)
   {
     this->resize(DimsType(dim1_size, dim2_size, dim3_size));
@@ -939,14 +942,14 @@ class NumArray<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
   : BaseClass(r)
   {}
 
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 4, void>>
   NumArray(Int32 dim1_size, Int32 dim2_size,
            Int32 dim3_size, Int32 dim4_size)
   : BaseClass(DimsType(dim1_size, dim2_size, dim3_size, dim4_size))
   {
   }
 
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 4, void>>
   NumArray(Int32 dim1_size, Int32 dim2_size,
            Int32 dim3_size, Int32 dim4_size, eMemoryRessource r)
   : BaseClass(DimsType(dim1_size, dim2_size, dim3_size, dim4_size), r)
@@ -960,7 +963,7 @@ class NumArray<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
 
  public:
 
-  template <typename X = ExtentsType, typename = is_fully_dynamic<X>>
+  template <typename X = ExtentsType, typename = std::enable_if_t<X::nb_dynamic == 4, void>>
   void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, Int32 dim4_size)
   {
     this->resize(DimsType(dim1_size, dim2_size, dim3_size, dim4_size));

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -653,7 +653,7 @@ class NumArrayIntermediate<DataType, 4, ExtentType, LayoutType>
  *
  * L'implémentation actuelle supporte des tableaux jusqu'à 4 dimensions. L'accès
  * aux éléments se fait via l'opérateur 'operator()'. Ces opérateurs d'accès spécifiques
- * dépendent du rang sont fournis par les spécialisations de la classe NumArrayIntermediate.
+ * dépendent du rang et sont fournis par les spécialisations de la classe NumArrayIntermediate.
  *
  * \warning Le redimensionnement via resize() ne conserve pas les valeurs existantes
  *

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -33,6 +33,9 @@
 namespace Arcane
 {
 
+template <typename DataType, int Rank, typename ExtentType, typename LayoutType>
+class NumArrayIntermediate;
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -304,6 +307,352 @@ class NumArrayBase
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
+ * \brief Spécialisation pour les tableaux à 1 dimension.
+ */
+template <typename DataType, typename ExtentType, typename LayoutType>
+class NumArrayIntermediate<DataType, 1, ExtentType, LayoutType>
+: public NumArrayBase<DataType, ExtentType, LayoutType>
+{
+ public:
+
+  using BaseClass = NumArrayBase<DataType, ExtentType, LayoutType>;
+  using DimsType = typename ExtentType::DimsType;
+  using BaseClass::resize;
+  using BaseClass::operator();
+  using BaseClass::s;
+  using ConstSpanType = MDSpan<const DataType, ExtentType, LayoutType>;
+  using SpanType = MDSpan<DataType, ExtentType, LayoutType>;
+
+ protected:
+
+  using BaseClass::m_span;
+
+ protected:
+
+  //! Construit un tableau vide
+  NumArrayIntermediate() = default;
+  explicit NumArrayIntermediate(const DimsType& extents)
+  : BaseClass(extents)
+  {}
+  NumArrayIntermediate(const DimsType& extents, eMemoryRessource r)
+  : BaseClass(extents, r)
+  {
+  }
+  explicit NumArrayIntermediate(eMemoryRessource r)
+  : BaseClass(r)
+  {}
+
+ public:
+
+  //! Valeur de la première dimension
+  constexpr Int32 dim1Size() const { return m_span.extent0(); }
+
+  //! Valeur de la première dimension
+  constexpr Int32 extent0() const { return m_span.extent0(); }
+
+ public:
+
+  //! Valeur pour l'élément \a i
+  DataType operator()(Int32 i) const { return m_span(i); }
+  //! Positionne la valeur pour l'élément \a i
+  DataType& operator()(Int32 i) { return m_span(i); }
+  //! Positionne la valeur pour l'élément \a i
+  DataType& s(Int32 i) { return m_span(i); }
+  //! Récupère une référence pour l'élément \a i
+  DataType& operator[](Int32 i) { return m_span(i); }
+  //! Valeur pour l'élément \a i
+  DataType operator[](Int32 i) const { return m_span(i); }
+
+ public:
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
+  SubConstType operator()(Int32 i, Int32 a) const { return m_span(i, a); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  SubType operator()(Int32 i, Int32 a) { return m_span(i, a); }
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
+  Sub2ConstType operator()(Int32 i, Int32 a, Int32 b) const { return m_span(i, a, b); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  Sub2Type operator()(Int32 i, Int32 a, Int32 b) { return m_span(i, a, b); }
+
+ public:
+
+  constexpr operator SpanType() { return this->span(); }
+  constexpr operator ConstSpanType() const { return this->constSpan(); }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Spécialisation pour les tableaux à 2 dimensions.
+ */
+template <typename DataType, typename ExtentType, typename LayoutType>
+class NumArrayIntermediate<DataType, 2, ExtentType, LayoutType>
+: public NumArrayBase<DataType, ExtentType, LayoutType>
+{
+ public:
+
+  using BaseClass = NumArrayBase<DataType, ExtentType, LayoutType>;
+  using DimsType = typename ExtentType::DimsType;
+  using BaseClass::resize;
+  using BaseClass::operator();
+  using BaseClass::s;
+
+ protected:
+
+  using BaseClass::m_span;
+
+ protected:
+
+  //! Construit un tableau vide
+  NumArrayIntermediate() = default;
+  explicit NumArrayIntermediate(const DimsType& extents)
+  : BaseClass(extents)
+  {}
+  NumArrayIntermediate(const DimsType& extents, eMemoryRessource r)
+  : BaseClass(extents, r)
+  {
+  }
+  explicit NumArrayIntermediate(eMemoryRessource r)
+  : BaseClass(r)
+  {}
+
+ public:
+
+  //! Valeur de la première dimension
+  constexpr Int32 dim1Size() const { return m_span.extent0(); }
+  //! Valeur de la deuxième dimension
+  constexpr Int32 dim2Size() const { return m_span.extent1(); }
+
+  //! Valeur de la première dimension
+  constexpr Int32 extent0() const { return m_span.extent0(); }
+  //! Valeur de la deuxième dimension
+  constexpr Int32 extent1() const { return m_span.extent1(); }
+
+ public:
+
+  //! Valeur pour l'élément \a i,j
+  DataType operator()(Int32 i, Int32 j) const
+  {
+    return m_span(i, j);
+  }
+  //! Positionne la valeur pour l'élément \a i,j
+  DataType& operator()(Int32 i, Int32 j)
+  {
+    return m_span(i, j);
+  }
+  //! Positionne la valeur pour l'élément \a i,j
+  DataType& s(Int32 i, Int32 j)
+  {
+    return m_span(i, j);
+  }
+
+ public:
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
+  SubConstType operator()(Int32 i, Int32 j, Int32 a) const { return m_span(i, j, a); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  SubType operator()(Int32 i, Int32 j, Int32 a) { return m_span(i, j, a); }
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
+  Sub2ConstType operator()(Int32 i, Int32 j, Int32 a, Int32 b) const { return m_span(i, j, a, b); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  Sub2Type operator()(Int32 i, Int32 j, Int32 a, Int32 b) { return m_span(i, j, a, b); }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Spécialisation pour les tableaux à 3 dimensions.
+ */
+template <typename DataType, typename ExtentType, typename LayoutType>
+class NumArrayIntermediate<DataType, 3, ExtentType, LayoutType>
+: public NumArrayBase<DataType, ExtentType, LayoutType>
+{
+ public:
+
+  using BaseClass = NumArrayBase<DataType, ExtentType, LayoutType>;
+  using DimsType = typename ExtentType::DimsType;
+  using BaseClass::resize;
+  using BaseClass::operator();
+  using BaseClass::s;
+
+ protected:
+
+  using BaseClass::m_span;
+
+ protected:
+
+  //! Construit un tableau vide
+  NumArrayIntermediate() = default;
+  explicit NumArrayIntermediate(const DimsType& extents)
+  : BaseClass(extents)
+  {}
+  NumArrayIntermediate(const DimsType& extents, eMemoryRessource r)
+  : BaseClass(extents, r)
+  {
+  }
+  explicit NumArrayIntermediate(eMemoryRessource r)
+  : BaseClass(r)
+  {}
+
+ public:
+
+  //! Valeur de la première dimension
+  constexpr Int32 dim1Size() const { return m_span.extent0(); }
+  //! Valeur de la deuxième dimension
+  constexpr Int32 dim2Size() const { return m_span.extent1(); }
+  //! Valeur de la troisième dimension
+  constexpr Int32 dim3Size() const { return m_span.extent2(); }
+
+  //! Valeur de la première dimension
+  constexpr Int32 extent0() const { return m_span.extent0(); }
+  //! Valeur de la deuxième dimension
+  constexpr Int32 extent1() const { return m_span.extent1(); }
+  //! Valeur de la troisième dimension
+  constexpr Int32 extent2() const { return m_span.extent2(); }
+
+ public:
+
+  //! Valeur pour l'élément \a i,j,k
+  DataType operator()(Int32 i, Int32 j, Int32 k) const
+  {
+    return m_span(i, j, k);
+  }
+  //! Positionne la valeur pour l'élément \a i,j,k
+  DataType& operator()(Int32 i, Int32 j, Int32 k)
+  {
+    return m_span(i, j, k);
+  }
+  //! Positionne la valeur pour l'élément \a i,j,k
+  DataType& s(Int32 i, Int32 j, Int32 k)
+  {
+    return m_span(i, j, k);
+  }
+
+ public:
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
+  SubConstType operator()(Int32 i, Int32 j, Int32 k, Int32 a) const { return m_span(i, j, k, a); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  SubType operator()(Int32 i, Int32 j, Int32 k, Int32 a) { return m_span(i, j, k, a); }
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
+  Sub2ConstType operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) const { return m_span(i, j, k, a, b); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) { return m_span(i, j, k, a, b); }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Spécialisation pour les tableaux à 4 dimensions.
+ */
+template <typename DataType, typename ExtentType, typename LayoutType>
+class NumArrayIntermediate<DataType, 4, ExtentType, LayoutType>
+: public NumArrayBase<DataType, ExtentType, LayoutType>
+{
+ public:
+
+  using BaseClass = NumArrayBase<DataType, ExtentType, LayoutType>;
+  using DimsType = typename ExtentType::DimsType;
+  using BaseClass::resize;
+  using BaseClass::operator();
+  using BaseClass::s;
+
+ protected:
+
+  using BaseClass::m_span;
+
+ protected:
+
+  //! Construit un tableau vide
+  NumArrayIntermediate() = default;
+  explicit NumArrayIntermediate(const DimsType& extents)
+  : BaseClass(extents)
+  {}
+  NumArrayIntermediate(const DimsType& extents, eMemoryRessource r)
+  : BaseClass(extents, r)
+  {
+  }
+  explicit NumArrayIntermediate(eMemoryRessource r)
+  : BaseClass(r)
+  {}
+
+ public:
+
+  //! Valeur de la première dimension
+  constexpr Int32 dim1Size() const { return m_span.extent0(); }
+  //! Valeur de la deuxième dimension
+  constexpr Int32 dim2Size() const { return m_span.extent1(); }
+  //! Valeur de la troisième dimension
+  constexpr Int32 dim3Size() const { return m_span.extent2(); }
+  //! Valeur de la quatrième dimension
+  constexpr Int32 dim4Size() const { return m_span.extent3(); }
+
+  //! Valeur de la première dimension
+  constexpr Int32 extent0() const { return m_span.extent0(); }
+  //! Valeur de la deuxième dimension
+  constexpr Int32 extent1() const { return m_span.extent1(); }
+  //! Valeur de la troisième dimension
+  constexpr Int32 extent2() const { return m_span.extent2(); }
+  //! Valeur de la quatrième dimension
+  constexpr Int32 extent3() const { return m_span.extent3(); }
+
+ public:
+
+  //! Valeur pour l'élément \a i,j,k,l
+  DataType operator()(Int32 i, Int32 j, Int32 k, Int32 l) const
+  {
+    return m_span(i, j, k, l);
+  }
+  //! Positionne la valeur pour l'élément \a i,j,k,l
+  DataType& operator()(Int32 i, Int32 j, Int32 k, Int32 l)
+  {
+    return m_span(i, j, k, l);
+  }
+  // TODO: rendre obsolète
+  //! Positionne la valeur pour l'élément \a i,j,k,l
+  DataType& s(Int32 i, Int32 j, Int32 k, Int32 l)
+  {
+    return m_span(i, j, k, l);
+  }
+
+ public:
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
+  SubConstType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) const { return m_span(i, j, k, l, a); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
+  SubType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) { return m_span(i, j, k, l, a); }
+
+  //! Valeur pour l'élément \a i et la composante \a a
+  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
+  Sub2ConstType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) const { return m_span(i, j, k, l, a, b); }
+  //! Valeur pour l'élément \a i et la composante \a [a][b]
+  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
+  Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) { return m_span(i, j, k, l, a, b); }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
  * \brief Tableau à 1 dimension pour les types numériques.
  *
  * Les tableaux à une dimension possèdent l'opérateur 'operator[]' pour
@@ -313,12 +662,12 @@ class NumArrayBase
  */
 template <int X0, class DataType, typename LayoutType>
 class NumArray<DataType, ExtentsV<X0>, LayoutType>
-: public NumArrayBase<DataType, ExtentsV<X0>, LayoutType>
+: public NumArrayIntermediate<DataType, 1, ExtentsV<X0>, LayoutType>
 {
  public:
 
   using ExtentsType = ExtentsV<X0>;
-  using BaseClass = NumArrayBase<DataType, ExtentsType, LayoutType>;
+  using BaseClass = NumArrayIntermediate<DataType, 1, ExtentsType, LayoutType>;
   using BaseClass::resize;
   using BaseClass::operator();
   using BaseClass::s;
@@ -396,48 +745,6 @@ class NumArray<DataType, ExtentsV<X0>, LayoutType>
   {
     this->resize(DimsType(dim1_size));
   }
-
- public:
-
-  //! Valeur de la première dimension
-  constexpr Int32 dim1Size() const { return m_span.extent0(); }
-
-  //! Valeur de la première dimension
-  constexpr Int32 extent0() const { return m_span.extent0(); }
-
- public:
-
-  //! Valeur pour l'élément \a i
-  DataType operator()(Int32 i) const { return m_span(i); }
-  //! Positionne la valeur pour l'élément \a i
-  DataType& operator()(Int32 i) { return m_span(i); }
-  //! Positionne la valeur pour l'élément \a i
-  DataType& s(Int32 i) { return m_span(i); }
-  //! Récupère une référence pour l'élément \a i
-  DataType& operator[](Int32 i) { return m_span(i); }
-  //! Valeur pour l'élément \a i
-  DataType operator[](Int32 i) const { return m_span(i); }
-
- public:
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 a) const { return m_span(i, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 a) { return m_span(i, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 a, Int32 b) const { return m_span(i, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 a, Int32 b) { return m_span(i, a, b); }
-
- public:
-
-  constexpr operator SpanType() { return this->span(); }
-  constexpr operator ConstSpanType() const { return this->constSpan(); }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -449,12 +756,12 @@ class NumArray<DataType, ExtentsV<X0>, LayoutType>
  */
 template <int X0, int X1, class DataType, typename LayoutType>
 class NumArray<DataType, ExtentsV<X0, X1>, LayoutType>
-: public NumArrayBase<DataType, ExtentsV<X0, X1>, LayoutType>
+: public NumArrayIntermediate<DataType, 2, ExtentsV<X0, X1>, LayoutType>
 {
  public:
 
   using ExtentsType = ExtentsV<X0, X1>;
-  using BaseClass = NumArrayBase<DataType, ExtentsType, LayoutType>;
+  using BaseClass = NumArrayIntermediate<DataType, 2, ExtentsType, LayoutType>;
   using BaseClass::resize;
   using BaseClass::operator();
   using BaseClass::s;
@@ -520,50 +827,6 @@ class NumArray<DataType, ExtentsV<X0, X1>, LayoutType>
   }
 
  public:
-
-  //! Valeur de la première dimension
-  constexpr Int32 dim1Size() const { return m_span.extent0(); }
-  //! Valeur de la deuxième dimension
-  constexpr Int32 dim2Size() const { return m_span.extent1(); }
-
-  //! Valeur de la première dimension
-  constexpr Int32 extent0() const { return m_span.extent0(); }
-  //! Valeur de la deuxième dimension
-  constexpr Int32 extent1() const { return m_span.extent1(); }
-
- public:
-
-  //! Valeur pour l'élément \a i,j
-  DataType operator()(Int32 i, Int32 j) const
-  {
-    return m_span(i, j);
-  }
-  //! Positionne la valeur pour l'élément \a i,j
-  DataType& operator()(Int32 i, Int32 j)
-  {
-    return m_span(i, j);
-  }
-  //! Positionne la valeur pour l'élément \a i,j
-  DataType& s(Int32 i, Int32 j)
-  {
-    return m_span(i, j);
-  }
-
- public:
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 j, Int32 a) const { return m_span(i, j, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 j, Int32 a) { return m_span(i, j, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 j, Int32 a, Int32 b) const { return m_span(i, j, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 j, Int32 a, Int32 b) { return m_span(i, j, a, b); }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -575,12 +838,12 @@ class NumArray<DataType, ExtentsV<X0, X1>, LayoutType>
  */
 template <int X0, int X1, int X2, class DataType, typename LayoutType>
 class NumArray<DataType, ExtentsV<X0, X1, X2>, LayoutType>
-: public NumArrayBase<DataType, ExtentsV<X0, X1, X2>, LayoutType>
+: public NumArrayIntermediate<DataType, 3, ExtentsV<X0, X1, X2>, LayoutType>
 {
  public:
 
   using ExtentsType = ExtentsV<X0, X1, X2>;
-  using BaseClass = NumArrayBase<DataType, ExtentsType, LayoutType>;
+  using BaseClass = NumArrayIntermediate<DataType, 3, ExtentsType, LayoutType>;
   using BaseClass::resize;
   using BaseClass::operator();
   using BaseClass::s;
@@ -631,73 +894,23 @@ class NumArray<DataType, ExtentsV<X0, X1, X2>, LayoutType>
   {
     this->resize(DimsType(dim1_size, dim2_size, dim3_size));
   }
-
- public:
-
-  //! Valeur de la première dimension
-  constexpr Int32 dim1Size() const { return m_span.extent0(); }
-  //! Valeur de la deuxième dimension
-  constexpr Int32 dim2Size() const { return m_span.extent1(); }
-  //! Valeur de la troisième dimension
-  constexpr Int32 dim3Size() const { return m_span.extent2(); }
-
-  //! Valeur de la première dimension
-  constexpr Int32 extent0() const { return m_span.extent0(); }
-  //! Valeur de la deuxième dimension
-  constexpr Int32 extent1() const { return m_span.extent1(); }
-  //! Valeur de la troisième dimension
-  constexpr Int32 extent2() const { return m_span.extent2(); }
-
- public:
-
-  //! Valeur pour l'élément \a i,j,k
-  DataType operator()(Int32 i, Int32 j, Int32 k) const
-  {
-    return m_span(i, j, k);
-  }
-  //! Positionne la valeur pour l'élément \a i,j,k
-  DataType& operator()(Int32 i, Int32 j, Int32 k)
-  {
-    return m_span(i, j, k);
-  }
-  //! Positionne la valeur pour l'élément \a i,j,k
-  DataType& s(Int32 i, Int32 j, Int32 k)
-  {
-    return m_span(i, j, k);
-  }
-
- public:
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 j, Int32 k, Int32 a) const { return m_span(i, j, k, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 j, Int32 k, Int32 a) { return m_span(i, j, k, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) const { return m_span(i, j, k, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) { return m_span(i, j, k, a, b); }
 };
 
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
+  /*---------------------------------------------------------------------------*/
+  /*---------------------------------------------------------------------------*/
+  /*!
  * \brief Tableau à 4 dimensions pour les types numériques.
  *
  * \sa NumArrayBase
  */
 template <int X0, int X1, int X2, int X3, class DataType, typename LayoutType>
 class NumArray<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
-: public NumArrayBase<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
+: public NumArrayIntermediate<DataType, 4, ExtentsV<X0, X1, X2, X3>, LayoutType>
 {
  public:
 
   using ExtentsType = ExtentsV<X0, X1, X2, X3>;
-  using BaseClass = NumArrayBase<DataType, ExtentsType, LayoutType>;
+  using BaseClass = NumArrayIntermediate<DataType, 4, ExtentsType, LayoutType>;
   using BaseClass::resize;
   using BaseClass::operator();
   using BaseClass::s;
@@ -752,60 +965,6 @@ class NumArray<DataType, ExtentsV<X0, X1, X2, X3>, LayoutType>
   {
     this->resize(DimsType(dim1_size, dim2_size, dim3_size, dim4_size));
   }
-
- public:
-
-  //! Valeur de la première dimension
-  constexpr Int32 dim1Size() const { return m_span.extent0(); }
-  //! Valeur de la deuxième dimension
-  constexpr Int32 dim2Size() const { return m_span.extent1(); }
-  //! Valeur de la troisième dimension
-  constexpr Int32 dim3Size() const { return m_span.extent2(); }
-  //! Valeur de la quatrième dimension
-  constexpr Int32 dim4Size() const { return m_span.extent3(); }
-
-  //! Valeur de la première dimension
-  constexpr Int32 extent0() const { return m_span.extent0(); }
-  //! Valeur de la deuxième dimension
-  constexpr Int32 extent1() const { return m_span.extent1(); }
-  //! Valeur de la troisième dimension
-  constexpr Int32 extent2() const { return m_span.extent2(); }
-  //! Valeur de la quatrième dimension
-  constexpr Int32 extent3() const { return m_span.extent3(); }
-
- public:
-
-  //! Valeur pour l'élément \a i,j,k,l
-  DataType operator()(Int32 i, Int32 j, Int32 k, Int32 l) const
-  {
-    return m_span(i, j, k, l);
-  }
-  //! Positionne la valeur pour l'élément \a i,j,k,l
-  DataType& operator()(Int32 i, Int32 j, Int32 k, Int32 l)
-  {
-    return m_span(i, j, k, l);
-  }
-  //! Positionne la valeur pour l'élément \a i,j,k,l
-  DataType& s(Int32 i, Int32 j, Int32 k, Int32 l)
-  {
-    return m_span(i, j, k, l);
-  }
-
- public:
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) const { return m_span(i, j, k, l, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) { return m_span(i, j, k, l, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) const { return m_span(i, j, k, l, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) { return m_span(i, j, k, l, a, b); }
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/TestNumArray.cc
+++ b/arcane/src/arcane/utils/tests/TestNumArray.cc
@@ -404,7 +404,7 @@ TEST(NumArray3,Layout)
     _checkRightLayoutDim3(a);
   }
   {
-    NumArray<Real,ExtentsV<DynExtent,3,DynExtent>,RightLayout3> a({2,5});
+    NumArray<Real,ExtentsV<DynExtent,3,DynExtent>,RightLayout3> a(2,5);
     std::cout << "TEST_NUMARRAY3 RightLayout 5\n";
     _checkRightLayoutDim3(a);
   }
@@ -430,7 +430,7 @@ TEST(NumArray3,Layout)
     _checkLeftLayoutDim3(a);
   }
   {
-    NumArray<Real,ExtentsV<DynExtent,3,DynExtent>,LeftLayout3> a({2,5});
+    NumArray<Real,ExtentsV<DynExtent,3,DynExtent>,LeftLayout3> a(2,5);
     std::cout << "TEST_NUMARRAY3 LeftLayout 5\n";
     _checkLeftLayoutDim3(a);
   }

--- a/arcane/src/arcane/utils/tests/TestNumArray.cc
+++ b/arcane/src/arcane/utils/tests/TestNumArray.cc
@@ -506,6 +506,22 @@ template class NumArray<float,ExtentsV<DynExtent,2,3>,RightLayout<3>>;
 template class NumArray<float,ExtentsV<2,3>>;
 template class NumArray<float,ExtentsV<2>>;
 template class NumArray<float,ExtentsV<3,DynExtent>>;
+
+template class MDSpan<float,MDDim4,RightLayout<4>>;
+template class MDSpan<float,MDDim3,RightLayout<3>>;
+template class MDSpan<float,MDDim2,RightLayout<2>>;
+
+template class MDSpan<float,MDDim4,LeftLayout<4>>;
+template class MDSpan<float,MDDim3,LeftLayout<3>>;
+template class MDSpan<float,MDDim2,LeftLayout<2>>;
+
+template class MDSpan<float,MDDim1>;
+
+template class MDSpan<float,ExtentsV<7,DynExtent,2,3>,RightLayout<4>>;
+template class MDSpan<float,ExtentsV<DynExtent,2,3>,RightLayout<3>>;
+template class MDSpan<float,ExtentsV<2,3>>;
+template class MDSpan<float,ExtentsV<2>>;
+template class MDSpan<float,ExtentsV<3,DynExtent>>;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The specialization is now in an intermediate class: `NumArrayIntermediate` and `MDSpanIntermediate`.
