### PR TITLE
Remove in Arcane the deprecated usage of ItemConnectedListView

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -740,6 +740,9 @@ message(STATUS "ARCANE_EXTERNAL_LIBRARY_DIRS is ${ARCANE_EXTERNAL_LIBRARY_DIRS}"
 # les branches de développement de Arcane auront été fusionnées
 # target_compile_definitions(arcane_build_compile_flags INTERFACE ARCANE_NO_USING_FOR_STREAM)
 
+# Force à rendre privé les structures gérant les connectivités pour préparer leur suppression
+target_compile_definitions(arcane_build_compile_flags INTERFACE ARCANE_FORCE_HIDE_ITEM_CONNECTIVITY_STRUCTURE)
+
 if (UNIX)
   # Sur certaines plateformes (ex: centos7), il faut ajouter ces options
   # pour la compilation.

--- a/arcane/src/arcane/aleph/tests/AlephTestModule.cc
+++ b/arcane/src/arcane/aleph/tests/AlephTestModule.cc
@@ -397,16 +397,18 @@ initAmrRefineMesh(Integer nb_to_refine)
     for (Integer j = 0, js = CELL_NB_H_CHILDREN(cell); j < js; ++j) {
       //debug()<<"\t\t[amrRefineMesh] child cell #"<<cell.hChild(j).localId();
       m_cell_temperature[cells[CELL_H_CHILD(cell, j).localId()]] = m_cell_temperature[cells[lid]];
-      ENUMERATE_FACE (iFace, allCells().view()[CELL_H_CHILD(cell, j).localId()].toCell().faces()) {
-        Face face = *iFace;
+      auto faces = allCells().view()[CELL_H_CHILD(cell, j).localId()].toCell().faces();
+      Integer index = 0;
+      for( Face face : faces ){
         if (face.isSubDomainBoundary()) {
           //debug() << "\t\t\t[amrRefineMesh] outer face #"<< (*iFace).localId()<<", index="<<iFace.index()<<", T="<<m_face_temperature[cell.face(iFace.index())];
-          m_face_temperature[iFace] = m_face_temperature[cell.face(iFace.index())];
+          m_face_temperature[face] = m_face_temperature[cell.face(index)];
         }
         else {
           //debug() << "\t\t\t[amrRefineMesh] inner face #"<< (*iFace).localId();//<<", T="<<m_face_temperature[face.toFace()];
-          m_face_temperature[iFace] = 0;
+          m_face_temperature[face] = 0;
         }
+        ++index;
       }
     }
   }

--- a/arcane/src/arcane/core/ItemConnectedEnumeratorBase.h
+++ b/arcane/src/arcane/core/ItemConnectedEnumeratorBase.h
@@ -54,7 +54,7 @@ class ItemConnectedEnumeratorBase
   explicit ItemConnectedEnumeratorBase(const ConstArrayView<Int32> local_ids)
   : m_local_ids(local_ids.data()), m_count(local_ids.size()) {}
   template<int E> explicit ItemConnectedEnumeratorBase(const ItemConnectedListView<E>& rhs)
-  : m_local_ids(rhs.localIds().data()), m_count(rhs.localIds().size())
+  : m_local_ids(rhs._localIds().data()), m_count(rhs._localIds().size())
 #ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
     , m_local_id_offset(rhs.m_local_id_offset)
 #endif

--- a/arcane/src/arcane/core/ItemConnectedListView.h
+++ b/arcane/src/arcane/core/ItemConnectedListView.h
@@ -254,6 +254,15 @@ class ItemConnectedListView
     return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,(m_local_ids.data()+this->size()),m_local_id_offset));
   }
 
+  friend std::ostream& operator<<(std::ostream& o,const ItemConnectedListView<Extent>& a)
+  {
+    o << a.m_local_ids.localIds();
+    return o;
+  }
+
+  ARCANE_DEPRECATED_REASON("Y2023: Use iterator to get values or use operator[]")
+  Int32ConstArrayView localIds() const { return m_local_ids; }
+
 #ifdef ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
  private:
 #else
@@ -266,11 +275,6 @@ class ItemConnectedListView
     return ItemInternalVectorView(m_shared_info,m_local_ids);
   }
 
-  // TODO Rendre obsolète
- 
-  //! Tableau des numéros locaux des entités
-  Int32ConstArrayView localIds() const { return m_local_ids; }
-
   // TODO: rendre obsolète
   inline ItemEnumerator enumerator() const;
 
@@ -278,6 +282,9 @@ class ItemConnectedListView
 
   //! Vue sur le tableau des indices
   ItemIndexArrayView indexes() const { return m_local_ids; }
+
+  //! Vue sur le tableau des indices
+  Int32ConstArrayView _localIds() const { return m_local_ids; }
 
  protected:
   

--- a/arcane/src/arcane/core/ItemEnumeratorBase.h
+++ b/arcane/src/arcane/core/ItemEnumeratorBase.h
@@ -64,7 +64,7 @@ class ItemEnumeratorBase
   ItemEnumeratorBase(const ItemVectorView& rhs)
   : ItemEnumeratorBase((const ItemInternalVectorView&)rhs,nullptr) {}
   template<int E> ItemEnumeratorBase(const ItemConnectedListView<E>& rhs)
-  : m_local_ids(rhs.localIds().data()), m_count(rhs.localIds().size()){}
+  : m_local_ids(rhs._localIds().data()), m_count(rhs._localIds().size()){}
 
   ItemEnumeratorBase(const ItemEnumerator& rhs);
   ItemEnumeratorBase(const ItemInternalEnumerator& rhs);

--- a/arcane/src/arcane/core/ItemTypes.h
+++ b/arcane/src/arcane/core/ItemTypes.h
@@ -35,8 +35,12 @@ namespace Arcane
 #define ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
 
 // A définir si on souhaite cacher les méthodes d'accès aux structures
-// internes des connectivités.
-// #define ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
+// internes des connectivités. Pour l'instant (mi-2023) on ne le fait que
+// pour les sources internes à Arcane mais ensuite il faudra le généraliser.
+// (La macro ARCANE_FORCE_... est définie dans le CMakeLists.txt principal)
+#ifdef ARCANE_FORCE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
+#define ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
+#endif
 
 // A définir si on souhaite utiliser les classes spécifiques pour gérer
 // les entités connectées (sinon on utilise ItemVectorView)

--- a/arcane/src/arcane/std/DumpWEnsight7.cc
+++ b/arcane/src/arcane/std/DumpWEnsight7.cc
@@ -1036,8 +1036,8 @@ _saveGroup(std::ostream& ofile, const GroupPartInfo& ensight_grp,
       else { // mesh has general items
         for (Item mi : items) {
           Cell cell = mi.toCell();
-          ENUMERATE_FACE (face, cell.faces()) {
-            writeFileInt(ofile, face->nbNode());
+          for (Face face : cell.faces()) {
+            writeFileInt(ofile, face.nbNode());
           }
         }
       }

--- a/arcane/src/arcane/tests/AMRTestModule.cc
+++ b/arcane/src/arcane/tests/AMRTestModule.cc
@@ -298,7 +298,7 @@ _loadBalance()
   VariableItemInt32& cells_new_owner = mesh()->toPrimaryMesh()->itemsNewOwner(IK_Cell);
   ENUMERATE_FACE(iface,allFaces()) {
     if (!iface->isOwn())
-      ENUMERATE_CELL(icell,iface->cells())
+      for (CellLocalId icell : iface->cells())
         cells_new_owner[icell] = iface->owner();
   }
   info() << "Own cells before migration (" << ownCells().size() << " / " << allCells().size() << " )";

--- a/arcane/src/arcane/tests/CustomMeshTestModule.cc
+++ b/arcane/src/arcane/tests/CustomMeshTestModule.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CustomMeshTestModule.cc                          C) 2000-2021             */
+/* CustomMeshTestModule.cc                                      C) 2000-2023 */
 /*                                                                           */
 /* Test Module for custom mesh                                               */
 /*---------------------------------------------------------------------------*/
@@ -100,14 +100,14 @@ _testEnumerationAndConnectivities(IMesh* mesh)
     info() << "cell number of nodes " << icell->nodes().size();
     info() << "cell number of faces " << icell->faces().size();
     info() << "cell number of edges " << icell->edges().size();
-    ENUMERATE_NODE (inode, icell->nodes()) {
-      info() << "cell node " << inode.index() << " lid " << inode.localId() << " uid " << inode->uniqueId().asInt64();
+    for (Node node : icell->nodes()) {
+      info() << "cell node lid " << node.localId() << " uid " << node.uniqueId().asInt64();
     }
-    ENUMERATE_FACE (iface, icell->faces()) {
-      info() << "cell face " << iface.index() << " lid " << iface.localId() << " uid " << iface->uniqueId().asInt64();
+    for (Face face : icell->faces()) {
+      info() << "cell face lid " << face.localId() << " uid " << face.uniqueId().asInt64();
     }
-    ENUMERATE_EDGE (iedge, icell->edges()) {
-      info() << "cell edge " << iedge.index() << " lid " << iedge.localId() << " uid " << iedge->uniqueId().asInt64();
+    for (Edge edge : icell->edges()) {
+      info() << "cell edge lid " << edge.localId() << " uid " << edge.uniqueId().asInt64();
     }
   }
   // ALL FACES
@@ -120,28 +120,28 @@ _testEnumerationAndConnectivities(IMesh* mesh)
     info() << "face number of edges " << iface->edges().size();
     info() << "face back cell " << iface->backCell().localId();
     info() << "face front cell " << iface->frontCell().localId();
-    ENUMERATE_NODE (inode, iface->nodes()) {
-      info() << "face node " << inode.index() << " lid " << inode.localId() << " uid " << inode->uniqueId().asInt64();
+    for (Node node : iface->nodes()) {
+      info() << "face node lid " << node.localId() << " uid " << node.uniqueId().asInt64();
     }
     auto cell_index = 0;
     bool are_face_cells_ok = true;
-    ENUMERATE_CELL (icell, iface->cells()) {
-      info() << "face cell " << icell.index() << " lid " << icell.localId() << " uid " << icell->uniqueId().asInt64();
+    for (Cell cell : iface->cells()) {
+      info() << "face cell lid " << cell.localId() << " uid " << cell.uniqueId().asInt64();
       if (cell_index == 0) {
         if (iface->itemBase().flags() & ItemFlags::II_FrontCellIsFirst)
-          are_face_cells_ok = are_face_cells_ok && icell->uniqueId() == iface->frontCell().uniqueId();
+          are_face_cells_ok = are_face_cells_ok && cell.uniqueId() == iface->frontCell().uniqueId();
         else
-          are_face_cells_ok = are_face_cells_ok && icell->uniqueId() == iface->backCell().uniqueId();
+          are_face_cells_ok = are_face_cells_ok && cell.uniqueId() == iface->backCell().uniqueId();
       }
       else
-        are_face_cells_ok = are_face_cells_ok && icell->uniqueId() == iface->frontCell().uniqueId();
+        are_face_cells_ok = are_face_cells_ok && cell.uniqueId() == iface->frontCell().uniqueId();
       ++cell_index;
     }
     if (!are_face_cells_ok) {
-      fatal() << "Problem with face cells.";
+      ARCANE_FATAL("Problem with face cells.");
     }
-    ENUMERATE_EDGE (iedge, iface->edges()) {
-      info() << "face edge " << iedge.index() << " lid " << iedge.localId() << " uid " << iedge->uniqueId().asInt64();
+    for (Edge edge : iface->edges()) {
+      info() << "face edge lid " << edge.localId() << " uid " << edge.uniqueId().asInt64();
     }
   }
   // Check face flags
@@ -154,14 +154,14 @@ _testEnumerationAndConnectivities(IMesh* mesh)
     info() << "node number of faces " << inode->faces().size();
     info() << "node number of cells " << inode->cells().size();
     info() << "node number of edges " << inode->edges().size();
-    ENUMERATE_FACE (iface, inode->faces()) {
-      info() << "node face " << iface.index() << " lid " << iface.localId() << " uid " << iface->uniqueId().asInt64();
+    for (Face face : inode->faces()) {
+      info() << "node face lid " << face.localId() << " uid " << face.uniqueId().asInt64();
     }
-    ENUMERATE_CELL (icell, inode->cells()) {
-      info() << "node cell " << icell.index() << " lid " << icell.localId() << " uid " << icell->uniqueId().asInt64();
+    for (Cell cell : inode->cells()) {
+      info() << "node cell lid " << cell.localId() << " uid " << cell.uniqueId().asInt64();
     }
-    ENUMERATE_EDGE (iedge, inode->edges()) {
-      info() << "face edge " << iedge.index() << " lid " << iedge.localId() << " uid " << iedge->uniqueId().asInt64();
+    for (Edge edge : inode->edges()) {
+      info() << "node edge lid " << edge.localId() << " uid " << edge.uniqueId().asInt64();
     }
   }
   // ALL EDGES
@@ -172,14 +172,14 @@ _testEnumerationAndConnectivities(IMesh* mesh)
     info() << "edge number of faces " << iedge->faces().size();
     info() << "edge number of cells " << iedge->cells().size();
     info() << "edge number of nodes " << iedge->nodes().size();
-    ENUMERATE_FACE (iface, iedge->faces()) {
-      info() << "edge face " << iface.index() << " lid " << iface.localId() << " uid " << iface->uniqueId().asInt64();
+    for (Face face : iedge->faces()) {
+      info() << "edge face lid " << face.localId() << " uid " << face.uniqueId();
     }
-    ENUMERATE_CELL (icell, iedge->cells()) {
-      info() << "edge cell " << icell.index() << " lid " << icell.localId() << " uid " << icell->uniqueId().asInt64();
+    for (Cell cell : iedge->cells()) {
+      info() << "edge cell lid " << cell.localId() << " uid " << cell.uniqueId();
     }
-    ENUMERATE_NODE (inode, iedge->nodes()) {
-      info() << "edge node " << inode.index() << " lid " << inode.localId() << " uid " << inode->uniqueId().asInt64();
+    for (Node node : iedge->nodes()) {
+      info() << "edge node lid " << node.localId() << " uid " << node.uniqueId();
     }
   }
 }
@@ -457,7 +457,7 @@ _checkBoundaryFaceGroup(IMesh* mesh, const String& boundary_face_group_name) con
   ENUMERATE_FACE (iface, boundary_face_group) {
     are_face_boundaries = are_face_boundaries && iface->isSubDomainBoundary();
     if (!iface->isSubDomainBoundary()) {
-      info() << String::format("Face {0} with nodes {1} is not boundary", iface->uniqueId(), iface->nodes().localIds());
+      info() << String::format("Face {0} with nodes {1} is not boundary", iface->uniqueId(), iface->nodes());
     }
   }
   if (!are_face_boundaries)
@@ -477,7 +477,7 @@ _checkInternalFaceGroup(IMesh* mesh, const String& internal_face_group_name) con
   ENUMERATE_FACE (iface, internal_face_group) {
     are_face_internals = are_face_internals && !iface->isSubDomainBoundary();
     if (iface->isSubDomainBoundary()) {
-      info() << String::format("Face {0} with nodes {1} is not an internal face", iface->uniqueId(), iface->nodes().localIds());
+      info() << String::format("Face {0} with nodes {1} is not an internal face", iface->uniqueId(), iface->nodes());
     }
   }
   if (!are_face_internals)

--- a/arcane/src/arcane/tests/MeshModificationTester.cc
+++ b/arcane/src/arcane/tests/MeshModificationTester.cc
@@ -240,7 +240,7 @@ _refineCells()
         to_add_cells.add(cell->node(2).uniqueId().asInt64());
         to_add_cells.add(cell->node(3).uniqueId().asInt64());
         Real3 center;
-        ENUMERATE_NODE(inode, cell->nodes()) {
+        for( NodeLocalId inode : cell->nodeIds()) {
           center += nodes_coords[inode];
           info() << String::format("ADD CENTER {0}",nodes_coords[inode]);
         }

--- a/arcane/src/arcane/tests/SubMeshTestModule.cc
+++ b/arcane/src/arcane/tests/SubMeshTestModule.cc
@@ -525,11 +525,11 @@ _compute3AddItems()
     if (check_variable) {
       ENUMERATE_CELL(icell,parent2sub) {
         (*new_cell_uids)[icell] = icell->uniqueId();
-        ENUMERATE_FACE(iface,icell->faces()){
-          (*new_face_uids)[iface] = iface->uniqueId();
+        for ( Face face : icell->faces()){
+          (*new_face_uids)[face] = face.uniqueId();
         }
-        ENUMERATE_NODE(inode,icell->nodes()){
-          (*new_node_uids)[inode] = inode->uniqueId();
+        for ( Node node : icell->nodes()){
+          (*new_node_uids)[node] = node.uniqueId();
         }
       }
     }
@@ -570,7 +570,7 @@ _compute5MoveItems()
   VariableItemInt32& cells_new_owner = mesh()->toPrimaryMesh()->itemsNewOwner(IK_Cell);
   ENUMERATE_FACE(iface,allFaces()) {
     if (!iface->isOwn())
-      ENUMERATE_CELL(icell,iface->cells())
+      for( CellLocalId icell : iface->cells())
         cells_new_owner[icell] = iface->owner();
   }
   info() << "Own cells before migration (" << ownCells().size() << " / " << allCells().size() << " )";

--- a/arcane/src/arcane/tests/graph/GraphUnitTest.cc
+++ b/arcane/src/arcane/tests/graph/GraphUnitTest.cc
@@ -421,7 +421,7 @@ _createGraphOfDof()
 
   // On remplit le tableau links_infos
   ENUMERATE_CELL (icell, ownCells()) {
-    const Cell& cell = *icell;
+    Cell cell = *icell;
 
     //  Take only cell with nb_facemax faces, number of dual node per link is constant...
     if (cell.faces().size() != nb_facemax) {
@@ -431,8 +431,7 @@ _createGraphOfDof()
 
     links_infos2[links_infos_index++] = m_dualUid_mng.uniqueIdOf(cell);
 
-    ENUMERATE_FACE (iface, cell.faces()) {
-      auto const& face = *iface;
+    for ( Face face : cell.faces()) {
       links_infos2[links_infos_index] = face_to_dual_node_property[face];
       links_infos_index++;
     }


### PR DESCRIPTION
This remove in the source of Arcane the use of 'ENUMERATE*' when using item connectivity (i.e: `node.cells()` or `cell.faces()` but not for groups like `allCells()`)
For example, it replaces:

```{.cpp}
ENUMERATE_FACE(iface,cell.faces()){
  const Face face = *iface;
}
```

with

```
for( Face iface : cell.faces() ){
}
```

This change will be required in a future version if we want to do something different between iteration over `ItemGroup` and iteration over items connected to another item.