### PR TITLE
Add support to specifiy additionnal information on 'Array'

### DIFF
--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -85,18 +85,6 @@ _getAllocationArgs() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-MemoryAllocationArgs MemoryAllocationOptions::
-allocationArgs() const
-{
-  MemoryAllocationArgs x;
-  x.setMemoryLocationHint(m_memory_location_hint);
-  x.setDevice(m_device);
-  return x;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 void ArrayMetaData::
 _setMemoryLocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_type)
 {
@@ -245,6 +233,24 @@ void ArrayMetaData::
 throwUnsupportedSpecificAllocator()
 {
   throw BadAllocException("Changing allocator is only supported for UniqueArray");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void AbstractArrayBase::
+setDebugName(const String& name)
+{
+  m_md->allocation_options.setArrayName(name);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+String AbstractArrayBase::
+debugName() const
+{
+  return m_md->allocation_options.arrayName();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -91,7 +91,7 @@ _setMemoryLocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_
   MemoryAllocationArgs old_args = _getAllocationArgs();
   allocation_options.setMemoryLocationHint(new_hint);
   MemoryAllocationArgs new_args = _getAllocationArgs();
-  AllocatedMemoryInfo mem_info(ptr,size,capacity);
+  AllocatedMemoryInfo mem_info(ptr,size*sizeof_true_type,capacity*sizeof_true_type);
   _allocator()->notifyMemoryArgsChanged(old_args,new_args,mem_info);
 }
 

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -240,6 +240,14 @@ class ARCCORE_COLLECTIONS_EXPORT AbstractArrayBase
   {
     return m_md->allocation_options;
   }
+  /*!
+   * \brief Positionne le nom du tableau pour les informations de debug.
+   *
+   * Ce nom peut être utilisé par exemple pour les affichages listing.
+   */
+  void setDebugName(const String& name);
+  //! Nom de debug (nul si aucun nom spécifié)
+  String debugName() const;
 
  protected:
 

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -922,11 +922,10 @@ class AbstractArray
       _resizeAndCopyView(rhs_span);
     }
     else{
-      IMemoryAllocator* a = rhs.allocator();
       _destroy();
       _internalDeallocate();
       _reset();
-      _initFromAllocator(a,0);
+      _initFromAllocator(rhs.allocationOptions(),0);
       _initFromSpan(rhs_span);
     }
   }

--- a/arccore/src/collections/arccore/collections/ArrayDebugInfo.h
+++ b/arccore/src/collections/arccore/collections/ArrayDebugInfo.h
@@ -1,0 +1,73 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ArrayDebugInfo.h                                            (C) 2000-2023 */
+/*                                                                           */
+/* Informations de debug pour les classes tableaux.                          */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCCORE_COLLECTIONS_ARRAYDEBUGINFO_H
+#define ARCCORE_COLLECTIONS_ARRAYDEBUGINFO_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/collections/CollectionsGlobal.h"
+
+#include "arccore/base/String.h"
+
+#include <atomic>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arccore
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations de debug pour les classes tableaux.
+ *
+ * Cette classe utilise un compteur de référence. Toutes les instances
+ * doivent donc être allouée dynamiquement.
+ */
+class ARCCORE_COLLECTIONS_EXPORT ArrayDebugInfo
+{
+ public:
+
+  ArrayDebugInfo() = default;
+
+ private:
+
+  ~ArrayDebugInfo() = default;
+
+ public:
+
+  void addReference() { ++m_nb_ref; }
+  void removeReference()
+  {
+    Int32 n = --m_nb_ref;
+    if (n == 0)
+      delete this;
+  }
+  void setName(const String& name) { m_name = name; }
+  const String& name() const { return m_name; }
+
+ private:
+
+  std::atomic<Int32> m_nb_ref = 0;
+  String m_name;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arccore
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arccore/src/collections/arccore/collections/CMakeLists.txt
+++ b/arccore/src/collections/arccore/collections/CMakeLists.txt
@@ -3,10 +3,12 @@ set(SOURCES
   Array.cc
   Array2.h
   Array2.cc
+  ArrayDebugInfo.h
   CollectionsGlobal.h
   IMemoryAllocator.h
   MemoryAllocationArgs.h
   MemoryAllocationOptions.h
+  MemoryAllocationOptions.cc
   MemoryAllocator.cc
 )
 

--- a/arccore/src/collections/arccore/collections/CollectionsGlobal.h
+++ b/arccore/src/collections/arccore/collections/CollectionsGlobal.h
@@ -105,9 +105,9 @@ class AllocatedMemoryInfo
 
   //! Adresse du début de la zone allouée.
   void* baseAddress() const { return m_base_address; }
-  //! Taille de la zone mémoire utilisée. (-1) si inconnue
+  //! Taille en octets de la zone mémoire utilisée. (-1) si inconnue
   Int64 size() const { return m_size; }
-  //! Taille de la zone mémoire allouée. (-1) si inconnue
+  //! Taille en octets de la zone mémoire allouée. (-1) si inconnue
   Int64 capacity() const { return m_capacity; }
 
  public:

--- a/arccore/src/collections/arccore/collections/CollectionsGlobal.h
+++ b/arccore/src/collections/arccore/collections/CollectionsGlobal.h
@@ -35,11 +35,14 @@ namespace Arccore
 class IMemoryAllocator;
 class PrintableMemoryAllocator;
 class AlignedMemoryAllocator;
+class AlignedMemoryAllocator3;
 class DefaultMemoryAllocator;
+class DefaultMemoryAllocator3;
 class ArrayImplBase;
 class ArrayMetaData;
 class MemoryAllocationArgs;
 class MemoryAllocationOptions;
+class ArrayDebugInfo;
 template<typename DataType> class ArrayTraits;
 template<typename DataType> class ArrayImplT;
 template<typename DataType> class Array;

--- a/arccore/src/collections/arccore/collections/MemoryAllocationOptions.cc
+++ b/arccore/src/collections/arccore/collections/MemoryAllocationOptions.cc
@@ -1,0 +1,107 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* MemoryAllocationOptions.cc                                  (C) 2000-2023 */
+/*                                                                           */
+/* Options pour configurer les allocations.                                  */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/collections/MemoryAllocationOptions.h"
+#include "arccore/collections/MemoryAllocationArgs.h"
+#include "arccore/collections/ArrayDebugInfo.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arccore
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+MemoryAllocationOptions::
+MemoryAllocationOptions(const MemoryAllocationOptions& rhs)
+: m_allocator(rhs.m_allocator)
+, m_memory_location_hint(rhs.m_memory_location_hint)
+, m_device(rhs.m_device)
+, m_debug_info(rhs.m_debug_info)
+{
+  if (m_debug_info)
+    m_debug_info->addReference();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+MemoryAllocationOptions& MemoryAllocationOptions::
+operator=(const MemoryAllocationOptions& rhs)
+{
+  if (&rhs == this)
+    return (*this);
+  if (m_debug_info)
+    m_debug_info->removeReference();
+  m_allocator = rhs.m_allocator;
+  m_memory_location_hint = rhs.m_memory_location_hint;
+  m_device = rhs.m_device;
+  m_debug_info = rhs.m_debug_info;
+  if (m_debug_info)
+    m_debug_info->addReference();
+  return (*this);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+MemoryAllocationOptions::
+~MemoryAllocationOptions()
+{
+  if (m_debug_info)
+    m_debug_info->removeReference();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+MemoryAllocationArgs MemoryAllocationOptions::
+allocationArgs() const
+{
+  MemoryAllocationArgs x;
+  x.setMemoryLocationHint(m_memory_location_hint);
+  x.setDevice(m_device);
+  return x;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MemoryAllocationOptions::
+setArrayName(const String& name)
+{
+  if (!m_debug_info) {
+    m_debug_info = new ArrayDebugInfo();
+    m_debug_info->addReference();
+  }
+  m_debug_info->setName(name);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+String MemoryAllocationOptions::
+arrayName() const
+{
+  return (m_debug_info) ? m_debug_info->name() : String{};
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arccore
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/MemoryAllocationOptions.h
+++ b/arccore/src/collections/arccore/collections/MemoryAllocationOptions.h
@@ -55,6 +55,12 @@ class ARCCORE_COLLECTIONS_EXPORT MemoryAllocationOptions
 
  public:
 
+  MemoryAllocationOptions(const MemoryAllocationOptions& rhs);
+  MemoryAllocationOptions& operator=(const MemoryAllocationOptions& rhs);
+  ~MemoryAllocationOptions();
+
+ public:
+
   IMemoryAllocator* allocator() const { return m_allocator; }
   void setAllocator(IMemoryAllocator* v) { m_allocator = v; }
 
@@ -64,6 +70,10 @@ class ARCCORE_COLLECTIONS_EXPORT MemoryAllocationOptions
   Int8 device() const { return m_device; }
   void setDevice(Int8 device) { m_device = device; }
 
+  void setArrayName(const String& name);
+  String arrayName() const;
+
+  //! Arguments pour 'IMemoryAllocator' associés à ces options
   MemoryAllocationArgs allocationArgs() const;
 
  public:
@@ -84,6 +94,7 @@ class ARCCORE_COLLECTIONS_EXPORT MemoryAllocationOptions
   IMemoryAllocator* m_allocator = nullptr;
   eMemoryLocationHint m_memory_location_hint = eMemoryLocationHint::None;
   Int8 m_device = -1;
+  ArrayDebugInfo* m_debug_info = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/MemoryAllocator.cc
+++ b/arccore/src/collections/arccore/collections/MemoryAllocator.cc
@@ -239,7 +239,7 @@ allocate(size_t new_size, MemoryAllocationArgs)
 /*---------------------------------------------------------------------------*/
 
 AllocatedMemoryInfo AlignedMemoryAllocator3::
-allocate(MemoryAllocationArgs args, Int64 new_size)
+allocate([[maybe_unused]] MemoryAllocationArgs args, Int64 new_size)
 {
 #ifdef ARCCORE_OS_LINUX
   void* ptr = nullptr;
@@ -294,7 +294,7 @@ reallocate(void* current_ptr, size_t new_size, MemoryAllocationArgs)
 /*---------------------------------------------------------------------------*/
 
 AllocatedMemoryInfo AlignedMemoryAllocator3::
-reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size)
+reallocate([[maybe_unused]] MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size)
 {
 #ifdef ARCCORE_OS_LINUX
   ARCCORE_UNUSED(current_ptr);
@@ -341,7 +341,7 @@ deallocate(void* ptr, MemoryAllocationArgs)
 /*---------------------------------------------------------------------------*/
 
 void AlignedMemoryAllocator3::
-deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr)
+deallocate([[maybe_unused]] MemoryAllocationArgs args, AllocatedMemoryInfo ptr)
 {
 #ifdef ARCCORE_OS_LINUX
   ::free(ptr.baseAddress());
@@ -418,7 +418,7 @@ adjustCapacity(size_t wanted_capacity, size_t element_size, MemoryAllocationArgs
 /*---------------------------------------------------------------------------*/
 
 Int64 AlignedMemoryAllocator3::
-adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const
+adjustedCapacity([[maybe_unused]] MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const
 {
   return adjustMemoryCapacity(wanted_capacity, element_size, m_alignment);
 }

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -1071,6 +1071,47 @@ TEST(Array, AllocatorV2)
   }
 }
 
+TEST(Array, DebugInfo)
+{
+  using namespace Arccore;
+  DefaultMemoryAllocator3 m_default_allocator;
+  MemoryAllocationOptions allocate_options2(&m_default_allocator, eMemoryLocationHint::None, 0);
+
+  String a1_name("Array1");
+  UniqueArray<Int32> a3;
+  {
+    std::cout << "Array a1\n";
+    UniqueArray<Int32> a1(allocate_options2);
+    a1.setDebugName(a1_name);
+    ASSERT_EQ(a1.allocationOptions(), allocate_options2);
+    ASSERT_EQ(a1.size(), 0);
+    ASSERT_EQ(a1.capacity(), 0);
+    ASSERT_EQ(a1.data(), nullptr);
+    ASSERT_EQ(a1.debugName(), a1_name);
+
+    std::cout << "Array a2\n";
+    UniqueArray<Int32> a2(a1);
+    ASSERT_SAME_ARRAY_INFOS(a2, a1);
+    ASSERT_EQ(a2.data(), nullptr);
+    ASSERT_EQ(a2.debugName(), a1_name);
+    a1.reserve(3);
+    a1.add(5);
+    a1.add(7);
+    a1.add(12);
+    a1.add(3);
+    a1.add(1);
+    ASSERT_EQ(a1.size(), 5);
+    a2.add(9);
+    a2.add(17);
+    ASSERT_EQ(a2.debugName(), a1_name);
+    ASSERT_EQ(a2.size(), 2);
+
+    a3 = a2;
+  }
+  ASSERT_EQ(a3.debugName(), a1_name);
+  ASSERT_EQ(a3.size(), 2);
+}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -978,7 +978,7 @@ class TesterMemoryAllocatorV3
     // Cette méthode n'est appelée qu'une seule fois donc on teste directement les valeurs attendues
     ASSERT_EQ(old_args.memoryLocationHint(), eMemoryLocationHint::None);
     ASSERT_EQ(new_args.memoryLocationHint(), eMemoryLocationHint::MainlyHost);
-    ASSERT_EQ(ptr.size(), 2);
+    ASSERT_EQ(ptr.size(), 8);
     m_default_allocator.notifyMemoryArgsChanged(old_args, new_args, ptr);
   }
 


### PR DESCRIPTION
At the moment, it is only possible to add a name to the array.

Also fix bad values for arguments in `IMemoryAllocator::notifyMemoryArgsChanged` and correctly propagate values of `MemoryAllocationOptions` in `UniqueArray::operator=`.