### PR TITLE
Various improvement in Array classes

### DIFF
--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -37,6 +37,9 @@ namespace Arccore
  *
  * Cette classe sert pour contenir les meta-données communes à toutes les
  * implémentations qui dérivent de AbstractArray.
+ *
+ * Seul UniqueArray a le droit d'utiliser un allocateur autre que l'allocateur
+ * par défaut.
  */
 class ARCCORE_COLLECTIONS_EXPORT ArrayMetaData
 {
@@ -366,8 +369,7 @@ class AbstractArray
     // pouvoir conserver l'instance de l'allocateur. Par défaut
     // on utilise une taille de 1 élément.
     if (a && a!=m_md->allocator){
-      Int64 c = (acapacity>1) ? acapacity : 1;
-      _directFirstAllocateWithAllocator(c,a);
+      _directFirstAllocateWithAllocator(acapacity,a);
     }
   }
 
@@ -383,7 +385,7 @@ class AbstractArray
     // Si on a un allocateur spécifique, il faut allouer un
     // bloc pour conserver cette information.
     if (a != m_md->allocator)
-      _directFirstAllocateWithAllocator(1,a);
+      _directFirstAllocateWithAllocator(0,a);
     _updateReferences();
   }
   IMemoryAllocator* allocator() const
@@ -537,7 +539,8 @@ class AbstractArray
   {
     _allocateMetaData();
     m_md->allocator = a;
-    _allocateMP(new_capacity);
+    if (new_capacity>0)
+      _allocateMP(new_capacity);
     m_md->nb_ref = _getNbRef();
     m_md->size = 0;
     _updateReferences();

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -1685,6 +1685,13 @@ class UniqueArray
     this->_initFromAllocator(allocator,asize);
     this->_resize(asize);
   }
+  //! Créé un tableau avec l'allocateur \a allocator en recopiant les valeurs \a rhs.
+  UniqueArray(IMemoryAllocator* allocator,Span<const T> rhs)
+  {
+    this->_initFromAllocator(allocator,rhs.size());
+    this->_initFromSpan(rhs);
+  }
+
   //! Copie les valeurs de \a rhs dans cette instance.
   void operator=(const Array<T>& rhs)
   {

--- a/arccore/src/collections/arccore/collections/Array2.h
+++ b/arccore/src/collections/arccore/collections/Array2.h
@@ -215,7 +215,7 @@ class Array2
       this->_reserve(4);
     }
     Span<const DataType> aview(rhs.data(),total);
-    Base::_copyView(aview);
+    Base::_resizeAndCopyView(aview);
     m_md->dim1_size = rhs.dim1Size();
     m_md->dim2_size = rhs.dim2Size();
     _arccoreCheckSharedNull();

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -705,6 +705,30 @@ TEST(Array, Misc3)
   }
 }
 
+TEST(Array, Misc4)
+{
+  using namespace Arccore;
+
+  IMemoryAllocator* allocator1 = AlignedMemoryAllocator::Simd();
+  IMemoryAllocator* allocator2 = AlignedMemoryAllocator::CacheLine();
+
+  {
+    UniqueArray<Int32> a(allocator1);
+    ASSERT_EQ(a.allocator(),allocator1);
+    a.add(27);
+    a.add(38);
+    a.add(13);
+    a.add(-5);
+    UniqueArray<Int32> c(a.clone());
+    ASSERT_EQ(c.size(),a.size());
+    ASSERT_EQ(c.constSpan(),a.constSpan());
+    UniqueArray<Int32> d(allocator2,a);
+    ASSERT_EQ(d.allocator(),allocator2);
+    ASSERT_EQ(d.size(),a.size());
+    ASSERT_EQ(d.constSpan(),a.constSpan());
+  }
+}
+
 namespace Arccore
 {
 // Instancie explicitement les classes tableaux pour garantir


### PR DESCRIPTION
- Propagate custom `IMemoryAllocator` in copy constructor and assignment operator from `Array` or derived class
- Add a constructor `UniqueArray(IMemoryAllocator*,Span<const T>)`
- No longer reserve memory for empty array with custom allocator
- Use `Array::constSpan()` instead of `Array::constView()` in some parts to allow usage of array with more than 2Go elements.