### PR TITLE
Allow use of a specific MPI driver for launching tests

### DIFF
--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CustomMpiDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CustomMpiDriver.cs
@@ -101,9 +101,10 @@ namespace Arcane.ExecDrivers.Common
         p.MpiLauncherArgs.Add("-d tv");
         p.UseTotalview = false;
       }
-
-      int nb_thread = p.NbTaskPerProcess * p.NbSharedMemorySubDomain;
-      Console.WriteLine("NB_THREAD={0} ({1},{2})", nb_thread, p.NbSharedMemorySubDomain, p.NbTaskPerProcess);
+      int nb_task = Math.Max(p.NbTaskPerProcess,1);
+      int nb_shared_memory = Math.Max(p.NbSharedMemorySubDomain,1);
+      int nb_thread = nb_task * nb_shared_memory;
+      Console.WriteLine("NB_THREAD={0} (nb_shm={1},nb_task={2})", nb_thread, nb_shared_memory, nb_task);
 
       p.MpiLauncherArgs.Add("-n");
       p.MpiLauncherArgs.Add(p.NbProc.ToString());

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CustomMpiDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CustomMpiDriver.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Arcane.ExecDrivers.Common;
+
+namespace Arcane.ExecDrivers.Common
+{
+  // Informations de configuration.
+  // Les champs de cette classe sont initialisés via JSON
+  class Config
+  {
+    public string MpiDistrib { get; set; }
+    public string MpiRoot { get; set; }
+    public string MpiPrefix { get; set; }
+  }
+
+  class CustomMpiDriver : ICustomExecDriver
+  {
+    bool m_is_init;
+    Config m_config;
+    Assembly m_json_assembly;
+    string m_config_path;
+
+    public string Name { get { return "CustomMpiDriver"; } }
+
+    void _Init()
+    {
+      if (m_is_init)
+        return;
+      // Avec '.Net Core 3.0', il faut charger explicitement la DLL
+      // de 'NewtonSoft.Json' (car cette classe est chargée dynamiquement)
+      {
+        Assembly a = Assembly.GetExecutingAssembly();
+        string assembly_path = Path.GetDirectoryName(a.Location);
+        m_config_path = Path.Combine(assembly_path, "ArcaneCea.config");
+        Console.WriteLine("LOCATION_PATH={0}", m_config_path);
+        string json_assembly_path = Path.Combine(assembly_path,"Newtonsoft.Json.dll");
+        Console.WriteLine("Trying loading newtonsoft.json={0}", json_assembly_path);
+        m_json_assembly = Utils.LoadAssembly(json_assembly_path);
+        Console.WriteLine("Newtonsoft? {0}",m_json_assembly!=null);
+      }
+
+      string host_name = Environment.MachineName;
+      _ReadConfig();
+      Console.WriteLine("TRY CUSTOM MPI_LAUNCHER machine={0} mpi_root={1}", host_name, m_config.MpiRoot);
+      m_is_init = true;
+    }
+
+    void _ReadConfig()
+    {
+      // Lit le fichier de configuration 'ArcaneCea.config' au format JSON
+      // qui doit se trouver dans le même répertoire que cette assembly.
+
+      Newtonsoft.Json.JsonSerializer ser = new Newtonsoft.Json.JsonSerializer();
+      using (StreamReader sr = new StreamReader(m_config_path)) {
+        Newtonsoft.Json.JsonTextReader r = new Newtonsoft.Json.JsonTextReader(sr);
+        m_config = (Config)ser.Deserialize(r, typeof(Config));
+      }
+    }
+
+    public bool HandleMpiLauncher(Arcane.ExecDrivers.Common.ExecDriverProperties p, string mpi_launcher)
+    {
+      _Init();
+      Console.WriteLine("TRY CUSTOM MPI_LAUNCHER name={0}", mpi_launcher);
+      Console.WriteLine("OS_VERSION={0}", Environment.OSVersion.VersionString);
+      if (mpi_launcher.EndsWith("ccc_mprun", StringComparison.Ordinal))
+        return _HandleCCCMprun(p);
+      if (mpi_launcher.EndsWith("mpiexec", StringComparison.Ordinal))
+        return _HandleMpiExec(p);
+      return false;
+    }
+
+    bool _HandleMpiExec(ExecDriverProperties p)
+    {
+      Console.WriteLine("Handle Mpiexec");
+      return false;
+    }
+
+    // Gère le lancement via 'ccc_mprun'
+    bool _HandleCCCMprun(ExecDriverProperties p)
+    {
+      Console.WriteLine("Handling 'ccc_mprun'");
+
+      // Si on est dans un job slurm, on suppose qu'on est sur un noeud de l'allocation
+      // (ce n'est pas forcément le cas. Pour être sur, il faudrait regarder si le noeud
+      // sur lequel on tourne est dans la liste des noeuds de la variable d'environnement
+      // SLURM_JOB_NODELIST.
+      string job_id = Utils.GetEnvironmentVariable("SLURM_JOB_ID");
+      bool is_already_allocated = !string.IsNullOrEmpty(job_id);
+      Console.WriteLine("is_already_allocated={0}", is_already_allocated);
+
+      if (is_already_allocated) {
+        // Avec ccc_mprun, il faut ajouter au srun l'option '--exclusive' pour ne pas
+        // avoir de problèmes de cohérence sur le nombre de processus à utiliser.
+        p.MpiLauncherArgs.Add("-E");
+        p.MpiLauncherArgs.Add("--exclusive");
+      }
+
+      if (p.UseTotalview) {
+        p.MpiLauncherArgs.Add("-d tv");
+        p.UseTotalview = false;
+      }
+
+      int nb_thread = p.NbTaskPerProcess * p.NbSharedMemorySubDomain;
+      Console.WriteLine("NB_THREAD={0} ({1},{2})", nb_thread, p.NbSharedMemorySubDomain, p.NbTaskPerProcess);
+
+      p.MpiLauncherArgs.Add("-n");
+      p.MpiLauncherArgs.Add(p.NbProc.ToString());
+
+      if (!is_already_allocated) {
+        p.MpiLauncherArgs.AddRange(new string[] { "-x", "-v", });
+      }
+      // Alloue les coeurs suivant le nombre de threads demandes
+      // et specifie un nombre de noeuds pour etre sur que les threads seront bien repartis
+      if (nb_thread > 1) {
+        int nb_thread_power_2 = 1;
+        while (nb_thread_power_2 < nb_thread)
+          nb_thread_power_2 *= 2;
+        p.MpiLauncherArgs.Add("-c" + nb_thread_power_2);
+        //Utils.SetEnvironmentVariable("ARCANE_BIND_THREADS", "1");
+        //Utils.SetEnvironmentVariable("ARCANE_SPINLOCK_BARRIER", "1");
+      }
+
+      return true;
+    }
+  }
+}

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CustomMpiDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CustomMpiDriver.cs
@@ -1,26 +1,13 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using Arcane.ExecDrivers.Common;
 
 namespace Arcane.ExecDrivers.Common
 {
-  // Informations de configuration.
-  // Les champs de cette classe sont initialisés via JSON
-  class Config
-  {
-    public string MpiDistrib { get; set; }
-    public string MpiRoot { get; set; }
-    public string MpiPrefix { get; set; }
-  }
-
   class CustomMpiDriver : ICustomExecDriver
   {
     bool m_is_init;
-    Config m_config;
-    Assembly m_json_assembly;
-    string m_config_path;
 
     public string Name { get { return "CustomMpiDriver"; } }
 
@@ -28,35 +15,9 @@ namespace Arcane.ExecDrivers.Common
     {
       if (m_is_init)
         return;
-      // Avec '.Net Core 3.0', il faut charger explicitement la DLL
-      // de 'NewtonSoft.Json' (car cette classe est chargée dynamiquement)
-      {
-        Assembly a = Assembly.GetExecutingAssembly();
-        string assembly_path = Path.GetDirectoryName(a.Location);
-        m_config_path = Path.Combine(assembly_path, "ArcaneCea.config");
-        Console.WriteLine("LOCATION_PATH={0}", m_config_path);
-        string json_assembly_path = Path.Combine(assembly_path,"Newtonsoft.Json.dll");
-        Console.WriteLine("Trying loading newtonsoft.json={0}", json_assembly_path);
-        m_json_assembly = Utils.LoadAssembly(json_assembly_path);
-        Console.WriteLine("Newtonsoft? {0}",m_json_assembly!=null);
-      }
-
       string host_name = Environment.MachineName;
-      _ReadConfig();
-      Console.WriteLine("TRY CUSTOM MPI_LAUNCHER machine={0} mpi_root={1}", host_name, m_config.MpiRoot);
+      Console.WriteLine("TRY CUSTOM MPI_LAUNCHER machine={0}");
       m_is_init = true;
-    }
-
-    void _ReadConfig()
-    {
-      // Lit le fichier de configuration 'ArcaneCea.config' au format JSON
-      // qui doit se trouver dans le même répertoire que cette assembly.
-
-      Newtonsoft.Json.JsonSerializer ser = new Newtonsoft.Json.JsonSerializer();
-      using (StreamReader sr = new StreamReader(m_config_path)) {
-        Newtonsoft.Json.JsonTextReader r = new Newtonsoft.Json.JsonTextReader(sr);
-        m_config = (Config)ser.Deserialize(r, typeof(Config));
-      }
     }
 
     public bool HandleMpiLauncher(Arcane.ExecDrivers.Common.ExecDriverProperties p, string mpi_launcher)

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
@@ -542,6 +542,9 @@ namespace Arcane.ExecDrivers.Common
       // supprime les arguments positionnés par les anciens appels.
       m_properties.MpiLauncherArgs.Clear();
       string mpi_exec_name = Utils.MpiExecName;
+      string custom_mpi_driver = Utils.CustomMpiDriver;
+      if (!String.IsNullOrEmpty(custom_mpi_driver))
+        mpi_exec_name = custom_mpi_driver;
       m_properties.MpiLauncher = mpi_exec_name;
       if (m_custom_driver != null) {
         if (m_custom_driver.HandleMpiLauncher(m_properties, mpi_exec_name))

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
@@ -369,8 +369,19 @@ namespace Arcane.ExecDrivers.Common
         Console.WriteLine("Using visual studio debugger");
         use_devenv = true;
       }
+
       if (m_properties.NbProc != 0)
         is_parallel = true;
+      bool force_use_mpiexec = false;
+      {
+        string str = Utils.GetEnvironmentVariable("ARCANE_ALWAYS_USE_MPI_DRIVER");
+        if (str=="1" || str=="TRUE")
+          force_use_mpiexec = true;
+      }
+      if (m_properties.NbProc==0 && force_use_mpiexec){
+        Console.WriteLine("Force using mpi driver to launch sequential test");
+        m_properties.NbProc = 1;
+      }
       if (!String.IsNullOrEmpty(m_dotnet_assembly)){
         m_use_dotnet = true;
         Utils.SetEnvironmentVariable("ARCANE_DOTNET_ASSEMBLY", m_dotnet_assembly);
@@ -447,6 +458,7 @@ namespace Arcane.ExecDrivers.Common
           sub_args.Add(exe_name);
           exe_name = Utils.ValgrindExecName;
         }
+
         if (m_properties.NbProc == 0) {
           command = exe_name;
           _HandleMpiLauncher();

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
@@ -340,13 +340,19 @@ namespace Arcane.ExecDrivers.Common
 
       if (m_properties.NbProc != 0)
         is_parallel = true;
-      bool force_use_mpiexec = false;
+      // Regarde si on force l'utilisation du lanceur MPI (en général mpixec) même pour les jobs séquentiels
+      // Cela peut être nécessaire sur certaines plateformes
+      // On le fait si demandé via une variable d'environnement ou si
+      // on utilise un driver spécifique.
+      bool force_use_mpi_driver = !String.IsNullOrEmpty(Utils.CustomMpiDriver);
       {
         string str = Utils.GetEnvironmentVariable("ARCANE_ALWAYS_USE_MPI_DRIVER");
         if (str=="1" || str=="TRUE")
-          force_use_mpiexec = true;
+          force_use_mpi_driver = true;
+        if (str=="0" || str=="FALSE")
+          force_use_mpi_driver = false;
       }
-      if (m_properties.NbProc==0 && force_use_mpiexec){
+      if (m_properties.NbProc==0 && force_use_mpi_driver){
         Console.WriteLine("Force using mpi driver to launch sequential test");
         m_properties.NbProc = 1;
       }

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
@@ -184,40 +184,8 @@ namespace Arcane.ExecDrivers.Common
     {
       m_properties = new ExecDriverProperties();
       m_additional_assemblies = new List<Assembly>();
-      Console.WriteLine("Try adding custom drivers");
-      _TryAddAssembly("Arcane.CeaExecDrivers.dll");
-    }
-
-    void _TryAddAssembly(string file_name)
-    {
-      Assembly this_assembly = Assembly.GetAssembly(typeof(ExecDriver));
-      string this_assembly_path = Path.GetDirectoryName(this_assembly.Location);
-      string lib_path = this_assembly_path;
-      string full_path = Path.Combine(lib_path, file_name);
-      Console.WriteLine("Try loading assembly '{0}'", full_path);
-      try {
-        if (!File.Exists(full_path))
-          return;
-        Assembly b = Utils.LoadAssembly(full_path);
-        if (b != null) {
-          m_additional_assemblies.Add(b);
-          Console.WriteLine("Found custom driver named '{0}'", full_path);
-          foreach (Type t in b.GetTypes()) {
-            if (t.Name == "MainClass") {
-              Console.WriteLine("Found type named '{0}'", t.FullName);
-              ConstructorInfo m = t.GetConstructor(new Type[0]);
-              Console.WriteLine("EXEC_METHOD = {0}", m);
-              object o = m.Invoke(new object[0]);
-              Console.WriteLine("CREATE Ob={0}", o);
-              m_custom_driver = (ICustomExecDriver)o;
-              Console.WriteLine("Custome driver ={0}", m_custom_driver);
-            }
-          }
-        }
-      }
-      catch (Exception ex) {
-        Console.WriteLine(String.Format("Can not load assembly '{0}' ex={1}", file_name, ex.Message));
-      }
+      m_custom_driver = new CustomMpiDriver();
+      Console.WriteLine("Custome driver ={0}", m_custom_driver);
     }
 
     public void ParseArgs(string[] args, Mono.Options.OptionSet additional_options)

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/Utils.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/Utils.cs
@@ -66,6 +66,7 @@ namespace Arcane.ExecDrivers.Common
     public static string ConfigMpiexecPreflags { get; set; }
     public static string ConfigMpiexecPostflags { get; set; }
     public static string ConfigMpiVendorName { get; set; }
+    public static string CustomMpiDriver { get; set; }
 
     static Dictionary<string,string> m_settings;
 
@@ -108,6 +109,7 @@ namespace Arcane.ExecDrivers.Common
       m_mono_exec_path = NormalizePath(_ReadConfig(settings, "MonoExecPath"));
       DotnetCoreClrPath = NormalizePath(_ReadConfig(settings, "DotnetCoreClrPath"));
       m_external_libraries = _ReadConfig(settings, "ExternalLibraries");
+      CustomMpiDriver = _ReadConfig(settings, "CustomMpiDriver");
 
       ConfigMpiexec = NormalizePath(_ReadConfig(settings, "Config_MPIEXEC"));
       ConfigMpiexecNumprocFlag = NormalizePath(_ReadConfig(settings, "Config_MPIEXEC_NUMPROC_FLAG"));

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.dll.config.json
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.dll.config.json
@@ -3,6 +3,7 @@
     "CodeLibPath" : "@ARCANE_INSTALL_LIB@",
     "CodeSharePath" : "@ARCANE_INSTALL_SHR@",
     "MpiBinary" : "@MPIEXEC_EXECUTABLE@",
+    "CustomMpiDriver" : "@ARCANE_CUSTOM_MPI_DRIVER@",
     "ValgrindBinary" : "@VALGRIND_EXEC_NAME@",
     "MonoExecPath" : "@MONO_EXEC_PATH@",
     "DotnetCoreClrPath" : "@DOTNET_EXEC@",


### PR DESCRIPTION
It is needed on machines using  ressource manager (i.e. SLURM) to allocate cores.
This is the case for TGCC or CCRT clusters