### PR TITLE
Use 'PublishDir' property to specify publish directory for axlstar

### DIFF
--- a/axlstar/CMakeLists.txt
+++ b/axlstar/CMakeLists.txt
@@ -94,7 +94,7 @@ if (AXLSTAR_DOTNET_RUNNER STREQUAL coreclr)
   #  3. /p:UseSharedCompilation=false (pour ne pas garder la compilateur actif entre deux compilations)
   # La méthode 1. évite de laisser des processus tourner et n'ajoute pas de temps à la compilation
   # donc on l'utilise par défaut.
-  set(AXLSTAR_BUILD_COMMAND_ARGS publish /nodeReuse:false /v:Normal /p:UseSharedCompilation=false ${AXL_SOLUTION_FILE} /p:AxlToolsExeFramework=netcoreapp${CORECLR_VERSION} -o ${AXLSTAR_PUBLISH_DIR}/)
+  set(AXLSTAR_BUILD_COMMAND_ARGS publish /nodeReuse:false /v:Normal /p:UseSharedCompilation=false ${AXL_SOLUTION_FILE} /p:AxlToolsExeFramework=netcoreapp${CORECLR_VERSION} /p:PublishDir=${AXLSTAR_PUBLISH_DIR}/)
 endif()
 set(AXLSTAR_BUILD_COMMAND_ARGS ${AXLSTAR_BUILD_COMMAND_ARGS} ${AXLSTAR_MSBUILD_COMMON_COMMAND_ARGS})
 


### PR DESCRIPTION
The option `-o` is no longer supported for `dotnet publish` when the argument is a solution.
This change is in effect since version 7.0.200 of dotnet.

See https://github.com/dotnet/sdk/pull/29065 and https://github.com/dotnet/sdk/issues/15607