### PR TITLE
Cleanup variable synchronizer

### DIFF
--- a/arcane/src/arcane/impl/IDataSynchronizeBuffer.h
+++ b/arcane/src/arcane/impl/IDataSynchronizeBuffer.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IDataSynchronizeBuffer.h                                    (C) 2000-2022 */
+/* IDataSynchronizeBuffer.h                                    (C) 2000-2023 */
 /*                                                                           */
 /* Interface d'un buffer générique pour la synchronisation de donnéess.      */
 /*---------------------------------------------------------------------------*/
@@ -55,26 +55,43 @@ class ARCANE_IMPL_EXPORT IDataSynchronizeBuffer
 
   //! Nombre de rangs.
   virtual Int32 nbRank() const = 0;
+
   //! Indique si les buffers sont globaux.
   virtual bool hasGlobalBuffer() const = 0;
+
   //! Buffer d'envoi
   virtual Span<std::byte> globalSendBuffer() = 0;
+
   //! Buffer de réception
   virtual Span<std::byte> globalReceiveBuffer() = 0;
+
   //! Buffer d'envoi pour le rang \a index
   virtual Span<std::byte> sendBuffer(Int32 index) = 0;
+
   //! Buffer de réception pour le rang \a index
   virtual Span<std::byte> receiveBuffer(Int32 index) = 0;
+
   //! Déplacement depuis le début de sendBuffer() pour le rang \a index
   virtual Int64 sendDisplacement(Int32 index) const = 0;
+
   //! Déplacement depuis le début de receiveBuffer() pour le rang \a index
   virtual Int64 receiveDisplacement(Int32 index) const = 0;
-  //! Recopie dans les données depuis le buffer de réception.
+
+  //! Recopie dans les données depuis le buffer de réception du rang \a index.
   virtual void copyReceive(Int32 index) = 0;
-  //! Recopie dans le buffer d'envoi les données
+
+  //! Recopie toutes les données depuis le buffer de réception.
+  virtual void copyAllReceive();
+
+  //! Recopie dans le buffer d'envoi les données du rang \a index
   virtual void copySend(Int32 index) = 0;
+
+  //! Recopie dans le buffer d'envoi toute les données
+  virtual void copyAllSend();
+
   //! Taille totale à envoyer en octet
   virtual Int64 totalSendSize() const = 0;
+
   //! Taille totale à recevoir en octet
   virtual Int64 totalReceiveSize() const = 0;
 };

--- a/arcane/src/arcane/impl/IGenericVariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/IGenericVariableSynchronizerDispatcher.h
@@ -64,36 +64,6 @@ class ARCANE_IMPL_EXPORT IGenericVariableSynchronizerDispatcherFactory
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-/*!
- * \brief Informations pour construire un dispatcher générique.
- */
-class ARCANE_IMPL_EXPORT GenericVariableSynchronizeDispatcherBuildInfo
-{
- public:
-
-  GenericVariableSynchronizeDispatcherBuildInfo(IParallelMng* pm, GroupIndexTable* table,
-                                                Ref<IGenericVariableSynchronizerDispatcherFactory> factory)
-  : m_parallel_mng(pm)
-  , m_table(table)
-  , m_factory(factory)
-  {}
-
- public:
-
-  IParallelMng* parallelMng() const { return m_parallel_mng; }
-  //! Table d'index pour le groupe. Peut-être nul.
-  GroupIndexTable* table() const { return m_table; }
-  Ref<IGenericVariableSynchronizerDispatcherFactory> factory() { return m_factory; }
-
- private:
-
-  IParallelMng* m_parallel_mng;
-  GroupIndexTable* m_table;
-  Ref<IGenericVariableSynchronizerDispatcherFactory> m_factory;
-};
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 /*
  * \brief Classe de base abstraite pour les implémentations génériques.
  *

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -80,12 +80,8 @@ VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
     GroupIndexTable* table = nullptr;
     if (!group.isAllItems())
       table = group.localIdToIndex().get();
-    GenericVariableSynchronizeDispatcherBuildInfo bi(pm,table,generic_factory);
-    m_dispatcher = new VariableSynchronizerDispatcher(pm,DispatcherType::create<GenericVariableSynchronizeDispatcher>(bi));
-
-    //VariableSynchronizeDispatcherBuildInfo bi(pm,nullptr);
-    //DispatcherType* dt = DispatcherType::create<SimpleVariableSynchronizeDispatcher>(bi);
-    //m_dispatcher = new VariableSynchronizerDispatcher(pm,dt);
+    VariableSynchronizeDispatcherBuildInfo bi(pm,table,generic_factory);
+    m_dispatcher = new VariableSynchronizerDispatcher(pm,DispatcherType::create<VariableSynchronizeDispatcher>(bi));
   }
   m_dispatcher->setItemGroupSynchronizeInfo(&m_sync_list);
   m_multi_dispatcher = new VariableSynchronizerMultiDispatcher(pm);

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
@@ -36,20 +36,20 @@ namespace Arcane
 
 namespace
 {
-ArrayView<Byte>
-_toLegacySmallView(Span<std::byte> bytes)
-{
-  void* data = bytes.data();
-  Int32 size = bytes.smallView().size();
-  return { size, reinterpret_cast<Byte*>(data) };
-}
+  ArrayView<Byte>
+  _toLegacySmallView(Span<std::byte> bytes)
+  {
+    void* data = bytes.data();
+    Int32 size = bytes.smallView().size();
+    return { size, reinterpret_cast<Byte*>(data) };
+  }
 
-}
+} // namespace
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> VariableSynchronizeDispatcher<SimpleType>::
 VariableSynchronizeDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi)
 : m_parallel_mng(bi.parallelMng())
 {
@@ -62,7 +62,7 @@ VariableSynchronizeDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> VariableSynchronizeDispatcher<SimpleType>::
 ~VariableSynchronizeDispatcher()
 {
   delete m_buffer_copier;
@@ -71,13 +71,13 @@ template<typename SimpleType> VariableSynchronizeDispatcher<SimpleType>::
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 applyDispatch(IArrayDataT<SimpleType>* data)
 {
   if (m_is_in_sync)
     ARCANE_FATAL("Only one pending serialisation is supported");
   m_is_in_sync = true;
-  m_1d_buffer.setDataView(MutableMemoryView{data->view()});
+  m_1d_buffer.setDataView(MutableMemoryView{ data->view() });
   _beginSynchronize(m_1d_buffer);
   _endSynchronize(m_1d_buffer);
   m_is_in_sync = false;
@@ -86,7 +86,7 @@ applyDispatch(IArrayDataT<SimpleType>* data)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 applyDispatch(IArray2DataT<SimpleType>* data)
 {
   if (m_is_in_sync)
@@ -95,13 +95,13 @@ applyDispatch(IArray2DataT<SimpleType>* data)
   SimpleType* value_ptr = value.data();
   // Cette valeur doit être la même sur tous les procs
   Integer dim2_size = value.dim2Size();
-  if (dim2_size==0)
+  if (dim2_size == 0)
     return;
   m_is_in_sync = true;
   Integer dim1_size = value.dim1Size();
-  m_2d_buffer.compute(m_buffer_copier,m_sync_info,dim2_size);
-  ArrayView<SimpleType> buf(dim1_size,value_ptr);
-  m_2d_buffer.setDataView(MutableMemoryView(buf,dim2_size));
+  m_2d_buffer.compute(m_buffer_copier, m_sync_info, dim2_size);
+  ArrayView<SimpleType> buf(dim1_size, value_ptr);
+  m_2d_buffer.setDataView(MutableMemoryView(buf, dim2_size));
   _beginSynchronize(m_2d_buffer);
   _endSynchronize(m_2d_buffer);
   m_is_in_sync = false;
@@ -110,25 +110,25 @@ applyDispatch(IArray2DataT<SimpleType>* data)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 applyDispatch(IScalarDataT<SimpleType>*)
 {
-  ARCANE_THROW(NotSupportedException,"Can not synchronize scalar data");
+  ARCANE_THROW(NotSupportedException, "Can not synchronize scalar data");
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 applyDispatch(IMultiArray2DataT<SimpleType>*)
 {
-  ARCANE_THROW(NotSupportedException,"Can not synchronize multiarray2 data");
+  ARCANE_THROW(NotSupportedException, "Can not synchronize multiarray2 data");
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info)
 {
   m_sync_info = sync_info;
@@ -140,7 +140,7 @@ setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info)
  * \brief Calcul et alloue les tampons nécessaire aux envois et réceptions
  * pour les synchronisations des variables 1D.
  */
-template<typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
+template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 compute()
 {
   if (!m_sync_info)
@@ -152,7 +152,7 @@ compute()
   //                       << " this=" << (IVariableSynchronizeDispatcher*)this
   //                       << " m_sync_list=" << &m_sync_list;
 
-  m_1d_buffer.compute(m_buffer_copier,m_sync_info,1);
+  m_1d_buffer.compute(m_buffer_copier, m_sync_info, 1);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -164,7 +164,7 @@ compute()
  * terme de memoire.
  */
 void VariableSynchronizeDispatcherSyncBufferBase::
-compute(IBufferCopier* copier,ItemGroupSynchronizeInfo* sync_info,Int32 dim2_size)
+compute(IBufferCopier* copier, ItemGroupSynchronizeInfo* sync_info, Int32 dim2_size)
 {
   m_buffer_copier = copier;
   m_sync_info = sync_info;
@@ -184,25 +184,25 @@ compute(IBufferCopier* copier,ItemGroupSynchronizeInfo* sync_info,Int32 dim2_siz
   const Int32 datatype_size = m_ghost_memory_view.datatypeSize();
   {
     Integer array_index = 0;
-    for( Integer i=0, is=sync_list.size(); i<is; ++i ){
+    for (Integer i = 0, is = sync_list.size(); i < is; ++i) {
       const VariableSyncInfo& vsi = sync_list[i];
       Int32ConstArrayView ghost_grp = vsi.ghostIds();
       Integer local_size = ghost_grp.size();
       Int32 displacement = array_index;
-      m_ghost_displacements[i] =  displacement * datatype_size;
-      m_ghost_locals_buffer[i] = m_ghost_memory_view.subView(displacement,local_size);
+      m_ghost_displacements[i] = displacement * datatype_size;
+      m_ghost_locals_buffer[i] = m_ghost_memory_view.subView(displacement, local_size);
       array_index += local_size;
     }
   }
   {
     Integer array_index = 0;
-    for( Integer i=0, is=sync_list.size(); i<is; ++i ){
+    for (Integer i = 0, is = sync_list.size(); i < is; ++i) {
       const VariableSyncInfo& vsi = sync_list[i];
       Int32ConstArrayView share_grp = vsi.shareIds();
       Integer local_size = share_grp.size();
       Int32 displacement = array_index;
-      m_share_displacements[i] =  displacement * datatype_size;
-      m_share_locals_buffer[i] = m_share_memory_view.subView(displacement,local_size);
+      m_share_displacements[i] = displacement * datatype_size;
+      m_share_locals_buffer[i] = m_share_memory_view.subView(displacement, local_size);
       array_index += local_size;
     }
   }
@@ -252,7 +252,7 @@ copySend(Integer index)
  * \todo: ne pas converver les tampons pour chaque type de donnée des variables
  * car leur conservation est couteuse en terme de memoire.
  */
-template<typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::SyncBuffer::
+template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::SyncBuffer::
 _allocateBuffers()
 {
   auto sync_list = m_sync_info->infos();
@@ -260,15 +260,15 @@ _allocateBuffers()
 
   Integer total_ghost_buffer = 0;
   Integer total_share_buffer = 0;
-  for( Integer i=0; i<nb_message; ++i ){
+  for (Integer i = 0; i < nb_message; ++i) {
     total_ghost_buffer += sync_list[i].nbGhost();
     total_share_buffer += sync_list[i].nbShare();
   }
-  m_ghost_buffer.resize(total_ghost_buffer*m_dim2_size);
-  m_share_buffer.resize(total_share_buffer*m_dim2_size);
+  m_ghost_buffer.resize(total_ghost_buffer * m_dim2_size);
+  m_share_buffer.resize(total_share_buffer * m_dim2_size);
 
-  m_ghost_memory_view = MutableMemoryView(Span<SimpleType>(m_ghost_buffer.data(),total_ghost_buffer),m_dim2_size);
-  m_share_memory_view = MutableMemoryView(Span<SimpleType>(m_share_buffer.data(),total_share_buffer),m_dim2_size);
+  m_ghost_memory_view = MutableMemoryView(Span<SimpleType>(m_ghost_buffer.data(), total_ghost_buffer), m_dim2_size);
+  m_share_memory_view = MutableMemoryView(Span<SimpleType>(m_share_buffer.data(), total_share_buffer), m_dim2_size);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -328,39 +328,39 @@ compute()
 /*---------------------------------------------------------------------------*/
 
 void VariableSynchronizerMultiDispatcher::
-synchronize(VariableCollection vars,ConstArrayView<VariableSyncInfo> sync_infos)
+synchronize(VariableCollection vars, ConstArrayView<VariableSyncInfo> sync_infos)
 {
-  Ref<IParallelExchanger> exchanger{ParallelMngUtils::createExchangerRef(m_parallel_mng)};
+  Ref<IParallelExchanger> exchanger{ ParallelMngUtils::createExchangerRef(m_parallel_mng) };
   Integer nb_rank = sync_infos.size();
   Int32UniqueArray recv_ranks(nb_rank);
-  for( Integer i=0; i<nb_rank; ++i ){
+  for (Integer i = 0; i < nb_rank; ++i) {
     Int32 rank = sync_infos[i].targetRank();
     exchanger->addSender(rank);
     recv_ranks[i] = rank;
   }
   exchanger->initializeCommunicationsMessages(recv_ranks);
-  for( Integer i=0; i<nb_rank; ++i ){
+  for (Integer i = 0; i < nb_rank; ++i) {
     ISerializeMessage* msg = exchanger->messageToSend(i);
     ISerializer* sbuf = msg->serializer();
     Int32ConstArrayView share_ids = sync_infos[i].shareIds();
     sbuf->setMode(ISerializer::ModeReserve);
-    for( VariableCollection::Enumerator ivar(vars); ++ivar; ){
-      (*ivar)->serialize(sbuf,share_ids,nullptr);
+    for (VariableCollection::Enumerator ivar(vars); ++ivar;) {
+      (*ivar)->serialize(sbuf, share_ids, nullptr);
     }
     sbuf->allocateBuffer();
     sbuf->setMode(ISerializer::ModePut);
-    for( VariableCollection::Enumerator ivar(vars); ++ivar; ){
-      (*ivar)->serialize(sbuf,share_ids,nullptr);
+    for (VariableCollection::Enumerator ivar(vars); ++ivar;) {
+      (*ivar)->serialize(sbuf, share_ids, nullptr);
     }
   }
   exchanger->processExchange();
-  for( Integer i=0; i<nb_rank; ++i ){
+  for (Integer i = 0; i < nb_rank; ++i) {
     ISerializeMessage* msg = exchanger->messageToReceive(i);
     ISerializer* sbuf = msg->serializer();
     Int32ConstArrayView ghost_ids = sync_infos[i].ghostIds();
     sbuf->setMode(ISerializer::ModeGet);
-    for( VariableCollection::Enumerator ivar(vars); ++ivar; ){
-      (*ivar)->serialize(sbuf,ghost_ids,nullptr);
+    for (VariableCollection::Enumerator ivar(vars); ++ivar;) {
+      (*ivar)->serialize(sbuf, ghost_ids, nullptr);
     }
   }
 }
@@ -383,7 +383,7 @@ VariableSynchronizerDispatcher::
 void VariableSynchronizerDispatcher::
 setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info)
 {
-  for( IVariableSynchronizeDispatcher* d : m_dispatcher->dispatchers() )
+  for (IVariableSynchronizeDispatcher* d : m_dispatcher->dispatchers())
     d->setItemGroupSynchronizeInfo(sync_info);
 }
 
@@ -393,10 +393,10 @@ setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info)
 void VariableSynchronizerDispatcher::
 compute()
 {
-  ConstArrayView<IVariableSynchronizeDispatcher*> dispatchers = m_dispatcher->dispatchers();
   m_parallel_mng->traceMng()->info(4) << "DISPATCH RECOMPUTE";
-  for( Integer i=0, is=dispatchers.size(); i<is; ++i )
-    dispatchers[i]->compute();
+  auto dispatchers = m_dispatcher->dispatchers();
+  for (IVariableSynchronizeDispatcher* d : dispatchers)
+    d->compute();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -406,15 +406,15 @@ compute()
 /*---------------------------------------------------------------------------*/
 
 void VariableSyncInfo::
-_changeIds(Array<Int32>& ids,Int32ConstArrayView old_to_new_ids)
+_changeIds(Array<Int32>& ids, Int32ConstArrayView old_to_new_ids)
 {
   UniqueArray<Int32> orig_ids(ids);
   ids.clear();
 
-  for( Integer z=0, zs=orig_ids.size(); z<zs; ++z ){
+  for (Integer z = 0, zs = orig_ids.size(); z < zs; ++z) {
     Int32 old_id = orig_ids[z];
     Int32 new_id = old_to_new_ids[old_id];
-    if (new_id!=NULL_ITEM_LOCAL_ID)
+    if (new_id != NULL_ITEM_LOCAL_ID)
       ids.add(new_id);
   }
 }
@@ -425,8 +425,8 @@ _changeIds(Array<Int32>& ids,Int32ConstArrayView old_to_new_ids)
 void VariableSyncInfo::
 changeLocalIds(Int32ConstArrayView old_to_new_ids)
 {
-  _changeIds(m_share_ids,old_to_new_ids);
-  _changeIds(m_ghost_ids,old_to_new_ids);
+  _changeIds(m_share_ids, old_to_new_ids);
+  _changeIds(m_ghost_ids, old_to_new_ids);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -442,8 +442,6 @@ changeLocalIds(Int32ConstArrayView old_to_new_ids)
 class SimpleVariableSynchronizerDispatcher
 : public AbstractGenericVariableSynchronizerDispatcher
 {
-  using SyncBufferBase = VariableSynchronizeDispatcherSyncBufferBase;
-
  public:
 
   class Factory;
@@ -509,40 +507,39 @@ arcaneCreateSimpleVariableSynchronizerFactory(IParallelMng* pm)
 void SimpleVariableSynchronizerDispatcher::
 beginSynchronize(IDataSynchronizeBuffer* vs_buf)
 {
-  IParallelMng* pm = this->m_parallel_mng;
+  IParallelMng* pm = m_parallel_mng;
 
-  bool use_blocking_send = false;
+  const bool use_blocking_send = false;
   auto sync_list = _syncInfo()->infos();
-  Integer nb_message = sync_list.size();
+  Int32 nb_message = sync_list.size();
 
   /*pm->traceMng()->info() << " ** ** COMMON BEGIN SYNC n=" << nb_message
                          << " this=" << (IVariableSynchronizeDispatcher*)this
                          << " m_sync_list=" << &this->m_sync_list;*/
 
-  //SyncBuffer& sync_buffer = m_1d_buffer;
   // Envoie les messages de réception non bloquant
-  for( Integer i=0; i<nb_message; ++i ){
+  for (Integer i = 0; i < nb_message; ++i) {
     const VariableSyncInfo& vsi = sync_list[i];
-    auto ghost_local_buffer = _toLegacySmallView(vs_buf->receiveBuffer(i));
-    if (!ghost_local_buffer.empty()){
-      Parallel::Request rval = pm->recv(ghost_local_buffer,vsi.targetRank(),false);
+    auto buf = _toLegacySmallView(vs_buf->receiveBuffer(i));
+    if (!buf.empty()) {
+      Parallel::Request rval = pm->recv(buf, vsi.targetRank(), false);
       m_all_requests.add(rval);
     }
   }
 
-  // Envoie les messages d'envoie en mode non bloquant.
-  for( Integer i=0; i<nb_message; ++i ){
-    const VariableSyncInfo& vsi = sync_list[i];
-    auto share_local_buffer = _toLegacySmallView(vs_buf->sendBuffer(i));
+  vs_buf->copyAllSend();
 
-    vs_buf->copySend(i);
+  // Envoie les messages d'envoi en mode non bloquant.
+  for (Integer i = 0; i < nb_message; ++i) {
+    const VariableSyncInfo& vsi = sync_list[i];
+    auto buf = _toLegacySmallView(vs_buf->sendBuffer(i));
 
     //ConstArrayView<SimpleType> const_share = share_local_buffer;
-    if (!share_local_buffer.empty()){
+    if (!buf.empty()) {
       //for( Integer i=0, is=share_local_buffer.size(); i<is; ++i )
       //trace->info() << "TO rank=" << vsi.m_target_rank << " I=" << i << " V=" << share_local_buffer[i]
       //                << " lid=" << share_grp[i] << " v2=" << var_values[share_grp[i]];
-      Parallel::Request rval = pm->send(share_local_buffer,vsi.targetRank(),use_blocking_send);
+      Parallel::Request rval = pm->send(buf, vsi.targetRank(), use_blocking_send);
       if (!use_blocking_send)
         m_all_requests.add(rval);
     }
@@ -557,27 +554,48 @@ endSynchronize(IDataSynchronizeBuffer* vs_buf)
 {
   IParallelMng* pm = m_parallel_mng;
 
-  auto sync_list = _syncInfo()->infos();
-  Integer nb_message = sync_list.size();
-
   /*pm->traceMng()->info() << " ** ** COMMON END SYNC n=" << nb_message
                          << " this=" << (IVariableSynchronizeDispatcher*)this
                          << " m_sync_list=" << &this->m_sync_list;*/
 
-  // Attend que les receptions se terminent
+  // Attend que les réceptions se terminent
   pm->waitAllRequests(m_all_requests);
   m_all_requests.clear();
 
   // Recopie dans la variable le message de retour.
-  for( Integer i=0; i<nb_message; ++i )
-    vs_buf->copyReceive(i);
+  vs_buf->copyAllReceive();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IDataSynchronizeBuffer::
+copyAllSend()
+{
+  Int32 nb_rank = nbRank();
+  for (Int32 i = 0; i < nb_rank; ++i)
+    copySend(i);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IDataSynchronizeBuffer::
+copyAllReceive()
+{
+  Int32 nb_rank = nbRank();
+  for (Int32 i = 0; i < nb_rank; ++i)
+    copyReceive(i);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #define ARCANE_INSTANTIATE(type) \
-  template class ARCANE_TEMPLATE_EXPORT VariableSynchronizeDispatcher<type>;\
+  template class ARCANE_TEMPLATE_EXPORT VariableSynchronizeDispatcher<type>; \
   template class ARCANE_TEMPLATE_EXPORT GenericVariableSynchronizeDispatcher<type>;
 
 ARCANE_INSTANTIATE(Byte);

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
@@ -256,19 +256,18 @@ template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::S
 _allocateBuffers()
 {
   auto sync_list = m_sync_info->infos();
-  Integer nb_message = sync_list.size();
 
-  Integer total_ghost_buffer = 0;
-  Integer total_share_buffer = 0;
-  for (Integer i = 0; i < nb_message; ++i) {
-    total_ghost_buffer += sync_list[i].nbGhost();
-    total_share_buffer += sync_list[i].nbShare();
+  Int64 total_ghost_buffer = 0;
+  Int64 total_share_buffer = 0;
+  for (auto& s : sync_list) {
+    total_ghost_buffer += s.nbGhost();
+    total_share_buffer += s.nbShare();
   }
-  m_ghost_buffer.resize(total_ghost_buffer * m_dim2_size);
-  m_share_buffer.resize(total_share_buffer * m_dim2_size);
+  m_buffer.resize((total_ghost_buffer + total_share_buffer) * m_dim2_size);
+  Int64 share_offset = total_ghost_buffer * m_dim2_size;
 
-  m_ghost_memory_view = MutableMemoryView(Span<SimpleType>(m_ghost_buffer.data(), total_ghost_buffer), m_dim2_size);
-  m_share_memory_view = MutableMemoryView(Span<SimpleType>(m_share_buffer.data(), total_share_buffer), m_dim2_size);
+  m_ghost_memory_view = MutableMemoryView(m_buffer.span().subspan(0, total_ghost_buffer), m_dim2_size);
+  m_share_memory_view = MutableMemoryView(m_buffer.span().subspan(share_offset, total_share_buffer), m_dim2_size);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -283,10 +283,8 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
 
   private:
 
-    //! Buffer pour toutes les données des entités fantômes qui serviront en réception
-    UniqueArray<SimpleType> m_ghost_buffer;
-    //! Buffer pour toutes les données des entités partagées qui serviront en envoi
-    UniqueArray<SimpleType> m_share_buffer;
+    //! Buffer contenant les données concaténées en envoi et réception
+    UniqueArray<SimpleType> m_buffer;
   };
 
  public:

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -41,12 +41,8 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 class VariableSynchronizer;
-class Timer;
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 class VariableSynchronizerMultiDispatcher;
+class Timer;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -142,15 +138,29 @@ class ARCANE_IMPL_EXPORT IVariableSynchronizeDispatcher
 class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcherBuildInfo
 {
  public:
-  VariableSynchronizeDispatcherBuildInfo(IParallelMng* pm, GroupIndexTable* table)
-  : m_parallel_mng(pm), m_table(table) { }
+
+  VariableSynchronizeDispatcherBuildInfo(IParallelMng* pm, GroupIndexTable* table,
+                                         Ref<IGenericVariableSynchronizerDispatcherFactory> factory)
+  : m_parallel_mng(pm)
+  , m_table(table)
+  , m_factory(factory)
+  {}
+
  public:
-  IParallelMng* parallelMng() const{ return m_parallel_mng; }
+
+  IParallelMng* parallelMng() const { return m_parallel_mng; }
   //! Table d'index pour le groupe. Peut-être nul.
   GroupIndexTable* table() const { return m_table; }
+  Ref<IGenericVariableSynchronizerDispatcherFactory> factory() const
+  {
+    return m_factory;
+  }
+
  private:
+
   IParallelMng* m_parallel_mng;
   GroupIndexTable* m_table;
+  Ref<IGenericVariableSynchronizerDispatcherFactory> m_factory;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -261,7 +271,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcherSyncBufferBase
  * Cette classe est abstraite. La classe dérivée doit fournir une implémentation
  * de beginSynchronize() et endSynchronize().
  */
-template<class SimpleType>
+template <class SimpleType>
 class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
 : public IDataTypeDataDispatcherT<SimpleType>
 , public IVariableSynchronizeDispatcher
@@ -272,16 +282,16 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
 
  public:
 
-  //! Gère les buffers d'envoie et réception pour la synchronisation
+  //! Gère les buffers d'envoi et réception pour la synchronisation
   class ARCANE_IMPL_EXPORT SyncBuffer
   : public SyncBufferBase
   {
 
-  public:
+   public:
 
     void _allocateBuffers() override;
 
-  private:
+   private:
 
     //! Buffer contenant les données concaténées en envoi et réception
     UniqueArray<SimpleType> m_buffer;
@@ -297,60 +307,31 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
   void applyDispatch(IScalarDataT<SimpleType>* data) override;
   void applyDispatch(IArrayDataT<SimpleType>* data) override;
   void applyDispatch(IArray2DataT<SimpleType>* data) override;
-  void applyDispatch(IMultiArray2DataT<SimpleType>* data) override;
-  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) override;
-  void compute() override;
+
+ public:
+
+  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) final;
+  void compute() final;
 
  protected:
 
-  virtual void _beginSynchronize(SyncBufferBase& sync_buffer) =0;
-  virtual void _endSynchronize(SyncBufferBase& sync_buffer) =0;
+  void _beginSynchronize(SyncBufferBase& sync_buffer)
+  {
+    m_generic_instance->beginSynchronize(sync_buffer.genericBuffer());
+  }
+  void _endSynchronize(SyncBufferBase& sync_buffer)
+  {
+    m_generic_instance->endSynchronize(sync_buffer.genericBuffer());
+  }
 
- protected:
+ private:
 
   IParallelMng* m_parallel_mng = nullptr;
   IBufferCopier* m_buffer_copier = nullptr;
   ItemGroupSynchronizeInfo* m_sync_info = nullptr;
-  //TODO: a supprimer car l'information est dans \a m_sync_info;
-  ConstArrayView<VariableSyncInfo> m_sync_list;
   SyncBuffer m_1d_buffer;
   SyncBuffer m_2d_buffer;
   bool m_is_in_sync = false;
-
- private:
-};
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Class template pour les implémentations génériques indépendantes
- * du type de donnée utilisé.
- */
-template <typename SimpleType>
-class ARCANE_IMPL_EXPORT GenericVariableSynchronizeDispatcher
-: public VariableSynchronizeDispatcher<SimpleType>
-{
- public:
-
-  using SyncBufferBase = VariableSynchronizeDispatcherSyncBufferBase;
-
- public:
-
-  explicit GenericVariableSynchronizeDispatcher(GenericVariableSynchronizeDispatcherBuildInfo& bi);
-
-  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) override
-  {
-    VariableSynchronizeDispatcher<SimpleType>::setItemGroupSynchronizeInfo(sync_info);
-    m_generic_instance->setItemGroupSynchronizeInfo(sync_info);
-  }
-  void compute() override;
-
- protected:
-
-  void _beginSynchronize(SyncBufferBase& sync_buffer) override;
-  void _endSynchronize(SyncBufferBase& sync_buffer) override;
-
- private:
 
   Ref<IGenericVariableSynchronizerDispatcherFactory> m_factory;
   Ref<IGenericVariableSynchronizerDispatcher> m_generic_instance;

--- a/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.cc
@@ -152,12 +152,8 @@ beginSynchronize(IDataSynchronizeBuffer* vs_buf)
   double send_copy_time = 0.0;
   {
     MpiTimeInterval tit(&send_copy_time);
-
     // Recopie les buffers d'envoi
-    auto sync_list = _syncInfo()->infos();
-    Integer nb_message = sync_list.size();
-    for (Integer i = 0; i < nb_message; ++i)
-      vs_buf->copySend(i);
+    vs_buf->copyAllSend();
   }
   Int64 total_share_size = vs_buf->totalSendSize();
   m_mpi_parallel_mng->stat()->add("SyncSendCopy", send_copy_time, total_share_size);
@@ -239,8 +235,7 @@ endSynchronize(IDataSynchronizeBuffer* vs_buf)
   // Recopie les valeurs recues
   {
     MpiTimeInterval tit(&copy_time);
-    for (Integer i = 0; i < nb_message; ++i)
-      vs_buf->copyReceive(i);
+    vs_buf->copyAllReceive();
   }
 
   Int64 total_ghost_size = vs_buf->totalReceiveSize();

--- a/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.cc
@@ -117,8 +117,7 @@ beginSynchronize(IDataSynchronizeBuffer* vs_buf)
 
   {
     MpiTimeInterval tit(&sync_copy_send_time);
-    for( Integer i=0; i<nb_message; ++i )
-      vs_buf->copySend(i);
+    vs_buf->copyAllSend();
   }
 
   {
@@ -136,8 +135,7 @@ beginSynchronize(IDataSynchronizeBuffer* vs_buf)
 
   {
     MpiTimeInterval tit(&sync_copy_recv_time);
-    for( Integer i=0; i<nb_message; ++i )
-      vs_buf->copyReceive(i);
+    vs_buf->copyAllReceive();
   }
 
   pm->stat()->add("SyncCopySend",sync_copy_send_time,1);

--- a/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.cc
@@ -151,11 +151,12 @@ beginSynchronize(IDataSynchronizeBuffer* vs_buf)
     }
   }
 
-  // Envoie les messages d'envoie en mode non bloquant.
+  vs_buf->copyAllSend();
+
+  // Envoie les messages d'envoi en mode non bloquant.
   for( Integer i=0; i<nb_message; ++i ){
     const VariableSyncInfo& vsi = sync_list[i];
     auto share_local_buffer = vs_buf->sendBuffer(i).smallView();
-    vs_buf->copySend(i);
     if (!share_local_buffer.empty()){
       MPI_Request mpi_request;
       mpi_profiling->iSend(share_local_buffer.data(),share_local_buffer.size(),
@@ -217,7 +218,7 @@ endSynchronize(IDataSynchronizeBuffer* vs_buf)
       double end_time = MPI_Wtime();
       wait_time += (end_time-begin_time);
     }
-    // Pour chaque requete terminee, effectue la copie
+    // Pour chaque requête terminée, effectue la copie
     for( int z=0; z<nb_completed_request; ++z ){
       int mpi_request_index = completed_requests[z];
       Integer index = m_remaining_recv_request_indexes[mpi_request_index];

--- a/arcane/src/arcane/parallel/mpi/MpiNeighborVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiNeighborVariableSynchronizeDispatcher.cc
@@ -129,9 +129,7 @@ beginSynchronize(IDataSynchronizeBuffer* buf)
     MpiTimeInterval tit(&send_copy_time);
 
     // Recopie les buffers d'envoi
-    Integer nb_message = buf->nbRank();
-    for (Integer i = 0; i < nb_message; ++i)
-      buf->copySend(i);
+    buf->copyAllSend();
   }
   Int64 total_share_size = buf->totalSendSize();
   m_mpi_parallel_mng->stat()->add("SyncSendCopy", send_copy_time, total_share_size);
@@ -185,8 +183,7 @@ endSynchronize(IDataSynchronizeBuffer* buf)
   // Recopie les valeurs recues
   {
     MpiTimeInterval tit(&copy_time);
-    for (Integer i = 0; i < nb_message; ++i)
-      buf->copyReceive(i);
+    buf->copyAllReceive();
   }
 
   Int64 total_ghost_size = buf->totalReceiveSize();

--- a/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
@@ -325,8 +325,8 @@ class MpiParallelMngUtilsFactory
     }
     VariableSynchronizerDispatcher* vd = nullptr;
     if (generic_factory.get()){
-      GenericVariableSynchronizeDispatcherBuildInfo bi(mpi_pm,table,generic_factory);
-      vd = new VariableSynchronizerDispatcher(pm,DispatcherType::create<GenericVariableSynchronizeDispatcher>(bi));
+      VariableSynchronizeDispatcherBuildInfo bi(mpi_pm,table,generic_factory);
+      vd = new VariableSynchronizerDispatcher(pm,DispatcherType::create<VariableSynchronizeDispatcher>(bi));
     }
     if (!vd)
       ARCANE_FATAL("No synchronizer created");

--- a/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
@@ -174,8 +174,7 @@ beginSynchronize(IDataSynchronizeBuffer* ds_buf)
     }
 
     // Recopie les buffers d'envoi dans \a var_values
-    for (Integer i = 0; i < nb_message; ++i)
-      ds_buf->copySend(i);
+    ds_buf->copyAllSend();
 
     // Poste les messages d'envoi en mode non bloquant.
     for (Integer i = 0; i < nb_message; ++i) {


### PR DESCRIPTION
- Remove class `GenericVariableSynchronizeDispatcherBuildInfo`. The factory is now in `VariableSynchronizeDispatcherBuildInfo`
- Use one buffer for receive and send instead of two buffers
- Add methods `IDataSynchronizeBuffer::copyAllReceive()` and `IDataSynchronizeBuffer::copyAllSend()` to do all send and receive copies.