### PR TITLE
Provide empty implementation for methods using 'IMultiArray2Data'

### DIFF
--- a/arcane/src/arcane/core/AbstractDataVisitor.cc
+++ b/arcane/src/arcane/core/AbstractDataVisitor.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AbstractDataVisitor.cc                                      (C) 2000-2016 */
+/* AbstractDataVisitor.cc                                      (C) 2000-2023 */
 /*                                                                           */
 /* Visiteur abstrait pour une donnée.                                        */
 /*---------------------------------------------------------------------------*/
@@ -19,10 +19,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -43,12 +41,6 @@ void AbstractDataVisitor::
 applyDataVisitor(IArray2Data* data)
 {
   data->visitArray2(this);
-}
-
-void AbstractDataVisitor::
-applyDataVisitor(IMultiArray2Data* data)
-{
-  data->visitMultiArray2(this);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -297,7 +289,7 @@ _throwException(eDataType dt)
                             dataTypeName(dt));
   throw NotImplementedException(A_FUNCINFO,s);
 }
-
+#if 0
 void AbstractMultiArray2DataVisitor::
 applyVisitor(IMultiArray2DataT<Byte>* data)
 {
@@ -360,11 +352,12 @@ applyVisitor(IMultiArray2DataT<Real3x3>* data)
   ARCANE_UNUSED(data);
   _throwException(DT_Real3x3);
 }
+#endif
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/AbstractDataVisitor.h
+++ b/arcane/src/arcane/core/AbstractDataVisitor.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AbstractDataVisitor.h                                       (C) 2000-2016 */
+/* AbstractDataVisitor.h                                       (C) 2000-2023 */
 /*                                                                           */
 /* Visiteur abstrait pour une donnée.                                        */
 /*---------------------------------------------------------------------------*/
@@ -19,7 +19,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -126,20 +127,6 @@ class ARCANE_CORE_EXPORT AbstractArray2DataVisitor
 class ARCANE_CORE_EXPORT AbstractMultiArray2DataVisitor
 : public IMultiArray2DataVisitor
 {
- public:
-
-  virtual void applyVisitor(IMultiArray2DataT<Byte>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Int16>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Int32>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Int64>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real2>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real3>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real2x2>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real3x3>* data);
-
- protected:
-  
   void _throwException(eDataType dt);
 };
 
@@ -163,13 +150,12 @@ class ARCANE_CORE_EXPORT AbstractDataVisitor
   virtual void applyDataVisitor(IScalarData* data);
   virtual void applyDataVisitor(IArrayData* data);
   virtual void applyDataVisitor(IArray2Data* data);
-  virtual void applyDataVisitor(IMultiArray2Data* data);
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/Data.cc
+++ b/arcane/src/arcane/core/Data.cc
@@ -1,19 +1,24 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Data.cc                                                     (C) 2000-2021 */
+/* Data.cc                                                     (C) 2000-2023 */
 /*                                                                           */
 /* Types liés aux 'IData'.                                                   */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arcane/IData.h"
+
+#include "arcane/utils/String.h"
+#include "arcane/utils/NotSupportedException.h"
+
 #include "arcane/IDataFactory.h"
 #include "arcane/IDataStorageFactory.h"
-#include "arcane/IData.h"
+#include "arcane/IDataVisitor.h"
 #include "arcane/ISerializedData.h"
 #include "arcane/core/internal/IDataInternal.h"
 
@@ -26,7 +31,33 @@ namespace Arccore
 {
 ARCCORE_DEFINE_REFERENCE_COUNTED_CLASS(Arcane::IData);
 ARCCORE_DEFINE_REFERENCE_COUNTED_CLASS(Arcane::ISerializedData);
+} // namespace Arccore
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IDataVisitor::
+applyDataVisitor(IMultiArray2Data*)
+{
+  ARCANE_THROW(NotSupportedException, "using applyDataVisitor with IMultiArray2Data is no longer supported");
 }
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IData::
+visitMultiArray2(IMultiArray2DataVisitor*)
+{
+  ARCANE_THROW(NotSupportedException, "Visiting IMultiArray2Data is no longer supported");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/DataTypeDispatchingDataVisitor.cc
+++ b/arcane/src/arcane/core/DataTypeDispatchingDataVisitor.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DataTypeDispatchingDataVisitor.cc                           (C) 2000-2016 */
+/* DataTypeDispatchingDataVisitor.cc                           (C) 2000-2023 */
 /*                                                                           */
 /* IDataVisitor dispatchant les opérations suivant le type de donnée.        */
 /*---------------------------------------------------------------------------*/
@@ -16,7 +16,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -250,64 +251,7 @@ applyVisitor(IArray2DataT<Real3x3>* data)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Byte>* data)
-{
-  m_byte->applyDispatch(data);
 }
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Real>* data)
-{
-  m_real->applyDispatch(data);
-}
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Int16>* data)
-{
-  m_int16->applyDispatch(data);
-}
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Int32>* data)
-{
-  m_int32->applyDispatch(data);
-}
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Int64>* data)
-{
-  m_int64->applyDispatch(data);
-}
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Real2>* data)
-{
-  m_real2->applyDispatch(data);
-}
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Real3>* data)
-{
-  m_real3->applyDispatch(data);
-}
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Real2x2>* data)
-{
-  m_real2x2->applyDispatch(data);
-}
-
-void AbstractDataTypeDispatchingDataVisitor::
-applyVisitor(IMultiArray2DataT<Real3x3>* data)
-{
-  m_real3x3->applyDispatch(data);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_END_NAMESPACE
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/DataTypeDispatchingDataVisitor.h
+++ b/arcane/src/arcane/core/DataTypeDispatchingDataVisitor.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DataTypeDispatchingDataVisitor.h                            (C) 2000-2022 */
+/* DataTypeDispatchingDataVisitor.h                            (C) 2000-2023 */
 /*                                                                           */
 /* IDataVisitor dispatchant les opérations suivant le type de donnée.        */
 /*---------------------------------------------------------------------------*/
@@ -37,7 +37,7 @@ class ARCANE_CORE_EXPORT IDataTypeDataDispatcherT
   virtual void applyDispatch(IScalarDataT<DataType>* data) =0;
   virtual void applyDispatch(IArrayDataT<DataType>* data) =0;
   virtual void applyDispatch(IArray2DataT<DataType>* data) =0;
-  virtual void applyDispatch(IMultiArray2DataT<DataType>* data) =0;
+  virtual void applyDispatch(IMultiArray2DataT<DataType>*) {}
 };
 
 /*---------------------------------------------------------------------------*/
@@ -130,17 +130,8 @@ class ARCANE_CORE_EXPORT AbstractDataTypeDispatchingDataVisitor
   virtual void applyVisitor(IArray2DataT<Real2x2>* data);
   virtual void applyVisitor(IArray2DataT<Real3x3>* data);
 
-  virtual void applyVisitor(IMultiArray2DataT<Byte>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Int16>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Int32>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Int64>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real2>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real3>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real2x2>* data);
-  virtual void applyVisitor(IMultiArray2DataT<Real3x3>* data);
-    
  private:
+
   IDataTypeDataDispatcherT<Byte>* m_byte;
   IDataTypeDataDispatcherT<Real>* m_real;
   IDataTypeDataDispatcherT<Int16>* m_int16;

--- a/arcane/src/arcane/core/IData.h
+++ b/arcane/src/arcane/core/IData.h
@@ -203,7 +203,7 @@ class ARCANE_CORE_EXPORT IData
    * \deprecated Ce visiteur est obsolète car il n'y a pas plus
    * d'implémentation de IMultiArray2.
    */
-  virtual void visitMultiArray2(IMultiArray2DataVisitor* visitor) = 0;
+  virtual void visitMultiArray2(IMultiArray2DataVisitor* visitor);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/IDataVisitor.h
+++ b/arcane/src/arcane/core/IDataVisitor.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IDataVisitor.h                                              (C) 2000-2016 */
+/* IDataVisitor.h                                              (C) 2000-2023 */
 /*                                                                           */
 /* Interface du pattern visitor pour une donnée.                             */
 /*---------------------------------------------------------------------------*/
@@ -19,7 +19,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -41,15 +42,16 @@ class IMultiArray2Data;
 class ARCANE_CORE_EXPORT IDataVisitor
 {
  public:
-  
-  virtual ~IDataVisitor(){}
+
+  virtual ~IDataVisitor() {}
 
  public:
 
-  virtual void applyDataVisitor(IScalarData* data) =0;
-  virtual void applyDataVisitor(IArrayData* data) =0;
-  virtual void applyDataVisitor(IArray2Data* data) =0;
-  virtual void applyDataVisitor(IMultiArray2Data* data) =0;
+  virtual void applyDataVisitor(IScalarData* data) = 0;
+  virtual void applyDataVisitor(IArrayData* data) = 0;
+  virtual void applyDataVisitor(IArray2Data* data) = 0;
+  // No longer used. Throw NotSupportedException
+  virtual void applyDataVisitor(IMultiArray2Data*);
 };
 
 /*---------------------------------------------------------------------------*/
@@ -60,18 +62,21 @@ class ARCANE_CORE_EXPORT IDataVisitor
 class ARCANE_CORE_EXPORT IScalarDataVisitor
 {
  public:
-  virtual ~IScalarDataVisitor(){}
+
+  virtual ~IScalarDataVisitor() {}
+
  public:
-  virtual void applyVisitor(IScalarDataT<Byte>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Real>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Int16>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Int32>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Int64>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Real2>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Real3>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Real2x2>* data) =0;
-  virtual void applyVisitor(IScalarDataT<Real3x3>* data) =0;
-  virtual void applyVisitor(IScalarDataT<String>* data) =0;
+
+  virtual void applyVisitor(IScalarDataT<Byte>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Real>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Int16>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Int32>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Int64>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Real2>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Real3>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Real2x2>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<Real3x3>* data) = 0;
+  virtual void applyVisitor(IScalarDataT<String>* data) = 0;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -83,20 +88,20 @@ class ARCANE_CORE_EXPORT IArrayDataVisitor
 {
  public:
 
-  virtual ~IArrayDataVisitor(){}
+  virtual ~IArrayDataVisitor() {}
 
  public:
 
-  virtual void applyVisitor(IArrayDataT<Byte>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Real>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Int16>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Int32>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Int64>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Real2>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Real3>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Real2x2>* data) =0;
-  virtual void applyVisitor(IArrayDataT<Real3x3>* data) =0;
-  virtual void applyVisitor(IArrayDataT<String>* data) =0;
+  virtual void applyVisitor(IArrayDataT<Byte>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Real>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Int16>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Int32>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Int64>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Real2>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Real3>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Real2x2>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<Real3x3>* data) = 0;
+  virtual void applyVisitor(IArrayDataT<String>* data) = 0;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -108,52 +113,53 @@ class ARCANE_CORE_EXPORT IArray2DataVisitor
 {
  public:
 
-  virtual ~IArray2DataVisitor(){}
+  virtual ~IArray2DataVisitor() {}
 
  public:
 
-  virtual void applyVisitor(IArray2DataT<Byte>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Real>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Int16>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Int32>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Int64>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Real2>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Real3>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Real2x2>* data) =0;
-  virtual void applyVisitor(IArray2DataT<Real3x3>* data) =0;
+  virtual void applyVisitor(IArray2DataT<Byte>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Real>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Int16>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Int32>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Int64>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Real2>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Real3>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Real2x2>* data) = 0;
+  virtual void applyVisitor(IArray2DataT<Real3x3>* data) = 0;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
  * \brief Interface du pattern visitor pour une donnée tableau 2D à taille variable
+ *
+ * \deprecated Ne plus utiliser car le type sous-jacent n'est plus utilisé
  */
 class ARCANE_CORE_EXPORT IMultiArray2DataVisitor
 {
  public:
 
-  virtual ~IMultiArray2DataVisitor(){}
+  virtual ~IMultiArray2DataVisitor() {}
 
  public:
 
-  virtual void applyVisitor(IMultiArray2DataT<Byte>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Real>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Int16>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Int32>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Int64>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Real2>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Real3>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Real2x2>* data) =0;
-  virtual void applyVisitor(IMultiArray2DataT<Real3x3>* data) =0;
+  virtual void applyVisitor(IMultiArray2DataT<Byte>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Real>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Int16>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Int32>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Int64>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Real2>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Real3>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Real2x2>*) {}
+  virtual void applyVisitor(IMultiArray2DataT<Real3x3>*) {}
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
-
+#endif

--- a/arcane/src/arcane/impl/Array2Data.cc
+++ b/arcane/src/arcane/impl/Array2Data.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Array2Data.cc                                               (C) 2000-2022 */
+/* Array2Data.cc                                               (C) 2000-2023 */
 /*                                                                           */
 /* Donnée du type 'Array2'.                                                  */
 /*---------------------------------------------------------------------------*/
@@ -131,10 +131,6 @@ class Array2DataT
   void visitArray2(IArray2DataVisitor* visitor) override
   {
     visitor->applyVisitor(this);
-  }
-  void visitMultiArray2(IMultiArray2DataVisitor*) override
-  {
-    ARCANE_THROW(NotSupportedException, "Can not visit multiarray2 data with array data");
   }
 
  public:

--- a/arcane/src/arcane/impl/ArrayData.cc
+++ b/arcane/src/arcane/impl/ArrayData.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayData.cc                                                (C) 2000-2022 */
+/* ArrayData.cc                                                (C) 2000-2023 */
 /*                                                                           */
 /* Donnée du type 'Array'.                                                   */
 /*---------------------------------------------------------------------------*/
@@ -129,10 +129,6 @@ class ArrayDataT
   void visitArray2(IArray2DataVisitor*) override
   {
     ARCANE_THROW(NotSupportedException,"Can not visit array2 data with array data");
-  }
-  void visitMultiArray2(IMultiArray2DataVisitor*) override
-  {
-    ARCANE_THROW(NotSupportedException,"Can not visit multiarray2 data with array data");
   }
 
  public:

--- a/arcane/src/arcane/impl/NumArrayData.cc
+++ b/arcane/src/arcane/impl/NumArrayData.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* NumArrayData.cc                                             (C) 2000-2022 */
+/* NumArrayData.cc                                             (C) 2000-2023 */
 /*                                                                           */
 /* Donnée de type 'NumArray'.                                                */
 /*---------------------------------------------------------------------------*/
@@ -155,10 +155,6 @@ class NumArrayDataT
   void visitArray2(IArray2DataVisitor*) override
   {
     ARCANE_THROW(NotSupportedException, "Can not visit array2 data with NumArray data");
-  }
-  void visitMultiArray2(IMultiArray2DataVisitor*) override
-  {
-    ARCANE_THROW(NotSupportedException, "Can not visit multiarray2 data with NumArray data");
   }
 
  public:

--- a/arcane/src/arcane/impl/ScalarData.cc
+++ b/arcane/src/arcane/impl/ScalarData.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ScalarData.cc                                               (C) 2000-2022 */
+/* ScalarData.cc                                               (C) 2000-2023 */
 /*                                                                           */
 /* Donnée de type scalaire.                                                  */
 /*---------------------------------------------------------------------------*/
@@ -251,16 +251,6 @@ void ScalarDataT<DataType>::
 visitArray2(IArray2DataVisitor*)
 {
   ARCANE_THROW(NotSupportedException, "Can not visit array2 data with scalar data");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template <typename DataType>
-void ScalarDataT<DataType>::
-visitMultiArray2(IMultiArray2DataVisitor*)
-{
-  ARCANE_THROW(NotSupportedException, "Can not visit multiarray2 data with array data");
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ScalarData.h
+++ b/arcane/src/arcane/impl/ScalarData.h
@@ -100,7 +100,6 @@ class ScalarDataT
   void visitScalar(IScalarDataVisitor* visitor) override;
   void visitArray(IArrayDataVisitor* visitor) override;
   void visitArray2(IArray2DataVisitor* visitor) override;
-  void visitMultiArray2(IMultiArray2DataVisitor* visitor) override;
 
  public:
 

--- a/arcane/src/arcane/impl/StringArrayData.cc
+++ b/arcane/src/arcane/impl/StringArrayData.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StringArrayData.cc                                          (C) 2000-2022 */
+/* StringArrayData.cc                                          (C) 2000-2023 */
 /*                                                                           */
 /* Donnée de type 'UniqueArray<String>'.                                     */
 /*---------------------------------------------------------------------------*/
@@ -105,7 +105,6 @@ public:
   void visitScalar(IScalarDataVisitor* visitor) override;
   void visitArray(IArrayDataVisitor* visitor) override;
   void visitArray2(IArray2DataVisitor* visitor) override;
-  void visitMultiArray2(IMultiArray2DataVisitor* visitor) override;
 
  public:
 
@@ -404,15 +403,6 @@ void StringArrayData::
 visitArray2(IArray2DataVisitor*)
 {
   ARCANE_THROW(NotSupportedException, "Can not visit array2 data with array data");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void StringArrayData::
-visitMultiArray2(IMultiArray2DataVisitor*)
-{
-  ARCANE_THROW(NotSupportedException, "Can not visit multiarray2 data with array data");
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/StringScalarData.cc
+++ b/arcane/src/arcane/impl/StringScalarData.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StringScalarData.cc                                         (C) 2000-2022 */
+/* StringScalarData.cc                                         (C) 2000-2023 */
 /*                                                                           */
 /* Donnée scalaire de type 'String'.                                         */
 /*---------------------------------------------------------------------------*/
@@ -107,7 +107,6 @@ class StringScalarData
   void visitScalar(IScalarDataVisitor* visitor) override;
   void visitArray(IArrayDataVisitor* visitor) override;
   void visitArray2(IArray2DataVisitor* visitor) override;
-  void visitMultiArray2(IMultiArray2DataVisitor* visitor) override;
 
  public:
 
@@ -312,15 +311,6 @@ void StringScalarData::
 visitArray2(IArray2DataVisitor*)
 {
   throw NotSupportedException(A_FUNCINFO, "Can not visit array2 data with scalar data");
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void StringScalarData::
-visitMultiArray2(IMultiArray2DataVisitor*)
-{
-  throw NotSupportedException(A_FUNCINFO, "Can not visit multiarray2 data with array data");
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Before this modification, visitors and dispatchers used virtual pure methods.
With a default implementation the users no longer need to provide an implementation. This will allow us to remove this interface later.