### PR TITLE
Improve CI for win32

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -50,6 +50,8 @@ jobs:
             ctest_specific_args : '-I 1,75'
 
     env:
+      # Indique pour IntelMPI de ne pas faire d'attente active
+      I_MPI_WAIT_MODE: 1
       CCACHE_BASEDIR: ${{github.workspace}}
       CCACHE_DIR: '${{ github.workspace }}/ccache'
       CCACHE_COMPRESS: true

--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -36,12 +36,6 @@ jobs:
             vcpkg_os: windows-2019
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
             ctest_specific_args : '-I 1,75'
-          - os: 'windows-2022'
-            full_name: 'windows-2022-msmpi'
-            triplet: x64-windows
-            vcpkg_os: windows-2022
-            cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER="ccache"'
-            ctest_specific_args : '-I 1,75'
           - os: 'windows-2019'
             full_name: 'windows-2019-intelmpi'
             triplet: x64-windows


### PR DESCRIPTION
- Remove target `windows2022-msmpi`
- Add environment variable `I_MPI_WAIT_MODE=1`