### PR TITLE
Add new interface 'IMemoryAllocator3' to manage allocators

### DIFF
--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -48,7 +48,7 @@ class BadAllocException
 IMemoryAllocator* ArrayMetaData::
 _defaultAllocator()
 {
-  return &DefaultMemoryAllocator::shared_null_instance;
+  return &DefaultMemoryAllocator3::shared_null_instance;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -97,13 +97,14 @@ allocationArgs() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void AbstractArrayBase::
-setMemoryAllocationHint(eMemoryLocationHint new_hint)
+void ArrayMetaData::
+_setMemoryAllocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_type)
 {
-  MemoryAllocationArgs old_args = m_md->_getAllocationArgs();
-  m_md->allocation_options.setMemoryLocationHint(new_hint);
-  MemoryAllocationArgs new_args = m_md->_getAllocationArgs();
-  m_md->_allocator()->notifyMemoryArgsChanged(old_args,new_args,AllocatedMemoryInfo{});
+  MemoryAllocationArgs old_args = _getAllocationArgs();
+  allocation_options.setMemoryLocationHint(new_hint);
+  MemoryAllocationArgs new_args = _getAllocationArgs();
+  AllocatedMemoryInfo mem_info(ptr,size,capacity);
+  _allocator()->notifyMemoryArgsChanged(old_args,new_args,mem_info);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -115,10 +115,10 @@ _allocate(Int64 new_capacity,Int64 sizeof_true_type)
   MemoryAllocationArgs alloc_args = _getAllocationArgs();
   IMemoryAllocator* a = _allocator();
   size_t s_new_capacity = (size_t)new_capacity;
-  s_new_capacity = a->adjustCapacity(s_new_capacity,sizeof_true_type,alloc_args);
+  s_new_capacity = a->adjustedCapacity(alloc_args,s_new_capacity,sizeof_true_type);
   size_t s_sizeof_true_type = (size_t)sizeof_true_type;
   size_t elem_size = s_new_capacity * s_sizeof_true_type;
-  MemoryPointer p = a->allocate(elem_size,alloc_args);
+  MemoryPointer p = a->allocate(alloc_args,elem_size).baseAddress();
 #ifdef ARCCORE_DEBUG_ARRAY
   std::cout << "ArrayImplBase::ALLOCATE: elemsize=" << elem_size
             << " typesize=" << sizeof_true_type
@@ -141,34 +141,33 @@ _allocate(Int64 new_capacity,Int64 sizeof_true_type)
 /*---------------------------------------------------------------------------*/
 
 ArrayMetaData::MemoryPointer ArrayMetaData::
-_reallocate(Int64 new_capacity,Int64 sizeof_true_type,MemoryPointer current)
+_reallocate(Int64 new_capacity, Int64 sizeof_true_type, MemoryPointer current)
 {
   _checkAllocator();
   MemoryAllocationArgs alloc_args = _getAllocationArgs();
   IMemoryAllocator* a = _allocator();
+  const Int64 current_allocated_size = capacity * sizeof_true_type;
+  const Int64 current_size = this->size * sizeof_true_type;
+  new_capacity = a->adjustedCapacity(alloc_args, new_capacity, sizeof_true_type);
+  size_t elem_size = new_capacity * sizeof_true_type;
 
-  size_t s_new_capacity = (size_t)new_capacity;
-  s_new_capacity = a->adjustCapacity(s_new_capacity,sizeof_true_type,alloc_args);
-  size_t s_sizeof_true_type = (size_t)sizeof_true_type;
-  size_t elem_size = s_new_capacity * s_sizeof_true_type;
-  
   MemoryPointer p = nullptr;
   {
+    AllocatedMemoryInfo current_info(current, current_size, current_allocated_size);
     const bool use_realloc = a->hasRealloc(alloc_args);
     // Lorsqu'on voudra implémenter un realloc avec alignement, il faut passer
     // par use_realloc = false car sous Linux il n'existe pas de méthode realloc
     // garantissant l'alignement (alors que sous Win32 si :) ).
     // use_realloc = false;
     if (use_realloc) {
-      p = a->reallocate(current, elem_size, alloc_args);
+      p = a->reallocate(alloc_args, current_info, elem_size).baseAddress();
     }
     else {
-      p = a->allocate(elem_size, alloc_args);
+      p = a->allocate(alloc_args, elem_size).baseAddress();
       //GG: TODO: regarder si 'current' peut être nul (a priori je ne pense pas...)
       if (p && current) {
-        size_t current_size = this->size * s_sizeof_true_type;
         ::memcpy(p, current, current_size);
-        a->deallocate(current, alloc_args);
+        a->deallocate(alloc_args, current_info);
       }
     }
   }
@@ -178,7 +177,7 @@ _reallocate(Int64 new_capacity,Int64 sizeof_true_type,MemoryPointer current)
             << " size=" << new_capacity << " datasize=" << sizeof_true_impl
             << " ptr=" << current << " new_p=" << p << '\n';
 #endif
-  if (!p){
+  if (!p) {
     std::ostringstream ostr;
     ostr << " Bad ArrayImplBase::reallocate() size=" << elem_size
          << " capacity=" << new_capacity
@@ -186,7 +185,7 @@ _reallocate(Int64 new_capacity,Int64 sizeof_true_type,MemoryPointer current)
          << " old_ptr=" << current << '\n';
     throw BadAllocException(ostr.str());
   }
-  this->capacity = (Int64)s_new_capacity;
+  this->capacity = new_capacity;
   return p;
 }
 
@@ -194,11 +193,14 @@ _reallocate(Int64 new_capacity,Int64 sizeof_true_type,MemoryPointer current)
 /*---------------------------------------------------------------------------*/
 
 void ArrayMetaData::
-_deallocate(MemoryPointer current) noexcept
+_deallocate(MemoryPointer current, Int64 sizeof_true_type) noexcept
 {
-  if (_allocator()){
+  if (_allocator()) {
+    Int64 current_size = this->size * sizeof_true_type;
+    Int64 current_capacity = this->capacity * sizeof_true_type;
+    AllocatedMemoryInfo mem_info(current, current_size, current_capacity);
     MemoryAllocationArgs alloc_args = _getAllocationArgs();
-    _allocator()->deallocate(current,alloc_args);
+    _allocator()->deallocate(alloc_args, mem_info);
   }
 }
 

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -90,6 +90,7 @@ allocationArgs() const
 {
   MemoryAllocationArgs x;
   x.setMemoryLocationHint(m_memory_location_hint);
+  x.setDevice(m_device);
   return x;
 }
 

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -98,7 +98,7 @@ allocationArgs() const
 /*---------------------------------------------------------------------------*/
 
 void ArrayMetaData::
-_setMemoryAllocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_type)
+_setMemoryLocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_type)
 {
   MemoryAllocationArgs old_args = _getAllocationArgs();
   allocation_options.setMemoryLocationHint(new_hint);

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -64,6 +64,15 @@ _checkAllocator() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+MemoryAllocationArgs ArrayMetaData::
+_getAllocationArgs() const
+{
+  return allocation_options.allocationArgs();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 /*
  * TODO: pour les allocations, faire en sorte que le
  * début du tableau soit aligné sur 16 octets dans tous les cas.
@@ -76,12 +85,24 @@ _checkAllocator() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-MemoryAllocationArgs ArrayMetaData::
-_getAllocationArgs() const
+MemoryAllocationArgs MemoryAllocationOptions::
+allocationArgs() const
 {
   MemoryAllocationArgs x;
-  x.setMemoryLocationHint(allocation_options.m_memory_location_hint);
+  x.setMemoryLocationHint(m_memory_location_hint);
   return x;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void AbstractArrayBase::
+setMemoryAllocationHint(eMemoryLocationHint new_hint)
+{
+  MemoryAllocationArgs old_args = m_md->_getAllocationArgs();
+  m_md->allocation_options.setMemoryLocationHint(new_hint);
+  MemoryAllocationArgs new_args = m_md->_getAllocationArgs();
+  m_md->_allocator()->notifyMemoryArgsChanged(old_args,new_args,AllocatedMemoryInfo{});
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -1727,13 +1727,13 @@ class UniqueArray
   //! Créé un tableau en recopiant les valeurs \a rhs.
   UniqueArray(const Array<T>& rhs)
   {
-    this->_initFromAllocator(rhs.allocator(),0);
+    this->_initFromAllocator(rhs.allocationOptions(),0);
     this->_initFromSpan(rhs);
   }
   //! Créé un tableau en recopiant les valeurs \a rhs.
   UniqueArray(const UniqueArray<T>& rhs) : Array<T> {}
   {
-    this->_initFromAllocator(rhs.allocator(),0);
+    this->_initFromAllocator(rhs.allocationOptions(),0);
     this->_initFromSpan(rhs);
   }
   //! Créé un tableau en recopiant les valeurs \a rhs.

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -110,7 +110,7 @@ class ARCCORE_COLLECTIONS_EXPORT ArrayMetaData
   MemoryPointer _allocate(Int64 nb,Int64 sizeof_true_type);
   MemoryPointer _reallocate(Int64 nb,Int64 sizeof_true_type,MemoryPointer current);
   void _deallocate(MemoryPointer current,Int64 sizeof_true_type) ARCCORE_NOEXCEPT;
-  void _setMemoryAllocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_type);
+  void _setMemoryLocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_type);
 
  private:
 
@@ -492,9 +492,9 @@ class AbstractArray
  public:
 
   //! Modifie les informations sur la localisation mémoire
-  void setMemoryAllocationHint(eMemoryLocationHint new_hint)
+  void setMemoryLocationHint(eMemoryLocationHint new_hint)
   {
-    m_md->_setMemoryAllocationHint(new_hint,m_ptr,sizeof(T));
+    m_md->_setMemoryLocationHint(new_hint,m_ptr,sizeof(T));
   }
 
  private:

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -229,6 +229,7 @@ class ARCCORE_COLLECTIONS_EXPORT AbstractArrayBase
   {
     return m_md->allocation_options;
   }
+  void setMemoryAllocationHint(eMemoryLocationHint new_hint);
 
  protected:
 
@@ -247,6 +248,8 @@ class ARCCORE_COLLECTIONS_EXPORT AbstractArrayBase
   {
     return true;
   }
+
+  virtual Int64 _getDataTypeSize() const =0;
 
  protected:
 
@@ -618,6 +621,8 @@ class AbstractArray
   }
 
  protected:
+
+  Int64 _getDataTypeSize() const final { return sizeof(T); }
 
   //! Mise à jour des références
   virtual void _updateReferences()

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -109,7 +109,7 @@ class ARCCORE_COLLECTIONS_EXPORT ArrayMetaData
 
   MemoryPointer _allocate(Int64 nb,Int64 sizeof_true_type);
   MemoryPointer _reallocate(Int64 nb,Int64 sizeof_true_type,MemoryPointer current);
-  void _deallocate(MemoryPointer current) ARCCORE_NOEXCEPT;
+  void _deallocate(MemoryPointer current,Int64 sizeof_true_type) ARCCORE_NOEXCEPT;
 
  private:
 
@@ -552,7 +552,7 @@ class AbstractArray
         old_ptr[i].~T();
       }
       m_md->nb_ref = old_md->nb_ref;
-      m_md->_deallocate(old_ptr);
+      m_md->_deallocate(old_ptr,sizeof(T));
       _updateReferences();
     }
   }
@@ -560,7 +560,7 @@ class AbstractArray
   void _internalDeallocate()
   {
     if (!_isSharedNull())
-      m_md->_deallocate(m_ptr);
+      m_md->_deallocate(m_ptr,sizeof(T));
     if (m_md->is_not_null)
       _deallocateMetaData(m_md);
   }

--- a/arccore/src/collections/arccore/collections/CollectionsGlobal.h
+++ b/arccore/src/collections/arccore/collections/CollectionsGlobal.h
@@ -78,8 +78,37 @@ enum class eMemoryLocationHint : int8_t
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations sur une zone mémoire allouée
+ */
+class AllocatedMemoryInfo
+{
+ public:
 
-}
+  AllocatedMemoryInfo() = default;
+  explicit AllocatedMemoryInfo(void* base_address)
+  : m_base_address(base_address)
+  {}
+  AllocatedMemoryInfo(void* base_address, Int64 _size)
+  : m_base_address(base_address)
+  , m_size(_size)
+  {}
+
+  //! Adresse du début de la zone allouée.
+  void* baseAddress() const { return m_base_address; }
+  //! Taille de la zone mémoire. (-1) si inconnue
+  Int64 size() const { return m_size; }
+
+ public:
+
+  void* m_base_address = nullptr;
+  Int64 m_size = -1;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arccore
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/CollectionsGlobal.h
+++ b/arccore/src/collections/arccore/collections/CollectionsGlobal.h
@@ -79,7 +79,7 @@ enum class eMemoryLocationHint : int8_t
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Informations sur une zone mémoire allouée
+ * \brief Informations sur une zone mémoire allouée.
  */
 class AllocatedMemoryInfo
 {
@@ -89,20 +89,29 @@ class AllocatedMemoryInfo
   explicit AllocatedMemoryInfo(void* base_address)
   : m_base_address(base_address)
   {}
-  AllocatedMemoryInfo(void* base_address, Int64 _size)
+  AllocatedMemoryInfo(void* base_address, Int64 size)
   : m_base_address(base_address)
-  , m_size(_size)
+  , m_size(size)
+  , m_capacity(size)
+  {}
+  AllocatedMemoryInfo(void* base_address, Int64 size, Int64 capacity)
+  : m_base_address(base_address)
+  , m_size(size)
+  , m_capacity(capacity)
   {}
 
   //! Adresse du début de la zone allouée.
   void* baseAddress() const { return m_base_address; }
-  //! Taille de la zone mémoire. (-1) si inconnue
+  //! Taille de la zone mémoire utilisée. (-1) si inconnue
   Int64 size() const { return m_size; }
+  //! Taille de la zone mémoire allouée. (-1) si inconnue
+  Int64 capacity() const { return m_capacity; }
 
  public:
 
   void* m_base_address = nullptr;
   Int64 m_size = -1;
+  Int64 m_capacity = -1;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/CollectionsGlobal.h
+++ b/arccore/src/collections/arccore/collections/CollectionsGlobal.h
@@ -54,5 +54,35 @@ template<typename DataType> class SharedArray2;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+namespace Arccore
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+//! Indices sur la localisation mémoire attendue
+enum class eMemoryLocationHint : int8_t
+{
+  //! Aucune indice
+  None = 0,
+  //! Indique que la donnée sera plutôt utilisée sur accélérateur
+  MainlyDevice = 1,
+  //! Indique que la donnée sera plutôt utilisée sur CPU
+  MainlyHost = 2,
+  /*!
+   * \brief Indique que la donnée sera utilisée à la fois sur accélérateur et
+   * sur CPU et qu'elle ne sera pas souvent modifiée.
+   */
+  HostAndDeviceMostlyRead = 3
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 #endif  
 

--- a/arccore/src/collections/arccore/collections/IMemoryAllocator.h
+++ b/arccore/src/collections/arccore/collections/IMemoryAllocator.h
@@ -132,9 +132,13 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
  public:
 
   // Méthodes obsolètes
+  ARCCORE_DEPRECATED_REASON("Y2023: use allocate(MemoryAllocationArgs,Int64) instead")
   virtual void* allocate(size_t new_size, MemoryAllocationArgs);
+  ARCCORE_DEPRECATED_REASON("Y2023: use reallocate(MemoryAllocationArgs,AllocatedMemoryInfo,Int64) instead")
   virtual void* reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs);
+  ARCCORE_DEPRECATED_REASON("Y2023: use deallocate(MemoryAllocationArgs,AllocatedMemoryInfo) instead")
   virtual void deallocate(void* ptr, MemoryAllocationArgs);
+  ARCCORE_DEPRECATED_REASON("Y2023: use adjustedCapacity(MemoryAllocationArgs,Int64,Int64) instead")
   virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs);
 
  public:
@@ -144,13 +148,13 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
   // supprimées à terme.
   ARCCORE_DEPRECATED_REASON("Y2023: use hasRealloc(MemoryAllocationArgs) instead")
   virtual bool hasRealloc() const = 0;
-  ARCCORE_DEPRECATED_REASON("Y2023: use allocate(size_t,MemoryAllocationArgs) instead")
+  ARCCORE_DEPRECATED_REASON("Y2023: use allocate(MemoryAllocationArgs,Int64) instead")
   virtual void* allocate(size_t new_size) = 0;
-  ARCCORE_DEPRECATED_REASON("Y2023: use reallocate(AllocatedMemoryInfo,Int64,MemoryAllocationArgs) instead")
+  ARCCORE_DEPRECATED_REASON("Y2023: use reallocate(MemoryAllocationArgs,AllocatedMemoryInfo,Int64) instead")
   virtual void* reallocate(void* current_ptr, size_t new_size) = 0;
-  ARCCORE_DEPRECATED_REASON("Y2023: use deallocate(AllocatedMemoryInfo,MemoryAllocationArgs) instead")
+  ARCCORE_DEPRECATED_REASON("Y2023: use deallocate(MemoryAllocationArgs,AllocatedMemoryInfo) instead")
   virtual void deallocate(void* ptr) = 0;
-  ARCCORE_DEPRECATED_REASON("Y2023: use adjustCapacity(size_t,size_t,MemoryAllocationArgs) instead")
+  ARCCORE_DEPRECATED_REASON("Y2023: use adjustedCapacity(MemoryAllocationArgs,Int64,Int64) instead")
   virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size) = 0;
   ARCCORE_DEPRECATED_REASON("Y2023: use guarantedAlignment(MemoryAllocationArgs) instead")
   virtual size_t guarantedAlignment() = 0;
@@ -163,91 +167,37 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
  *
  * Elle contient les mêmes méthodes que IMemoryAllocator mais avec un argument
  * supplémentaire qui permet de spécialiser les allocations.
+ *
+ * \deprecated Utiliser 'IMemoryAllocator3' à la place.
  */
 class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator2
 : public IMemoryAllocator
 {
  public:
 
-  /*!
-   * \brief Indique si l'allocateur supporte la sémantique de realloc.
-   *
-   * Les allocateurs par défaut du C (malloc/realloc/free) supportent
-   * évidemment le realloc mais ce n'est pas forcément le cas
-   * des allocateurs spécifiques avec alignement mémoire (comme
-   * par exemple posix_memalign).
-   */
   virtual bool hasRealloc(MemoryAllocationArgs args) const = 0;
+  virtual size_t guarantedAlignment(MemoryAllocationArgs args) = 0;
 
-  /*!
-   * \brief Alloue de la mémoire pour \a new_size octets et retourne le pointeur.
-   *
-   * La sémantique est équivalent à malloc():
-   * - \a new_size peut valoir zéro et dans ce cas le pointeur retourné
-   * est soit nul, soit une valeur spécifique
-   * - le pointeur retourné peut être nul si la mémoire n'a pas pu être allouée.
-   */
+  ARCCORE_DEPRECATED_REASON("Y2023: this interface is deprecated. Use IMemoryAllocator3 instead")
   virtual void* allocate(size_t new_size, MemoryAllocationArgs args) = 0;
 
-  /*!
-   * \brief Réalloue de la mémoire pour \a new_size octets et retourne le pointeur.
-   *
-   * Le pointeur \a current_ptr doit avoir été alloué via l'appel à
-   * allocate() ou reallocate() de cette instance.
-   *
-   * La sémantique de cette méthode est équivalente à realloc():
-   * - \a current_ptr peut-être nul auquel cas cet appel est équivalent
-   * à allocate().
-   * - le pointeur retourné peut être nul si la mémoire n'a pas pu être allouée.
-   */
+  ARCCORE_DEPRECATED_REASON("Y2023: this interface is deprecated. Use IMemoryAllocator3 instead")
   virtual void* reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs args) = 0;
 
-  /*!
-   * \brief Libère la mémoire dont l'adresse de base est \a ptr.
-   *
-   * Le pointeur \a ptr doit avoir été alloué via l'appel à
-   * allocate() ou reallocate() de cette instance.
-   *
-   * La sémantique de cette méthode équivalente à free() et donc \a ptr
-   * peut être nul auquel cas aucune opération n'est effectuée.
-   */
+  ARCCORE_DEPRECATED_REASON("Y2023: this interface is deprecated. Use IMemoryAllocator3 instead")
   virtual void deallocate(void* ptr, MemoryAllocationArgs args) = 0;
 
-  /*!
-   * \brief Ajuste la capacité suivant la taille d'élément.
-   *
-   * Cette méthode est utilisée pour éventuellement modifié le nombre
-   * d'éléments alloués suivant leur taille. Cela permet par exemple
-   * pour les allocateurs alignés de garantir que le nombre d'éléments
-   * alloués est un multiple de cet alignement.
-   * 
-   */
+  ARCCORE_DEPRECATED_REASON("Y2023: this interface is deprecated. Use IMemoryAllocator3 instead")
   virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs args) = 0;
-
-  /*!
-   * \brief Valeur de l'alignement garanti par l'allocateur.
-   *
-   * Cette méthode permet de s'assurer qu'un allocateur a un alignement suffisant
-   * pour certaines opérations comme la vectorisation par exemple.
-   *
-   * S'il n'y a aucune garantie, retourne 0.
-   */
-  virtual size_t guarantedAlignment(MemoryAllocationArgs args) = 0;
 
  private:
 
-  bool hasRealloc() const final { return hasRealloc(MemoryAllocationArgs{}); }
-  void* allocate(size_t new_size) final { return allocate(new_size, MemoryAllocationArgs{}); }
-  void* reallocate(void* current_ptr, size_t new_size) final
-  {
-    return reallocate(current_ptr, new_size, MemoryAllocationArgs{});
-  }
-  void deallocate(void* ptr) final { return deallocate(ptr, MemoryAllocationArgs{}); }
-  size_t adjustCapacity(size_t wanted_capacity, size_t element_size) final
-  {
-    return adjustCapacity(wanted_capacity, element_size, MemoryAllocationArgs{});
-  }
-  size_t guarantedAlignment() final { return guarantedAlignment(MemoryAllocationArgs{}); }
+  bool hasRealloc() const final;
+  void* allocate(size_t new_size) final;
+  void* reallocate(void* current_ptr, size_t new_size) final;
+  void deallocate(void* ptr) final;
+  size_t adjustCapacity(size_t wanted_capacity, size_t element_size) final;
+  size_t guarantedAlignment() final;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/IMemoryAllocator.h
+++ b/arccore/src/collections/arccore/collections/IMemoryAllocator.h
@@ -21,6 +21,7 @@
 
 namespace Arccore
 {
+// TODO: retourner infos sur pointeur + taille dans allocate()
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -62,17 +63,17 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
    * des allocateurs spécifiques avec alignement mémoire (comme
    * par exemple posix_memalign).
    */
-  virtual bool hasRealloc(MemoryAllocationArgs) const;
+  virtual bool hasRealloc(MemoryAllocationArgs args) const;
 
   /*!
    * \brief Alloue de la mémoire pour \a new_size octets et retourne le pointeur.
    *
    * La sémantique est équivalent à malloc():
    * - \a new_size peut valoir zéro et dans ce cas le pointeur retourné
-   * est soit nul, soit une valeur spécifique
+   * est soit nul, soit une valeur non spécifiée.
    * - le pointeur retourné peut être nul si la mémoire n'a pas pu être allouée.
    */
-  virtual void* allocate(size_t new_size, MemoryAllocationArgs);
+  virtual AllocatedMemoryInfo allocate(MemoryAllocationArgs args, Int64 new_size);
 
   /*!
    * \brief Réalloue de la mémoire pour \a new_size octets et retourne le pointeur.
@@ -85,7 +86,7 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
    * à allocate().
    * - le pointeur retourné peut être nul si la mémoire n'a pas pu être allouée.
    */
-  virtual void* reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs);
+  virtual AllocatedMemoryInfo reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size);
 
   /*!
    * \brief Libère la mémoire dont l'adresse de base est \a ptr.
@@ -96,7 +97,7 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
    * La sémantique de cette méthode équivalente à free() et donc \a ptr
    * peut être nul auquel cas aucune opération n'est effectuée.
    */
-  virtual void deallocate(void* ptr, MemoryAllocationArgs);
+  virtual void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr);
 
   /*!
    * \brief Ajuste la capacité suivant la taille d'élément.
@@ -107,17 +108,34 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
    * alloués est un multiple de cet alignement.
    * 
    */
-  virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs);
+  virtual Int64 adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const;
 
   /*!
-  * \brief Valeur de l'alignement garanti par l'allocateur.
-  *
-  * Cette méthode permet de s'assurer qu'un allocateur a un alignement suffisant
-  * pour certaines opérations comme la vectorisation par exemple.
-  *
-  * S'il n'y a aucune garantie, retourne 0.
-  */
-  virtual size_t guarantedAlignment(MemoryAllocationArgs);
+   * \brief Valeur de l'alignement garanti par l'allocateur.
+   *
+   * Cette méthode permet de s'assurer qu'un allocateur a un alignement suffisant
+   * pour certaines opérations comme la vectorisation par exemple.
+   *
+   * S'il n'y a aucune garantie, retourne 0.
+   */
+  virtual size_t guarantedAlignment(MemoryAllocationArgs args) const;
+
+  /*!
+   * \brief Notifie du changement des arguments spécifiques à l'instance.
+   *
+   * \param Zone mémoire allouée
+   * \param old_args ancienne valeur des arguments
+   * \param new_args nouvelle valeur des arguments
+   */
+  virtual void notifyMemoryArgsChanged(MemoryAllocationArgs old_args, MemoryAllocationArgs new_args, AllocatedMemoryInfo ptr);
+
+ public:
+
+  // Méthodes obsolètes
+  virtual void* allocate(size_t new_size, MemoryAllocationArgs);
+  virtual void* reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs);
+  virtual void deallocate(void* ptr, MemoryAllocationArgs);
+  virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs);
 
  public:
 
@@ -128,9 +146,9 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
   virtual bool hasRealloc() const = 0;
   ARCCORE_DEPRECATED_REASON("Y2023: use allocate(size_t,MemoryAllocationArgs) instead")
   virtual void* allocate(size_t new_size) = 0;
-  ARCCORE_DEPRECATED_REASON("Y2023: use reallocate(void*,size_t,MemoryAllocationArgs) instead")
+  ARCCORE_DEPRECATED_REASON("Y2023: use reallocate(AllocatedMemoryInfo,Int64,MemoryAllocationArgs) instead")
   virtual void* reallocate(void* current_ptr, size_t new_size) = 0;
-  ARCCORE_DEPRECATED_REASON("Y2023: use deallocate(void*_t,MemoryAllocationArgs) instead")
+  ARCCORE_DEPRECATED_REASON("Y2023: use deallocate(AllocatedMemoryInfo,MemoryAllocationArgs) instead")
   virtual void deallocate(void* ptr) = 0;
   ARCCORE_DEPRECATED_REASON("Y2023: use adjustCapacity(size_t,size_t,MemoryAllocationArgs) instead")
   virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size) = 0;
@@ -207,13 +225,13 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator2
   virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs args) = 0;
 
   /*!
-  * \brief Valeur de l'alignement garanti par l'allocateur.
-  *
-  * Cette méthode permet de s'assurer qu'un allocateur a un alignement suffisant
-  * pour certaines opérations comme la vectorisation par exemple.
-  *
-  * S'il n'y a aucune garantie, retourne 0.
-  */
+   * \brief Valeur de l'alignement garanti par l'allocateur.
+   *
+   * Cette méthode permet de s'assurer qu'un allocateur a un alignement suffisant
+   * pour certaines opérations comme la vectorisation par exemple.
+   *
+   * S'il n'y a aucune garantie, retourne 0.
+   */
   virtual size_t guarantedAlignment(MemoryAllocationArgs args) = 0;
 
  private:
@@ -230,6 +248,96 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator2
     return adjustCapacity(wanted_capacity, element_size, MemoryAllocationArgs{});
   }
   size_t guarantedAlignment() final { return guarantedAlignment(MemoryAllocationArgs{}); }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Interface de la version 3 de IMemoryAllocator.
+ *
+ * Elle contient les mêmes méthodes que IMemoryAllocator mais avec un argument
+ * supplémentaire qui permet de spécialiser les allocations.
+ */
+class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator3
+: public IMemoryAllocator
+{
+  using BaseClass = IMemoryAllocator;
+
+ public:
+
+  /*!
+   * \brief Indique si l'allocateur supporte la sémantique de realloc.
+   *
+   * Les allocateurs par défaut du C (malloc/realloc/free) supportent
+   * évidemment le realloc mais ce n'est pas forcément le cas
+   * des allocateurs spécifiques avec alignement mémoire (comme
+   * par exemple posix_memalign).
+   */
+  virtual bool hasRealloc(MemoryAllocationArgs) const { return false; }
+
+  /*!
+   * \brief Alloue de la mémoire pour \a new_size octets et retourne le pointeur.
+   *
+   * La sémantique est équivalent à malloc():
+   * - \a new_size peut valoir zéro et dans ce cas le pointeur retourné
+   * est soit nul, soit une valeur spécifique
+   * - le pointeur retourné peut être nul si la mémoire n'a pas pu être allouée.
+   */
+  virtual AllocatedMemoryInfo allocate(MemoryAllocationArgs args, Int64 new_size) = 0;
+
+  /*!
+   * \brief Réalloue de la mémoire pour \a new_size octets et retourne le pointeur.
+   *
+   * Le pointeur \a current_ptr doit avoir été alloué via l'appel à
+   * allocate() ou reallocate() de cette instance.
+   *
+   * La sémantique de cette méthode est équivalente à realloc():
+   * - \a current_ptr peut-être nul auquel cas cet appel est équivalent
+   * à allocate().
+   * - le pointeur retourné peut être nul si la mémoire n'a pas pu être allouée.
+   */
+  virtual AllocatedMemoryInfo reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size) = 0;
+
+  /*!
+   * \brief Libère la mémoire dont l'adresse de base est \a ptr.
+   *
+   * Le pointeur \a ptr doit avoir été alloué via l'appel à
+   * allocate() ou reallocate() de cette instance.
+   *
+   * La sémantique de cette méthode équivalente à free() et donc \a ptr
+   * peut être nul auquel cas aucune opération n'est effectuée.
+   */
+  virtual void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr) = 0;
+
+  /*!
+   * \brief Ajuste la capacité suivant la taille d'élément.
+   *
+   * Cette méthode est utilisée pour éventuellement modifié le nombre
+   * d'éléments alloués suivant leur taille. Cela permet par exemple
+   * pour les allocateurs alignés de garantir que le nombre d'éléments
+   * alloués est un multiple de cet alignement.
+   * 
+   */
+  virtual Int64 adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const = 0;
+
+  /*!
+   * \brief Valeur de l'alignement garanti par l'allocateur.
+   *
+   * Cette méthode permet de s'assurer qu'un allocateur a un alignement suffisant
+   * pour certaines opérations comme la vectorisation par exemple.
+   *
+   * S'il n'y a aucune garantie, retourne 0.
+   */
+  virtual size_t guarantedAlignment(MemoryAllocationArgs args) const = 0;
+
+ private:
+
+  bool hasRealloc() const final;
+  void* allocate(size_t new_size) final;
+  void* reallocate(void* current_ptr, size_t new_size) final;
+  void deallocate(void* ptr) final;
+  size_t adjustCapacity(size_t wanted_capacity, size_t element_size) final;
+  size_t guarantedAlignment() final;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -452,6 +560,84 @@ class ARCCORE_COLLECTIONS_EXPORT AlignedMemoryAllocator2
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
+ * \brief Allocateur mémoire avec alignement mémoire spécifique.
+ *
+ * Cette classe s'utilise via les deux méthodes publiques Simd()
+ * et CacheLine() qui retournent respectivement un allocateur avec
+ * un alignement adéquat pour autoriser la vectorisation et un allocateur
+ * aligné sur une ligne de cache.
+ */
+class ARCCORE_COLLECTIONS_EXPORT AlignedMemoryAllocator3
+: public IMemoryAllocator3
+{
+ private:
+
+  static AlignedMemoryAllocator3 SimdAllocator;
+  static AlignedMemoryAllocator3 CacheLineAllocator;
+
+ public:
+
+  // TODO: essayer de trouver les bonnes valeurs en fonction de la cible.
+  // 64 est OK pour toutes les architectures x64 à la fois pour le SIMD
+  // et la ligne de cache.
+
+  // IMPORTANT : Si on change la valeur ici, il faut changer la taille de
+  // l'alignement de ArrayImplBase.
+
+  // TODO Pour l'instant seul un alignement sur 64 est autorisé. Pour
+  // autoriser d'autres valeurs, il faut modifier l'implémentation dans
+  // ArrayImplBase.
+
+  // TODO marquer les méthodes comme 'final'.
+
+  //! Alignement pour les structures utilisant la vectorisation
+  static constexpr Integer simdAlignment() { return 64; }
+  //! Alignement pour une ligne de cache.
+  static constexpr Integer cacheLineAlignment() { return 64; }
+
+  /*!
+   * \brief Allocateur garantissant l'alignement pour utiliser
+   * la vectorisation sur la plateforme cible.
+   *
+   * Il s'agit de l'alignement pour le type plus restrictif et donc il
+   * est possible d'utiliser cet allocateur pour toutes les structures vectorielles.
+   */
+  static AlignedMemoryAllocator3* Simd()
+  {
+    return &SimdAllocator;
+  }
+
+  /*!
+   * \brief Allocateur garantissant l'alignement sur une ligne de cache.
+   */
+  static AlignedMemoryAllocator3* CacheLine()
+  {
+    return &CacheLineAllocator;
+  }
+
+ protected:
+
+  explicit AlignedMemoryAllocator3(Integer alignment)
+  : m_alignment((size_t)alignment)
+  {}
+
+ public:
+
+  bool hasRealloc(MemoryAllocationArgs) const override { return false; }
+  AllocatedMemoryInfo allocate(MemoryAllocationArgs args, Int64 new_size) override;
+  AllocatedMemoryInfo reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size) override;
+  void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr) override;
+  Int64 adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const override;
+  size_t guarantedAlignment(MemoryAllocationArgs) const override { return m_alignment; }
+
+ private:
+
+  size_t m_alignment;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
  * \brief Allocateur mémoire via malloc/realloc/free avec impression listing.
  *
  * Cet allocateur est principalement utilisé à des fins de debugging.
@@ -465,7 +651,7 @@ class ARCCORE_COLLECTIONS_EXPORT PrintableMemoryAllocator
  public:
 
   void* allocate(size_t new_size) override;
-  void* reallocate(void* current_ptr,size_t new_size) override;
+  void* reallocate(void* current_ptr, size_t new_size) override;
   void deallocate(void* ptr) override;
 };
 

--- a/arccore/src/collections/arccore/collections/IMemoryAllocator.h
+++ b/arccore/src/collections/arccore/collections/IMemoryAllocator.h
@@ -300,12 +300,6 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator3
 class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator
 : public IMemoryAllocator
 {
-  friend class ArrayMetaData;
-
- private:
-
-  static DefaultMemoryAllocator shared_null_instance;
-
  public:
 
   bool hasRealloc() const override;
@@ -323,21 +317,23 @@ class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator
  *
  * TODO: marquer les méthodes comme 'final'.
  */
-class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator2
-: public IMemoryAllocator2
+class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator3
+: public IMemoryAllocator3
 {
+  friend class ArrayMetaData;
+
  private:
 
-  static DefaultMemoryAllocator2 shared_null_instance;
+  static DefaultMemoryAllocator3 shared_null_instance;
 
  public:
 
   bool hasRealloc(MemoryAllocationArgs) const override;
-  void* allocate(size_t new_size, MemoryAllocationArgs) override;
-  void* reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs) override;
-  void deallocate(void* ptr, MemoryAllocationArgs) override;
-  size_t adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs) override;
-  size_t guarantedAlignment(MemoryAllocationArgs) override { return 0; }
+  AllocatedMemoryInfo allocate(MemoryAllocationArgs, Int64 new_size) override;
+  AllocatedMemoryInfo reallocate(MemoryAllocationArgs, AllocatedMemoryInfo current_ptr, Int64 new_size) override;
+  void deallocate(MemoryAllocationArgs, AllocatedMemoryInfo ptr) override;
+  Int64 adjustedCapacity(MemoryAllocationArgs, Int64 wanted_capacity, Int64 element_size) const override;
+  size_t guarantedAlignment(MemoryAllocationArgs) const override { return 0; }
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/MemoryAllocationArgs.h
+++ b/arccore/src/collections/arccore/collections/MemoryAllocationArgs.h
@@ -34,9 +34,13 @@ class ARCCORE_COLLECTIONS_EXPORT MemoryAllocationArgs
   void setMemoryLocationHint(eMemoryLocationHint mem_advice) { m_memory_location_hint = mem_advice; }
   eMemoryLocationHint memoryLocationHint() const { return m_memory_location_hint; }
 
+  Int8 device() const { return m_device; }
+  void setDevice(Int8 device) { m_device = device; }
+
  private:
 
   eMemoryLocationHint m_memory_location_hint = eMemoryLocationHint::None;
+  Int8 m_device = (-1);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/MemoryAllocationOptions.h
+++ b/arccore/src/collections/arccore/collections/MemoryAllocationOptions.h
@@ -22,14 +22,6 @@
 namespace Arccore
 {
 
-enum class eMemoryLocationHint : int8_t
-{
-  None = 0,
-  MainlyDevice = 1,
-  MainlyHost = 2,
-  HostAndDeviceMostlyRead = 3
-};
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
@@ -62,7 +54,9 @@ class ARCCORE_COLLECTIONS_EXPORT MemoryAllocationOptions
   eMemoryLocationHint memoryLocationHint() const { return m_memory_location_hint; }
   void setMemoryLocationHint(eMemoryLocationHint mem_advice) { m_memory_location_hint = mem_advice; }
 
- public:
+  MemoryAllocationArgs allocationArgs() const;
+
+  public:
 
   friend bool operator==(const MemoryAllocationOptions& a, const MemoryAllocationOptions& b)
   {

--- a/arccore/src/collections/arccore/collections/MemoryAllocationOptions.h
+++ b/arccore/src/collections/arccore/collections/MemoryAllocationOptions.h
@@ -40,9 +40,16 @@ class ARCCORE_COLLECTIONS_EXPORT MemoryAllocationOptions
   {
   }
 
-  explicit MemoryAllocationOptions(IMemoryAllocator* allocator, eMemoryLocationHint mem_hint)
+  MemoryAllocationOptions(IMemoryAllocator* allocator, eMemoryLocationHint mem_hint)
   : m_allocator(allocator)
   , m_memory_location_hint(mem_hint)
+  {
+  }
+
+  MemoryAllocationOptions(IMemoryAllocator* allocator, eMemoryLocationHint mem_hint, Int8 device)
+  : m_allocator(allocator)
+  , m_memory_location_hint(mem_hint)
+  , m_device(device)
   {
   }
 
@@ -54,21 +61,29 @@ class ARCCORE_COLLECTIONS_EXPORT MemoryAllocationOptions
   eMemoryLocationHint memoryLocationHint() const { return m_memory_location_hint; }
   void setMemoryLocationHint(eMemoryLocationHint mem_advice) { m_memory_location_hint = mem_advice; }
 
+  Int8 device() const { return m_device; }
+  void setDevice(Int8 device) { m_device = device; }
+
   MemoryAllocationArgs allocationArgs() const;
 
-  public:
+ public:
 
   friend bool operator==(const MemoryAllocationOptions& a, const MemoryAllocationOptions& b)
   {
-    if (a.m_allocator == b.m_allocator)
-      return true;
-    return (a.m_memory_location_hint == b.m_memory_location_hint);
+    if (a.m_allocator != b.m_allocator)
+      return false;
+    if (a.m_memory_location_hint != b.m_memory_location_hint)
+      return false;
+    if (a.m_device != b.m_device)
+      return false;
+    return true;
   }
 
  private:
 
   IMemoryAllocator* m_allocator = nullptr;
   eMemoryLocationHint m_memory_location_hint = eMemoryLocationHint::None;
+  Int8 m_device = -1;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/MemoryAllocator.cc
+++ b/arccore/src/collections/arccore/collections/MemoryAllocator.cc
@@ -39,8 +39,7 @@ namespace Arccore
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-DefaultMemoryAllocator DefaultMemoryAllocator::shared_null_instance;
-DefaultMemoryAllocator2 DefaultMemoryAllocator2::shared_null_instance;
+DefaultMemoryAllocator3 DefaultMemoryAllocator3::shared_null_instance;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -101,7 +100,7 @@ adjustCapacity(size_t wanted_capacity, size_t)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-bool DefaultMemoryAllocator2::
+bool DefaultMemoryAllocator3::
 hasRealloc(MemoryAllocationArgs) const
 {
   return true;
@@ -110,35 +109,35 @@ hasRealloc(MemoryAllocationArgs) const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void* DefaultMemoryAllocator2::
-allocate(size_t new_size, MemoryAllocationArgs)
+AllocatedMemoryInfo DefaultMemoryAllocator3::
+allocate(MemoryAllocationArgs, Int64 new_size)
 {
-  return ::malloc(new_size);
+  return { ::malloc(new_size), new_size };
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void* DefaultMemoryAllocator2::
-reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs)
+AllocatedMemoryInfo DefaultMemoryAllocator3::
+reallocate(MemoryAllocationArgs, AllocatedMemoryInfo current_ptr, Int64 new_size)
 {
-  return ::realloc(current_ptr, new_size);
+  return { ::realloc(current_ptr.baseAddress(), new_size), new_size };
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void DefaultMemoryAllocator2::
-deallocate(void* ptr, MemoryAllocationArgs)
+void DefaultMemoryAllocator3::
+deallocate(MemoryAllocationArgs,AllocatedMemoryInfo ptr)
 {
-  ::free(ptr);
+  ::free(ptr.baseAddress());
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-size_t DefaultMemoryAllocator2::
-adjustCapacity(size_t wanted_capacity, size_t, MemoryAllocationArgs)
+Int64 DefaultMemoryAllocator3::
+adjustedCapacity(MemoryAllocationArgs, Int64 wanted_capacity, Int64 ) const
 {
   return wanted_capacity;
 }

--- a/arccore/src/collections/arccore/collections/MemoryAllocator.cc
+++ b/arccore/src/collections/arccore/collections/MemoryAllocator.cc
@@ -533,6 +533,40 @@ adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+bool IMemoryAllocator2::
+hasRealloc() const
+{
+  return hasRealloc(MemoryAllocationArgs{});
+}
+void* IMemoryAllocator2::
+allocate(size_t new_size)
+{
+  return allocate(new_size, MemoryAllocationArgs{});
+}
+void* IMemoryAllocator2::
+reallocate(void* current_ptr, size_t new_size)
+{
+  return reallocate(current_ptr, new_size, MemoryAllocationArgs{});
+}
+void IMemoryAllocator2::
+deallocate(void* ptr)
+{
+  return deallocate(ptr, MemoryAllocationArgs{});
+}
+size_t IMemoryAllocator2::
+adjustCapacity(size_t wanted_capacity, size_t element_size)
+{
+  return adjustCapacity(wanted_capacity, element_size, MemoryAllocationArgs{});
+}
+size_t IMemoryAllocator2::
+guarantedAlignment()
+{
+  return guarantedAlignment(MemoryAllocationArgs{});
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 bool IMemoryAllocator3::
 hasRealloc() const
 {

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -875,7 +875,7 @@ TEST(Array, Allocator)
   using namespace Arccore;
   PrintableMemoryAllocator printable_allocator;
   PrintableMemoryAllocator printable_allocator2;
-  IMemoryAllocator* allocator1 = AlignedMemoryAllocator::Simd();
+  IMemoryAllocator* allocator1 = AlignedMemoryAllocator3::Simd();
   IMemoryAllocator* allocator2 = AlignedMemoryAllocator2::Simd();
   {
     std::cout << "Array a1\n";

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -997,11 +997,11 @@ TEST(Array, AllocatorV2)
   TesterMemoryAllocatorV2 testerv2_allocator;
   TesterMemoryAllocatorV2 testerv2_allocator2;
   MemoryAllocationOptions allocate_options1(&testerv2_allocator, eMemoryLocationHint::HostAndDeviceMostlyRead);
-  MemoryAllocationOptions allocate_options2(&testerv2_allocator);
+  MemoryAllocationOptions allocate_options2(&testerv2_allocator, eMemoryLocationHint::None, 0);
   {
     MemoryAllocationOptions opt3(&testerv2_allocator);
     opt3.setMemoryLocationHint(eMemoryLocationHint::HostAndDeviceMostlyRead);
-    ASSERT_EQ(opt3,allocate_options1);
+    ASSERT_EQ(opt3, allocate_options1);
   }
   {
     std::cout << "Array a1\n";
@@ -1013,7 +1013,7 @@ TEST(Array, AllocatorV2)
 
     std::cout << "Array a2\n";
     UniqueArray<Int32> a2(a1);
-    ASSERT_SAME_ARRAY_INFOS(a2,a1);
+    ASSERT_SAME_ARRAY_INFOS(a2, a1);
     ASSERT_EQ(a2.data(), nullptr);
     a1.reserve(3);
     a1.add(5);
@@ -1047,7 +1047,7 @@ TEST(Array, AllocatorV2)
 
     UniqueArray<Int32> array[2];
     MemoryAllocationOptions allocator3 = allocate_options1;
-    for( Integer i=0; i<2; ++i ){
+    for (Integer i = 0; i < 2; ++i) {
       array[i] = UniqueArray<Int32>(allocator3);
     }
     ASSERT_EQ(array[0].allocationOptions(), allocator3);

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -937,51 +937,63 @@ TEST(Array, Allocator)
  * On ne doit l'appeler qu'avec args.memoryLocationHint() qui vaut
  * eMemoryLocationHint::None or eMemoryLocationHint::HostAndDeviceMostlyRead
  */
-class TesterMemoryAllocatorV2
-: public IMemoryAllocator2
+class TesterMemoryAllocatorV3
+: public IMemoryAllocator3
 {
  public:
 
   bool hasRealloc(MemoryAllocationArgs args) const override
   {
     _checkValid(args);
-    return m_default_allocator.hasRealloc();
+    return m_default_allocator.hasRealloc(args);
   }
-  void* allocate(size_t new_size, MemoryAllocationArgs args) override
+  AllocatedMemoryInfo allocate(MemoryAllocationArgs args, Int64 new_size) override
   {
     _checkValid(args);
-    return m_default_allocator.allocate(new_size);
+    return m_default_allocator.allocate(args,new_size);
   }
-  void* reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs args) override
+  AllocatedMemoryInfo reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size) override
   {
     _checkValid(args);
-    return m_default_allocator.reallocate(current_ptr,new_size);
+    return m_default_allocator.reallocate(args, current_ptr, new_size);
   }
-  void deallocate(void* ptr, MemoryAllocationArgs args) override
+  void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr) override
   {
     _checkValid(args);
-    m_default_allocator.deallocate(ptr);
+    m_default_allocator.deallocate(args, ptr);
   }
-  size_t adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs args) override
+  Int64 adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const override
   {
     _checkValid(args);
-    return m_default_allocator.adjustCapacity(wanted_capacity,element_size);
+    return m_default_allocator.adjustedCapacity(args, wanted_capacity, element_size);
   }
-  size_t guarantedAlignment(MemoryAllocationArgs args) override
+  size_t guarantedAlignment(MemoryAllocationArgs args) const override
   {
     _checkValid(args);
-    return m_default_allocator.guarantedAlignment();
+    return m_default_allocator.guarantedAlignment(args);
+  }
+
+  void notifyMemoryArgsChanged(MemoryAllocationArgs old_args, MemoryAllocationArgs new_args, AllocatedMemoryInfo ptr) override
+  {
+    // Cette méthode n'est appelée qu'une seule fois donc on teste directement les valeurs attendues
+    ASSERT_EQ(old_args.memoryLocationHint(), eMemoryLocationHint::None);
+    ASSERT_EQ(new_args.memoryLocationHint(), eMemoryLocationHint::MainlyHost);
+    ASSERT_EQ(ptr.size(), 2);
+    m_default_allocator.notifyMemoryArgsChanged(old_args, new_args, ptr);
   }
 
  private:
 
-  DefaultMemoryAllocator m_default_allocator;
+  DefaultMemoryAllocator3 m_default_allocator;
 
  private:
 
   static void _checkValid(MemoryAllocationArgs args)
   {
-    bool is_valid = args.memoryLocationHint() ==eMemoryLocationHint::None || args.memoryLocationHint() ==eMemoryLocationHint::HostAndDeviceMostlyRead;
+    bool v1 = args.memoryLocationHint() == eMemoryLocationHint::None;
+    bool v2 = args.memoryLocationHint() == eMemoryLocationHint::MainlyHost;
+    bool v3 = args.memoryLocationHint() == eMemoryLocationHint::HostAndDeviceMostlyRead;
+    bool is_valid = v1 || v2 || v3;
     ASSERT_TRUE(is_valid);
   }
 };
@@ -994,8 +1006,8 @@ class TesterMemoryAllocatorV2
 TEST(Array, AllocatorV2)
 {
   using namespace Arccore;
-  TesterMemoryAllocatorV2 testerv2_allocator;
-  TesterMemoryAllocatorV2 testerv2_allocator2;
+  TesterMemoryAllocatorV3 testerv2_allocator;
+  TesterMemoryAllocatorV3 testerv2_allocator2;
   MemoryAllocationOptions allocate_options1(&testerv2_allocator, eMemoryLocationHint::HostAndDeviceMostlyRead);
   MemoryAllocationOptions allocate_options2(&testerv2_allocator, eMemoryLocationHint::None, 0);
   {
@@ -1022,6 +1034,10 @@ TEST(Array, AllocatorV2)
     a1.add(3);
     a1.add(1);
     ASSERT_EQ(a1.size(), 5);
+    a2.add(9);
+    a2.add(17);
+    // Pour tester notifyMemoryArgsChanged()
+    a2.setMemoryLocationHint(eMemoryLocationHint::MainlyHost);
 
     std::cout << "Array a3\n";
     UniqueArray<Int32> a3(allocate_options1);


### PR DESCRIPTION
This new interface use structures to pass arguments and return values to allow further modifications.

The current pointer information are also passed in methods `reallocate()` and `deallocate()`. This will allow the implementation to directly do the memory copy in the reallocate. This may be used for example with managed memory to use direct copy instead of relying on `memcpy()` in `ArrayMetaData::_reallocate()`.
