### PR TITLE
Update CI using vcpkg (vcpkg version 2022.11 + tests with Intel MPI on windows)

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -23,37 +23,37 @@ jobs:
             triplet: x64-linux
             vcpkg_os: ubuntu-20.04
             cmake_specific_args : '-DARCCORE_BUILD_MODE=Debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
-            ctest_specific_args : '-I 1,50'
+            ctest_specific_args : '-I 1,60'
           - os: ubuntu-22.04
             full_name: 'ubuntu-22.04'
             triplet: x64-linux
             vcpkg_os: ubuntu-22.04
             cmake_specific_args : '-DARCCORE_BUILD_MODE=Debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
-            ctest_specific_args : '-I 1,50'
+            ctest_specific_args : '-I 1,60'
           - os: 'windows-2019'
             full_name: 'windows-2019-msmpi'
             triplet: x64-windows
             vcpkg_os: windows-2019
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
-            ctest_specific_args : '-I 1,60'
+            ctest_specific_args : '-I 1,75'
           - os: 'windows-2022'
             full_name: 'windows-2022-msmpi'
             triplet: x64-windows
             vcpkg_os: windows-2022
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
-            ctest_specific_args : '-I 1,60'
+            ctest_specific_args : '-I 1,75'
           - os: 'windows-2019'
             full_name: 'windows-2019-intelmpi'
             triplet: x64-windows
             vcpkg_os: windows-2019
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
-            ctest_specific_args : '-I 1,60'
+            ctest_specific_args : '-I 1,75'
           - os: 'windows-2022'
             full_name: 'windows-2022-intelmpi'
             triplet: x64-windows
             vcpkg_os: windows-2022
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
-            ctest_specific_args : '-I 1,60'
+            ctest_specific_args : '-I 1,75'
 
     env:
       CCACHE_BASEDIR: ${{github.workspace}}

--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -166,11 +166,12 @@ jobs:
         shell: bash
         run: |
           cmake --build "${{ env.CMAKE_BUILD_DIR }}"
+          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target copy_dlls
 
       - name: Get 'ccache' status
         run: ccache -s -v
 
-      # - name: Test arcane
-      #   shell: bash
-      #   run: |
-      #     cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }}
+      - name: Test arcane
+        shell: bash
+        run: |
+          cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }}

--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -12,28 +12,44 @@ on:
 
 jobs:
   job:
-    name: ${{ matrix.os }}-ci-direct
+    name: ${{ matrix.full_name }}-ci-direct
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-20.04
+            full_name: 'ubuntu-20.04'
             triplet: x64-linux
             vcpkg_os: ubuntu-20.04
             cmake_specific_args : '-DARCCORE_BUILD_MODE=Debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
             ctest_specific_args : '-I 1,50'
           - os: ubuntu-22.04
+            full_name: 'ubuntu-22.04'
             triplet: x64-linux
             vcpkg_os: ubuntu-22.04
             cmake_specific_args : '-DARCCORE_BUILD_MODE=Debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
             ctest_specific_args : '-I 1,50'
           - os: 'windows-2019'
+            full_name: 'windows-2019-msmpi'
             triplet: x64-windows
             vcpkg_os: windows-2019
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
             ctest_specific_args : '-I 1,60'
           - os: 'windows-2022'
+            full_name: 'windows-2022-msmpi'
+            triplet: x64-windows
+            vcpkg_os: windows-2022
+            cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
+            ctest_specific_args : '-I 1,60'
+          - os: 'windows-2019'
+            full_name: 'windows-2019-intelmpi'
+            triplet: x64-windows
+            vcpkg_os: windows-2019
+            cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
+            ctest_specific_args : '-I 1,60'
+          - os: 'windows-2022'
+            full_name: 'windows-2022-intelmpi'
             triplet: x64-windows
             vcpkg_os: windows-2022
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
@@ -52,7 +68,7 @@ jobs:
       VCPKG_ROOT: '${{ github.workspace }}/../../build_base/framework-ci/vcpkg'
       VCPKG_BUILD_DIR: '${{ github.workspace }}/../../build_base/framework-ci/vcpkg'
       BUILD_COMMANDS_ROOT: '${{ github.workspace }}/../../build_base/framework-ci/_build'
-      VCPKG_INSTALL_HASH_PACKAGE_NAME: '1.0.16-${{ matrix.vcpkg_os }}-${{ matrix.triplet }}'
+      VCPKG_INSTALL_HASH_PACKAGE_NAME: '1.1.0-${{ matrix.full_name }}-${{ matrix.triplet }}'
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       FRAMEWORKCI_BRANCH: main
@@ -99,9 +115,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{env.CCACHE_DIR}}
-          key: framework-ccache1-${{matrix.os}}-${{ github.run_number }}
+          key: framework-ccache1-${{matrix.full_name}}-${{ github.run_number }}
           restore-keys: |
-            framework-ccache1-${{matrix.os}}
+            framework-ccache1-${{matrix.full_name}}
 
       - name: 'Display environment after setup'
         shell: 'bash'
@@ -154,7 +170,7 @@ jobs:
       - name: Get 'ccache' status
         run: ccache -s -v
 
-      - name: Test arcane
-        shell: bash
-        run: |
-          cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }}
+      # - name: Test arcane
+      #   shell: bash
+      #   run: |
+      #     cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }}

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -1223,15 +1223,29 @@ if (_NOT_FOUND_PACKAGE_LIST)
 endif()
 
 # ----------------------------------------------------------------------------
+# Gestion des DLLs pour Windows:
+# 1. Ajoute une commande et une cible pour copier les DLLs dans le répertoire 'lib'
+# 2. Si on utilise IntelMPI, copie 'libfabric.dll' dans ce même répertoire. Cette
+# bibliothèque n'est pas utilisée lors de l'édition de lien mais est nécessaire
+# lors de l'exécution pour ne pas planter lors de l'appel à MPI_Init()
 #
 # TODO: ne pas mettre en dur l'exécutable de test mais laisser aux sous-répertoires
-# la possibilité d'ajouter des exécutables
+# la possibilité d'ajouter des exécutables.
+#
+# TODO: pour 'libfabric.dll', plutôt modifier le package 'intel-mpi' de 'vcpkg' pour
+# indiquer explicitement où se trouve cette DLL.
 #
 file(APPEND ${ARCANE_COPY_DLLS_CONFIG_FILE} "list(APPEND EXE_LIST \"$<TARGET_FILE:arcane_tests_exec>\")\n")
 set(ARCANE_COPY_DLL_GENERATED_FILE ${CMAKE_CURRENT_BINARY_DIR}/copy_dlls_config.$<CONFIG>.cmake)
 file(GENERATE OUTPUT ${ARCANE_COPY_DLL_GENERATED_FILE} INPUT ${ARCANE_COPY_DLLS_CONFIG_FILE})
 add_custom_target(copy_dlls
   COMMAND ${CMAKE_COMMAND} -D CONFIG_INCLUDE_FILE=${ARCANE_COPY_DLL_GENERATED_FILE} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ArcaneCopyDLLs.cmake )
+
+find_path(INTEL_LIBFABRIC NAMES "libfabric.dll" PATH_SUFFIXES bin)
+if (INTEL_LIBFABRIC)
+  message (STATUS "Found 'libfabric.dll' in = '${INTEL_LIBFABRIC}'")
+  file(COPY ${INTEL_LIBFABRIC}/libfabric.dll DESTINATION "${LIBRARY_OUTPUT_PATH}")
+endif()
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------

--- a/arccon/build-system/Modules/FindTBB.cmake
+++ b/arccon/build-system/Modules/FindTBB.cmake
@@ -18,7 +18,12 @@ unset(CMAKE_MODULE_PATH)
 find_package(TBB CONFIG QUIET COMPONENTS tbb)
 set(CMAKE_MODULE_PATH ${_SAVED_CMAKE_MODULE_PATH})
 
-if (TBB_tbb_FOUND)
+# vcpkg ne positionne ni TBB_tbb_found ni TBB_IMPORTED_TARGETS
+# On utilise donc direction 'TBB::tbb'
+if (TBB_tbb_FOUND OR TARGET TBB::tbb)
+  if (NOT TBB_IMPORTED_TARGETS)
+    set(TBB_IMPORTED_TARGETS TBB::tbb)
+  endif()
   message(STATUS "[TBB] TBB_DIR = ${TBB_DIR}")
   message(STATUS "[TBB] TBB_IMPORTED_TARGETS = ${TBB_IMPORTED_TARGETS}")
   foreach(_component ${TBB_IMPORTED_TARGETS})


### PR DESCRIPTION
- Upgrade to version 2022.11.14 of `vcpkg`
- Add a CI using Intel MPI on windows