### PR TITLE
Add explicit use of MPI_ANY_SOURCE and MPI_PROC_NULL semantic in MessageRank

### DIFF
--- a/arccore/src/message_passing/arccore/message_passing/MessagePassingGlobal.h
+++ b/arccore/src/message_passing/arccore/message_passing/MessagePassingGlobal.h
@@ -38,11 +38,23 @@ class ITimeMetricCollector;
 
 namespace Arccore::MessagePassing
 {
-//! Numéro correspondant à un rang nul
+/*!
+ * \brief Numéro correspondant à un rang nul.
+ *
+ * La signification du rang nul dépend de la situation.
+ *
+ * \sa MessageRank.
+ */
 static const Int32 A_NULL_RANK = static_cast<Int32>(-1);
 
 //! Numéro correspondant à un rang nul
 static const Int32 A_NULL_TAG_VALUE = static_cast<Int32>(-1);
+
+//! Numéro correspondant à MPI_ANY_SOURCE
+static const Int32 A_ANY_SOURCE_RANK = static_cast<Int32>(-2);
+
+//! Numéro correspondant à MPI_PROC_NULL
+static const Int32 A_PROC_NULL_RANK = static_cast<Int32>(-3);
 
 class Communicator;
 class IRequestCreator;

--- a/arccore/src/message_passing/arccore/message_passing/MessageRank.h
+++ b/arccore/src/message_passing/arccore/message_passing/MessageRank.h
@@ -29,34 +29,75 @@ namespace Arccore::MessagePassing
  * Le type exact du rang dépend de l'implémentation. Pour être le plus
  * générique possible, on utilise le type 'Int32' qui est aussi celui
  * utilisé par MPI.
+ *
+ * Il existe trois valeurs spéciales pour le rang:
+ * - la valeur par défaut
+ * - la valeur procNullRank() qui correspond à MPI_PROC_NULL
+ * - la valeur anySourceRang() qui correspond à MPI_ANY_SOURCE
+ *
+ * \sa PointToPointMessageInfo
  */
 class ARCCORE_MESSAGEPASSING_EXPORT MessageRank
 {
  public:
-  MessageRank() : m_rank(A_NULL_RANK){}
-  explicit MessageRank(Int32 rank) : m_rank(rank){}
-  friend bool operator==(const MessageRank& a,const MessageRank& b)
+
+  /*!
+   * \brief Rang par défaut.
+   *
+   * La signification du rang par défaut dépend du type de message.
+   * \sa PointToPointMessageInfo.
+   */
+  MessageRank()
+  : m_rank(A_NULL_RANK)
+  {}
+
+  explicit MessageRank(Int32 rank)
+  : m_rank(rank)
+  {}
+
+  friend bool operator==(const MessageRank& a, const MessageRank& b)
   {
-    return a.m_rank==b.m_rank;
+    return a.m_rank == b.m_rank;
   }
-  friend bool operator!=(const MessageRank& a,const MessageRank& b)
+  friend bool operator!=(const MessageRank& a, const MessageRank& b)
   {
-    return a.m_rank!=b.m_rank;
+    return a.m_rank != b.m_rank;
   }
-  friend bool operator<(const MessageRank& a,const MessageRank& b)
+  friend bool operator<(const MessageRank& a, const MessageRank& b)
   {
-    return a.m_rank<b.m_rank;
+    return a.m_rank < b.m_rank;
   }
+
+  //! Valeur du rang
   Int32 value() const { return m_rank; }
+
+  //! Positionne la valeur du rang
   void setValue(Int32 rank) { m_rank = rank; }
-  bool isNull() const { return m_rank==A_NULL_RANK; }
+
+  //! Vrai si rang non initialisé correspondant au rang par défaut
+  bool isNull() const { return m_rank == A_NULL_RANK; }
+
+  //! Vrai si rang correspondant à anySourceRank()
+  bool isAnySource() const { return m_rank == A_ANY_SOURCE_RANK; }
+
+  //! Vrai si rang correspondant à procNullRank()
+  bool isProcNull() const { return m_rank == A_PROC_NULL_RANK; }
+
+  //! Rang correspondant à MPI_ANY_SOURCE
+  static MessageRank anySourceRank() { return MessageRank(A_ANY_SOURCE_RANK); }
+
+  //! Rang correspondant à MPI_PROC_NULL
+  static MessageRank procNullRank() { return MessageRank(A_PROC_NULL_RANK); }
+
   void print(std::ostream& o) const;
-  friend inline std::ostream& operator<<(std::ostream& o,const MessageRank& tag)
+  friend inline std::ostream& operator<<(std::ostream& o, const MessageRank& tag)
   {
     tag.print(o);
     return o;
   }
+
  private:
+
   Int32 m_rank;
 };
 

--- a/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiAdapter.cc
+++ b/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiAdapter.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MpiAdapter.cc                                               (C) 2000-2022 */
+/* MpiAdapter.cc                                               (C) 2000-2023 */
 /*                                                                           */
 /* Gestionnaire de parallélisme utilisant MPI.                               */
 /*---------------------------------------------------------------------------*/
@@ -1002,7 +1002,9 @@ directRecv(void* recv_buffer,Int64 recv_buffer_size,
   double end_time = 0.0;
   
   int i_proc = 0;
-  if (proc==A_NULL_RANK)
+  if (proc==A_PROC_NULL_RANK)
+    ARCCORE_THROW(NotImplementedException,"Receive with MPI_PROC_NULL");
+  if (proc==A_NULL_RANK || proc==A_ANY_SOURCE_RANK)
     i_proc = MPI_ANY_SOURCE;
   else
     i_proc = static_cast<int>(proc);
@@ -1119,7 +1121,9 @@ _probeMessage(MessageRank source,MessageTag tag,bool is_blocking)
   MPI_Message message;
   int ret = 0;
   int mpi_source = source.value();
-  if (source.isNull())
+  if (source.isProcNull())
+    ARCCORE_THROW(NotImplementedException,"Probe with MPI_PROC_NULL");
+  if (source.isNull() || source.isAnySource())
     mpi_source = MPI_ANY_SOURCE;
   int mpi_tag = tag.value();
   if (tag.isNull())
@@ -1167,7 +1171,9 @@ _legacyProbeMessage(MessageRank source,MessageTag tag,bool is_blocking)
   MPI_Message message;
   int ret = 0;
   int mpi_source = source.value();
-  if (source.isNull())
+  if (source.isProcNull())
+    ARCCORE_THROW(NotImplementedException,"Probe with MPI_PROC_NULL");
+  if (source.isNull() || source.isAnySource())
     mpi_source = MPI_ANY_SOURCE;
   int mpi_tag = tag.value();
   if (tag.isNull())


### PR DESCRIPTION
At the moment there is no distinction between `MPI_ANY_SOURCE` and `MPI_PROC_NULL` in `MessageRank` and the use of `MPI_PROC_NULL` is not handled.
This PR add two specific values of `MessageRank` to handle these two cases in the future.
The use of `MPI_PROC_NULL` is not supported at the moment.
 