### PR TITLE
Improve compatibility between 'ItemConnectedListView' and 'ItemVectorView'

### DIFF
--- a/arcane/src/arcane/core/Item.h
+++ b/arcane/src/arcane/core/Item.h
@@ -711,6 +711,7 @@ class ARCANE_CORE_EXPORT ItemWithNodes
   friend class ItemConnectedEnumeratorBaseT<ThatClass>;
   friend class ItemVectorT<ThatClass>;
   friend class ItemVectorViewT<ThatClass>;
+  friend class ItemConnectedListViewT<ThatClass>;
   friend class ItemVectorViewConstIteratorT<ThatClass>;
   friend class ItemConnectedListViewConstIteratorT<ThatClass>;
   friend class SimdItemT<ThatClass>;
@@ -794,6 +795,7 @@ class ARCANE_CORE_EXPORT Edge
   friend class ItemConnectedEnumeratorBaseT<ThatClass>;
   friend class ItemVectorT<ThatClass>;
   friend class ItemVectorViewT<ThatClass>;
+  friend class ItemConnectedListViewT<ThatClass>;
   friend class ItemVectorViewConstIteratorT<ThatClass>;
   friend class ItemConnectedListViewConstIteratorT<ThatClass>;
   friend class SimdItemT<ThatClass>;
@@ -927,6 +929,7 @@ class ARCANE_CORE_EXPORT Face
   friend class ItemConnectedEnumeratorBaseT<ThatClass>;
   friend class ItemVectorT<ThatClass>;
   friend class ItemVectorViewT<ThatClass>;
+  friend class ItemConnectedListViewT<ThatClass>;
   friend class ItemVectorViewConstIteratorT<ThatClass>;
   friend class ItemConnectedListViewConstIteratorT<ThatClass>;
   friend class SimdItemT<ThatClass>;
@@ -1172,6 +1175,7 @@ class ARCANE_CORE_EXPORT Cell
   friend class ItemConnectedEnumeratorBaseT<ThatClass>;
   friend class ItemVectorT<ThatClass>;
   friend class ItemVectorViewT<ThatClass>;
+  friend class ItemConnectedListViewT<ThatClass>;
   friend class ItemVectorViewConstIteratorT<ThatClass>;
   friend class ItemConnectedListViewConstIteratorT<ThatClass>;
   friend class SimdItemT<ThatClass>;
@@ -1376,6 +1380,7 @@ class Particle
   friend class ItemConnectedEnumeratorBaseT<ThatClass>;
   friend class ItemVectorT<ThatClass>;
   friend class ItemVectorViewT<ThatClass>;
+  friend class ItemConnectedListViewT<ThatClass>;
   friend class ItemVectorViewConstIteratorT<ThatClass>;
   friend class ItemConnectedListViewConstIteratorT<ThatClass>;
   friend class SimdItemT<ThatClass>;
@@ -1480,6 +1485,7 @@ class DoF
   friend class ItemConnectedEnumeratorBaseT<ThatClass>;
   friend class ItemVectorT<ThatClass>;
   friend class ItemVectorViewT<ThatClass>;
+  friend class ItemConnectedListViewT<ThatClass>;
   friend class ItemVectorViewConstIteratorT<ThatClass>;
   friend class ItemConnectedListViewConstIteratorT<ThatClass>;
   friend class SimdItemT<ThatClass>;

--- a/arcane/src/arcane/core/ItemConnectedListView.h
+++ b/arcane/src/arcane/core/ItemConnectedListView.h
@@ -51,6 +51,7 @@ class ItemConnectedListViewConstIterator
  protected:
 
   template<int Extent> friend class ItemConnectedListView;
+  friend class ItemVectorViewConstIterator;
 
  protected:
 
@@ -207,6 +208,8 @@ class ItemConnectedListView
 {
   friend ItemVector;
   friend class ItemEnumeratorBase;
+  friend class ItemVectorView;
+  friend class ItemConnectedEnumeratorBase;
   template<typename ItemType> friend class ItemEnumeratorBaseT;
 
  public:
@@ -356,9 +359,6 @@ class ItemConnectedListViewT
 #else
  public:
 #endif
-
-  // TODO: rendre obsolète
-  operator ItemVectorViewT<ItemType> () const { return ItemVectorViewT<ItemType>(m_shared_info,m_local_ids); }
 
   // TODO: rendre obsolète
   inline ItemEnumeratorT<ItemType> enumerator() const

--- a/arcane/src/arcane/core/ItemVectorView.h
+++ b/arcane/src/arcane/core/ItemVectorView.h
@@ -17,6 +17,7 @@
 #include "arcane/ItemInternalVectorView.h"
 #include "arcane/ItemIndexArrayView.h"
 #include "arcane/ItemInfoListView.h"
+#include "arcane/ItemConnectedListView.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -61,6 +62,16 @@ class ItemVectorViewConstIterator
 #endif
   ItemVectorViewConstIterator(ItemSharedInfo* shared_info,const Int32* local_id_ptr)
   : m_shared_info(shared_info), m_local_id_ptr(local_id_ptr){}
+
+ public:
+
+  // Temporaire (01/2023) pour conversion avec nouveau type ItemConnectedListView
+  ItemVectorViewConstIterator(const ItemConnectedListViewConstIterator& v)
+  : m_shared_info(v.m_shared_info), m_local_id_ptr(v.m_local_id_ptr)
+#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
+    , m_local_id_offset(v.m_local_id_offset)
+  #endif
+  {}
 
  public:
 
@@ -157,6 +168,12 @@ class ItemVectorViewConstIteratorT
 
  public:
 
+  // Temporaire (01/2023) pour conversion avec nouveau type ItemConnectedListView
+  ItemVectorViewConstIteratorT(const ItemConnectedListViewConstIteratorT<ItemType>& v)
+  : ItemVectorViewConstIterator(v){}
+
+ public:
+
   typedef ItemVectorViewConstIteratorT<ItemType> ThatClass;
   typedef ItemType value_type;
 
@@ -238,6 +255,14 @@ class ARCANE_CORE_EXPORT ItemVectorView
   ItemVectorView(IItemFamily* family,ItemIndexArrayView indexes);
   ItemVectorView(const impl::ItemIndexedListView<DynExtent>& view)
   : m_local_ids(view.constLocalIds()), m_shared_info(view.m_shared_info) { }
+
+  // Temporaire (01/2023) pour conversion avec nouveau type ItemConnectedListView
+  ItemVectorView(const ItemConnectedListView<DynExtent>& v)
+  : m_local_ids(v.m_local_ids), m_shared_info(v.m_shared_info)
+  #ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
+  , m_local_id_offset(v.m_local_id_offset)
+  #endif
+  { }
 
  protected:
 
@@ -361,6 +386,10 @@ class ItemVectorViewT
   : ItemVectorView(family,local_ids) {}
   ItemVectorViewT(IItemFamily* family,ItemIndexArrayView indexes)
   : ItemVectorView(family,indexes) {}
+
+  // Temporaire (01/2023) pour conversion avec nouveau type ItemConnectedListView
+  ItemVectorViewT(const ItemConnectedListViewT<ItemType>& v)
+  : ItemVectorView(v){}
 
  protected:
 

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -1469,7 +1469,12 @@ _testFaces()
   ENUMERATE_(Cell,icell,allCells()){
     Cell cell = *icell;
     for( Face face : cell.faces() ){
-      vc.areEqual(face.oppositeCell(cell).itemLocalId(),face.oppositeCellId(cell),"OppositeCell");
+      vc.areEqual(face.oppositeCell(cell).itemLocalId(),face.oppositeCellId(cell),"OppositeCell1");
+    }
+    Int32 nb_face = cell.nbFace();
+    FaceConnectedListViewType faces = cell.faces();
+    for(Int32 i=0; i<nb_face; ++i ){
+      vc.areEqual(faces[i].oppositeCell(cell).itemLocalId(),faces[i].oppositeCellId(cell),"OppositeCell2");
     }
   }
 }

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -1476,6 +1476,18 @@ _testFaces()
     for(Int32 i=0; i<nb_face; ++i ){
       vc.areEqual(faces[i].oppositeCell(cell).itemLocalId(),faces[i].oppositeCellId(cell),"OppositeCell2");
     }
+    // Teste la compatibilité entre ItemVectorView et ItemConnectedListView.
+    // Pour maintenant la compatibilité entre les versions de 3.8+ et antérieures
+    // on doit pouvoir convertir un 'ItemConnectedListView' en un 'ItemVectorView'
+    // et de même pour les itérateurs
+    FaceVectorView faces_as_vector = cell.faces();
+    FaceVectorView::const_iterator face_vector_begin2 = cell.faces().begin();
+    FaceVectorView::const_iterator face_vector_begin1 = faces_as_vector.begin();
+    auto face_begin1 = faces.begin();
+    if (face_begin1!=face_vector_begin1)
+      ARCANE_FATAL("Bad face1");
+    if (face_vector_begin1!=face_vector_begin2)
+      ARCANE_FATAL("Bad face2");
   }
 }
 


### PR DESCRIPTION
This is a temporary compatibility layer to help migrate from `ItemVectorView` to `ItemConnectedListView` for connected items.
