### PR TITLE
Simplify 'ItemInfoListView'

### DIFF
--- a/arcane/src/arcane/Item.h
+++ b/arcane/src/arcane/Item.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Item.h                                                      (C) 2000-2022 */
+/* Item.h                                                      (C) 2000-2023 */
 /*                                                                           */
 /* Informations sur les éléments du maillage.                                */
 /*---------------------------------------------------------------------------*/
@@ -85,6 +85,7 @@ class ARCANE_CORE_EXPORT Item
   friend class ItemVectorViewConstIterator;
   friend class SimdItem;
   friend class SimdItemEnumeratorBase;
+  friend class ItemInfoListView;
   template<typename ItemType> friend class ItemEnumeratorBaseT;
 
  public:
@@ -508,6 +509,7 @@ class ARCANE_CORE_EXPORT Node
   friend class ItemVectorViewT<Node>;
   friend class ItemVectorViewConstIteratorT<Node>;
   friend class SimdItemT<Node>;
+  friend class ItemInfoListViewT<Node>;
 
  public:
 
@@ -652,6 +654,7 @@ class ARCANE_CORE_EXPORT ItemWithNodes
   friend class ItemVectorViewT<ItemWithNodes>;
   friend class ItemVectorViewConstIteratorT<ItemWithNodes>;
   friend class SimdItemT<ItemWithNodes>;
+  friend class ItemInfoListViewT<ItemWithNodes>;
 
  protected:
 
@@ -731,6 +734,7 @@ class ARCANE_CORE_EXPORT Edge
   friend class ItemVectorViewT<Edge>;
   friend class ItemVectorViewConstIteratorT<Edge>;
   friend class SimdItemT<Edge>;
+  friend class ItemInfoListViewT<Edge>;
 
  public:
 
@@ -859,6 +863,7 @@ class ARCANE_CORE_EXPORT Face
   friend class ItemVectorViewT<Face>;
   friend class ItemVectorViewConstIteratorT<Face>;
   friend class SimdItemT<Face>;
+  friend class ItemInfoListViewT<Face>;
 
  public:
 
@@ -1099,6 +1104,7 @@ class ARCANE_CORE_EXPORT Cell
   friend class ItemVectorViewT<Cell>;
   friend class ItemVectorViewConstIteratorT<Cell>;
   friend class SimdItemT<Cell>;
+  friend class ItemInfoListViewT<Cell>;
 
  public:
 
@@ -1294,6 +1300,7 @@ class Particle
   friend class ItemVectorViewT<Particle>;
   friend class ItemVectorViewConstIteratorT<Particle>;
   friend class SimdItemT<Particle>;
+  friend class ItemInfoListViewT<Particle>;
 
  private:
 
@@ -1394,6 +1401,7 @@ class DoF
   friend class ItemVectorViewT<DoF>;
   friend class ItemVectorViewConstIteratorT<DoF>;
   friend class SimdItemT<DoF>;
+  friend class ItemInfoListViewT<DoF>;
 
  private:
 
@@ -1589,7 +1597,7 @@ ItemLocalIdT(ItemType item)
 inline Item ItemInfoListView::
 operator[](ItemLocalId local_id) const
 {
-  return Item(impl::ItemBase(ItemBaseBuildInfo(local_id.localId(), m_item_shared_info)));
+  return Item(local_id.localId(), m_item_shared_info);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1598,7 +1606,7 @@ operator[](ItemLocalId local_id) const
 inline Item ItemInfoListView::
 operator[](Int32 local_id) const
 {
-  return Item(impl::ItemBase(ItemBaseBuildInfo(local_id, m_item_shared_info)));
+  return Item(local_id, m_item_shared_info);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1607,7 +1615,7 @@ operator[](Int32 local_id) const
 template<typename ItemType> inline ItemType ItemInfoListViewT<ItemType>::
 operator[](ItemLocalId local_id) const
 {
-  return ItemType(impl::ItemBase(ItemBaseBuildInfo(local_id.localId(), m_item_shared_info)));
+  return ItemType(local_id.localId(), m_item_shared_info);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1616,7 +1624,7 @@ operator[](ItemLocalId local_id) const
 template<typename ItemType> inline ItemType ItemInfoListViewT<ItemType>::
 operator[](Int32 local_id) const
 {
-  return ItemType(impl::ItemBase(ItemBaseBuildInfo(local_id, m_item_shared_info)));
+  return ItemType(local_id, m_item_shared_info);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemInfoListView.cc
+++ b/arcane/src/arcane/ItemInfoListView.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemInfoListView.cc                                         (C) 2000-2022 */
+/* ItemInfoListView.cc                                         (C) 2000-2023 */
 /*                                                                           */
 /* Vue sur une liste pour obtenir des informations sur les entités.          */
 /*---------------------------------------------------------------------------*/
@@ -40,12 +40,13 @@ ItemInfoListView(IItemFamily* family)
 void ItemInfoListView::
 _checkValid(eItemKind expected_kind)
 {
-  if (!m_family)
+  IItemFamily* family = itemFamily();
+  if (!family)
     return;
-  eItemKind my_kind = m_family->itemKind();
+  eItemKind my_kind = family->itemKind();
   if (my_kind != expected_kind)
     ARCANE_FATAL("Bad kind family={0} kind={1} expected_kind={2}",
-                 m_family->fullName(), my_kind, expected_kind);
+                 family->fullName(), my_kind, expected_kind);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/ItemInfoListView.h
+++ b/arcane/src/arcane/ItemInfoListView.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemInfoListView.h                                          (C) 2000-2022 */
+/* ItemInfoListView.h                                          (C) 2000-2023 */
 /*                                                                           */
 /* Vue sur une liste pour obtenir des informations sur les entités.          */
 /*---------------------------------------------------------------------------*/
@@ -62,7 +62,7 @@ class ARCANE_CORE_EXPORT ItemInfoListView
  public:
 
   //! Famille associée
-  IItemFamily* itemFamily() const { return m_family; }
+  IItemFamily* itemFamily() const { return m_item_shared_info->itemFamily(); }
 
   // NOTE: Les définitions des deux méthodes operator[] sont dans Item.h
 
@@ -99,22 +99,13 @@ class ARCANE_CORE_EXPORT ItemInfoListView
  private:
 
   // Seule ItemFamily peut créer des instances via ce constructeur
-  ItemInfoListView(IItemFamily* family, ItemSharedInfo* shared_info, ItemInternalArrayView items_internal)
-  : m_family(family)
-  , m_item_shared_info(shared_info)
-  , m_item_internal_list(items_internal)
+  explicit ItemInfoListView(ItemSharedInfo* shared_info)
+  : m_item_shared_info(shared_info)
   {}
-
-  ItemInternalArrayView _itemsInternal() const { return m_item_internal_list; }
-
- private:
-
-  IItemFamily* m_family = nullptr;
 
  protected:
 
   ItemSharedInfo* m_item_shared_info = ItemSharedInfo::nullInstance();
-  ItemInternalArrayView m_item_internal_list;
 
  protected:
 

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -386,7 +386,7 @@ itemsInternal()
 ItemInfoListView ItemFamily::
 itemInfoListView()
 {
-  return ItemInfoListView(this,m_common_item_shared_info,itemsInternal());
+  return ItemInfoListView(m_common_item_shared_info);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
- Remove unused fields
- Use direct constructors in `ItemInfoListView::operator[]`
