### PR TITLE
Remove in 'MDSpan' and 'NumArray' the subscript operator overloads for 'RealN' and 'RealNxN'.

### DIFF
--- a/arcane/src/arcane/utils/MDSpan.h
+++ b/arcane/src/arcane/utils/MDSpan.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MDSpan.h                                                    (C) 2000-2022 */
+/* MDSpan.h                                                    (C) 2000-2023 */
 /*                                                                           */
 /* Vue sur un tableaux multi-dimensionnel pour les types numériques.         */
 /*---------------------------------------------------------------------------*/
@@ -195,12 +195,6 @@ class MDSpanIntermediate<DataType, 1, Extents, LayoutPolicy>
   constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i) const { return m_ptr + offset(i); }
   //! Valeur pour l'élément \a i
   constexpr ARCCORE_HOST_DEVICE DataType operator[](Int32 i) const { return m_ptr[offset(i)]; }
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  constexpr ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 a) const { return m_ptr[offset(i)][a]; }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  constexpr ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 a, Int32 b) const { return m_ptr[offset(i)][a][b]; }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -259,18 +253,6 @@ class MDSpanIntermediate<DataType, 2, Extents, LayoutPolicy>
   constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j) const { return m_ptr[offset(i, j)]; }
   //! Pointeur sur la valeur pour l'élément \a i,j
   constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j) const { return m_ptr + offset(i, j); }
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  constexpr ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 j, Int32 a) const
-  {
-    return m_ptr[offset(i, j)][a];
-  }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  constexpr ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 j, Int32 a, Int32 b) const
-  {
-    return m_ptr[offset(i, j)][a][b];
-  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -332,18 +314,6 @@ class MDSpanIntermediate<DataType, 3, Extents, LayoutPolicy>
   ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j, Int32 k) const { return m_ptr[offset(i, j, k)]; }
   //! Pointeur sur la valeur pour l'élément \a i,j,k
   ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j, Int32 k) const { return m_ptr + offset(i, j, k); }
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 j, Int32 k, Int32 a) const
-  {
-    return m_ptr[offset(i, j, k)][a];
-  }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) const
-  {
-    return m_ptr[offset(i, j, k)][a][b];
-  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -416,18 +386,6 @@ class MDSpanIntermediate<DataType, 4, Extents, LayoutPolicy>
   constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j, Int32 k, Int32 l) const
   {
     return m_ptr + offset(i, j, k, l);
-  }
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  constexpr ARCCORE_HOST_DEVICE SubType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) const
-  {
-    return m_ptr[offset(i, j, k, l)][a];
-  }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  constexpr ARCCORE_HOST_DEVICE Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) const
-  {
-    return m_ptr[offset(i, j, k, l)][a][b];
   }
 };
 

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* NumArray.h                                                  (C) 2000-2022 */
+/* NumArray.h                                                  (C) 2000-2023 */
 /*                                                                           */
 /* Tableaux multi-dimensionnel pour les types numériques.                    */
 /*---------------------------------------------------------------------------*/
@@ -367,22 +367,6 @@ class NumArrayIntermediate<DataType, 1, ExtentType, LayoutPolicy>
 
  public:
 
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 a) const { return m_span(i, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 a) { return m_span(i, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 a, Int32 b) const { return m_span(i, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 a, Int32 b) { return m_span(i, a, b); }
-
- public:
-
   constexpr operator SpanType() { return this->span(); }
   constexpr operator ConstSpanType() const { return this->constSpan(); }
 };
@@ -452,22 +436,6 @@ class NumArrayIntermediate<DataType, 2, ExtentType, LayoutPolicy>
   {
     return m_span(i, j);
   }
-
- public:
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 j, Int32 a) const { return m_span(i, j, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 j, Int32 a) { return m_span(i, j, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 j, Int32 a, Int32 b) const { return m_span(i, j, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 j, Int32 a, Int32 b) { return m_span(i, j, a, b); }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -539,22 +507,6 @@ class NumArrayIntermediate<DataType, 3, ExtentType, LayoutPolicy>
   {
     return m_span(i, j, k);
   }
-
- public:
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 j, Int32 k, Int32 a) const { return m_span(i, j, k, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 j, Int32 k, Int32 a) { return m_span(i, j, k, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) const { return m_span(i, j, k, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 a, Int32 b) { return m_span(i, j, k, a, b); }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -631,22 +583,6 @@ class NumArrayIntermediate<DataType, 4, Extents, LayoutPolicy>
   {
     return m_span(i, j, k, l);
   }
-
- public:
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename SubConstType = typename NumericTraitsT<X>::SubscriptConstType>
-  SubConstType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) const { return m_span(i, j, k, l, a); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename SubType = typename NumericTraitsT<X>::SubscriptType>
-  SubType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a) { return m_span(i, j, k, l, a); }
-
-  //! Valeur pour l'élément \a i et la composante \a a
-  template <typename X = DataType, typename Sub2ConstType = typename NumericTraitsT<X>::Subscript2ConstType>
-  Sub2ConstType operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) const { return m_span(i, j, k, l, a, b); }
-  //! Valeur pour l'élément \a i et la composante \a [a][b]
-  template <typename X = DataType, typename Sub2Type = typename NumericTraitsT<X>::Subscript2Type>
-  Sub2Type operator()(Int32 i, Int32 j, Int32 k, Int32 l, Int32 a, Int32 b) { return m_span(i, j, k, l, a, b); }
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/TestNumArray.cc
+++ b/arcane/src/arcane/utils/tests/TestNumArray.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -446,7 +446,7 @@ TEST(NumArray,RealN)
   {
     NumArray<Real2,MDDim1> a(5);
     a(2) = Real2(0.0,3.2);
-    a(3,1) = 2.0;
+    a(3)(1) = 2.0;
     ASSERT_EQ(a(3).y,2.0);
   }
 
@@ -454,7 +454,7 @@ TEST(NumArray,RealN)
     NumArray<Real3,MDDim1> a(5);
     const Real3 v(0.0,3.2,5.6);
     a(0) = v;
-    a(4,1) = 4.0;
+    a(4)(1) = 4.0;
     ASSERT_EQ(a(4).y,4.0);
     ASSERT_EQ(a(0),v);
   }
@@ -464,12 +464,12 @@ TEST(NumArray,RealN)
     const Real2 v0(1.2,1.7);
     const Real2x2 v(Real2(3.2,5.6), Real2(3.4,1.7));
     a(0) = v;
-    a(3,1,0) = v0.x;
-    a(3,1,1) = v0.y;
-    a(4,1,0) = 4.0;
+    a(3)(1,0) = v0.x;
+    a(3)(1,1) = v0.y;
+    a(4)(1,0) = 4.0;
     ASSERT_EQ(a(4).y.x,4.0);
     ASSERT_EQ(a(0),v);
-    ASSERT_EQ(a(3,1),v0);
+    ASSERT_EQ(a(3)(1),v0);
   }
 
   {
@@ -477,13 +477,13 @@ TEST(NumArray,RealN)
     const Real3 v0(1.2,3.4,1.7);
     const Real3x3 v(Real3(0.0,3.2,5.6), Real3(1.2,3.4,1.7), Real3(9.2,1.4,5.0));
     a(0) = v;
-    a(3,1,0) = v0.x;
-    a(3,1,1) = v0.y;
-    a(3,1,2) = v0.z;
-    a(4,1,2) = 4.0;
+    a(3)(1)(0) = v0.x;
+    a(3)(1)(1) = v0.y;
+    a(3)(1)(2) = v0.z;
+    a(4)(1)(2) = 4.0;
     ASSERT_EQ(a(4).y.z,4.0);
     ASSERT_EQ(a(0),v);
-    ASSERT_EQ(a(3,1),v0);
+    ASSERT_EQ(a(3)(1),v0);
   }
 }
 


### PR DESCRIPTION
These overloads were temporary to test some functionalities.