### PR TITLE
Better handling of 'StandaloneSubDomain'

### DIFF
--- a/arcane/src/arcane/impl/ArcaneSimpleExecutor.cc
+++ b/arcane/src/arcane/impl/ArcaneSimpleExecutor.cc
@@ -67,6 +67,10 @@ class ArcaneSimpleExecutor::Impl
   }
   ~Impl()
   {
+    for (ITimeStats* ts : m_time_stats_list){
+      ts->endGatherStats();
+      delete ts;
+    }
     if (m_arcane_main){
       m_arcane_main->finalize();
       delete m_arcane_main;
@@ -80,6 +84,7 @@ class ArcaneSimpleExecutor::Impl
   ApplicationBuildInfo m_application_build_info;
   bool m_has_minimal_verbosity_level = false;
   bool m_has_output_level = false;
+  UniqueArray<ITimeStats*> m_time_stats_list;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -228,9 +233,10 @@ createSubDomain(const String& case_file_name)
     sdbi.setCaseFileName(String());
     sdbi.setCaseBytes(ByteConstArrayView());
   }
+  // Le service de statistiques doit être détruit explicitement
   ITimeStats* time_stat = main_factory->createTimeStats(world_pm->timerMng(),tr,"Stats");
-  //sub_info->m_time_stats = time_stat;
   time_stat->beginGatherStats();
+  m_p->m_time_stats_list.add(time_stat);
   world_pm->setTimeStats(time_stat);
 
   ISubDomain* sub_domain(session->createSubDomain(sdbi));

--- a/arcane/src/arcane/launcher/ArcaneLauncher.cc
+++ b/arcane/src/arcane/launcher/ArcaneLauncher.cc
@@ -51,7 +51,7 @@ bool _checkInitCalled()
   }
   return false;
 }
-StandaloneSubDomain global_standalone_sub_domain;
+bool global_has_standalone_sub_domain = false;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -392,13 +392,22 @@ createStandaloneAcceleratorMng()
 StandaloneSubDomain ArcaneLauncher::
 createStandaloneSubDomain(const String& case_file_name)
 {
-  if (global_standalone_sub_domain._isValid())
+  if (global_has_standalone_sub_domain)
     ARCANE_FATAL("ArcaneLauncher::createStandaloneSubDomain() should only be called once");
   _initStandalone();
   StandaloneSubDomain s;
   s._initUniqueInstance(case_file_name);
-  global_standalone_sub_domain = s;
+  global_has_standalone_sub_domain = true;
   return s;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ArcaneLauncher::
+_notifyRemoveStandaloneSubDomain()
+{
+  global_has_standalone_sub_domain = false;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/launcher/ArcaneLauncher.h
+++ b/arcane/src/arcane/launcher/ArcaneLauncher.h
@@ -71,6 +71,8 @@ class IMainFactory;
  */
 class ARCANE_LAUNCHER_EXPORT ArcaneLauncher
 {
+  friend StandaloneSubDomain;
+
  public:
 
   /*!
@@ -216,6 +218,7 @@ class ARCANE_LAUNCHER_EXPORT ArcaneLauncher
  private:
 
   static void _initStandalone();
+  static void _notifyRemoveStandaloneSubDomain();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/launcher/StandaloneSubDomain.cc
+++ b/arcane/src/arcane/launcher/StandaloneSubDomain.cc
@@ -34,6 +34,10 @@ class StandaloneSubDomain::Impl
  public:
 
   Impl() = default;
+  ~Impl()
+  {
+    StandaloneSubDomain::_notifyRemoveStandaloneSubDomain();
+  }
 
   void init(const String& case_file_name)
   {
@@ -109,6 +113,15 @@ bool StandaloneSubDomain::
 _isValid()
 {
   return m_p.get();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void StandaloneSubDomain::
+_notifyRemoveStandaloneSubDomain()
+{
+  ArcaneLauncher::_notifyRemoveStandaloneSubDomain();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/launcher/StandaloneSubDomain.h
+++ b/arcane/src/arcane/launcher/StandaloneSubDomain.h
@@ -70,6 +70,7 @@ class ARCANE_LAUNCHER_EXPORT StandaloneSubDomain
   // Pour ArcaneLauncher.
   void _initUniqueInstance(const String& case_file_name);
   bool _isValid();
+  static void _notifyRemoveStandaloneSubDomain();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -315,8 +315,7 @@ arcane_add_accelerator_test_sequential(standalone_accelerator_testemptykernel du
 
 arcane_add_test_sequential(standalone_subdomain1 dummy.arc "-A,StandaloneSubDomainMethod=Test1")
 arcane_add_test_sequential(standalone_subdomain2 dummy.arc "-A,StandaloneSubDomainMethod=Test2")
-# Ne fonctionne pas encore
-# arcane_add_test_parallel(standalone_subdomain2 dummy.arc 4 "-A,StandaloneSubDomainMethod=Test2")
+arcane_add_test_parallel(standalone_subdomain2 dummy.arc 4 "-A,StandaloneSubDomainMethod=Test2")
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
- Destroy the unique instance of `StandaloneSubDomain` as soon as there is no reference on the instance. Before this PR the destruction occurred in the global destructors.
- Add missing call to `delete` for instance of `ITimeStats` creating during the call to `ArcaneSimpleExecutor::createSubDomain()`