### PR TITLE
Cleanup 'ItemConnectedListView'

### DIFF
--- a/arcane/src/arcane/core/DataTypeDispatchingDataVisitor.h
+++ b/arcane/src/arcane/core/DataTypeDispatchingDataVisitor.h
@@ -98,37 +98,48 @@ class ARCANE_CORE_EXPORT AbstractDataTypeDispatchingDataVisitor
   ~AbstractDataTypeDispatchingDataVisitor();
 
  public:
-  virtual void applyVisitor(IScalarDataT<Byte>* data);
-  virtual void applyVisitor(IScalarDataT<Real>* data);
-  virtual void applyVisitor(IScalarDataT<Int16>* data);
-  virtual void applyVisitor(IScalarDataT<Int32>* data);
-  virtual void applyVisitor(IScalarDataT<Int64>* data);
-  virtual void applyVisitor(IScalarDataT<Real2>* data);
-  virtual void applyVisitor(IScalarDataT<Real3>* data);
-  virtual void applyVisitor(IScalarDataT<Real2x2>* data);
-  virtual void applyVisitor(IScalarDataT<Real3x3>* data);
-  virtual void applyVisitor(IScalarDataT<String>* data);
 
-  virtual void applyVisitor(IArrayDataT<Byte>* data);
-  virtual void applyVisitor(IArrayDataT<Real>* data);
-  virtual void applyVisitor(IArrayDataT<Int16>* data);
-  virtual void applyVisitor(IArrayDataT<Int32>* data);
-  virtual void applyVisitor(IArrayDataT<Int64>* data);
-  virtual void applyVisitor(IArrayDataT<Real2>* data);
-  virtual void applyVisitor(IArrayDataT<Real3>* data);
-  virtual void applyVisitor(IArrayDataT<Real2x2>* data);
-  virtual void applyVisitor(IArrayDataT<Real3x3>* data);
-  virtual void applyVisitor(IArrayDataT<String>* data);
+  void applyVisitor(IScalarDataT<Byte>* data) override;
+  void applyVisitor(IScalarDataT<Real>* data) override;
+  void applyVisitor(IScalarDataT<Int16>* data) override;
+  void applyVisitor(IScalarDataT<Int32>* data) override;
+  void applyVisitor(IScalarDataT<Int64>* data) override;
+  void applyVisitor(IScalarDataT<Real2>* data) override;
+  void applyVisitor(IScalarDataT<Real3>* data) override;
+  void applyVisitor(IScalarDataT<Real2x2>* data) override;
+  void applyVisitor(IScalarDataT<Real3x3>* data) override;
+  void applyVisitor(IScalarDataT<String>* data) override;
 
-  virtual void applyVisitor(IArray2DataT<Byte>* data);
-  virtual void applyVisitor(IArray2DataT<Real>* data);
-  virtual void applyVisitor(IArray2DataT<Int16>* data);
-  virtual void applyVisitor(IArray2DataT<Int32>* data);
-  virtual void applyVisitor(IArray2DataT<Int64>* data);
-  virtual void applyVisitor(IArray2DataT<Real2>* data);
-  virtual void applyVisitor(IArray2DataT<Real3>* data);
-  virtual void applyVisitor(IArray2DataT<Real2x2>* data);
-  virtual void applyVisitor(IArray2DataT<Real3x3>* data);
+  void applyVisitor(IArrayDataT<Byte>* data) override;
+  void applyVisitor(IArrayDataT<Real>* data) override;
+  void applyVisitor(IArrayDataT<Int16>* data) override;
+  void applyVisitor(IArrayDataT<Int32>* data) override;
+  void applyVisitor(IArrayDataT<Int64>* data) override;
+  void applyVisitor(IArrayDataT<Real2>* data) override;
+  void applyVisitor(IArrayDataT<Real3>* data) override;
+  void applyVisitor(IArrayDataT<Real2x2>* data) override;
+  void applyVisitor(IArrayDataT<Real3x3>* data) override;
+  void applyVisitor(IArrayDataT<String>* data) override;
+
+  void applyVisitor(IArray2DataT<Byte>* data) override;
+  void applyVisitor(IArray2DataT<Real>* data) override;
+  void applyVisitor(IArray2DataT<Int16>* data) override;
+  void applyVisitor(IArray2DataT<Int32>* data) override;
+  void applyVisitor(IArray2DataT<Int64>* data) override;
+  void applyVisitor(IArray2DataT<Real2>* data) override;
+  void applyVisitor(IArray2DataT<Real3>* data) override;
+  void applyVisitor(IArray2DataT<Real2x2>* data) override;
+  void applyVisitor(IArray2DataT<Real3x3>* data) override;
+
+  void applyVisitor(IMultiArray2DataT<Byte>*) override {}
+  void applyVisitor(IMultiArray2DataT<Real>*) override {}
+  void applyVisitor(IMultiArray2DataT<Int16>*) override {}
+  void applyVisitor(IMultiArray2DataT<Int32>*) override {}
+  void applyVisitor(IMultiArray2DataT<Int64>*) override {}
+  void applyVisitor(IMultiArray2DataT<Real2>*) override {}
+  void applyVisitor(IMultiArray2DataT<Real3>*) override {}
+  void applyVisitor(IMultiArray2DataT<Real2x2>*) override {}
+  void applyVisitor(IMultiArray2DataT<Real3x3>*) override {}
 
  private:
 

--- a/arcane/src/arcane/core/Item.h
+++ b/arcane/src/arcane/core/Item.h
@@ -649,13 +649,13 @@ class ARCANE_CORE_EXPORT Node
   CellLocalId cellId(Int32 i) const { return _cellId(i); }
 
   //! Liste des arêtes du noeud
-  EdgeVectorView edges() const { return _edgeList(); }
+  EdgeConnectedListViewType edges() const { return _edgeList(); }
 
   //! Liste des faces du noeud
-  FaceVectorView faces() const { return _faceList(); }
+  FaceConnectedListViewType faces() const { return _faceList(); }
 
   //! Liste des mailles du noeud
-  CellVectorView cells() const { return _cellList(); }
+  CellConnectedListViewType cells() const { return _cellList(); }
 
   //! Liste des arêtes du noeud
   EdgeLocalIdView edgeIds() const { return _edgeIds(); }

--- a/arcane/src/arcane/core/Item.h
+++ b/arcane/src/arcane/core/Item.h
@@ -84,6 +84,7 @@ class ARCANE_CORE_EXPORT Item
   friend class ItemVector;
   friend class ItemVectorView;
   friend class ItemVectorViewConstIterator;
+  friend class ItemConnectedListViewConstIterator;
   friend class SimdItem;
   friend class SimdItemEnumeratorBase;
   friend class ItemInfoListView;
@@ -559,6 +560,7 @@ class ARCANE_CORE_EXPORT Node
   friend class ItemVectorViewT<Node>;
   friend class ItemConnectedListViewT<Node>;
   friend class ItemVectorViewConstIteratorT<Node>;
+  friend class ItemConnectedListViewConstIteratorT<Node>;
   friend class SimdItemT<Node>;
   friend class ItemInfoListViewT<Node>;
 
@@ -705,6 +707,7 @@ class ARCANE_CORE_EXPORT ItemWithNodes
   friend class ItemVectorT<ItemWithNodes>;
   friend class ItemVectorViewT<ItemWithNodes>;
   friend class ItemVectorViewConstIteratorT<ItemWithNodes>;
+  friend class ItemConnectedListViewConstIteratorT<ItemWithNodes>;
   friend class SimdItemT<ItemWithNodes>;
   friend class ItemInfoListViewT<ItemWithNodes>;
 
@@ -785,6 +788,7 @@ class ARCANE_CORE_EXPORT Edge
   friend class ItemVectorT<Edge>;
   friend class ItemVectorViewT<Edge>;
   friend class ItemVectorViewConstIteratorT<Edge>;
+  friend class ItemConnectedListViewConstIteratorT<Edge>;
   friend class SimdItemT<Edge>;
   friend class ItemInfoListViewT<Edge>;
 
@@ -915,6 +919,7 @@ class ARCANE_CORE_EXPORT Face
   friend class ItemVectorT<Face>;
   friend class ItemVectorViewT<Face>;
   friend class ItemVectorViewConstIteratorT<Face>;
+  friend class ItemConnectedListViewConstIteratorT<Face>;
   friend class SimdItemT<Face>;
   friend class ItemInfoListViewT<Face>;
 
@@ -1157,6 +1162,7 @@ class ARCANE_CORE_EXPORT Cell
   friend class ItemVectorT<Cell>;
   friend class ItemVectorViewT<Cell>;
   friend class ItemVectorViewConstIteratorT<Cell>;
+  friend class ItemConnectedListViewConstIteratorT<Cell>;
   friend class SimdItemT<Cell>;
   friend class ItemInfoListViewT<Cell>;
 
@@ -1358,6 +1364,7 @@ class Particle
   friend class ItemVectorT<Particle>;
   friend class ItemVectorViewT<Particle>;
   friend class ItemVectorViewConstIteratorT<Particle>;
+  friend class ItemConnectedListViewConstIteratorT<Particle>;
   friend class SimdItemT<Particle>;
   friend class ItemInfoListViewT<Particle>;
 
@@ -1460,6 +1467,7 @@ class DoF
   friend class ItemVectorT<DoF>;
   friend class ItemVectorViewT<DoF>;
   friend class ItemVectorViewConstIteratorT<DoF>;
+  friend class ItemConnectedListViewConstIteratorT<DoF>;
   friend class SimdItemT<DoF>;
   friend class ItemInfoListViewT<DoF>;
 

--- a/arcane/src/arcane/core/ItemConnectedListView.h
+++ b/arcane/src/arcane/core/ItemConnectedListView.h
@@ -61,12 +61,6 @@ class ItemConnectedListView
 
  public:
 
-  // Temporaire pour rendre les sources compatibles
-  operator ItemInternalVectorView() const
-  {
-    return ItemInternalVectorView(m_shared_info,m_local_ids);
-  }
-
   //! Accède au \a i-ème élément du vecteur
   Item operator[](Integer index) const { return Item(m_local_ids[index],m_shared_info); }
 
@@ -85,22 +79,30 @@ class ItemConnectedListView
     return const_iterator(m_shared_info,m_local_ids.data()+this->size());
   }
 
+#ifdef ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
+ private:
+#else
  public:
+#endif
+
+  // Temporaire pour rendre les sources compatibles
+  operator ItemInternalVectorView() const
+  {
+    return ItemInternalVectorView(m_shared_info,m_local_ids);
+  }
 
   // TODO Rendre obsolète
  
   //! Tableau des numéros locaux des entités
   Int32ConstArrayView localIds() const { return m_local_ids; }
 
+  // TODO: rendre obsolète
+  inline ItemEnumerator enumerator() const;
+
  private:
 
   //! Vue sur le tableau des indices
   ItemIndexArrayView indexes() const { return m_local_ids; }
-
- public:
-
-  // TODO: rendre obsolète
-  inline ItemEnumerator enumerator() const;
 
  protected:
   
@@ -122,6 +124,7 @@ class ItemConnectedListViewT
   friend class ItemEnumerator;
   friend class Item;
   friend class ItemWithNodes;
+  friend class Node;
   friend class Edge;
   friend class Face;
   friend class Cell;
@@ -153,11 +156,6 @@ class ItemConnectedListViewT
 
  public:
 
-  // TODO: rendre obsolète
-  operator ItemVectorViewT<ItemType> () const { return ItemVectorViewT<ItemType>(m_shared_info,m_local_ids); }
-
- public:
-
   ItemType operator[](Integer index) const
   {
     return ItemType(m_local_ids[index],m_shared_info);
@@ -165,11 +163,6 @@ class ItemConnectedListViewT
 
  public:
   
-  // TODO: rendre obsolète
-  inline ItemEnumeratorT<ItemType> enumerator() const
-  {
-    return ItemEnumeratorT<ItemType>(m_shared_info,m_local_ids.localIds());
-  }
   inline const_iterator begin() const
   {
     return const_iterator(m_shared_info,m_local_ids.data());
@@ -177,6 +170,21 @@ class ItemConnectedListViewT
   inline const_iterator end() const
   {
     return const_iterator(m_shared_info,m_local_ids.data()+this->size());
+  }
+
+#ifdef ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
+ private:
+#else
+ public:
+#endif
+
+  // TODO: rendre obsolète
+  operator ItemVectorViewT<ItemType> () const { return ItemVectorViewT<ItemType>(m_shared_info,m_local_ids); }
+
+  // TODO: rendre obsolète
+  inline ItemEnumeratorT<ItemType> enumerator() const
+  {
+    return ItemEnumeratorT<ItemType>(m_shared_info,m_local_ids.localIds());
   }
 };
 

--- a/arcane/src/arcane/core/ItemConnectedListView.h
+++ b/arcane/src/arcane/core/ItemConnectedListView.h
@@ -27,6 +27,152 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
+ * \internal
+ * \brief Itérateur pour la classe ItemConnectedListView.
+ *
+ * Cette classe est interne à Arcane. Elle s'utilise via le for-range:
+ *
+ * \code
+ * Node node;
+ * for( Item item : node.cell() )
+ *    ;
+ * \endcode
+ */
+class ItemConnectedListViewConstIterator
+{
+ protected:
+
+  template<int Extent> friend class ItemConnectedListView;
+
+ protected:
+
+  ItemConnectedListViewConstIterator(ItemSharedInfo* shared_info,const Int32* local_id_ptr)
+  : m_shared_info(shared_info), m_local_id_ptr(local_id_ptr){}
+
+ public:
+
+  typedef ItemConnectedListViewConstIterator ThatClass;
+  typedef std::random_access_iterator_tag iterator_category;
+  //! Type indexant le tableau
+  typedef Item value_type;
+  //! Type indexant le tableau
+  typedef Integer size_type;
+  //! Type d'une distance entre itérateur éléments du tableau
+  typedef std::ptrdiff_t difference_type;
+
+ public:
+
+  //TODO A supprimer avec le C++20
+  typedef const Item* pointer;
+  //TODO A supprimer avec le C++20
+  typedef const Item& reference;
+
+ public:
+
+  Item operator*() const { return Item(*m_local_id_ptr,m_shared_info); }
+  ThatClass& operator++() { ++m_local_id_ptr; return (*this); }
+  ThatClass& operator--() { --m_local_id_ptr; return (*this); }
+  void operator+=(difference_type v) { m_local_id_ptr += v; }
+  void operator-=(difference_type v) { m_local_id_ptr -= v; }
+  difference_type operator-(const ThatClass& b) const
+  {
+    return this->m_local_id_ptr - b.m_local_id_ptr;
+  }
+  friend ThatClass operator-(const ThatClass& a,difference_type v)
+  {
+    const Int32* ptr = a.m_local_id_ptr - v;
+    return ThatClass(a.m_shared_info,ptr);
+  }
+  friend ThatClass operator+(const ThatClass& a,difference_type v)
+  {
+    const Int32* ptr = a.m_local_id_ptr + v;
+    return ThatClass(a.m_shared_info,ptr);
+  }
+  friend bool operator<(const ThatClass& lhs,const ThatClass& rhs)
+  {
+    return lhs.m_local_id_ptr <= rhs.m_local_id_ptr;
+  }
+  //! Compare les indices d'itération de deux instances
+  friend bool operator==(const ThatClass& lhs,const ThatClass& rhs)
+  {
+    return lhs.m_local_id_ptr == rhs.m_local_id_ptr;
+  }
+  friend bool operator!=(const ThatClass& lhs,const ThatClass& rhs)
+  {
+    return !(lhs==rhs);
+  }
+
+  ARCANE_DEPRECATED_REASON("Y2022: This method returns a temporary. Use 'operator*' instead")
+  Item operator->() const { return _itemInternal(); }
+
+ protected:
+
+  ItemSharedInfo* m_shared_info;
+  const Int32* m_local_id_ptr;
+
+ protected:
+
+  inline ItemInternal* _itemInternal() const
+  {
+    return m_shared_info->m_items_internal[ *m_local_id_ptr ];
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template<typename ItemType>
+class ItemConnectedListViewConstIteratorT
+: public ItemConnectedListViewConstIterator
+{
+  friend class ItemConnectedListViewT<ItemType>;
+
+ private:
+
+  ItemConnectedListViewConstIteratorT(ItemSharedInfo* shared_info,const Int32* ARCANE_RESTRICT local_id_ptr)
+  : ItemConnectedListViewConstIterator(shared_info,local_id_ptr){}
+
+ public:
+
+  typedef ItemConnectedListViewConstIteratorT<ItemType> ThatClass;
+  typedef ItemType value_type;
+
+ public:
+
+  //TODO A supprimer avec le C++20
+  typedef const Item* pointer;
+  //TODO A supprimer avec le C++20
+  typedef const Item& reference;
+
+ public:
+
+  ItemType operator*() const { return ItemType(*m_local_id_ptr,m_shared_info); }
+  ThatClass& operator++() { ++m_local_id_ptr; return (*this); }
+  ThatClass& operator--() { --m_local_id_ptr; return (*this); }
+  difference_type operator-(const ThatClass& b) const
+  {
+    return this->m_local_id_ptr - b.m_local_id_ptr;
+  }
+  friend ThatClass operator-(const ThatClass& a,difference_type v)
+  {
+    const Int32* ptr = a.m_local_id_ptr - v;
+    return ThatClass(a.m_shared_info,ptr);
+  }
+  friend ThatClass operator+(const ThatClass& a,difference_type v)
+  {
+    const Int32* ptr = a.m_local_id_ptr + v;
+    return ThatClass(a.m_shared_info,ptr);
+  }
+
+ public:
+
+  ARCANE_DEPRECATED_REASON("Y2022: This method returns a temporary. Use 'operator*' instead")
+  ItemType operator->() const { return this->_itemInternal(); }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
  * \brief Vue sur une liste d'entités connectées à une autre entité.
  *
  * \warning la vue n'est valide que tant que le tableau associé n'est
@@ -42,7 +188,7 @@ class ItemConnectedListView
 
  public:
 
-  using const_iterator = ItemVectorViewConstIterator;
+  using const_iterator = ItemConnectedListViewConstIterator;
   using difference_type = std::ptrdiff_t;
   using value_type = Item;
   using reference_type = Item&;
@@ -137,7 +283,7 @@ class ItemConnectedListViewT
 
  public:
 
-  using const_iterator = ItemVectorViewConstIteratorT<ItemType>;
+  using const_iterator = ItemConnectedListViewConstIteratorT<ItemType>;
   using difference_type = std::ptrdiff_t;
   using value_type = ItemType;
 

--- a/arcane/src/arcane/core/ItemLocalId.h
+++ b/arcane/src/arcane/core/ItemLocalId.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemLocalId.h                                               (C) 2000-2022 */
+/* ItemLocalId.h                                               (C) 2000-2023 */
 /*                                                                           */
 /* Index local sur une entité du maillage.                                   */
 /*---------------------------------------------------------------------------*/
@@ -19,8 +19,18 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+namespace ArcaneTest
+{
+class MeshUnitTest;
+}
+
 namespace Arcane
 {
+namespace mesh
+{
+  class IndexedItemConnectivityAccessor;
+}
+
 // TODO: rendre obsolète les constructeurs qui prennent un argument
 // un ItemEnumerator
 
@@ -122,33 +132,47 @@ class ItemLocalIdT
 template <typename ItemType>
 class ItemLocalIdViewT
 {
+  friend class ItemConnectivityContainerView;
+  friend mesh::IndexedItemConnectivityAccessor;
+  friend ArcaneTest::MeshUnitTest;
+  friend class Item;
+
  public:
+
   using LocalIdType = typename ItemLocalIdTraitsT<ItemType>::LocalIdType;
   using SpanType = SmallSpan<const LocalIdType>;
   using iterator = typename SpanType::iterator;
   using const_iterator = typename SpanType::const_iterator;
+
  public:
-  constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewT(SpanType ids) : m_ids(ids){}
-  constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewT(const LocalIdType* ids,Int32 s) : m_ids(ids,s){}
+
   ItemLocalIdViewT() = default;
-  constexpr ARCCORE_HOST_DEVICE operator SpanType() const { return m_ids; }
+
+ private:
+
+  constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewT(SpanType ids)
+  : m_ids(ids)
+  {}
+  constexpr ARCCORE_HOST_DEVICE ItemLocalIdViewT(const LocalIdType* ids, Int32 s)
+  : m_ids(ids, s)
+  {}
+
  public:
-  constexpr ARCCORE_HOST_DEVICE SpanType ids() const { return m_ids; }
+
   constexpr ARCCORE_HOST_DEVICE LocalIdType operator[](Int32 i) const { return m_ids[i]; }
   constexpr ARCCORE_HOST_DEVICE Int32 size() const { return m_ids.size(); }
-  constexpr ARCCORE_HOST_DEVICE iterator begin() { return m_ids.begin(); }
-  constexpr ARCCORE_HOST_DEVICE iterator end() { return m_ids.end(); }
   constexpr ARCCORE_HOST_DEVICE const_iterator begin() const { return m_ids.begin(); }
   constexpr ARCCORE_HOST_DEVICE const_iterator end() const { return m_ids.end(); }
+
  public:
-  constexpr ARCCORE_HOST_DEVICE const LocalIdType* data() const { return m_ids.data(); }
- public:
+ private:
 
   static ARCCORE_HOST_DEVICE ItemLocalIdViewT<ItemType>
   fromIds(SmallSpan<const Int32> v)
   {
     return ItemLocalIdViewT<ItemType>(reinterpret_cast<const LocalIdType*>(v.data()), v.size());
   }
+
   ConstArrayView<Int32> toViewInt32() const
   {
     return { size(), reinterpret_cast<const Int32*>(data()) };
@@ -157,6 +181,8 @@ class ItemLocalIdViewT
   {
     return { reinterpret_cast<const Int32*>(data()), size() };
   }
+  constexpr ARCCORE_HOST_DEVICE const LocalIdType* data() const { return m_ids.data(); }
+  constexpr ARCCORE_HOST_DEVICE SpanType ids() const { return m_ids; }
 
  private:
 

--- a/arcane/src/arcane/core/ItemSharedInfo.h
+++ b/arcane/src/arcane/core/ItemSharedInfo.h
@@ -63,6 +63,7 @@ class ARCANE_CORE_EXPORT ItemSharedInfo
   friend class mesh::ItemSharedInfoWithType;
   friend class ItemInternalVectorView;
   friend class ItemVectorViewConstIterator;
+  friend class ItemConnectedListViewConstIterator;
   friend class ItemVectorView;
   friend class ItemEnumeratorBase;
   friend class ItemInternalCompatibility;

--- a/arcane/src/arcane/core/ItemTypes.h
+++ b/arcane/src/arcane/core/ItemTypes.h
@@ -306,8 +306,14 @@ using CellConnectedListView = ItemConnectedListViewT<Cell>;
  */
 using DoFConnectedListView = ItemConnectedListViewT<DoF>;
 
-#define ARCANE_USE_SPECIFIC_ITEMCONNECTED
+// A définir si on souhaite cacher les méthodes d'accès aux structures
+// internes des connectivités.
+// #define ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
+
+// #define ARCANE_USE_SPECIFIC_ITEMCONNECTED
 #ifdef ARCANE_USE_SPECIFIC_ITEMCONNECTED
+//! Liste d'entités connectées
+using ItemConnectedListViewType = ItemConnectedListView<DynExtent>;
 //! Liste de noeuds connectés
 using NodeConnectedListViewType = NodeConnectedListView;
 //! Liste d'arêtes connectées
@@ -316,7 +322,11 @@ using EdgeConnectedListViewType = EdgeConnectedListView;
 using FaceConnectedListViewType = FaceConnectedListView;
 //! Liste de mailles connectées
 using CellConnectedListViewType = CellConnectedListView;
+//! Liste générique d'entités connectées
+template<typename ItemType> using ItemConnectedListViewTypeT = ItemConnectedListViewT<ItemType>;
 #else
+//! Liste d'entités connectées
+using ItemConnectedListViewType = ItemVectorView;
 //! Liste de noeuds connectés
 using NodeConnectedListViewType = NodeVectorView;
 //! Liste d'arêtes connectées
@@ -325,6 +335,8 @@ using EdgeConnectedListViewType = EdgeVectorView;
 using FaceConnectedListViewType = FaceVectorView;
 //! Liste de mailles connectées
 using CellConnectedListViewType = CellVectorView;
+//! Liste générique d'entités connectées
+template<typename ItemType> using ItemConnectedListViewTypeT = ItemVectorViewT<ItemType>;
 #endif
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemTypes.h
+++ b/arcane/src/arcane/core/ItemTypes.h
@@ -83,6 +83,10 @@ class ItemVectorViewConstIterator;
 template<typename ItemType>
 class ItemVectorViewConstIteratorT;
 
+class ItemConnectedListViewConstIterator;
+template<typename ItemType>
+class ItemConnectedListViewConstIteratorT;
+
 template <typename ItemType>
 class ItemLocalIdViewT;
 
@@ -310,7 +314,7 @@ using DoFConnectedListView = ItemConnectedListViewT<DoF>;
 // internes des connectivités.
 // #define ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
 
-// #define ARCANE_USE_SPECIFIC_ITEMCONNECTED
+#define ARCANE_USE_SPECIFIC_ITEMCONNECTED
 #ifdef ARCANE_USE_SPECIFIC_ITEMCONNECTED
 //! Liste d'entités connectées
 using ItemConnectedListViewType = ItemConnectedListView<DynExtent>;

--- a/arcane/src/arcane/impl/LoadBalanceMng.cc
+++ b/arcane/src/arcane/impl/LoadBalanceMng.cc
@@ -177,18 +177,19 @@ class CriteriaMng
   }
 
  private:
+
   void _setup();
   Integer _findEntity(const String& entity) const;
-  void _computeMemCell(const Cell& cell);
+  void _computeMemCell(Cell cell);
 
   //! Calcule de la contribution d'un entité sur les mailles adjacentes.
   template <typename ItemKind>
-  Real _computeMemContrib(const ItemVectorViewT<ItemKind> list)
+  Real _computeMemContrib(ItemConnectedListViewTypeT<ItemKind> list)
   {
-    Real contrib = 0;
-    ItemEnumeratorT<ItemKind> iterator = list.enumerator();
-    for ( ; iterator() ; ++iterator) {
-      contrib += 1.0/(Real)(*iterator).nbCell();
+    Real contrib = 0.0;
+    //ItemEnumeratorT<ItemKind> iterator = list.enumerator();
+    for ( const auto& item : list ) {
+      contrib += 1.0/(Real)(item.nbCell());
     }
     return contrib;
   }
@@ -324,7 +325,8 @@ getResidentMemory(const String& entity) const
 /*---------------------------------------------------------------------------*/
 // Pour les mailles, on calcule la contribution mémoire des noeuds, aretes et faces.
 void CriteriaMng::
-_computeMemCell(const Cell& cell) {
+_computeMemCell(Cell cell)
+{
   Real contrib;
   if (cell.localId() == m_buffer.id) // already computed
     return;
@@ -538,8 +540,8 @@ _computeComm()
   if (cellCommContrib()) {
     ENUMERATE_CELL(icell, mesh->ownCells()) {
       Real mem = (*m_mass_res_weight)[icell];
-      ENUMERATE_FACE(iface, icell->faces()) {
-        (*m_comm_costs)[iface] += mem*penalty;
+      for( Face face : icell->faces()) {
+        (*m_comm_costs)[face] += mem*penalty;
       }
     }
   }

--- a/arcane/src/arcane/mesh/BasicItemPairGroupComputeFunctor.cc
+++ b/arcane/src/arcane/mesh/BasicItemPairGroupComputeFunctor.cc
@@ -11,8 +11,6 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/ArcanePrecomp.h"
-
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/ArgumentException.h"
 
@@ -136,10 +134,9 @@ _computeAdjency(ItemPairGroupImpl* array,
     // Pour ne pas s'ajouter à sa propre liste
     if (items_list[local_id] != forbidden_value)
       items_list[local_id] = local_id;
-    for( ItemEnumerator ilinkitem(get_link_item_enumerator(item)); ilinkitem.hasNext(); ++ilinkitem ){
-      Item linkitem = *ilinkitem;
-      for( ItemEnumerator isubitem(get_sub_item_enumerator(linkitem)); isubitem.hasNext(); ++isubitem ){
-        Int32 sub_local_id = isubitem.localId();
+    for( Item linkitem : get_link_item_enumerator(item) ){
+      for( Item subitem : get_sub_item_enumerator(linkitem) ){
+        Int32 sub_local_id = subitem.localId();
         if (items_list[sub_local_id]==forbidden_value || items_list[sub_local_id]==local_id)
           continue;
         items_list[sub_local_id] = local_id;

--- a/arcane/src/arcane/mesh/BasicItemPairGroupComputeFunctor.h
+++ b/arcane/src/arcane/mesh/BasicItemPairGroupComputeFunctor.h
@@ -17,6 +17,7 @@
 #include "arcane/utils/TraceAccessor.h"
 #include "arcane/utils/IFunctor.h"
 #include "arcane/IMeshUtilities.h"
+#include "arcane/Item.h"
 
 #include <map>
 #include <functional>
@@ -115,7 +116,7 @@ class BasicItemPairGroupComputeFunctor
   void _computeFaceFaceEdgeAdjency(ItemPairGroupImpl* array);
   void _computeFaceFaceCellAdjency(ItemPairGroupImpl* array);
 
-  typedef std::function<ItemVectorView(Item)> GetItemVectorViewFunctor;
+  using GetItemVectorViewFunctor = std::function<ItemConnectedListViewType(Item)>;
   void _computeAdjency(ItemPairGroupImpl* array,GetItemVectorViewFunctor get_item_enumerator,
                        GetItemVectorViewFunctor get_sub_item_enumerator);
 };

--- a/arcane/src/arcane/mesh/ExternalPartitionConstraint.cc
+++ b/arcane/src/arcane/mesh/ExternalPartitionConstraint.cc
@@ -57,20 +57,20 @@ addLinkedCells(Int64Array& linked_cells,Int32Array& linked_owners)
     else if (group.itemKind() == IK_Face){
       marque++;
       ENUMERATE_FACE(iface,group.faceGroup()){
-	ENUMERATE_NODE(inode,iface->nodes()){
-	  ENUMERATE_CELL(icell, inode->cells()){
-	    if (filtre_cell[icell.localId()]!=marque){
-	      cells.add(*icell);
-	      filtre_cell[icell.localId()]=marque;
-	    }
-	  }
-	}
+        for( Node node : iface->nodes()){
+          for( Cell cell : node.cells()){
+            if (filtre_cell[cell.localId()]!=marque){
+              cells.add(cell);
+              filtre_cell[cell.localId()]=marque;
+            }
+          }
+        }
       }
     }
     else if (group.itemKind() == IK_Node){
       ENUMERATE_NODE(inode,group.nodeGroup()){
-        ENUMERATE_CELL(icell, inode->cells()){
-          cells.add(*icell);
+        for( Cell cell : inode->cells()){
+          cells.add(cell);
         }
       }
     }

--- a/arcane/src/arcane/mesh/FaceFamily.cc
+++ b/arcane/src/arcane/mesh/FaceFamily.cc
@@ -746,9 +746,9 @@ inline void FaceFamily::
 _removeFace(Face face)
 {
   ItemLocalId face_lid = face;
-  for( Int32 edge : face.edges().localIds().range() )
+  for( Int32 edge : face.edgeIds() )
     m_edge_family->removeFaceFromEdge(ItemLocalId(edge),face_lid);
-  for( Int32 node : face.nodes().localIds().range() )
+  for( Int32 node : face.nodeIds() )
     m_node_family->removeFaceFromNode(ItemLocalId(node),face_lid);
   _removeOne(face);
   // On ne supprime pas ici les autres relations (ici aucune)

--- a/arcane/src/arcane/mesh/FaceUniqueIdBuilder2.cc
+++ b/arcane/src/arcane/mesh/FaceUniqueIdBuilder2.cc
@@ -533,8 +533,7 @@ _computeSequential()
 
   for( Integer i=0; i<nb_cell; ++i ){    
     Cell cell = cells[i];
-    ENUMERATE_FACE(iface,cell.faces()){
-      Face face = *iface;
+    for( Face face : cell.faces()){
       if (face.uniqueId()==NULL_ITEM_UNIQUE_ID){
         face.mutableItemBase().setUniqueId(face_unique_id_counter);
         ++face_unique_id_counter;

--- a/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
@@ -307,7 +307,7 @@ addGhostLayers()
       if (cell_layer[cell_lid]!=(-1))
         continue;
       bool is_current_layer = false;
-      for( Int32 inode_local_id : cell.nodes().localIds() ){
+      for( Int32 inode_local_id : cell.nodeIds() ){
         Integer layer = node_layer[inode_local_id];
         //info() << "NODE_LAYER lid=" << i_node->localId() << " layer=" << layer;
         if (layer==current_layer){
@@ -319,7 +319,7 @@ addGhostLayers()
         cell_layer[cell_lid] = current_layer;
         //info() << "Current layer celluid=" << cell_uid;
         // Si non marqué, initialise à la couche courante + 1.
-        for( Int32 inode_local_id : cell.nodes().localIds() ){
+        for( Int32 inode_local_id : cell.nodeIds() ){
           Integer layer = node_layer[inode_local_id];
           if (layer==(-1)){
             //info() << "Marque node uid=" << i_node->uniqueId();

--- a/arcane/src/arcane/mesh/MeshExchange.cc
+++ b/arcane/src/arcane/mesh/MeshExchange.cc
@@ -946,43 +946,30 @@ _propagatesToChildConnectivities(IItemFamily* family)
       }
     }
   }
-  if(!m_mesh->useMeshItemFamilyDependencies())
-  {
-    switch(family->itemKind())
-    {
-      case IK_Face:
-        ENUMERATE_FACE(item, family->allItems())
-        {
-          ENUMERATE_CELL(icell,item->cells())
-          {
-            _addDestRank(*icell,m_cell_family,*item,family);
-          }
-        }
-        break ;
-      case IK_Edge:
-        ENUMERATE_EDGE(item, family->allItems())
-        {
-          ENUMERATE_CELL(icell,item->cells())
-          {
-            _addDestRank(*icell,m_cell_family,*item,family);
-          }
-        }
-        break ;
-      case IK_Node:
-      {
-        ENUMERATE_NODE(item, family->allItems())
-        {
-          ENUMERATE_CELL(icell,item->cells())
-          {
-            _addDestRank(*icell,m_cell_family,*item,family);
-          }
-        }
-        break ;
-      default:
-        break ;
+  if(!m_mesh->useMeshItemFamilyDependencies()){
+    switch(family->itemKind()){
+    case IK_Face:
+      ENUMERATE_(Face, item, family->allItems()) {
+        for( Cell cell : item->cells())
+          _addDestRank(cell,m_cell_family,*item,family);
       }
-    }
+      break;
+    case IK_Edge:
+      ENUMERATE_(Edge, item, family->allItems()){
+        for( Cell cell : item->cells() )
+          _addDestRank(cell,m_cell_family,*item,family);
+      }
+      break;
+    case IK_Node:
+      ENUMERATE_(Node, item, family->allItems()){
+        for( Cell cell : item->cells())
+          _addDestRank(cell,m_cell_family,*item,family);
+      }
+      break;
+    default:
+      break;
   }
+}
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
- Add a specific iterator for `ItemConnectedListView`
- Add a macro `ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE` to test removal of conversion from `ItemConnectedListView` to `ItemVectorView` or `ItemEnumerator`.
- Use for-loop instead of `ENUMERATE_` in several parts of Arcane.
