### PR TITLE
Do some optimizations in 'ItemConnectivityContainerView'

### DIFF
--- a/arcane/src/arcane/IndexedItemConnectivityView.h
+++ b/arcane/src/arcane/IndexedItemConnectivityView.h
@@ -47,9 +47,9 @@ class ARCANE_CORE_EXPORT IndexedItemConnectivityViewBase
  public:
 
   //! Nombre d'entités source
-  constexpr ARCCORE_HOST_DEVICE Int32 nbSourceItem() const { return m_container_view.m_nb_item.size(); }
+  constexpr ARCCORE_HOST_DEVICE Int32 nbSourceItem() const { return m_container_view.nbItem(); }
   //! Nombre d'entités connectées à l'entité \a lid
-  ARCCORE_HOST_DEVICE Int32 nbItem(ItemLocalId lid) const { return m_container_view.m_nb_item[lid]; }
+  ARCCORE_HOST_DEVICE Int32 nbItem(ItemLocalId lid) const { return m_container_view.m_nb_connected_items[lid]; }
   //! Liste des entités connectées à l'entité \a lid
   ARCCORE_HOST_DEVICE ItemLocalIdViewT<Item> items(ItemLocalId lid) const
   {

--- a/arcane/src/arcane/IndexedItemConnectivityView.h
+++ b/arcane/src/arcane/IndexedItemConnectivityView.h
@@ -53,7 +53,7 @@ class ARCANE_CORE_EXPORT IndexedItemConnectivityViewBase
   //! Liste des entités connectées à l'entité \a lid
   ARCCORE_HOST_DEVICE ItemLocalIdViewT<Item> items(ItemLocalId lid) const
   {
-    return { &m_container_view.m_list_data[m_container_view.m_indexes[lid]], m_container_view.m_nb_item[lid] };
+    return m_container_view.itemsIds<Item>(lid);
   }
   eItemKind sourceItemKind() const { return m_source_kind; }
   eItemKind targetItemKind() const { return m_target_kind; }
@@ -124,19 +124,19 @@ class IndexedItemConnectivityGenericViewT
   //! Liste des entités connectées à l'entité \a lid
   constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewType items(ItemLocalId1 lid) const
   {
-    const ItemLocalId* ptr = &m_container_view.m_list_data[m_container_view.m_indexes[lid]];
-    return { static_cast<const ItemLocalId2*>(ptr), m_container_view.m_nb_item[lid] };
+    return m_container_view.template itemsIds<ItemType2>(lid);
   }
+
   //! Liste des entités connectées à l'entité \a lid
   constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewType itemIds(ItemLocalId1 lid) const
   {
-    const ItemLocalId* ptr = &m_container_view.m_list_data[m_container_view.m_indexes[lid]];
-    return { static_cast<const ItemLocalId2*>(ptr), m_container_view.m_nb_item[lid] };
+    return m_container_view.template itemsIds<ItemType2>(lid);
   }
+
   //! i-ème entitée connectée à l'entité \a lid
-  ARCCORE_HOST_DEVICE ItemLocalId2 itemId(ItemLocalId1 lid, Int32 index) const
+  constexpr ARCCORE_HOST_DEVICE ItemLocalId2 itemId(ItemLocalId1 lid, Int32 index) const
   {
-    return ItemLocalId2(m_container_view.m_list_data[m_container_view.m_indexes[lid] + index]);
+    return m_container_view.template itemId<ItemLocalId2>(lid, index);
   }
 };
 

--- a/arcane/src/arcane/IndexedItemConnectivityView.h
+++ b/arcane/src/arcane/IndexedItemConnectivityView.h
@@ -37,9 +37,12 @@ class ARCANE_CORE_EXPORT IndexedItemConnectivityViewBase
 
   IndexedItemConnectivityViewBase() = default;
   IndexedItemConnectivityViewBase(ItemConnectivityContainerView container_view,
-                                  eItemKind source_kind,eItemKind target_kind)
-  : m_nb_item(container_view.m_nb_item), m_indexes(container_view.m_indexes), m_list_data(container_view.m_list)
-  , m_source_kind(source_kind), m_target_kind(target_kind)
+                                  eItemKind source_kind, eItemKind target_kind)
+  : m_nb_item(container_view.m_nb_item)
+  , m_indexes(container_view.m_indexes)
+  , m_list_data(container_view.m_list)
+  , m_source_kind(source_kind)
+  , m_target_kind(target_kind)
   {
   }
 
@@ -52,20 +55,19 @@ class ARCANE_CORE_EXPORT IndexedItemConnectivityViewBase
   //! Liste des entités connectées à l'entité \a lid
   ARCCORE_HOST_DEVICE ItemLocalIdViewT<Item> items(ItemLocalId lid) const
   {
-    const Int32* ptr = & m_list_data[m_indexes[lid]];
-    return { reinterpret_cast<const ItemLocalId*>(ptr), m_nb_item[lid] };
+    return { &m_list_data[m_indexes[lid]], m_nb_item[lid] };
   }
   eItemKind sourceItemKind() const { return m_source_kind; }
   eItemKind targetItemKind() const { return m_target_kind; }
 
   //! Initialise la vue
-  ARCANE_DEPRECATED_REASON("Y2022: This method is internal to Arcane and should be replaced by _init()")
-  void init(SmallSpan<const Int32> nb_item,SmallSpan<const Int32> indexes,
-            SmallSpan<const Int32> list_data,eItemKind source_kind,eItemKind target_kind)
+  ARCANE_DEPRECATED_REASON("Y2022: This method is internal to Arcane and should be replaced by call to constructor")
+  void init(SmallSpan<const Int32> nb_item, SmallSpan<const Int32> indexes,
+            SmallSpan<const Int32> list_data, eItemKind source_kind, eItemKind target_kind)
   {
     m_indexes = indexes;
     m_nb_item = nb_item;
-    m_list_data = list_data;
+    m_list_data = ItemLocalId::fromSpanInt32(list_data);
     m_source_kind = source_kind;
     m_target_kind = target_kind;
   }
@@ -85,17 +87,17 @@ class ARCANE_CORE_EXPORT IndexedItemConnectivityViewBase
 
   SmallSpan<const Int32> m_nb_item;
   SmallSpan<const Int32> m_indexes;
-  SmallSpan<const Int32> m_list_data;
+  SmallSpan<const ItemLocalId> m_list_data;
   eItemKind m_source_kind = IK_Unknown;
   eItemKind m_target_kind = IK_Unknown;
 
  protected:
 
-  [[noreturn]] void _badConversion(eItemKind k1,eItemKind k2) const;
-  inline void _checkValid(eItemKind k1,eItemKind k2) const
+  [[noreturn]] void _badConversion(eItemKind k1, eItemKind k2) const;
+  inline void _checkValid(eItemKind k1, eItemKind k2) const
   {
-    if (k1!=m_source_kind || k2!=m_target_kind)
-      _badConversion(k1,k2);
+    if (k1 != m_source_kind || k2 != m_target_kind)
+      _badConversion(k1, k2);
   }
 };
 
@@ -126,17 +128,18 @@ class IndexedItemConnectivityGenericViewT
   }
   IndexedItemConnectivityGenericViewT() = default;
  public:
+
   //! Liste des entités connectées à l'entité \a lid
-  ARCCORE_HOST_DEVICE ItemLocalIdViewType items(ItemLocalId1 lid) const
+  constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewType items(ItemLocalId1 lid) const
   {
-    const Int32* ptr = & m_list_data[m_indexes[lid]];
-    return { reinterpret_cast<const ItemLocalId2*>(ptr), m_nb_item[lid] };
+    const ItemLocalId* ptr = & m_list_data[m_indexes[lid]];
+    return { static_cast<const ItemLocalId2*>(ptr), m_nb_item[lid] };
   }
   //! Liste des entités connectées à l'entité \a lid
-  ARCCORE_HOST_DEVICE ItemLocalIdViewType itemIds(ItemLocalId1 lid) const
+  constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewType itemIds(ItemLocalId1 lid) const
   {
-    const Int32* ptr = & m_list_data[m_indexes[lid]];
-    return { reinterpret_cast<const ItemLocalId2*>(ptr), m_nb_item[lid] };
+    const ItemLocalId* ptr = & m_list_data[m_indexes[lid]];
+    return { static_cast<const ItemLocalId2*>(ptr), m_nb_item[lid] };
   }
   //! i-ème entitée connectée à l'entité \a lid
   ARCCORE_HOST_DEVICE ItemLocalId2 itemId(ItemLocalId1 lid,Int32 index) const

--- a/arcane/src/arcane/ItemConnectivityContainerView.cc
+++ b/arcane/src/arcane/ItemConnectivityContainerView.cc
@@ -27,8 +27,8 @@ namespace Arcane
 void ItemConnectivityContainerView::
 checkSame(ItemConnectivityContainerView rhs) const
 {
-  auto current_list = m_list;
-  auto ref_list = rhs.m_list;
+  auto current_list = m_list_data;
+  auto ref_list = rhs.m_list_data;
   auto current_indexes = m_indexes;
   auto ref_indexes = rhs.m_indexes;
   auto* current_list_ptr = current_list.data();

--- a/arcane/src/arcane/ItemConnectivityContainerView.cc
+++ b/arcane/src/arcane/ItemConnectivityContainerView.cc
@@ -31,18 +31,34 @@ checkSame(ItemConnectivityContainerView rhs) const
   auto ref_list = rhs.m_list_data;
   auto current_indexes = m_indexes;
   auto ref_indexes = rhs.m_indexes;
-  auto* current_list_ptr = current_list.data();
-  auto* ref_list_ptr = ref_list.data();
+  auto* current_list_ptr = current_list;
+  auto* ref_list_ptr = ref_list;
+  Int32 current_list_size = m_list_data_size;
+  Int32 ref_list_size = rhs.m_list_data_size;
   if (current_list_ptr!=ref_list_ptr)
     ARCANE_FATAL("Bad list base pointer current={0} ref={1}",current_list_ptr,ref_list_ptr);
-  if (current_list.size()!=ref_list.size())
-    ARCANE_FATAL("Bad list size current={0} ref={1}",current_list.size(),ref_list.size());
-  auto* current_indexes_ptr = current_indexes.data();
-  auto* ref_indexes_ptr = ref_indexes.data();
+  if (current_list_size!=ref_list_size)
+    ARCANE_FATAL("Bad list size current={0} ref={1}",current_list_size,ref_list_size);
+  auto* current_indexes_ptr = current_indexes;
+  auto* ref_indexes_ptr = ref_indexes;
+  Int32 current_indexes_size = m_nb_item;
+  Int32 ref_indexes_size = rhs.m_nb_item;
   if (current_indexes_ptr!=ref_indexes_ptr)
     ARCANE_FATAL("Bad indexes base pointer current={0} ref={1}",current_indexes_ptr,ref_indexes_ptr);
-  if (current_indexes.size()!=ref_indexes.size())
-    ARCANE_FATAL("Bad indexes size current={0} ref={1}",current_indexes.size(),ref_indexes.size());
+  if (current_indexes_size!=ref_indexes_size)
+    ARCANE_FATAL("Bad indexes size current={0} ref={1}",current_indexes_size,ref_indexes_size);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemConnectivityContainerView::
+_checkSize(Int32 indexes_size, Int32 nb_connected_item_size)
+{
+  // La valeur de 'nb_connected_item_size' doit être égale à 'indexes_size'
+  if (indexes_size!=nb_connected_item_size)
+    ARCANE_FATAL("Bad sizes indexes_size={0} nb_connected_item_size={1}",
+                 indexes_size,nb_connected_item_size);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemConnectivityContainerView.h
+++ b/arcane/src/arcane/ItemConnectivityContainerView.h
@@ -46,13 +46,16 @@ class ARCANE_CORE_EXPORT ItemConnectivityContainerView
   friend ItemInternalConnectivityList;
   friend IndexedItemConnectivityViewBase;
   friend mesh::IncrementalItemConnectivityBase;
+  template<typename ItemType1,typename ItemType2>
+  friend class IndexedItemConnectivityGenericViewT;
 
  private:
 
+ ItemConnectivityContainerView() = default;
  ItemConnectivityContainerView(SmallSpan<const ItemLocalId> _list,
                                SmallSpan<const Int32> _indexes,
                                SmallSpan<const Int32> _nb_item)
-  : m_list(_list), m_indexes(_indexes), m_nb_item(_nb_item)
+  : m_list_data(_list), m_indexes(_indexes), m_nb_item(_nb_item)
   {
   }
 
@@ -67,7 +70,7 @@ class ARCANE_CORE_EXPORT ItemConnectivityContainerView
 
  private:
 
-  SmallSpan<const ItemLocalId> m_list;
+  SmallSpan<const ItemLocalId> m_list_data;
   SmallSpan<const Int32> m_indexes;
   SmallSpan<const Int32> m_nb_item;
 };

--- a/arcane/src/arcane/ItemConnectivityContainerView.h
+++ b/arcane/src/arcane/ItemConnectivityContainerView.h
@@ -49,7 +49,7 @@ class ARCANE_CORE_EXPORT ItemConnectivityContainerView
 
  private:
 
- ItemConnectivityContainerView(SmallSpan<const Int32> _list,
+ ItemConnectivityContainerView(SmallSpan<const ItemLocalId> _list,
                                SmallSpan<const Int32> _indexes,
                                SmallSpan<const Int32> _nb_item)
   : m_list(_list), m_indexes(_indexes), m_nb_item(_nb_item)
@@ -67,7 +67,7 @@ class ARCANE_CORE_EXPORT ItemConnectivityContainerView
 
  private:
 
-  SmallSpan<const Int32> m_list;
+  SmallSpan<const ItemLocalId> m_list;
   SmallSpan<const Int32> m_indexes;
   SmallSpan<const Int32> m_nb_item;
 };

--- a/arcane/src/arcane/ItemLocalId.h
+++ b/arcane/src/arcane/ItemLocalId.h
@@ -149,6 +149,14 @@ class ItemLocalIdViewT
   {
     return ItemLocalIdViewT<ItemType>(reinterpret_cast<const LocalIdType*>(v.data()), v.size());
   }
+  ConstArrayView<Int32> toViewInt32() const
+  {
+    return { size(), reinterpret_cast<const Int32*>(data()) };
+  }
+  ARCCORE_HOST_DEVICE SmallSpan<const Int32> toSpanInt32() const
+  {
+    return { reinterpret_cast<const Int32*>(data()), size() };
+  }
 
  private:
 

--- a/arcane/src/arcane/ItemLocalId.h
+++ b/arcane/src/arcane/ItemLocalId.h
@@ -52,6 +52,19 @@ class ARCANE_CORE_EXPORT ItemLocalId
   constexpr ARCCORE_HOST_DEVICE Int32 localId() const { return m_local_id; }
   constexpr ARCCORE_HOST_DEVICE bool isNull() const { return m_local_id == NULL_ITEM_LOCAL_ID; }
 
+ public:
+
+  static SmallSpan<const ItemLocalId> fromSpanInt32(SmallSpan<const Int32> v)
+  {
+    auto* ptr = reinterpret_cast<const ItemLocalId*>(v.data());
+    return { ptr, v.size() };
+  }
+  static SmallSpan<const Int32> toSpanInt32(SmallSpan<const ItemLocalId> v)
+  {
+    auto* ptr = reinterpret_cast<const Int32*>(v.data());
+    return { ptr, v.size() };
+  }
+
  private:
 
   Int32 m_local_id = NULL_ITEM_LOCAL_ID;
@@ -63,9 +76,14 @@ class ARCANE_CORE_EXPORT ItemLocalId
  * \ingroup Mesh
  * \brief Index d'une entité \a ItemType dans une variable.
  */
-template <typename ItemType> class ItemLocalIdT
+template <typename ItemType>
+class ItemLocalIdT
 : public ItemLocalId
 {
+ public:
+
+  using ThatClass = ItemLocalIdT<ItemType>;
+
  public:
 
   ItemLocalIdT() = default;
@@ -75,6 +93,20 @@ template <typename ItemType> class ItemLocalIdT
   inline ItemLocalIdT(ItemInternal* item);
   inline ItemLocalIdT(ItemEnumeratorT<ItemType> enumerator);
   inline ItemLocalIdT(ItemType item);
+
+ public:
+
+  static SmallSpan<const ItemLocalId> fromSpanInt32(SmallSpan<const Int32> v)
+  {
+    auto* ptr = reinterpret_cast<const ThatClass*>(v.data());
+    return { ptr, v.size() };
+  }
+
+  static SmallSpan<const Int32> toSpanInt32(SmallSpan<const ThatClass> v)
+  {
+    auto* ptr = reinterpret_cast<const Int32*>(v.data());
+    return { ptr, v.size() };
+  }
 
  public:
 

--- a/arcane/src/arcane/impl/Application.cc
+++ b/arcane/src/arcane/impl/Application.cc
@@ -67,6 +67,8 @@
 
 #include "arcane/ItemEnumerator.h"
 #include "arcane/Item.h"
+#include "arcane/IndexedItemConnectivityView.h"
+#include "arcane/UnstructuredMeshConnectivity.h"
 
 #include "arccore_version.h"
 
@@ -742,11 +744,16 @@ initialize()
   m_trace->info() << "sizeof(ItemInternal)=" << sizeof(ItemInternal)
                   << " sizeof(ItemInternalConnectivityList)=" << sizeof(ItemInternalConnectivityList)
                   << " sizeof(ItemSharedInfo)=" << sizeof(ItemSharedInfo);
+  m_trace->info() << "sizeof(ItemLocalId)=" << sizeof(ItemLocalId)
+                  << " sizeof(ItemConnectivityContainerView)=" << sizeof(ItemConnectivityContainerView)
+                  << " sizeof(UnstructuredMeshConnectivityView)=" << sizeof(UnstructuredMeshConnectivityView);
   m_trace->info() << "sizeof(Item)=" << sizeof(Item)
                   << " sizeof(ItemEnumerator)=" << sizeof(ItemEnumerator)
                   << " sizeof(ItemVectorView)=" << sizeof(ItemVectorView)
                   << " sizeof(ItemVectorViewConstIterator)=" << sizeof(ItemVectorViewConstIterator)
                   << " ItemEnumeratorVersion=" << ItemEnumerator::version();
+  m_trace->info() << "sizeof(eItemKind)=" << sizeof(eItemKind)
+                  << " sizeof(IndexedItemConnectivityViewBase)=" << sizeof(IndexedItemConnectivityViewBase);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -368,7 +368,7 @@ _connectedItems(ItemLocalId item,ConnectivityItemVector& con_items) const
 ItemConnectivityContainerView IncrementalItemConnectivityBase::
 connectivityContainerView() const
 {
-  return { m_connectivity_list, m_connectivity_index, m_connectivity_nb_item };
+  return { ItemLocalId::fromSpanInt32(m_connectivity_list), m_connectivity_index, m_connectivity_nb_item };
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
@@ -9,8 +9,8 @@
 /*                                                                           */
 /* Connectivité incrémentale des entités.                                    */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_DOF_INCREMENTALITEMCONNECTIVITY_H
-#define ARCANE_DOF_INCREMENTALITEMCONNECTIVITY_H
+#ifndef ARCANE_INCREMENTALITEMCONNECTIVITY_H
+#define ARCANE_INCREMENTALITEMCONNECTIVITY_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/arcane/src/arcane/mesh/IndexedItemConnectivityAccessor.h
+++ b/arcane/src/arcane/mesh/IndexedItemConnectivityAccessor.h
@@ -43,9 +43,8 @@ class ARCANE_MESH_EXPORT IndexedItemConnectivityAccessor
 
   ItemVectorView operator()(ItemLocalId lid) const
   {
-    auto* ptr = reinterpret_cast<const Int32*>(&m_list_data[m_indexes[lid]]);
-    Int32ConstArrayView v(m_nb_item[lid], ptr);
-    return const_cast<IItemFamily*>(m_target_item_family)->view(v);
+    ItemLocalIdViewT<Item> x = this->items(lid);
+    return const_cast<IItemFamily*>(m_target_item_family)->view(x.toViewInt32());
   }
 
  private:

--- a/arcane/src/arcane/mesh/IndexedItemConnectivityAccessor.h
+++ b/arcane/src/arcane/mesh/IndexedItemConnectivityAccessor.h
@@ -5,11 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IndexedItemConnectivityAccessor.h                               (C) 2000-2021 */
+/* IndexedItemConnectivityAccessor.h                           (C) 2000-2022 */
 /*                                                                           */
 /* Connectivité incrémentale des entités.                                    */
 /*---------------------------------------------------------------------------*/
-#pragma once
+#ifndef ARCANE_MESH_INDEXEDITEMCONNECTIVITYACCESSOR_H
+#define ARCANE_MESH_INDEXEDITEMCONNECTIVITYACCESSOR_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -18,13 +19,13 @@
 #include "arcane/IItemFamily.h"
 #include "arcane/ItemVector.h"
 #include "arcane/VariableTypes.h"
-//#include "arcane/ItemInternal.h"
 #include "arcane/IIncrementalItemConnectivity.h"
 
 #include "arcane/mesh/MeshGlobal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
 namespace Arcane::mesh
 {
 
@@ -36,15 +37,15 @@ class ARCANE_MESH_EXPORT IndexedItemConnectivityAccessor
 {
  public:
 
-  IndexedItemConnectivityAccessor(IndexedItemConnectivityViewBase view, IItemFamily* target_item_family) ;
+  IndexedItemConnectivityAccessor(IndexedItemConnectivityViewBase view, IItemFamily* target_item_family);
   IndexedItemConnectivityAccessor(IIncrementalItemConnectivity* connectivity);
   IndexedItemConnectivityAccessor() = default;
 
   ItemVectorView operator()(ItemLocalId lid) const
   {
-    //assert(m_target_item_family) ;
-    const Integer* ptr = & m_list_data[m_indexes[lid]];
-    return const_cast<IItemFamily*>(m_target_item_family)->view(ConstArrayView<Integer>( m_nb_item[lid], ptr )) ;
+    auto* ptr = reinterpret_cast<const Int32*>(&m_list_data[m_indexes[lid]]);
+    Int32ConstArrayView v(m_nb_item[lid], ptr);
+    return const_cast<IItemFamily*>(m_target_item_family)->view(v);
   }
 
  private:
@@ -60,3 +61,4 @@ class ARCANE_MESH_EXPORT IndexedItemConnectivityAccessor
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#endif


### PR DESCRIPTION
- Use pointer to reduce the size of the class `ItemConnectivityContainerView`
- Use this class inside `IndexedItemConnectivityView`
- Use `ItemLocalId` instead of `Int32` in `ItemConnectivityContainerView`