### PR TITLE
Add support for additional meshes for services in case options 

### DIFF
--- a/arcane/src/arcane/CaseOptionService.h
+++ b/arcane/src/arcane/CaseOptionService.h
@@ -125,20 +125,29 @@ class CaseOptionServiceContainer
  *
  * Les instances de cette classe ne sont pas copiables.
  */
-class CaseOptionService
+class ARCANE_CORE_EXPORT CaseOptionService
 {
  public:
-  CaseOptionService(const CaseOptionBuildInfo& cob,bool allow_null,bool is_optional)
+
+ CaseOptionService(const CaseOptionBuildInfo& cob,bool allow_null,bool is_optional)
   : m_impl(new CaseOptionServiceImpl(cob,allow_null,is_optional))
   {
   }
+
   virtual ~CaseOptionService() = default;
+
+ public:
+
   CaseOptionService(const CaseOptionService&) = delete;
   const CaseOptionService& operator=(const CaseOptionService&) = delete;
+
  public:
+
   operator CaseOptions& () { return *_impl(); }
   operator const CaseOptions& () const { return *_impl(); }
+
  public:
+
   String rootTagName() const { return m_impl->rootTagName(); }
   String name() const { return m_impl->name(); }
   String serviceName() const { return m_impl->serviceName(); }
@@ -172,10 +181,32 @@ class CaseOptionService
   {
     m_impl->addDefaultValue(category,value);
   }
+  /*!
+   * \brief Positionne le nom du maillage auquel le service sera associé.
+   *
+   * Si nul, le service est associé au maillage par défaut du sous-domaine
+   * (ISubDomain::defaultMeshHandle()). L'association réelle se fait lors de la
+   * lecture des options. Appeler cette méthode après lecture des options n'aura
+   * aucun impact.
+   */
+  void setMeshName(const String& mesh_name);
+
+  /*!
+   * \brief Nom du maillage auquel le service est associé.
+   *
+   * Il s'agit du nom du maillage tel que spécifié dans le descripteur de service
+   * (le fichier 'axl'). Pour obtenir le maillage associé après lecture des options
+   * il faut utiliser ICaseOptions::meshHandle().
+   */
+  String meshName() const;
+
  protected:
+
   CaseOptionServiceImpl* _impl() { return m_impl.get(); }
   const CaseOptionServiceImpl* _impl() const { return m_impl.get(); }
+
  private:
+
   ReferenceCounter<CaseOptionServiceImpl> m_impl;
 };
 
@@ -220,7 +251,7 @@ class CaseOptionServiceT
  * \ingroup CaseOption
  * \brief Classe de base d'une option service pouvant être présente plusieurs fois.
  */
-class CaseOptionMultiService
+class ARCANE_CORE_EXPORT CaseOptionMultiService
 {
  public:
   CaseOptionMultiService(const CaseOptionBuildInfo& cob,bool allow_null)
@@ -248,10 +279,27 @@ class CaseOptionMultiService
   {
     m_impl->addAlternativeNodeName(lang,name);
   }
+  /*!
+   * \brief Positionne le nom du maillage auquel le service sera associé.
+   *
+   * \sa CaseOptionService::setMeshName()
+   */
+  void setMeshName(const String& mesh_name);
+
+  /*!
+   * \brief Nom du maillage auquel le service est associé.
+   *
+   * \sa CaseOptionService::axlMeshName();
+   */
+  String meshName() const;
+
  protected:
+
   CaseOptionMultiServiceImpl* _impl() { return m_impl.get(); }
   const CaseOptionMultiServiceImpl* _impl() const { return m_impl.get(); }
+
  private:
+
   ReferenceCounter<CaseOptionMultiServiceImpl> m_impl;
 };
 

--- a/arcane/src/arcane/CaseOptionService.h
+++ b/arcane/src/arcane/CaseOptionService.h
@@ -143,8 +143,15 @@ class ARCANE_CORE_EXPORT CaseOptionService
 
  public:
 
+  ARCANE_DEPRECATED_REASON("Y2022: Use toICaseOptions() instead")
   operator CaseOptions& () { return *_impl(); }
+
+  ARCANE_DEPRECATED_REASON("Y2022: Use toICaseOptions() instead")
   operator const CaseOptions& () const { return *_impl(); }
+
+ public:
+
+   const ICaseOptions* toICaseOptions() { return _impl(); }
 
  public:
 

--- a/arcane/src/arcane/CaseOptionServiceImpl.h
+++ b/arcane/src/arcane/CaseOptionServiceImpl.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CaseOptionServiceImpl.h                                     (C) 2000-2020 */
+/* CaseOptionServiceImpl.h                                     (C) 2000-2022 */
 /*                                                                           */
 /* Implémentation d'une option du jeu de données utilisant un service.       */
 /*---------------------------------------------------------------------------*/
@@ -63,6 +63,7 @@ class ARCANE_CORE_EXPORT CaseOptionServiceImpl
 : public CaseOptions
 {
  public:
+
   CaseOptionServiceImpl(const CaseOptionBuildInfo& cob,bool allow_null,bool is_optional);
 
  public:
@@ -86,6 +87,9 @@ class ARCANE_CORE_EXPORT CaseOptionServiceImpl
    */
   void setContainer(ICaseOptionServiceContainer* container);
 
+  void setMeshName(const String& mesh_name) { m_mesh_name = mesh_name; }
+  String meshName() const { return m_mesh_name; }
+
  protected:
 
   virtual void print(const String& lang,std::ostream& o) const;
@@ -99,6 +103,7 @@ class ARCANE_CORE_EXPORT CaseOptionServiceImpl
   String m_name;
   String m_default_value;
   String m_service_name;
+  String m_mesh_name;
   XmlNode m_element; //!< Element de l'option
   bool m_allow_null;
   bool m_is_optional;
@@ -149,6 +154,9 @@ class ARCANE_CORE_EXPORT CaseOptionMultiServiceImpl
    */
   void setContainer(ICaseOptionServiceContainer* container);
 
+  void setMeshName(const String& mesh_name) { m_mesh_name = mesh_name; }
+  String meshName() const { return m_mesh_name; }
+
  public:
 
   void _setNotifyAllocateFunctor(IFunctor* f)
@@ -164,6 +172,7 @@ class ARCANE_CORE_EXPORT CaseOptionMultiServiceImpl
 
   bool m_allow_null;
   String m_default_value;
+  String m_mesh_name;
   IFunctor* m_notify_functor;
   ICaseOptionServiceContainer* m_container;
   //! Liste des options allouées qu'il faudra supprimer.

--- a/arcane/src/arcane/CaseOptions.h
+++ b/arcane/src/arcane/CaseOptions.h
@@ -1110,8 +1110,15 @@ class ARCANE_CORE_EXPORT CaseOptions
  protected:
 
   void _setTranslatedName();
+  bool _setMeshHandleAndCheckDisabled(const String& mesh_name);
+
+ protected:
 
   CaseOptionsPrivate* m_p; //!< Implémentation
+
+ private:
+
+  void _setMeshHandle(const MeshHandle& handle);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ICaseOptionList.h
+++ b/arcane/src/arcane/ICaseOptionList.h
@@ -74,9 +74,20 @@ class ARCANE_CORE_EXPORT ICaseOptionList
   virtual void visit(ICaseDocumentVisitor* visitor) =0;
   //! Nom complet au format XPath correspondant à rootElement()
   virtual String xpathFullName() const =0;
-
+  //! Handle du maillage associé
+  virtual MeshHandle meshHandle() const =0;
+  //! Ajoute une référence
   virtual void addReference() =0;
+  //! Supprime une référence
   virtual void removeReference() =0;
+
+  /*!
+   * \brief Désactive l'option comme si elle était absente.
+   *
+   * Cela est utilisé par exemple si l'option est associée à un maillage
+   * qui n'est pas défini.
+   */
+  virtual void disable() = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -274,6 +274,7 @@ endif()
 ARCANE_ADD_TEST_SEQUENTIAL(caseoptions_opt testCaseOptions-3.arc)
 ARCANE_ADD_TEST_SEQUENTIAL(caseoptions_default testCaseOptions-4.arc)
 ARCANE_ADD_TEST_SEQUENTIAL(caseoptions_category testCaseOptions-5.arc -We,ARCANE_DEFAULT_CATEGORY,X1)
+arcane_add_test_sequential(caseoptions_multiplemesh testCaseOptions-multiple-mesh.arc -We,ARCANE_DEFAULT_CATEGORY,X3)
 
 ARCANE_ADD_TEST(timehistory testTimeHistory-1.arc)
 

--- a/arcane/src/arcane/tests/CaseOptionsTester.axl
+++ b/arcane/src/arcane/tests/CaseOptionsTester.axl
@@ -60,6 +60,7 @@
   >
     <defaultvalue category="X1">25.1 12.3 1.0</defaultvalue>
     <defaultvalue category="X2">3.5 2.3 -1.0e3</defaultvalue>
+    <defaultvalue category="X3">-2.1 -1.5 +1.0e5</defaultvalue>
    <description>SimpleReal3</description>
   </simple>
 
@@ -163,6 +164,7 @@
    type = "int32[]"
   >
     <defaultvalue category="X1">3 -4 5 -6 7</defaultvalue>
+    <defaultvalue category="X3">-1 0 23 42</defaultvalue>
    <description>SimpleInt32Array</description>
   </simple>
 
@@ -231,6 +233,7 @@
    type     = "TypesCaseOptionsTester::eSimpleEnum"
   >
     <defaultvalue category="X1">enum2</defaultvalue>
+    <defaultvalue category="X3">enum1</defaultvalue>
    <description>SimpleEnum</description>
    <enumvalue genvalue="TypesCaseOptionsTester::SEEnum1" name="enum1"/>
    <enumvalue genvalue="TypesCaseOptionsTester::SEEnum2" name="enum2"/>
@@ -369,6 +372,7 @@
   >
     <defaultvalue category="X1">enum3</defaultvalue>
     <defaultvalue category="X2">enum4</defaultvalue>
+    <defaultvalue category="X3">enum4</defaultvalue>
    <name lang='fr'>simple-enum-avec-defaut</name>
    <description>SimpleEnumWithDefault</description>
    <enumvalue genvalue="TypesCaseOptionsTester::SEEnum1" name="enum1"/>
@@ -379,10 +383,10 @@
 
   <!-- - - - - - post-processor1 - - - - -->
   <service-instance
-   name = "post-processor1"
-   type = "Arcane::IPostProcessorWriter"
-   minOccurs = "0"
-   maxOccurs = "unbounded"
+    name = "post-processor1"
+    type = "Arcane::IPostProcessorWriter"
+    minOccurs = "0"
+    maxOccurs = "unbounded"
   >
    <name lang='fr'>post-processor1-fr</name>
    <description>Liste des services de protection</description>
@@ -402,6 +406,7 @@
   <service-instance
    name = "post-processor3"
    type = "Arcane::IPostProcessorWriter"
+    mesh-name="Mesh1"
   >
    <name lang='fr'>post-processor3-fr</name>
    <description>Un service de post-traitement</description>
@@ -428,6 +433,7 @@
     name = "service-instance-test1"
     type = "ArcaneTest::IServiceInterface1"
     default = "ServiceTestImpl4"
+    mesh-name="Mesh1"
   >
     <defaultvalue category="X1">ServiceTestImpl2</defaultvalue>
     <defaultvalue category="X2">ServiceTestImpl3</defaultvalue>

--- a/arcane/src/arcane/tests/IServiceInterface.h
+++ b/arcane/src/arcane/tests/IServiceInterface.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IServiceInterface.h                                         (C) 2000-2018 */
+/* IServiceInterface.h                                         (C) 2000-2022 */
 /*                                                                           */
 /* Interfaces pour les tests des services.                                   */
 /*---------------------------------------------------------------------------*/
@@ -33,6 +33,8 @@ class IServiceInterface1
   virtual Arccore::Integer value() =0;
   virtual void* getPointer1() =0;
   virtual Arccore::String implementationName() const =0;
+  virtual Arccore::String meshName() const =0;
+  virtual void checkSubMesh(const Arccore::String&) {}
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/ServiceInterface1ImplTest.axl
+++ b/arcane/src/arcane/tests/ServiceInterface1ImplTest.axl
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?><!-- -*- SGML -*- -->
+
+<service name="ServiceInterface1ImplTest" version="1.0" namespace-name="ArcaneTest"> 
+  <description>
+    Service de test implémentant Module de test des options du jeu de données
+    Test des entités spéciales: 
+  </description>
+
+  <interface name="ArcaneTest::IServiceInterface1" />
+
+  <options>
+ 
+    <!-- - - - - - post-processor1 - - - - -->
+    <service-instance name = "post-processor1" type = "Arcane::IPostProcessorWriter">
+      <description>Service d'écriture</description>
+    </service-instance>
+
+    <!-- - - - - - post-processor1 - - - - -->
+    <service-instance name = "multi-post-processor" type = "Arcane::IPostProcessorWriter"
+                      minOccurs="0" maxOccurs="unbounded">
+      <description>Service d'écriture multiple</description>
+    </service-instance>
+
+    <!-- - - - - - complex1 - - - - -->
+    <complex name = "complex1" type = "Complex1">
+      <description>Complex1</description>
+
+      <simple name = "simple-real-2" type = "real" optional = "true">
+        <description>SimpleReal-2</description>
+      </simple>
+    </complex>
+  </options>
+</service>

--- a/arcane/src/arcane/tests/SingletonService.cc
+++ b/arcane/src/arcane/tests/SingletonService.cc
@@ -50,6 +50,7 @@ class SingletonService
   void* getPointer1() override { return this; }
   void* getPointer2() override { return this; }
   String implementationName() const override { return "SingletonService"; }
+  String meshName() const override { return String(); }
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/srcs.cmake
+++ b/arcane/src/arcane/tests/srcs.cmake
@@ -108,7 +108,9 @@ set(AXL_FILES
   accelerator/SimpleHydroAccelerator
   PDESRandomNumberGeneratorUnitTest
   RandomNumberGeneratorUnitTest
+  ServiceInterface1ImplTest
   SimpleTableOutputUnitTest
   SimpleTableComparatorUnitTest
+  SimpleTableOutputUnitTest
 )
 

--- a/arcane/tests/testCaseOptions-multiple-mesh.arc
+++ b/arcane/tests/testCaseOptions-multiple-mesh.arc
@@ -1,0 +1,195 @@
+<?xml version='1.0' ?><!-- -*- SGML -*- -->
+<cas codename="ArcaneTest" xml:lang="fr" codeversion="1.0">
+  <arcane>
+    <titre>Test Arcane 5</titre>
+    <description>Test Arcane 5</description>
+    <boucle-en-temps>CaseOptionsTester</boucle-en-temps>
+  </arcane>
+
+  <meshes>
+    <mesh>
+      <filename>sod.vtk</filename>
+    </mesh>
+    <mesh>
+      <filename>square_v41.msh</filename>
+    </mesh>
+  </meshes>
+
+  <fonctions>
+    <table nom='test-simple-enum' parametre='temps' valeur='string' interpolation='constant-par-morceaux'>
+      <valeur><x>2.</x><y>enum1</y></valeur>
+      <valeur><x>5.</x><y>enum2</y></valeur>
+      <valeur><x>10.</x><y>enum1</y></valeur>
+      <valeur><x>15.</x><y>enum2</y></valeur>
+      <valeur><x>18.</x><y>enum1</y></valeur>
+    </table>
+    <table nom='test-time-real' parametre='temps' valeur='reel' comul='1.e2' interpolation='lineaire'>
+      <valeur> <x>0.0</x> <y>2.0</y> </valeur>
+      <valeur> <x>4.0</x> <y>7.0</y> </valeur>
+      <valeur> <x>5.0</x> <y>31.</y> </valeur>
+      <valeur> <x>6.0</x> <y>50.0</y> </valeur>
+      <valeur> <x>10.0</x><y>-1.0</y> </valeur>
+      <valeur> <x>14.0</x><y>-3.0</y> </valeur>
+    </table>
+    <table nom='test-time-real-2' parametre='temps' valeur='reel' comul='1.e2' deltat-coef='0.0' interpolation='lineaire'>
+      <valeur> <x>0.0</x> <y>3.0</y> </valeur>
+      <valeur> <x>4.0</x> <y>9.0</y> </valeur>
+      <valeur> <x>5.0</x> <y>7.</y> </valeur>
+      <valeur> <x>6.0</x> <y>2.0</y> </valeur>
+      <valeur> <x>10.0</x><y>-1.0</y> </valeur>
+      <valeur> <x>14.0</x><y>-3.0</y> </valeur>
+    </table>
+    <table nom='test-time-bool' parametre='temps' valeur='bool' interpolation='constant-par-morceaux'>
+      <valeur><x>2.0</x><y>true</y></valeur>
+      <valeur><x>5.0</x><y>false</y></valeur>
+      <valeur><x>10.0</x><y>1</y></valeur>
+      <valeur><x>15.0</x><y>0</y></valeur>
+      <valeur><x>18.0</x><y>true</y></valeur>
+    </table>
+    <table nom='test-time-real3' parametre='temps' valeur='reel3' deltat-coef='0.0' interpolation='lineaire'>
+      <valeur> <x>0.0</x> <y>3.0 1.0 5.0</y> </valeur>
+      <valeur> <x>4.0</x> <y>9.0 2.0 7.0</y> </valeur>
+      <valeur> <x>5.0</x> <y>7.1 1.5 3.4</y> </valeur>
+      <valeur> <x>6.0</x> <y>2.0 7.2 4.9</y> </valeur>
+      <valeur> <x>10.0</x><y>-1.0 -2.0 5.0</y> </valeur>
+      <valeur> <x>14.0</x><y>-3.0  8.0 1.3</y> </valeur>
+    </table>
+  </fonctions>
+
+  <case-options-tester>
+    <test-id>6</test-id>
+    <max-iteration>20</max-iteration>
+
+    <simple-real>3.0</simple-real>
+    <simple-real>3.0</simple-real>
+    <simple-real-unit>4.2</simple-real-unit>
+    <simple-real-unit2 fonction="test-time-real">0.0</simple-real-unit2>
+    <simple-realarray-unit >2.2 2.3 0.1 3.5</simple-realarray-unit>
+    <simple-real2>3.5 7.2</simple-real2>
+    <simple-real2x2>3.1 3.0 2.9 2.7</simple-real2x2>
+    <simple-real3x3>3.3 3.2 2.1 1.1 0.3 0.5 7.2 7.1 4.0</simple-real3x3>
+    <simple-integer>4</simple-integer>
+    <simple-int32>-23</simple-int32>
+    <simple-int64>454653457457455474</simple-int64>
+    <simple-bool>true</simple-bool>
+    <simple-string>toto</simple-string>
+
+    <simple-real-array>3.0 4.1 5.6</simple-real-array>
+
+    <simple-real-array-multi>3.0 4.1 5.6</simple-real-array-multi>
+    <simple-real-array-multi>4.0 1.1 7.3</simple-real-array-multi>
+
+    <simple-integer-array>4 5 6 7</simple-integer-array>
+    <simple-int64-array>454653457457455474 -453463634634634634</simple-int64-array>
+    <simple-bool-array>true false false true</simple-bool-array>
+    <simple-string-array>toto titi tata tutu tete</simple-string-array>
+
+    <simple-with-standard-function fonction="std_func">4.5</simple-with-standard-function>
+
+    <simple-enum>enum1</simple-enum>
+    <simple-enum-function fonction="test-simple-enum">enum1</simple-enum-function>
+    <!-- <simple-enum-function fonction="test-simple-enum">enum1</simple-enum-function> -->
+    <post-processor1-fr name="Ensight7PostProcessor">
+      <nb-temps-par-fichier>1</nb-temps-par-fichier>
+      <fichier-binaire>false</fichier-binaire>
+    </post-processor1-fr>
+    <post-processor1-fr name="Ensight7PostProcessor"/>
+    <post-processor1-fr name="Ensight7PostProcessor">
+      <nb-temps-par-fichier>9</nb-temps-par-fichier>
+      <fichier-binaire>false</fichier-binaire>
+    </post-processor1-fr>
+
+    <post-processor2 name="Ensight7PostProcessor">
+      <nb-temps-par-fichier>12</nb-temps-par-fichier>
+      <fichier-binaire>false</fichier-binaire>
+    </post-processor2>
+    <post-processor2 name="Ensight7PostProcessor"/>
+    <post-processor2 name="Ensight7PostProcessor">
+      <nb-temps-par-fichier>5</nb-temps-par-fichier>
+      <fichier-binaire>false</fichier-binaire>
+    </post-processor2>
+
+    <post-processor3-fr name="Ensight7PostProcessor">
+      <nb-temps-par-fichier>32</nb-temps-par-fichier>
+      <fichier-binaire>false</fichier-binaire>
+    </post-processor3-fr>
+    <post-processor4 name="Ensight7PostProcessor">
+      <nb-temps-par-fichier>64</nb-temps-par-fichier>
+      <fichier-binaire>false</fichier-binaire>
+    </post-processor4>
+    <service-instance-test1 name="ServiceInterface1ImplTest" >
+      <post-processor1 name="Ensight7PostProcessor">
+        <nb-temps-par-fichier>3</nb-temps-par-fichier>
+        <fichier-binaire>true</fichier-binaire>
+      </post-processor1>
+      <multi-post-processor name="Ensight7PostProcessor">
+        <nb-temps-par-fichier>7</nb-temps-par-fichier>
+        <fichier-binaire>false</fichier-binaire>
+      </multi-post-processor>
+      <multi-post-processor name="Ensight7PostProcessor">
+        <nb-temps-par-fichier>1</nb-temps-par-fichier>
+        <fichier-binaire>false</fichier-binaire>
+      </multi-post-processor>
+    </service-instance-test1>
+    <complex1>
+      <simple-real-2>3</simple-real-2>
+      <simple-real-2-multi>5.2</simple-real-2-multi>
+      <simple-real-2-multi>2.3</simple-real-2-multi>
+      <simple-real3-2 fonction="test-time-real3">3.0 2.0 4.0</simple-real3-2>
+      <simple-integer-2>4</simple-integer-2>
+      <simple-enum-2>enum2</simple-enum-2>
+      <extended-real-int-2>enum1</extended-real-int-2>
+      <complex1-sub>
+        <sub-test1>2.0 3.0</sub-test1>
+        <sub-test2>1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0</sub-test2>
+      </complex1-sub>
+    </complex1>
+    <complex2>
+      <simple-bool-c2 fonction="test-time-bool">true</simple-bool-c2>
+      <simple-real-c2 fonction="test-time-real">1.</simple-real-c2>
+      <simple-integer-c2>4</simple-integer-c2>
+      <simple-enum-c2>enum1</simple-enum-c2>
+      <extended-real-int-c2>enum1</extended-real-int-c2>
+    </complex2>
+    <complex2>
+      <simple-bool-c2>true</simple-bool-c2>
+      <simple-real-c2 fonction="test-time-real-2">3</simple-real-c2>
+      <simple-integer-c2>4</simple-integer-c2>
+      <simple-enum-c2>enum1</simple-enum-c2>
+      <extended-real-int-c2>enum1</extended-real-int-c2>
+      <complex3>
+        <simple-real-c3>3</simple-real-c3>
+        <simple-integer-c3>4</simple-integer-c3>
+        <simple-enum-c3>enum1</simple-enum-c3>
+        <extended-real-int-c3>enum1</extended-real-int-c3>
+        <timeloop-tester name="CheckpointTesterService">
+          <nb-iteration>5</nb-iteration>
+          <backward-period>3</backward-period>
+        </timeloop-tester>
+      </complex3>
+      <complex3>
+        <simple-real-c3>5</simple-real-c3>
+        <simple-integer-c3>7</simple-integer-c3>
+        <simple-enum-c3>enum2</simple-enum-c3>
+        <extended-real-int-c3>enum2</extended-real-int-c3>
+        <timeloop-tester name="CheckpointTesterService">
+          <nb-iteration>12</nb-iteration>
+          <backward-period>4</backward-period>
+        </timeloop-tester>
+      </complex3>
+    </complex2>
+    <extended-real-int>enum1</extended-real-int>
+    <complex4>
+      <simple-real>5.2</simple-real>
+    </complex4>
+    <complex4>
+      <simple-real>5.2</simple-real>
+    </complex4>
+    <complex5>
+      <simple-real>4.9</simple-real>xs
+    </complex5>
+    <complex5>
+      <simple-real>4.9</simple-real>xs
+    </complex5>
+  </case-options-tester>
+</cas>


### PR DESCRIPTION
The developper can specify in the `axl` file on which mesh a service will be bound in the user case file (the `arc` file).
