### PR TITLE
Change node numerotation in HoneyCombMeshGenerator and improve corresponding sample

### DIFF
--- a/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeat.axl
+++ b/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeat.axl
@@ -8,5 +8,6 @@
   <variables>
     <variable field-name="cell_temperature" name="CellTemperature" data-type="real" item-kind="cell" dim="0" dump="true" />
     <variable field-name="node_temperature" name="NodeTemperature" data-type="real" item-kind="node" dim="0" dump="true" />
+    <variable field-name="cell_center" name="CellCenter" data-type="real3" item-kind="cell" dim="0" dump="true" />
   </variables>
 </module>

--- a/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeat2D_small.arc
+++ b/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeat2D_small.arc
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<case codename="HoneyCombHeat" xml:lang="en" codeversion="1.0">
+  <arcane>
+    <title>Sample</title>
+    <timeloop>HoneyCombHeatLoop</timeloop>
+  </arcane>
+
+  <meshes>
+    <mesh>
+      <generator name="HoneyComb2D" >
+        <origin>0.0 0.0</origin>
+        <nb-layer>5</nb-layer>
+        <pitch-size>1.0</pitch-size>
+      </generator>
+    </mesh>
+  </meshes>
+
+  <arcane-post-processing>
+    <output-period>10</output-period>
+    <output>
+      <variable>CellTemperature</variable>
+      <variable>NodeTemperature</variable>
+    </output>
+  </arcane-post-processing>
+</case>

--- a/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeatModule.cc
+++ b/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeatModule.cc
@@ -242,13 +242,13 @@ _buildCellByDirectionList()
 
   // Indice local de la face par directions pour Arcane avec le HoneyCombMeshGenerator:
   /*
-   *     0
-   *    / \
-   *   1   5
-   *   |   |
-   *   2   4
-   *    \ /
    *     3
+   *    / \
+   *   4   2
+   *   |   |
+   *   5   1
+   *    \ /
+   *     0
    */
 
   static constexpr int NB_DIRECTION = 6;
@@ -272,7 +272,7 @@ _buildCellByDirectionList()
     // puis vers le haut (3 ème direction)
     // puis vers le haut à gauche (4 ème direction)
     // puis vers le bas à gauche (5 ème direction)
-    std::array<Int32, NB_DIRECTION> next_directions = { 3, 4, 5, 0, 1, 2 };
+    std::array<Int32, NB_DIRECTION> next_directions = { 0, 1, 2, 3, 4, 5 };
 
     for (int i = 1; i < NB_DIRECTION; ++i) {
       Cell cell = _getLastCellFollowingDirection(begin_cells[i - 1], next_directions[i]);
@@ -282,7 +282,7 @@ _buildCellByDirectionList()
   }
 
   // Indice local de la face dans la direction souhaité
-  std::array<Int32, NB_DIRECTION> search_directions = { 4, 1, 2, 1, 4, 5 };
+  std::array<Int32, NB_DIRECTION> search_directions = { 1, 4, 5, 4, 1, 2 };
 
   // Pour chaque direction, on part de deux mailles de bord et on prend
   // toutes les mailles dans la direction 'direction_for_next'.
@@ -296,12 +296,12 @@ _buildCellByDirectionList()
   };
 
   std::array<std::array<BeginAndDirection, 2>, NB_DIRECTION> begin_and_directions = { {
-  { BeginAndDirection{ 0, 0 }, BeginAndDirection{ 5, 5 } }, // direction 0
-  { BeginAndDirection{ 1, 5 }, BeginAndDirection{ 2, 0 } }, // direction 1
-  { BeginAndDirection{ 2, 0 }, BeginAndDirection{ 3, 1 } }, // direction 2
-  { BeginAndDirection{ 3, 3 }, BeginAndDirection{ 2, 2 } }, // direction 3
-  { BeginAndDirection{ 4, 2 }, BeginAndDirection{ 5, 3 } }, // direction 4
-  { BeginAndDirection{ 5, 3 }, BeginAndDirection{ 0, 4 } } // direction 5
+  { BeginAndDirection{ 0, 3 }, BeginAndDirection{ 5, 2 } }, // direction 0
+  { BeginAndDirection{ 1, 2 }, BeginAndDirection{ 2, 3 } }, // direction 1
+  { BeginAndDirection{ 2, 3 }, BeginAndDirection{ 3, 4 } }, // direction 2
+  { BeginAndDirection{ 3, 0 }, BeginAndDirection{ 2, 5 } }, // direction 3
+  { BeginAndDirection{ 4, 5 }, BeginAndDirection{ 5, 0 } }, // direction 4
+  { BeginAndDirection{ 5, 0 }, BeginAndDirection{ 0, 1 } } // direction 5
   } };
 
   for (int i = 0; i < NB_DIRECTION; ++i) {
@@ -309,10 +309,16 @@ _buildCellByDirectionList()
     for (int j = 0; j < 2; ++j) {
       BeginAndDirection x = begin_and_directions[i][j];
       Cell cell = begin_cells[x.begin_cell];
+      Cell next_cell;
+      if (j==0){
+        next_cell = begin_cells[begin_and_directions[i][j+1].begin_cell];
+      }
       const Int32 next = x.direction_for_next;
       do {
         _addCellFollowingDirection(boundary_cells[i], cell, search_dir);
         cell = cell.face(next).oppositeCell(cell);
+        if (next_cell==cell)
+          break;
       } while (!cell.null());
     }
   }

--- a/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeatModule.cc
+++ b/arcane/samples_build/samples/honeycomb_heat/HoneyCombHeatModule.cc
@@ -19,6 +19,7 @@
 #include <arcane/UnstructuredMeshConnectivity.h>
 #include <arcane/ItemPrinter.h>
 #include <arcane/mesh/IncrementalItemConnectivity.h>
+#include <arcane/core/SimpleSVGMeshExporter.h>
 
 using namespace Arcane;
 
@@ -84,6 +85,7 @@ class HoneyCombHeatModule
 
   Int32 _getNeighbourFaceIndex(CellLocalId cell, CellLocalId neighbour_cell);
   Int32 _getCurrentFaceIndex(CellLocalId cell, FaceLocalId face);
+  void _buildCellByDirectionList();
 };
 
 /*---------------------------------------------------------------------------*/
@@ -161,6 +163,168 @@ _getNeighbourFaceIndex(CellLocalId cell, CellLocalId neighbour_cell)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+namespace
+{
+/*!
+ * A partir de la maille \a cell, parcours le maillage dans la direction
+ * suivant la \a i-ème face jusqu'à arriver au bord et retourne cette maille
+ * d'indice
+ * Retourne la dernière maille
+ */
+Cell
+_getLastCellFollowingDirection(Cell cell,Int32 i)
+{
+  Cell boundary_cell = cell;
+  do {
+    boundary_cell = cell;
+    cell = cell.face(i).oppositeCell(cell);
+  } while (!cell.null());
+  return boundary_cell;
+}
+
+void
+_addCellFollowingDirection(Array<Int32>& v,Cell cell,Int32 i)
+{
+  Cell current_cell = cell;
+  do {
+    current_cell = cell;
+    v.add(current_cell.localId());
+    cell = cell.face(i).oppositeCell(cell);
+  } while (!cell.null());
+}
+
+}
+
+void HoneyCombHeatModule::
+_buildCellByDirectionList()
+{
+  // La direction 0 est vers le bas à droite.
+  // La direction 1 est vers le haut à gauche
+  // La direction 2 est vers le bas à gauche
+  // Les directions 4, 5 et 6 sont construites en inversant la liste des mailles
+  // respectivement des dimensions 0, 1 et 2.
+
+  // Direction 0 -> face_index = 4
+  // Direction 1 -> face_index = 1
+  // Direction 2 -> face_index = 2
+
+  // Valeurs des directions pour un maillage de 5 couches.
+
+  // Indice Z= 0 [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+  //              18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+  //              34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+  //              50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60]
+
+  // Indice Z= 1 [ 4, 3, 2, 1, 0, 10, 9, 8, 7, 6, 5, 17, 16, 15, 14, 13, 12, 11,
+  //              25, 24, 23, 22, 21, 20, 19, 18, 34, 33, 32, 31, 30, 29, 28, 27,
+  //              26, 42, 41, 40, 39, 38, 37, 36, 35, 49, 48, 47, 46, 45, 44, 43,
+  //              55, 54, 53, 52, 51, 50, 60, 59, 58, 57, 56]
+
+  // Indice Z= 2 [ 34, 25, 17, 10, 4, 42, 33, 24, 16, 9, 3, 49, 41, 32, 23, 15, 8,
+  //                2, 55, 48, 40, 31, 22, 14, 7, 1, 60, 54, 47, 39, 30, 21, 13, 6,
+  //                0, 59, 53, 46, 38, 29, 20, 12, 5, 58, 52, 45, 37, 28, 19, 11, 57,
+  //               51, 44, 36, 27, 18, 56, 50, 43, 35, 26]
+
+  // Indice Z= 3 [ 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44,
+  //               43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27,
+  //               26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+  //                9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+
+  // Indice Z= 4 [ 56, 57, 58, 59, 60, 50, 51, 52, 53, 54, 55, 43, 44, 45, 46, 47, 48,
+  //               49, 35, 36, 37, 38, 39, 40, 41, 42, 26, 27, 28, 29, 30, 31, 32, 33,
+  //               34, 18, 19, 20, 21, 22, 23, 24, 25, 11, 12, 13, 14, 15, 16, 17, 5,
+  //                6, 7, 8, 9, 10, 0, 1, 2, 3, 4]
+
+  // Indice Z= 5 [ 26, 35, 43, 50, 56, 18, 27, 36, 44, 51, 57, 11, 19, 28, 37, 45, 52,
+  //               58, 5, 12, 20, 29, 38, 46, 53, 59, 0, 6, 13, 21, 30, 39, 47, 54, 60,
+  //                1, 7, 14, 22, 31, 40, 48, 55, 2, 8, 15, 23, 32, 41, 49, 3, 9, 16,
+  //               24, 33, 42, 4, 10, 17, 25, 34]
+
+  // Indice local de la face par directions pour Arcane avec le HoneyCombMeshGenerator:
+  /*
+   *     0
+   *    / \
+   *   1   5
+   *   |   |
+   *   2   4
+   *    \ /
+   *     3
+   */
+
+  static constexpr int NB_DIRECTION = 6;
+
+  UniqueArray<UniqueArray<Int32>> boundary_cells(NB_DIRECTION);
+  // Calcule les mailles au bord pour chaque direction.
+  // Pour la direction 0, on commence par la maille 0 (qui est à gauche en bas)
+
+  // Le code suivant ne fonctionne qu'en 2D et en séquentiel
+  IItemFamily* cell_family = defaultMesh()->cellFamily();
+
+  std::array<Cell, NB_DIRECTION> begin_cells;
+  begin_cells[0] = cell_family->findOneItem(0);
+  info() << "CELL0=" << ItemPrinter(begin_cells[0]);
+
+  // Cherche les 6 mailles de bord.
+  {
+    // Pour trouver la première maille de la direction 1 on part de la maille 0
+    // et on va en bas à droite jusqu'au bord
+    // puis vers le haut à droite (2 ème direction)
+    // puis vers le haut (3 ème direction)
+    // puis vers le haut à gauche (4 ème direction)
+    // puis vers le bas à gauche (5 ème direction)
+    std::array<Int32, NB_DIRECTION> next_directions = { 3, 4, 5, 0, 1, 2 };
+
+    for (int i = 1; i < NB_DIRECTION; ++i) {
+      Cell cell = _getLastCellFollowingDirection(begin_cells[i - 1], next_directions[i]);
+      begin_cells[i] = cell;
+      info() << "CELL[" << i << "]=" << ItemPrinter(cell);
+    }
+  }
+
+  // Indice local de la face dans la direction souhaité
+  std::array<Int32, NB_DIRECTION> search_directions = { 4, 1, 2, 1, 4, 5 };
+
+  // Pour chaque direction, on part de deux mailles de bord et on prend
+  // toutes les mailles dans la direction 'direction_for_next'.
+  // On obtient une liste A de mailles. Pour avoir la liste des toutes les
+  // mailles dans une direction on prend chaque maille de A et on ajoute toutes
+  // les mailles qui partent de A
+  struct BeginAndDirection
+  {
+    int begin_cell;
+    int direction_for_next;
+  };
+
+  std::array<std::array<BeginAndDirection, 2>, NB_DIRECTION> begin_and_directions = { {
+  { BeginAndDirection{ 0, 0 }, BeginAndDirection{ 5, 5 } }, // direction 0
+  { BeginAndDirection{ 1, 5 }, BeginAndDirection{ 2, 0 } }, // direction 1
+  { BeginAndDirection{ 2, 0 }, BeginAndDirection{ 3, 1 } }, // direction 2
+  { BeginAndDirection{ 3, 3 }, BeginAndDirection{ 2, 2 } }, // direction 3
+  { BeginAndDirection{ 4, 2 }, BeginAndDirection{ 5, 3 } }, // direction 4
+  { BeginAndDirection{ 5, 3 }, BeginAndDirection{ 0, 4 } } // direction 5
+  } };
+
+  for (int i = 0; i < NB_DIRECTION; ++i) {
+    const Int32 search_dir = search_directions[i];
+    for (int j = 0; j < 2; ++j) {
+      BeginAndDirection x = begin_and_directions[i][j];
+      Cell cell = begin_cells[x.begin_cell];
+      const Int32 next = x.direction_for_next;
+      do {
+        _addCellFollowingDirection(boundary_cells[i], cell, search_dir);
+        cell = cell.face(next).oppositeCell(cell);
+      } while (!cell.null());
+    }
+  }
+
+  for (int i = 0; i < NB_DIRECTION; ++i) {
+    info() << "DIRECTIONS: I=" << i << " list=" << boundary_cells[i] << "\n";
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 void HoneyCombHeatModule::
 startInit()
 {
@@ -172,6 +336,29 @@ startInit()
   m_global_deltat = 1.0;
 
   const bool is_verbose = false;
+
+  if (defaultMesh()->dimension() == 2) {
+    std::ofstream ofile("honeycomb.svg");
+    SimpleSVGMeshExporter exporter(ofile);
+    exporter.write(allCells());
+  }
+
+  _buildCellByDirectionList();
+
+  // Calcule le centre des mailles
+  VariableNodeReal3& nodes_coords(mesh()->nodesCoordinates());
+  ENUMERATE_ (Cell, icell, allCells()) {
+    Cell cell = *icell;
+    Int32 nb_node = cell.nbNode();
+    Real3 center;
+    for (NodeLocalId node : cell.nodeIds()) {
+      center += nodes_coords[node];
+    }
+    center /= nb_node;
+    m_cell_center[cell] = center;
+    if (is_verbose)
+      info() << "Cell " << ItemPrinter(cell) << " center=" << center;
+  }
 
   m_mesh_connectivity_view.setMesh(mesh());
 

--- a/arcane/src/arcane/std/HoneyCombMeshGenerator.cc
+++ b/arcane/src/arcane/std/HoneyCombMeshGenerator.cc
@@ -143,12 +143,12 @@ namespace
   {
     Real p = 0.5 * pitch;
     Real q = 0.5 * pitch / (math::sqrt(3.0));
-    coords[0] = { x + q, y + p, z };
-    coords[1] = { x - q, y + p, z };
-    coords[2] = { x - 2 * q, y, z };
-    coords[3] = { x - q, y - p, z };
-    coords[4] = { x + q, y - p, z };
-    coords[5] = { x + 2 * q, y, z };
+    coords[0] = { x - q, y - p, z };
+    coords[1] = { x + q, y - p, z };
+    coords[2] = { x + 2 * q, y, z };
+    coords[3] = { x + q, y + p, z };
+    coords[4] = { x - q, y + p, z };
+    coords[5] = { x - 2 * q, y, z };
   }
 
 } // namespace


### PR DESCRIPTION
The first node is now at the lower left vertex of the hexagon (instead of upper right).
It is coherent with the numbering used in CEA simulation codes using this kind of mesh.