### PR TITLE
Remove some coverity warnings in arccore

### DIFF
--- a/arccore/src/base/arccore/base/ArrayView.h
+++ b/arccore/src/base/arccore/base/ArrayView.h
@@ -299,7 +299,7 @@ class ArrayView
   }
 
   //! Remplit le tableau avec la valeur \a o
-  void fill(T o) noexcept
+  void fill(const T& o) noexcept
   {
     for( Integer i=0, n=m_size; i<n; ++i )
       m_ptr[i] = o;

--- a/arccore/src/base/arccore/base/Iterator.h
+++ b/arccore/src/base/arccore/base/Iterator.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Iterator.h                                                  (C) 2000-2018 */
+/* Iterator.h                                                  (C) 2000-2023 */
 /*                                                                           */
 /* Iterateurs (obsolète).                                                    */
 /*---------------------------------------------------------------------------*/
@@ -15,6 +15,8 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arccore/base/ArccoreGlobal.h"
+
+#include <utility>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -37,7 +39,8 @@ class IteratorBase
 {
  public:
 
-  IteratorBase(IT b,IT e) : m_begin(b), m_end(e) {}
+  IteratorBase(IT b,IT e)
+  : m_begin(std::move(b)), m_end(std::move(e)) {}
 
   void operator++(){ ++m_begin; }
   void operator--(){ --m_begin; }

--- a/arccore/src/base/arccore/base/Ref.h
+++ b/arccore/src/base/arccore/base/Ref.h
@@ -139,9 +139,9 @@ class Ref
   class Deleter : DeleterBase
   {
    public:
-    Deleter(Internal::ExternalRef h) : m_handle(h), m_no_destroy(false){}
+    Deleter(Internal::ExternalRef h) : m_handle(std::move(h)), m_no_destroy(false){}
     Deleter(Internal::ExternalRef h,bool no_destroy)
-    : m_handle(h), m_no_destroy(no_destroy){}
+    : m_handle(std::move(h)), m_no_destroy(no_destroy){}
     void operator()(InstanceType* tt)
     {
       if (m_no_destroy)

--- a/arccore/src/base/arccore/base/String.cc
+++ b/arccore/src/base/arccore/base/String.cc
@@ -215,8 +215,7 @@ operator=(std::string_view str)
 String& String::
 operator=(const std::string& str)
 {
-  String new_s(str);
-  return this->operator=(new_s);
+  return this->operator=(String(str));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/tests/TestRef.cc
+++ b/arccore/src/base/tests/TestRef.cc
@@ -70,7 +70,7 @@ class TestBaseType
 class TestBaseTypeNoRef
 {
  public:
-  TestBaseTypeNoRef(int a,std::string b) : m_a(a), m_b(b)
+  TestBaseTypeNoRef(int a,const std::string& b) : m_a(a), m_b(b)
   {
     std::cout << "CREATE ME this=" << this << "\n";
     ++global_nb_create;
@@ -119,7 +119,7 @@ class TestRefSharedPtr
  public:
   typedef TestBaseTypeNoRef BaseType;
  public:
-  TestRefSharedPtr(int a,std::string b) : TestBaseTypeNoRef(a,b){}
+  TestRefSharedPtr(int a,const std::string& b) : TestBaseTypeNoRef(a,b){}
 };
 }
 

--- a/arccore/src/message_passing/arccore/message_passing/RequestListBase.h
+++ b/arccore/src/message_passing/arccore/message_passing/RequestListBase.h
@@ -48,7 +48,7 @@ class ARCCORE_MESSAGEPASSING_EXPORT RequestListBase
 
  protected:
 
-  virtual void _add(Request r)
+  virtual void _add(const Request& r)
   {
     m_requests.add(r);
     m_requests_done.add(false);

--- a/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiSerializeMessageList.h
+++ b/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiSerializeMessageList.h
@@ -42,12 +42,11 @@ class MpiSerializeMessage;
 class ARCCORE_MESSAGEPASSINGMPI_EXPORT MpiSerializeMessageRequest
 {
  public:
-  MpiSerializeMessageRequest()
-  : m_mpi_message(nullptr), m_request() {}
+  MpiSerializeMessageRequest() = default;
   MpiSerializeMessageRequest(BasicSerializeMessage* mpi_message,Request request)
-  : m_mpi_message(mpi_message), m_request(request) {}
+  : m_mpi_message(mpi_message), m_request(std::move(request)) {}
  public:
-  BasicSerializeMessage* m_mpi_message;
+  BasicSerializeMessage* m_mpi_message = nullptr;
   Request m_request;
 };
 

--- a/arccore/src/trace/arccore/trace/TraceMng.cc
+++ b/arccore/src/trace/arccore/trace/TraceMng.cc
@@ -1255,10 +1255,10 @@ removeAllClassConfig()
   Mutex::ScopedLock sl(m_trace_mutex);
   // Comme tous les TraceClassConfig vont être détruit, il ne faut plus les
   // référencer dans les TraceClass.
-  for( auto i : m_trace_class_stack )
+  for( auto& i : m_trace_class_stack )
     i.m_info = &m_default_trace_class_config;
   m_current_msg_class.m_info = &m_default_trace_class_config;
-  for( auto i : m_trace_class_config_map )
+  for( const auto& i : m_trace_class_config_map )
     delete i.second;
   m_trace_class_config_map.clear();
 }
@@ -1272,8 +1272,7 @@ visitClassConfigs(IFunctorWithArgumentT<std::pair<String,TraceClassConfig>>* fun
   if (!functor)
     return;
   for( const auto& i : m_trace_class_config_map ){
-    std::pair<String,TraceClassConfig> x(i.first,*(i.second));
-    functor->executeFunctor(x);
+    functor->executeFunctor(std::make_pair(i.first,*(i.second)));
   }
 }
 


### PR DESCRIPTION
The new version of coverity has added some warnings. This PR remove some of them.