### PR TITLE
Fix values not initialiazed with default constructor in Array2::resize() in some cases

### DIFF
--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -1,15 +1,14 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Array.h                                                     (C) 2000-2022 */
+/* Array.h                                                     (C) 2000-2023 */
 /*                                                                           */
 /* Tableau 1D.                                                               */
 /*---------------------------------------------------------------------------*/
-
 #ifndef ARCCORE_COLLECTIONS_ARRAY_H
 #define ARCCORE_COLLECTIONS_ARRAY_H
 /*---------------------------------------------------------------------------*/
@@ -59,7 +58,8 @@ class ARCCORE_COLLECTIONS_EXPORT ArrayMetaData
   {}
 
  protected:
-  //! Nombre de références sur cet objet.
+
+ //! Nombre de références sur cet objet.
   Int64 nb_ref;
   //! Nombre d'éléments alloués
   Int64 capacity;
@@ -82,13 +82,16 @@ class ARCCORE_COLLECTIONS_EXPORT ArrayMetaData
   static void overlapError ARCCORE_NORETURN (const void* begin1,Int64 size1,
                                              const void* begin2,Int64 size2);
  protected:
-  using MemoryPointer = void*;
+
+ using MemoryPointer = void*;
 
   MemoryPointer _allocate(Int64 nb,Int64 sizeof_true_type);
   MemoryPointer _reallocate(Int64 nb,Int64 sizeof_true_type,MemoryPointer current);
   void _deallocate(MemoryPointer current) ARCCORE_NOEXCEPT;
+
  private:
-  void _checkAllocator() const;
+
+ void _checkAllocator() const;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -126,6 +129,7 @@ template<typename T>
 class ArrayTraits
 {
  public:
+
   typedef const T& ConstReferenceType;
   typedef FalseType IsPODType;
 };
@@ -198,6 +202,7 @@ class ARCCORE_COLLECTIONS_EXPORT AbstractArrayBase
   ArrayMetaData m_meta_data;
 
  protected:
+
  /*!
   * \brief Indique si \a m_md fait référence à \a m_meta_data.
   *
@@ -386,6 +391,7 @@ class AbstractArray
     return m_md->allocator;
   }
  public:
+
   operator ConstArrayView<T>() const
   {
     return ConstArrayView<T>(ARCCORE_CAST_SMALL_SIZE(size()),m_ptr);
@@ -394,7 +400,9 @@ class AbstractArray
   {
     return Span<const T>(m_ptr,m_md->size);
   }
+
  public:
+
   //! Nombre d'éléments du vecteur
   Integer size() const { return ARCCORE_CAST_SMALL_SIZE(m_md->size); }
   //! Nombre d'éléments du vecteur
@@ -420,6 +428,7 @@ class AbstractArray
     return false;
   }
  public:
+
   //! Elément d'indice \a i
   ConstReferenceType operator[](Int64 i) const
   {
@@ -433,13 +442,18 @@ class AbstractArray
     return m_ptr[i];
   }
  private:
+
   using AbstractArrayBase::m_meta_data;
+
  protected:
+
   // NOTE: Ces deux champs sont utilisés pour l'affichage TTF de totalview.
   // Si on modifie leur ordre il faut mettre à jour la partie correspondante
   // dans l'afficheur totalview de Arcane.
   T* m_ptr = nullptr;
+
  protected:
+
   //! Réserve le mémoire pour \a new_capacity éléments
   void _reserve(Int64 new_capacity)
   {
@@ -546,11 +560,14 @@ class AbstractArray
     _setMP(reinterpret_cast<TrueImpl*>(m_md->_reallocate(new_capacity,sizeof(T),m_ptr)));
   }
  public:
+
   void printInfos(std::ostream& o)
   {
     o << " Infos: size=" << m_md->size << " capacity=" << m_md->capacity << '\n';
   }
+
  protected:
+
   //! Mise à jour des références
   virtual void _updateReferences()
   {
@@ -828,8 +845,6 @@ class AbstractArray
     m_meta_data = ArrayMetaData();
     m_md = &m_meta_data;
   }
-
- private:
 };
 
 /*---------------------------------------------------------------------------*/
@@ -873,8 +888,11 @@ class Array
   using typename BaseClassType::size_type;
   using typename BaseClassType::difference_type;
  protected:
+
   Array() {}
+
  protected:
+
   //! Constructeur par déplacement (uniquement pour UniqueArray)
   Array(Array<T>&& rhs) ARCCORE_NOEXCEPT : AbstractArray<T>(std::move(rhs)) {}
 
@@ -887,15 +905,21 @@ class Array
     for( const auto& x : alist )
       this->add(x);
   }
+
  private:
+
   Array(const Array<T>& rhs) = delete;
   void operator=(const Array<T>& rhs) = delete;
 
+
  public:
+
   ~Array()
   {
   }
+
  public:
+
   operator ConstArrayView<T>() const
   {
     Integer s = arccoreCheckArraySize(m_md->size);
@@ -983,6 +1007,7 @@ class Array
   }
 
  public:
+
   //! Ajoute l'élément \a val à la fin du tableau
   void add(ConstReferenceType val)
   {
@@ -1022,13 +1047,15 @@ class Array
     this->_addRange(val.constSpan());
   }
   /*!
-   * \brief Change le nombre d'élément du tableau à \a s.
-   * Si le nouveau tableau est plus grand que l'ancien, les nouveaux
+   * \brief Change le nombre d'éléments du tableau à \a s.
+   *
+   * \note Si le nouveau tableau est plus grand que l'ancien, les nouveaux
    * éléments ne sont pas initialisés s'il s'agit d'un type POD.
    */
   void resize(Int64 s) { this->_resize(s); }
   /*!
-   * \brief Change le nombre d'élément du tableau à \a s.
+   * \brief Change le nombre d'éléments du tableau à \a s.
+   *
    * Si le nouveau tableau est plus grand que l'ancien, les nouveaux
    * éléments sont initialisé avec la valeur \a fill_value.
    */
@@ -1245,6 +1272,7 @@ class Array
   {
     return ArrayRange<const_pointer>(m_ptr,m_ptr+m_md->size);
   }
+
  public:
 
   //@{ Méthodes pour compatibilité avec la STL.
@@ -1254,7 +1282,8 @@ class Array
     this->add(val);
   }
   //@}
-private:
+
+ private:
 
   //! Method called from totalview debugger
   static int TV_ttf_display_type(const Arccore::Array<T> * obj);
@@ -1310,7 +1339,6 @@ class SharedArray
 
  public:
 
- public:
   //! Créé un tableau vide
   SharedArray() : Array<T>(), m_next(nullptr), m_prev(nullptr) {}
   //! Créé un tableau de \a size éléments contenant la valeur \a value.
@@ -1406,6 +1434,7 @@ class SharedArray
   {
     _removeReference();
   }
+
  public:
 
   //! Clone le tableau
@@ -1413,7 +1442,9 @@ class SharedArray
   {
     return SharedArray<T>(this->constSpan());
   }
+
  protected:
+
   void _initReference(const ThatClassType& rhs)
   {
     // TODO fusionner avec l'implémentation de SharedArray2
@@ -1490,11 +1521,14 @@ class SharedArray
     }
   }
  private:
+
   ThatClassType* m_next; //!< Référence suivante dans la liste chaînée
   ThatClassType* m_prev; //!< Référence précédente dans la liste chaînée
+
  private:
+
   //! Interdit
-  void operator=(const Array<T>& rhs);
+  void operator=(const Array<T>& rhs) = delete;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -1542,7 +1576,6 @@ class UniqueArray
 
  public:
 
- public:
   //! Créé un tableau vide
   UniqueArray() {}
   //! Créé un tableau de \a size éléments contenant la valeur \a value.
@@ -1668,7 +1701,9 @@ class UniqueArray
   ~UniqueArray() override
   {
   }
+
  public:
+
   /*!
    * \brief Échange les valeurs de l'instance avec celles de \a rhs.
    *

--- a/arccore/src/collections/arccore/collections/Array2.h
+++ b/arccore/src/collections/arccore/collections/Array2.h
@@ -1,15 +1,14 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Array2.h                                                    (C) 2000-2022 */
+/* Array2.h                                                    (C) 2000-2023 */
 /*                                                                           */
 /* Tableau 2D classique.                                                     */
 /*---------------------------------------------------------------------------*/
-
 #ifndef ARCCORE_UTILS_ARRAY2_H
 #define ARCCORE_UTILS_ARRAY2_H
 /*---------------------------------------------------------------------------*/
@@ -42,6 +41,7 @@ class Array2
 : private AbstractArray<DataType>
 {
  protected:
+
   enum CloneBehaviour
   {
     CB_Clone,
@@ -54,17 +54,23 @@ class Array2
   };
   //TODO: verifier qu'on n'affecte pas m_p->dim1_size ou
   // m_md->dim2_size si m_p est TrueImpl::shared_null.
+
  private:
+
   typedef AbstractArray<DataType> Base;
   typedef typename Base::ConstReferenceType ConstReferenceType;
+
  protected:
+
   using AbstractArray<DataType>::m_ptr;
   using AbstractArray<DataType>::m_md;
   using AbstractArray<DataType>::_setMP2;
   using AbstractArray<DataType>::_setMP;
   using AbstractArray<DataType>::_destroy;
   using AbstractArray<DataType>::_internalDeallocate;
+
  protected:
+
   Array2() : AbstractArray<DataType>() {}
   //! Créé un tableau de \a size1 * \a size2 éléments.
   Array2(Int64 size1,Int64 size2)
@@ -80,6 +86,7 @@ class Array2
   {
     this->copy(rhs);
   }
+
  protected:
 
   //! Créé un tableau vide avec un allocateur spécifique \a allocator
@@ -110,6 +117,7 @@ class Array2
   Array2(Array2<DataType>&& rhs) : AbstractArray<DataType>(std::move(rhs)) {}
 
  public:
+
   // TODO: retourner un Span.
   ArrayView<DataType> operator[](Int64 i)
   {
@@ -250,7 +258,9 @@ class Array2
   {
     return Span<const DataType>(m_ptr,m_md->size);
   }
+
  public:
+
   operator Array2View<DataType>()
   {
     return view();
@@ -284,6 +294,7 @@ class Array2
     return Span2<const DataType>(m_ptr,m_md->dim1_size,m_md->dim2_size);
   }
  public:
+
   Integer dim2Size() const { return ARCCORE_CAST_SMALL_SIZE(m_md->dim2_size); }
   Integer dim1Size() const { return ARCCORE_CAST_SMALL_SIZE(m_md->dim1_size); }
   Int64 largeDim2Size() const { return m_md->dim2_size; }
@@ -295,29 +306,56 @@ class Array2
     _arccoreCheckSharedNull();
   }
 
-  //! Redimensionne uniquement la première dimension en laissant la deuxième à l'identique
+  /*!
+   * \brief Redimensionne uniquement la première dimension en laissant
+   * la deuxième à l'identique.
+   *
+   * Les éventuelles nouvelles valeurs sont initialisées avec le constructeur par défaut.
+   */
   void resize(Int64 new_size)
   {
     _resize(new_size,IB_InitWithDefault);
   }
-  //! Redimensionne uniquement la première dimension en laissant la deuxième à l'identique
+
+  /*!
+   * \brief Redimensionne uniquement la première dimension en laissant
+   * la deuxième à l'identique.
+   *
+   * Les éventuelles nouvelles valeurs NE sont PAS initialisées.
+   */
   void resizeNoInit(Int64 new_size)
   {
     _resize(new_size,IB_NoInit);
   }
-  //! Réalloue les deux dimensions
+
+  /*!
+   * \brief Réalloue les deux dimensions.
+   *
+   * Les éventuelles nouvelles valeurs sont initialisées avec le constructeur par défaut.
+   */
   void resize(Int64 new_size1,Int64 new_size2)
   {
     _resize(new_size1,new_size2,IB_InitWithDefault);
   }
-  //! Réalloue les deux dimensions
+
+  /*!
+   * \brief Réalloue les deux dimensions.
+   *
+   * Les éventuelles nouvelles valeurs NE sont PAS initialisées.
+   */
   void resizeNoInit(Int64 new_size1,Int64 new_size2)
   {
     _resize(new_size1,new_size2,IB_NoInit);
   }
+
+  //! Nombre total d'éléments (dim1Size()*dim2Size())
   Integer totalNbElement() const { return ARCCORE_CAST_SMALL_SIZE(m_md->dim1_size*m_md->dim2_size); }
+
+  //! Nombre total d'éléments (largeDim1Size()*largeDim2Size())
   Int64 largeTotalNbElement() const { return m_md->dim1_size*m_md->dim2_size; }
+
  protected:
+
   //! Redimensionne uniquement la première dimension en laissant la deuxième à l'identique
   void _resize(Int64 new_size,InitBehaviour rb)
   {
@@ -328,6 +366,7 @@ class Array2
     m_md->dim1_size = new_size;
     _arccoreCheckSharedNull();
   }
+
   //! Réalloue les deux dimensions
   void _resize(Int64 new_size1,Int64 new_size2,InitBehaviour rb)
   {
@@ -348,6 +387,7 @@ class Array2
     else
       throw NotImplementedException("Array2::resize","already sized");
   }
+
   void _resizeFromEmpty(Int64 new_size1,Int64 new_size2,InitBehaviour rb)
   {
     _resize2(new_size1,new_size2,rb);
@@ -355,6 +395,7 @@ class Array2
     m_md->dim2_size = new_size2;
     _arccoreCheckSharedNull();
   }
+
   void _resizeSameDim1ReduceDim2(Int64 new_size2,InitBehaviour rb)
   {
     ARCCORE_ASSERT((new_size2<m_md->dim2_size),("Bad Size"));
@@ -368,6 +409,7 @@ class Array2
     m_md->dim2_size = new_size2;
     _arccoreCheckSharedNull();
   }
+
   void _resizeSameDim1IncreaseDim2(Int64 new_size2,InitBehaviour rb)
   {
     ARCCORE_ASSERT((new_size2>m_md->dim2_size),("Bad Size"));
@@ -381,7 +423,17 @@ class Array2
     }
     m_md->dim2_size = new_size2;
     _arccoreCheckSharedNull();
+    if (rb==IB_InitWithDefault){
+      // Remet les valeurs par défaut pour les nouveaux éléments
+      for( Int64 i=0; i<n; ++i ){
+        for( Int64 j=n2; j<new_size2; ++j ){
+          m_ptr[(i*new_size2)+j] = DataType{};
+        }
+      }
+      
+    }
   }
+
   void _resize2(Int64 d1,Int64 d2,InitBehaviour rb)
   {
     Int64 new_size = d1*d2;
@@ -397,15 +449,19 @@ class Array2
     else
       throw NotSupportedException("Array2::_resize2","invalid value InitBehaviour");
   }
+
   void _move(Array2<DataType>& rhs)
   {
     Base::_move(rhs);
   }
+
   void _swap(Array2<DataType>& rhs)
   {
     Base::_swap(rhs);
   }
+
  private:
+
   void _arccoreCheckSharedNull()
   {
     if (!m_ptr)
@@ -413,7 +469,9 @@ class Array2
     if (!m_md->is_not_null)
       ArrayMetaData::throwNotNullExpected();
   }
+
  protected:
+
   void _copyMetaData(const Array2<DataType>& rhs)
   {
     AbstractArray<DataType>::_copyMetaData(rhs);

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -557,6 +557,61 @@ TEST(Array2, Misc)
     ASSERT_TRUE(is_ok);
 #endif
   }
+  {
+    UniqueArray2<Int32> c;
+    c.resize(2, 1);
+    std::cout << "V1=" << c.to1DSpan() << "\n";
+    c[0][0] = 2;
+    c[1][0] = 3;
+    c.resize(2, 2);
+    std::cout << "V2=" << c.to1DSpan() << "\n";
+    ASSERT_EQ(c[0][0], 2);
+    ASSERT_EQ(c[1][0], 3);
+    ASSERT_EQ(c[0][1], 0);
+    ASSERT_EQ(c[1][1], 0);
+  }
+  {
+    UniqueArray2<Int32> c;
+    c.resizeNoInit(2, 1);
+    c[0][0] = 1;
+    c[1][0] = 2;
+    c.resizeNoInit(2, 2);
+    c[0][1] = 4;
+    c[1][1] = 5;
+    std::cout << "X1=" << c.to1DSpan() << "\n";
+    ASSERT_EQ(c[0][0], 1);
+    ASSERT_EQ(c[1][0], 2);
+    ASSERT_EQ(c[0][1], 4);
+    ASSERT_EQ(c[1][1], 5);
+    c.resize(3, 2);
+    std::cout << "X2=" << c.to1DSpan() << "\n";
+    ASSERT_EQ(c[0][0], 1);
+    ASSERT_EQ(c[1][0], 2);
+    ASSERT_EQ(c[0][1], 4);
+    ASSERT_EQ(c[1][1], 5);
+    ASSERT_EQ(c[2][0], 0);
+    ASSERT_EQ(c[2][1], 0);
+    c[2][0] = 8;
+    c[2][1] = 10;
+    c.resize(6, 5);
+    std::cout << "X3=" << c.to1DSpan() << "\n";
+    ASSERT_EQ(c[0][0], 1);
+    ASSERT_EQ(c[1][0], 2);
+    ASSERT_EQ(c[0][1], 4);
+    ASSERT_EQ(c[1][1], 5);
+    ASSERT_EQ(c[2][0], 8);
+    ASSERT_EQ(c[2][1], 10);
+    for (int i = 0; i < 4; ++i) {
+      ASSERT_EQ(c[i][2], 0);
+      ASSERT_EQ(c[i][3], 0);
+      ASSERT_EQ(c[i][4], 0);
+    }
+    for (int j = 0; j < 5; ++j) {
+      ASSERT_EQ(c[3][j], 0);
+      ASSERT_EQ(c[4][j], 0);
+      ASSERT_EQ(c[5][j], 0);
+    }
+  }
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The default constructor was not called to initialize additionnal values when called `resize()` with the same first dimension and increasing the second dimension (for exemple `resize(3,2)` then `resize(3,4)`). In this case, the additional values of the array might contains values of other elements before the resize.