### PR TITLE
Use by default the grid implementation instead of atomics for reduce operation on devices, 

### DIFF
--- a/arcane/src/arcane/accelerator/Reduce.h
+++ b/arcane/src/arcane/accelerator/Reduce.h
@@ -103,7 +103,7 @@ class ReduceDeviceInfo
   unsigned int* m_device_count = nullptr;
 
   //! Indique si on utilise la réduction par grille (sinon on utilise les atomiques)
-  bool m_use_grid_reduce = false;
+  bool m_use_grid_reduce = true;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/Runner.cc
+++ b/arcane/src/arcane/accelerator/core/Runner.cc
@@ -186,7 +186,7 @@ class Runner::Impl
   //TODO: mettre à None lorsqu'on aura supprimé Runner::setExecutionPolicy()
   eExecutionPolicy m_execution_policy = eExecutionPolicy::None;
   bool m_is_init = false;
-  eDeviceReducePolicy m_reduce_policy = eDeviceReducePolicy::Atomic;
+  eDeviceReducePolicy m_reduce_policy = eDeviceReducePolicy::Grid;
   DeviceId m_device_id;
 
  private:

--- a/arcane/src/arcane/accelerator/core/Runner.h
+++ b/arcane/src/arcane/accelerator/core/Runner.h
@@ -43,6 +43,11 @@ namespace Arcane::Accelerator
  * celui utilisé par défaut pour le thread courant. Pour garantir que les
  * kernels associés à ce runner seront bien exécutés sur le bon device il
  * est nécessaire d'appeler au moins une fois la méthode setAsCurrentDevice().
+ *
+ * Il est possible de changer le mécanisme utilisé pour les réductions via
+ * la méthode setDeviceReducePolicy(). Par défaut on utilise un kernel
+ * utilisant des synchronisations entre blocs. Cela permet de garantir la
+ * répétabilité des résultats.
  */
 class ARCANE_ACCELERATOR_CORE_EXPORT Runner
 {


### PR DESCRIPTION
Atomics are not always available and grid reduction gives reproducible results.