### PR TITLE
Add a class 'SmallArray' for arrays with a small memory buffer owned by the instance

### DIFF
--- a/arcane/src/arcane/utils/SmallArray.cc
+++ b/arcane/src/arcane/utils/SmallArray.cc
@@ -1,0 +1,111 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* SmallArray.cc                                               (C) 2000-2023 */
+/*                                                                           */
+/* Tableau 1D de données avec buffer pré-alloué.                             */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/SmallArray.h"
+
+#include <cstdlib>
+#include <cstring>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::impl
+{
+
+namespace
+{
+//! A mettre à true si on souhaite activer les traces d'allocation
+const bool is_verbose = false;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool StackMemoryAllocator::
+hasRealloc() const
+{
+  return true;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void* StackMemoryAllocator::
+allocate(size_t new_size)
+{
+  if (new_size <= m_preallocated_size) {
+    if (is_verbose)
+      std::cout << "ALLOCATE: use preallocated s=" << new_size << "\n";
+    return m_preallocated_buffer;
+  }
+
+  if (is_verbose)
+    std::cout << "ALLOCATE: use malloc s=" << new_size << "\n";
+  return std::malloc(new_size);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void* StackMemoryAllocator::
+reallocate(void* current_ptr, size_t new_size)
+{
+  if (current_ptr != m_preallocated_buffer) {
+    if (new_size < m_preallocated_size) {
+      // On passe d'un pointeur alloué vers notre buffer interne.
+      // Il faut recopier les valeurs. On ne connait pas exactement
+      // la taille de 'current_ptr' mais on est certain qu'elle est
+      // supérieure à 'm_preallocated_size' donc à 'new_size'.
+      // On ne recopie donc que ces valeurs là
+      if (is_verbose)
+        std::cout << "REALLOCATE: use own buffer from realloc s=" << new_size << "\n";
+      std::memcpy(m_preallocated_buffer, current_ptr, new_size);
+      std::free(current_ptr);
+      return m_preallocated_buffer;
+    }
+    if (is_verbose)
+      std::cout << "REALLOCATE: use realloc s=" << new_size << "\n";
+    return std::realloc(current_ptr, new_size);
+  }
+
+  if (new_size <= m_preallocated_size) {
+    if (is_verbose)
+      std::cout << "REALLOCATE: use buffer because small size s=" << new_size << "\n";
+    return m_preallocated_buffer;
+  }
+
+  // Il faut allouer et recopier depuis le buffer pré-alloué.
+  if (is_verbose)
+    std::cout << "REALLOCATE: use malloc and copy s=" << new_size << "\n";
+  void* new_ptr = std::malloc(new_size);
+  std::memcpy(new_ptr, m_preallocated_buffer, m_preallocated_size);
+  return new_ptr;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void StackMemoryAllocator::
+deallocate(void* ptr)
+{
+  if (ptr != m_preallocated_buffer)
+    std::free(ptr);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/SmallArray.h
+++ b/arcane/src/arcane/utils/SmallArray.h
@@ -1,0 +1,230 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* SmallArray.h                                                (C) 2000-2023 */
+/*                                                                           */
+/* Tableau 1D de données avec buffer pré-alloué.                             */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_UTILS_STACKARRAY_H
+#define ARCANE_UTILS_STACKARRAY_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/Array.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::impl
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \internal
+ * \brief Allocateur avec buffer pré-alloué.
+ *
+ * Le buffer pré-alloué \a m_preallocated_buffer est utilisé lorsque la
+ * taille demandée pour l'allocation est inférieure ou égale à
+ * \a m_preallocated_size.
+ *
+ * Le buffer utilisé doit rester valide durant toute la durée de vie de l'allocateur.
+ */
+class ARCANE_UTILS_EXPORT StackMemoryAllocator final
+: public IMemoryAllocator
+{
+ public:
+
+  StackMemoryAllocator(void* buf, size_t size)
+  : m_preallocated_buffer(buf)
+  , m_preallocated_size(size)
+  {}
+
+ public:
+
+  bool hasRealloc() const final;
+  void* allocate(size_t new_size) final;
+  void* reallocate(void* current_ptr, size_t new_size) final;
+  void deallocate(void* ptr) final;
+  size_t adjustCapacity(size_t wanted_capacity, size_t) final
+  {
+    return wanted_capacity;
+  }
+  size_t guarantedAlignment() final { return 0; }
+
+ private:
+
+  void* m_preallocated_buffer = nullptr;
+  size_t m_preallocated_size = 0;
+};
+
+} // namespace Arcane::impl
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \ingroup Collection
+ *
+ * \brief Tableau 1D de données avec buffer pré-alloué.
+ *
+ * Cette classe s'utilise comme UniqueArray mais contient un buffer de taille
+ * fixe égale à \a BufSize qui est utilisé si la quantité de mémoire nécessaire
+ * est inférieur à \a BufSize. Cela permet d'éviter des allocations dynamiques
+ * lorsque le nombre d'éléments est faible. Si la mémoire nécessaire est
+ * supérieure à BufSize, On utilise une allocation dynamique standard.
+ */
+template <typename T, size_t BufSize = 128>
+class SmallArray final
+: public Array<T>
+{
+  using BaseClassType = AbstractArray<T>;
+  static constexpr Int64 nb_element_in_buf = (BufSize != 0) ? (BufSize / sizeof(T)) : 0;
+
+ public:
+
+  using typename BaseClassType::ConstReferenceType;
+  static constexpr size_t MemorySize = BufSize;
+
+ public:
+
+  //! Créé un tableau vide
+  SmallArray()
+  : m_stack_allocator(m_stack_buffer, BufSize)
+  {
+    this->_initFromAllocator(&m_stack_allocator, nb_element_in_buf);
+  }
+
+  //! Créé un tableau de \a size éléments contenant la valeur \a value.
+  SmallArray(Int64 req_size, ConstReferenceType value)
+  : SmallArray()
+  {
+    this->_resize(req_size, value);
+  }
+
+  //! Créé un tableau de \a asize éléments contenant la valeur par défaut du type T()
+  explicit SmallArray(Int64 asize)
+  : SmallArray()
+  {
+    this->_resize(asize);
+  }
+
+  //! Créé un tableau de \a asize éléments contenant la valeur par défaut du type T()
+  explicit SmallArray(Int32 asize)
+  : SmallArray((Int64)asize)
+  {
+  }
+
+  //! Créé un tableau de \a asize éléments contenant la valeur par défaut du type T()
+  explicit SmallArray(size_t asize)
+  : SmallArray((Int64)asize)
+  {
+  }
+
+  //! Créé un tableau en recopiant les valeurs de la value \a aview.
+  SmallArray(const ConstArrayView<T>& aview)
+  : SmallArray(Span<const T>(aview))
+  {
+  }
+
+  //! Créé un tableau en recopiant les valeurs de la value \a aview.
+  SmallArray(const Span<const T>& aview)
+  : SmallArray()
+  {
+    this->_initFromSpan(aview);
+  }
+
+  //! Créé un tableau en recopiant les valeurs de la value \a aview.
+  SmallArray(const ArrayView<T>& aview)
+  : SmallArray(Span<const T>(aview))
+  {
+  }
+
+  //! Créé un tableau en recopiant les valeurs de la value \a aview.
+  SmallArray(const Span<T>& aview)
+  : SmallArray(Span<const T>(aview))
+  {
+  }
+
+  SmallArray(std::initializer_list<T> alist)
+  : SmallArray()
+  {
+    this->_initFromInitializerList(alist);
+  }
+
+  //! Créé un tableau en recopiant les valeurs \a rhs.
+  SmallArray(const Array<T>& rhs)
+  : SmallArray(rhs.constSpan())
+  {
+  }
+
+  //! Copie les valeurs de \a rhs dans cette instance.
+  void operator=(const Array<T>& rhs)
+  {
+    this->copy(rhs.constSpan());
+  }
+
+  //! Copie les valeurs de la vue \a rhs dans cette instance.
+  void operator=(const ArrayView<T>& rhs)
+  {
+    this->copy(rhs);
+  }
+
+  //! Copie les valeurs de la vue \a rhs dans cette instance.
+  void operator=(const Span<T>& rhs)
+  {
+    this->copy(rhs);
+  }
+
+  //! Copie les valeurs de la vue \a rhs dans cette instance.
+  void operator=(const ConstArrayView<T>& rhs)
+  {
+    this->copy(rhs);
+  }
+
+  //! Copie les valeurs de la vue \a rhs dans cette instance.
+  void operator=(const Span<const T>& rhs)
+  {
+    this->copy(rhs);
+  }
+
+  //! Détruit l'instance.
+  ~SmallArray() override
+  {
+    // Il faut détruire explicitement car notre allocateur
+    // sera détruit avant la classe de base et ne sera plus valide
+    // lors de la désallocation.
+    this->_destroy();
+    this->_internalDeallocate();
+    this->_reset();
+  }
+
+ public:
+
+  template <size_t N> SmallArray(SmallArray<T, N>&& rhs) = delete;
+  template <size_t N> SmallArray<T, BufSize> operator=(SmallArray<T, N>&& rhs) = delete;
+
+ private:
+
+  char m_stack_buffer[BufSize];
+  impl::StackMemoryAllocator m_stack_allocator;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/utils/srcs.cmake
+++ b/arcane/src/arcane/utils/srcs.cmake
@@ -127,6 +127,8 @@ set(ARCANE_SOURCES
   SignalException.h
   Simd.cc
   Simd.h
+  SmallArray.cc
+  SmallArray.h
   TestLogger.h
   TestLogger.cc
   TraceAccessor2.h

--- a/arcane/src/arcane/utils/tests/TestCollections.cc
+++ b/arcane/src/arcane/utils/tests/TestCollections.cc
@@ -84,6 +84,12 @@ _checkSmallArrayValues(Span<const Int32> view1,Span<const Int32> view2)
 TEST(Collections,SmallArray)
 {
   {
+    constexpr int N = 934;
+    char buf[N];
+    impl::StackMemoryAllocator b(buf,N);
+    ASSERT_EQ(b.guarantedAlignment(),0);
+  }
+  {
     SmallArray<Int32,400> buf1;
     for( Int32 i=0; i<200; ++i )
       buf1.add(i+1);
@@ -122,6 +128,14 @@ TEST(Collections,SmallArray)
 
     buf2 = ref_buf2;
     _checkSmallArrayValues(buf2,ref_buf2);
+    buf3 = ref_buf2.span();
+    _checkSmallArrayValues(buf3,ref_buf2);
+    buf4 = ref_buf2.constSpan();
+    _checkSmallArrayValues(buf4,ref_buf2);
+    buf5 = ref_buf2.view();
+    _checkSmallArrayValues(buf5,ref_buf2);
+    buf6 = ref_buf2.constView();
+    _checkSmallArrayValues(buf6,ref_buf2);
   }
   {
     for( int z=1; z<10; ++z ) {
@@ -151,6 +165,15 @@ TEST(Collections,SmallArray)
     for(Int32 i=0; i<n; ++i )
       ASSERT_EQ(buf[i],((i*2)+1));
   }
+  {
+    size_t s1 = 513;
+    SmallArray<Int32> buf1(s1);
+    ASSERT_EQ(buf1.size(),s1);
+
+    Int64 s2 = 217;
+    SmallArray<Int32> buf2(s2);
+    ASSERT_EQ(buf2.size(),s2);
+}
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/TestCollections.cc
+++ b/arcane/src/arcane/utils/tests/TestCollections.cc
@@ -10,6 +10,8 @@
 #include "arcane/utils/List.h"
 #include "arcane/utils/String.h"
 
+#include "arcane/utils/SmallArray.h"
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -62,6 +64,95 @@ TEST(Collections,Basic)
   ASSERT_TRUE(string_list.contains(str1));
 }
 
+void
+_checkSmallArrayValues(Span<const Int32> view)
+{
+  for( Int64 i=0, n=view.size(); i<n; ++i )
+    ASSERT_EQ(view[i],i+1);
+}
+
+void
+_checkSmallArrayValues(Span<const Int32> view1,Span<const Int32> view2)
+{
+  Int64 n1 = view1.size();
+  Int64 n2 = view2.size();
+  ASSERT_EQ(n1,n2);
+  for( Int64 i=0; i<n1; ++i )
+    ASSERT_EQ(view1[i],view2[i]);
+}
+
+TEST(Collections,SmallArray)
+{
+  {
+    SmallArray<Int32,400> buf1;
+    for( Int32 i=0; i<200; ++i )
+      buf1.add(i+1);
+    ASSERT_EQ(buf1.size(),200);
+    _checkSmallArrayValues(buf1);
+
+    buf1.resize(50);
+    buf1.shrink();
+    ASSERT_EQ(buf1.size(),50);
+    _checkSmallArrayValues(buf1);
+
+    for( Int32 i=0; i<200; ++i )
+      buf1.add(50+i+1);
+    ASSERT_EQ(buf1.size(),250);
+    _checkSmallArrayValues(buf1);
+  }
+  for( int z=1; z<10; ++z ) {
+    UniqueArray<Int32> ref_buf(250*z);
+    for(Int32 i=0, n=ref_buf.size(); i<n; ++i )
+      ref_buf[i] = (i+1)*2;
+
+    UniqueArray<Int32> ref_buf2(100*z*z);
+    for(Int32 i=0, n=ref_buf2.size(); i<n; ++i )
+      ref_buf2[i] = (i+13)*3;
+
+    SmallArray<Int32,1024> buf2(ref_buf);
+    _checkSmallArrayValues(buf2,ref_buf);
+    SmallArray<Int32,1024> buf3(ref_buf.span());
+    _checkSmallArrayValues(buf3,ref_buf);
+    SmallArray<Int32,1024> buf4(ref_buf.constSpan());
+    _checkSmallArrayValues(buf4,ref_buf);
+    SmallArray<Int32,1024> buf5(ref_buf.view());
+    _checkSmallArrayValues(buf5,ref_buf);
+    SmallArray<Int32,1024> buf6(ref_buf.constView());
+    _checkSmallArrayValues(buf6,ref_buf);
+
+    buf2 = ref_buf2;
+    _checkSmallArrayValues(buf2,ref_buf2);
+  }
+  {
+    for( int z=1; z<10; ++z ) {
+      Int32 n = 5+(z*100);
+      SmallArray<Int32> buf3(n);
+      ASSERT_EQ(buf3.size(),n);
+      for(Int32 i=0; i<n; ++i )
+        buf3[i] = (i*22)+1;
+      for(Int32 i=0; i<n; ++i )
+        ASSERT_EQ(buf3[i],((i*22)+1));
+    }
+  }
+  {
+    std::cout << "Test initializer_list 1\n";
+    SmallArray<Int32,20> buf = { 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25,
+      27, 29, 31, 33, 35, 37, 39, 41 };
+    Int32 n = 21;
+    ASSERT_EQ(buf.size(),n);
+    for(Int32 i=0; i<n; ++i )
+      ASSERT_EQ(buf[i],((i*2)+1));
+  }
+  {
+    std::cout << "Test initializer_list 2\n";
+    SmallArray<Int32,100> buf = { 1, 3, 5, 7, 9, 11 };
+    Int32 n = 6;
+    ASSERT_EQ(buf.size(),n);
+    for(Int32 i=0; i<n; ++i )
+      ASSERT_EQ(buf[i],((i*2)+1));
+  }
+}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -72,6 +163,8 @@ template class ListImplBase<String>;
 template class ListImplT<String>;
 template class Collection<String>;
 template class CollectionImplT<String>;
+
+template class SmallArray<Int32>;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This class has the same behavior that `UniqueArray` but contains a memory buffer to avoir allocating on the heap for small sizes.