### PR TITLE
Update Hdf5 utils classes

### DIFF
--- a/arcane/src/arcane/hdf5/CMakeLists.txt
+++ b/arcane/src/arcane/hdf5/CMakeLists.txt
@@ -4,9 +4,22 @@ set(PKGS ${PUBLIC_PKGS})
 foreach(package ${PKGS})
   arcane_find_package(${package})
 endforeach()
+
 if (NOT HDF5_FOUND)
   message(STATUS "Hdf5 not found. Disabling 'arcane_hdf5'")
   return()
+endif()
+
+message(STATUS "[hdf5] HDF5_VERSION=${HDF5_VERSION}")
+if (HDF5_VERSION)
+  if (HDF5_VERSION VERSION_LESS "1.10")
+    message(FATAL_ERROR "Your version (${HDF_VERSION}) of Hdf5 is too old. Version 1.10 or greater is required.")
+    return()
+  endif()
+else()
+  message(WARNING
+    "Your version of HDF5 is unknown. Version 1.10+ is required."
+    "Notwithstanding trying to use HDF5 but this may lead to errors during compilation.")
 endif()
 
 include(srcs.cmake)

--- a/arcane/src/arcane/hdf5/Hdf5Utils.h
+++ b/arcane/src/arcane/hdf5/Hdf5Utils.h
@@ -25,6 +25,8 @@
 
 #include "arcane/hdf5/ArcaneHdf5Global.h"
 
+// Désactive ces macros car on compile maintenant toujours avec HDF5 1.10+
+#if 0
 // Si HDF5 est compilé avec MPI, alors hdf5.h inclue mpi.h et il faut
 // signaler qu'on ne souhaite pas avoir la partie C++ de MPI
 // NOTE: Avec HDF5 1.10, ces deux macros sont définies donc il n'y a
@@ -37,6 +39,7 @@
 #ifndef MPICH_SKIP_MPICXX
 #define MPICH_SKIP_MPICXX
 #endif
+#endif
 
 // Cette macro pour MSVC avec les dll, pour eviter des symbols externes
 // indéfinis avec H5T_NATIVE*
@@ -47,8 +50,8 @@
 /*---------------------------------------------------------------------------*/
 
 // Il faut au moins hdf5 1.8
-#if (H5_VERS_MAJOR<2) && (H5_VERS_MAJOR==1 && H5_VERS_MINOR<8)
-#error "This version of HDF5 is too old. Version 1.8+ is required"
+#if (H5_VERS_MAJOR<2) && (H5_VERS_MAJOR==1 && H5_VERS_MINOR<10)
+#error "This version of HDF5 is too old. Version 1.10+ is required"
 #endif
 
 // Garde ces macros pour compatibilité mais il faudra les supprimer.


### PR DESCRIPTION
- Make sure we use Hdf5 version 1.10 or greater
- Make copy constructor deprecated for classes in `Hdf5Utils.h`.
- Add move constructor and move assignment operator for classes in `Hdf5Utils.h`.
- Remove definition of macros `OMPI_SKIP_MPICXX` and `MPICH_SKIP_MPICXX` because they are already defined by Hdf5 in version 1.10 and greater.