### PR TITLE
Use a specific container for 'RUNCOMMAND' using 'EnvAndGlobalCell' 

### DIFF
--- a/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.cc
+++ b/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommandMaterialEnumerate.cc                              (C) 2000-2022 */
+/* RunCommandMaterialEnumerate.cc                              (C) 2000-2023 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -21,19 +21,10 @@ namespace Arcane::Accelerator
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-extern "C++" ARCANE_ACCELERATOR_EXPORT EnvCellRunCommand
-operator<<(RunCommand& command,const Arcane::Materials::EnvCellVectorView& items)
+extern "C++" ARCANE_ACCELERATOR_EXPORT EnvAndGlobalCellRunCommand
+operator<<(RunCommand& command,const EnvAndGlobalCellRunCommand::Container& items)
 {
-  return EnvCellRunCommand(command,items);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-extern "C++" ARCANE_ACCELERATOR_EXPORT EnvCellRunCommand
-operator<<(RunCommand& command,Arcane::Materials::IMeshEnvironment* env)
-{
-  return EnvCellRunCommand(command,env->envView());
+  return EnvAndGlobalCellRunCommand(command,items);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/Concurrency.h
+++ b/arcane/src/arcane/core/Concurrency.h
@@ -210,12 +210,24 @@ arcaneParallelFor(Integer i0, Integer size, InstanceType* itype,
  * sur l'intervalle d'itération [i0,i0+size] avec les options \a options.
  */
 template <typename LambdaType> inline void
-arcaneParallelFor(Integer i0, Integer size, const ParallelLoopOptions& options,
+arcaneParallelFor(Integer i0, Integer size, const ForLoopRunInfo& options,
                   const LambdaType& lambda_function)
 {
   LambdaRangeFunctorT<LambdaType> ipf(lambda_function);
-  ParallelFor1DLoopInfo loop_info(i0, size, &ipf, ForLoopRunInfo(options));
+  ParallelFor1DLoopInfo loop_info(i0, size, &ipf, options);
   TaskFactory::executeParallelFor(loop_info);
+}
+
+/*!
+ * \ingroup Concurrency
+ * \brief Applique en concurrence la fonction lambda \a lambda_function
+ * sur l'intervalle d'itération [i0,i0+size] avec les options \a options.
+ */
+template <typename LambdaType> inline void
+arcaneParallelFor(Integer i0, Integer size, const ParallelLoopOptions& options,
+                  const LambdaType& lambda_function)
+{
+  arcaneParallelFor(i0, size, ForLoopRunInfo(options),lambda_function);
 }
 
 /*!


### PR DESCRIPTION
This is needed to allow usage of the same original container (for example `EnvCellVectorView`)  with several different kind of iterators. It also has the following advantages:
- the code is simpler
- this will allow us to reuse the function `_applyEnvCell()` for other containers.
