### PR TITLE
Improve usage of 'MemoryView' and 'MutableMemoryView'

### DIFF
--- a/arcane/src/arcane/accelerator/Reduce.h
+++ b/arcane/src/arcane/accelerator/Reduce.h
@@ -299,7 +299,7 @@ class Reducer
     //int threadId = threadIdx.x + blockDim.x * threadIdx.y + (blockDim.x * blockDim.y) * threadIdx.z;
     //if ((threadId%16)==0)
     //printf("Destroy device Id=%d\n",threadId);
-    auto buf_span = m_grid_memory_info.m_grid_memory_values.span();
+    auto buf_span = m_grid_memory_info.m_grid_memory_values.bytes();
     DataType* buf = reinterpret_cast<DataType*>(buf_span.data());
     SmallSpan<DataType> grid_buffer(buf,static_cast<Int32>(buf_span.size()));
 

--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -367,14 +367,14 @@ _setReducePolicy()
 void* ReduceMemoryImpl::
 allocateReduceDataMemory(MemoryView identity_view)
 {
-  auto identity_span = identity_view.span();
+  auto identity_span = identity_view.bytes();
   Int32 data_type_size = static_cast<Int32>(identity_span.size());
   m_data_type_size = data_type_size;
   if (data_type_size > m_size)
     _allocateMemoryForReduceData(data_type_size);
   // Recopie \a identity_view dans un buffer car on utilise l'asynchronisme
   // et la zone pointée par \a identity_view n'est pas forcément conservée
-  m_identity_buffer.copy(identity_view.span());
+  m_identity_buffer.copy(identity_view.bytes());
   MemoryCopyArgs copy_args(m_managed_memory, m_identity_buffer.span().data(), data_type_size);
   m_command->internalStream()->copyMemory(copy_args.addAsync());
   return m_managed_memory;
@@ -389,7 +389,7 @@ _allocateGridDataMemory()
   // TODO: pouvoir utiliser un padding pour éviter que les lignes de cache
   // entre les blocs se chevauchent
   Int32 total_size = CheckedConvert::toInt32(m_data_type_size * m_grid_size);
-  if (total_size <= m_grid_memory_info.m_grid_memory_values.size())
+  if (total_size <= m_grid_memory_info.m_grid_memory_values.bytes().size())
     return;
 
   m_grid_buffer.resize(total_size);

--- a/arcane/src/arcane/accelerator/core/RunQueueRuntime.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueRuntime.cc
@@ -49,7 +49,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT HostRunQueueStream
   void barrier() override { return m_runtime->barrier(); }
   void copyMemory(const MemoryCopyArgs& args) override
   {
-    std::memcpy(args.destination().span().data(), args.source().span().data(), args.source().size());
+    args.destination().copyHost(args.source());
   }
   void prefetchMemory(const MemoryPrefetchArgs&) override {}
   void* _internalImpl() override { return nullptr; }

--- a/arcane/src/arcane/accelerator/cuda/runtime/Test.cu
+++ b/arcane/src/arcane/accelerator/cuda/runtime/Test.cu
@@ -521,7 +521,7 @@ void arcaneTestCudaReductionX(int vsize,ax::RunQueue& queue)
   ReducerMin<double> min_double_reducer(command);
   Span<const int> xa = d_a.span();
   Span<int> xout = d_out.span();
-  auto func2 = [=] ARCCORE_HOST_DEVICE (Arcane::ArrayBoundsIndex<1> idx)
+  auto func2 = [=] ARCCORE_HOST_DEVICE (Arcane::ArrayIndex<1> idx)
   {
     auto [i] = idx();
     double vxa = (double)(xa[i]);

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -90,8 +90,8 @@ class HipRunQueueStream
   }
   void copyMemory(const MemoryCopyArgs& args) override
   {
-    auto r = hipMemcpyAsync(args.destination().span().data(), args.source().span().data(),
-                            args.source().size(), hipMemcpyDefault, m_hip_stream);
+    auto r = hipMemcpyAsync(args.destination().data(), args.source().data(),
+                            args.source().bytes().size(), hipMemcpyDefault, m_hip_stream);
     ARCANE_CHECK_HIP(r);
     if (!args.isAsync())
       barrier();
@@ -102,7 +102,7 @@ class HipRunQueueStream
     int device = hipCpuDeviceId;
     if (!d.isHost())
       device = d.asInt32();
-    auto src = args.source().span();
+    auto src = args.source().bytes();
     auto r = hipMemPrefetchAsync(src.data(), src.size(), device, m_hip_stream);
     ARCANE_CHECK_HIP(r);
     if (!args.isAsync())
@@ -323,7 +323,7 @@ class HipMemoryCopier
     // 'hipMemcpyDefault' sait automatiquement ce qu'il faut faire en tenant
     // uniquement compte de la valeur des pointeurs. Il faudrait voir si
     // utiliser \a from_mem et \a to_mem peut améliorer les performances.
-    ARCANE_CHECK_HIP(hipMemcpy(to.span().data(), from.span().data(), from.size(), hipMemcpyDefault));
+    ARCANE_CHECK_HIP(hipMemcpy(to.data(), from.data(), from.bytes().size(), hipMemcpyDefault));
   }
 };
 

--- a/arcane/src/arcane/utils/MemoryRessourceMng.cc
+++ b/arcane/src/arcane/utils/MemoryRessourceMng.cc
@@ -131,8 +131,8 @@ void MemoryRessourceMng::
 copy(MemoryView from, eMemoryRessource from_mem,
      MutableMemoryView to, eMemoryRessource to_mem)
 {
-  Int64 from_size = from.size();
-  Int64 to_size = to.size();
+  Int64 from_size = from.bytes().size();
+  Int64 to_size = to.bytes().size();
   if (from_size > to_size)
     ARCANE_FATAL("Destination copy is too small (to_size={0} from_size={1})", to_size, from_size);
 
@@ -150,10 +150,10 @@ copy(MemoryView from, eMemoryRessource from_mem,
                  from_mem);
 
   if (!_isHost(to_mem))
-    ARCANE_FATAL("Destination buffer is not accessible from host and no copier provided (localtion={0})",
+    ARCANE_FATAL("Destination buffer is not accessible from host and no copier provided (location={0})",
                  to_mem);
 
-  memcpy(to.span().data(), from.span().data(), from.size());
+  to.copyHost(from);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryView.cc
+++ b/arcane/src/arcane/utils/MemoryView.cc
@@ -1,0 +1,54 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* MemoryView.cc                                               (C) 2000-2023 */
+/*                                                                           */
+/* Vues constantes ou modifiables sur une zone mémoire.                       */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/MemoryView.h"
+
+#include "arcane/utils/FatalErrorException.h"
+
+#include <cstring>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MutableMemoryView::
+copyHost(MemoryView v)
+{
+  auto source = v.bytes();
+  auto destination = bytes();
+  Int64 source_size = source.size();
+  if (source_size==0)
+    return;
+  Int64 destination_size = destination.size();
+  if (source_size>destination_size)
+    ARCANE_FATAL("Destination is too small source_size={0} destination_size={1}",
+                 source_size,destination_size);
+  auto* dest_data = destination.data();
+  auto* source_data = source.data();
+  ARCANE_CHECK_POINTER(dest_data);
+  ARCANE_CHECK_POINTER(source_data);
+  std::memmove(destination.data(), source.data(), source_size);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryView.h
+++ b/arcane/src/arcane/utils/MemoryView.h
@@ -49,6 +49,17 @@ class ARCANE_UTILS_EXPORT MemoryView
   , m_datatype_size(static_cast<Int32>(sizeof(DataType)))
   {}
 
+ public:
+
+  template <typename DataType> constexpr MemoryView&
+  operator=(Span<DataType> v)
+  {
+    m_bytes = asBytes(v);
+    m_nb_element = v.size();
+    m_datatype_size = static_cast<Int32>(sizeof(DataType));
+    return (*this);
+  }
+
  private:
 
   constexpr MemoryView(Span<const std::byte> bytes, Int32 datatype_size, Int64 nb_element)
@@ -72,10 +83,10 @@ class ARCANE_UTILS_EXPORT MemoryView
   constexpr Int32 datatypeSize() const { return m_datatype_size; }
 
   //! Sous-vue à partir de l'indice \a begin_index et contenant \a nb_element
-  constexpr MemoryView subView(Int64 begin_index,Int64 nb_element) const
+  constexpr MemoryView subView(Int64 begin_index, Int64 nb_element) const
   {
     Int64 byte_offset = begin_index * m_datatype_size;
-    auto sub_bytes = m_bytes.subspan(byte_offset, nb_element*m_datatype_size);
+    auto sub_bytes = m_bytes.subspan(byte_offset, nb_element * m_datatype_size);
     return MemoryView(sub_bytes, m_datatype_size, nb_element);
   }
 
@@ -121,6 +132,17 @@ class ARCANE_UTILS_EXPORT MutableMemoryView
   , m_datatype_size(static_cast<Int32>(sizeof(DataType)))
   {}
 
+ public:
+
+  template <typename DataType> constexpr MutableMemoryView&
+  operator=(Span<DataType> v)
+  {
+    m_bytes = asWritableBytes(v);
+    m_nb_element = v.size();
+    m_datatype_size = static_cast<Int32>(sizeof(DataType));
+    return (*this);
+  }
+
  private:
 
   constexpr MutableMemoryView(Span<std::byte> bytes, Int32 datatype_size, Int64 nb_element)
@@ -148,13 +170,15 @@ class ARCANE_UTILS_EXPORT MutableMemoryView
   constexpr Int32 datatypeSize() const { return m_datatype_size; }
 
   //! Sous-vue à partir de l'indice \a begin_index
-  constexpr MutableMemoryView subView(Int64 begin_index,Int64 nb_element) const
+  constexpr MutableMemoryView subView(Int64 begin_index, Int64 nb_element) const
   {
     Int64 byte_offset = begin_index * m_datatype_size;
-    auto sub_bytes = m_bytes.subspan(byte_offset, nb_element*m_datatype_size);
+    auto sub_bytes = m_bytes.subspan(byte_offset, nb_element * m_datatype_size);
     return MutableMemoryView(sub_bytes, m_datatype_size, nb_element);
   }
+
  public:
+
   /*!
    * \brief Copie dans l'instance les données de \a v.
    *

--- a/arcane/src/arcane/utils/srcs.cmake
+++ b/arcane/src/arcane/utils/srcs.cmake
@@ -67,6 +67,7 @@ set(ARCANE_SOURCES
   ISO88591Transcoder.cc
   ISO88591Transcoder.h
   MemoryView.h
+  MemoryView.cc
   Misc.cc
   MD5HashAlgorithm.cc
   MD5HashAlgorithm.h


### PR DESCRIPTION
- Add storage of the size of the datatype
- Add constructor from `Span<DataType>`