### PR TITLE
Remove usage of  'dualnode' and 'link' items

### DIFF
--- a/axlstar/Arcane.Axl.T4/Arcane.Axl/Axl.From.Xsd/axl.cs
+++ b/axlstar/Arcane.Axl.T4/Arcane.Axl/Axl.From.Xsd/axl.cs
@@ -1380,12 +1380,6 @@ namespace Arcane.Axl.Xsd {
         cell,
         
         /// <remarks/>
-        dualnode,
-        
-        /// <remarks/>
-        link,
-        
-        /// <remarks/>
         particle,
         
         /// <remarks/>

--- a/axlstar/Arcane.Axl.T4/Arcane.Axl/Extensions/ItemKindExtensions.cs
+++ b/axlstar/Arcane.Axl.T4/Arcane.Axl/Extensions/ItemKindExtensions.cs
@@ -14,14 +14,10 @@ namespace Arcane.Axl
       switch(type){
       case Xsd.ItemKind.cell:
         return "Cell";
-      case Xsd.ItemKind.dualnode:
-        return "DualNode";
       case Xsd.ItemKind.edge:
         return "Edge";
       case Xsd.ItemKind.face:
         return "Face";
-      case Xsd.ItemKind.link:
-        return "Link";
       case Xsd.ItemKind.node:
         return "Node";
       case Xsd.ItemKind.particle:

--- a/axlstar/Arcane.Axl/Arcane.Axl/ItemKind.cs
+++ b/axlstar/Arcane.Axl/Arcane.Axl/ItemKind.cs
@@ -11,8 +11,6 @@ namespace Arcane.Axl
     Edge,
     Face,
     Cell,
-    DualNode,
-    Link,
     Particle,
     DoF
   }

--- a/axlstar/Arcane.Axl/Arcane.Axl/VariableInfo.cs
+++ b/axlstar/Arcane.Axl/Arcane.Axl/VariableInfo.cs
@@ -140,10 +140,6 @@ namespace Arcane.Axl
         m_item_kind = ItemKind.Face;
       else if (item_kind == "cell")
         m_item_kind = ItemKind.Cell;
-      else if (item_kind == "dualnode")
-        m_item_kind = ItemKind.DualNode;
-      else if (item_kind == "link")
-        m_item_kind = ItemKind.Link;
       else if (item_kind == "particle")
         m_item_kind = ItemKind.Particle;
       else if (item_kind == "dof")
@@ -154,7 +150,7 @@ namespace Arcane.Axl
         Console.WriteLine("** ERREUR: attribut \"item-kind\" de l'option <" + node.Name
              + "> invalide (" + item_kind + ").\n");
         Console.WriteLine("** Les types reconnus sont 'node', 'edge', "
-             + "'face', 'cell', 'link', 'dualnode', 'particle', 'dof' et 'none'.\n");
+             + "'face', 'cell', 'particle', 'dof' et 'none'.\n");
         Error(node, "mauvaise valeur pour l'attribut \"kind\"");
       }
 

--- a/axlstar/Arcane.Axl/axl.xsd
+++ b/axlstar/Arcane.Axl/axl.xsd
@@ -337,8 +337,6 @@
       <xs:enumeration value="edge" />
       <xs:enumeration value="face" />
       <xs:enumeration value="cell" />
-      <xs:enumeration value="dualnode" />
-      <xs:enumeration value="link" />
       <xs:enumeration value="particle" />
       <xs:enumeration value="dof" />
     </xs:restriction>


### PR DESCRIPTION
These items kind no longer exists in Arcane.