### PR TITLE
Remove usage of managed memory for reductions

### DIFF
--- a/arcane/src/arcane/accelerator/CommonCudaHipReduceImpl.h
+++ b/arcane/src/arcane/accelerator/CommonCudaHipReduceImpl.h
@@ -451,7 +451,7 @@ void _applyDeviceGeneric(const ReduceDeviceInfo<DataType>& dev_info)
   SmallSpan<DataType> grid_buffer = dev_info.m_grid_buffer;
   DataType identity = dev_info.m_identity;
   unsigned int* device_count = dev_info.m_device_count;
-  DataType* ptr = dev_info.m_final_ptr;
+  DataType* ptr = dev_info.m_device_final_ptr;
   DataType v = dev_info.m_current_value;
   bool do_grid_reduce = dev_info.m_use_grid_reduce;
 

--- a/arcane/src/arcane/accelerator/Reduce.h
+++ b/arcane/src/arcane/accelerator/Reduce.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Reduce.h                                                    (C) 2000-2022 */
+/* Reduce.h                                                    (C) 2000-2023 */
 /*                                                                           */
 /* Gestion des réductions pour les accélérateurs.                            */
 /*---------------------------------------------------------------------------*/
@@ -94,8 +94,10 @@ class ReduceDeviceInfo
   DataType m_current_value;
   //! Valeur de l'identité pour la réduction
   DataType m_identity;
-  //! Pointeur vers la donnée réduite (mémoire accessible depuis l'hôte)
-  DataType* m_final_ptr = nullptr;
+  //! Pointeur vers la donnée réduite (mémoire uniquement accessible depuis le device)
+  DataType* m_device_final_ptr = nullptr;
+  //! Pointeur vers la donnée réduite (mémoire uniquement accessible depuis l'hôte)
+  void* m_host_final_ptr = nullptr;
   //! Tableau avec une valeur par bloc pour la réduction
   SmallSpan<DataType> m_grid_buffer;
   /*!
@@ -156,7 +158,7 @@ class ReduceFunctorSum
   DataType applyDevice(const ReduceDeviceInfo<DataType>& dev_info)
   {
     _applyDevice(dev_info);
-    return *(dev_info.m_final_ptr);
+    return *(dev_info.m_device_final_ptr);
   }
   static DataType apply(std::atomic<DataType>* ptr,DataType v)
   {
@@ -178,7 +180,7 @@ class ReduceFunctorMax
   DataType applyDevice(const ReduceDeviceInfo<DataType>& dev_info)
   {
     _applyDevice(dev_info);
-    return *(dev_info.m_final_ptr);
+    return *(dev_info.m_device_final_ptr);
   }
   static DataType apply(std::atomic<DataType>* ptr,DataType v)
   {
@@ -202,7 +204,7 @@ class ReduceFunctorMin
   DataType applyDevice(const ReduceDeviceInfo<DataType>& dev_info)
   {
     _applyDevice(dev_info);
-    return *(dev_info.m_final_ptr);
+    return *(dev_info.m_device_final_ptr);
   }
   static DataType apply(std::atomic<DataType>* ptr,DataType v)
   {
@@ -266,6 +268,7 @@ class Reducer
     m_memory_impl = impl::internalGetOrCreateReduceMemoryImpl(&command);
     if (m_memory_impl){
       m_managed_memory_value = impl::allocateReduceDataMemory<DataType>(m_memory_impl,m_identity);
+      m_grid_memory_info = m_memory_impl->gridMemoryInfo();
     }
   }
   ARCCORE_HOST_DEVICE Reducer(const Reducer& rhs)
@@ -308,7 +311,8 @@ class Reducer
     impl::ReduceDeviceInfo<DataType> dvi;
     dvi.m_grid_buffer = grid_buffer;
     dvi.m_device_count = m_grid_memory_info.m_grid_device_count;
-    dvi.m_final_ptr = m_managed_memory_value;
+    dvi.m_device_final_ptr = m_managed_memory_value;
+    dvi.m_host_final_ptr = m_grid_memory_info.m_host_memory_for_reduced_value;
     dvi.m_current_value = m_local_value;
     dvi.m_identity = m_identity;
     dvi.m_use_grid_reduce = m_grid_memory_info.m_reduce_policy != eDeviceReducePolicy::Atomic;
@@ -337,30 +341,38 @@ class Reducer
   {
     return m_local_value;
   }
-  // Effectue la réduction et récupère la valeur. ATTENTION: ne faire qu'une seule fois.
+  //! Effectue la réduction et récupère la valeur. ATTENTION: ne faire qu'une seule fois.
   DataType reduce()
   {
-    // TODO: faire un fatal si 'm_is_master_instance' vaut 'false'.
-    // Effectue la réduction sur m_managed_memory_value
-    // One ne peut pas le faire avant car comme en CUDA elle est gérée
-    // par la mémoire unifiée, il n'est pas possible d'y accéder tant que
-    // le CPU est en train de le faire.
+    // Si la réduction est faite sur accélérateur, il faut recopier la valeur du device sur l'hôte.
+    DataType* final_ptr = m_managed_memory_value;
+    if (m_memory_impl){
+      m_memory_impl->copyReduceValueFromDevice();
+      final_ptr = reinterpret_cast<DataType*>(m_grid_memory_info.m_host_memory_for_reduced_value);
+    }
+
     if (m_parent_value){
       //std::cout << String::format("Reduce host has parent this={0} local_value={1} parent_value={2}\n",
       //                            this,m_local_value,*m_parent_value);
       //std::cout.flush();
-      ReduceFunctor::apply(m_parent_value,*m_managed_memory_value);
-      *m_managed_memory_value = *m_parent_value;
+      ReduceFunctor::apply(m_parent_value,*final_ptr);
+      *final_ptr = *m_parent_value;
     }
     else{
       //std::cout << String::format("Reduce host no parent this={0} local_value={1} managed={2}\n",
       //                            this,m_local_value,*m_managed_memory_value);
       //std::cout.flush();
     }
-    return *m_managed_memory_value;
+    return *final_ptr;
   }
  protected:
   impl::IReduceMemoryImpl* m_memory_impl = nullptr;
+  /*!
+   * \brief Pointeur vers la donnée qui contiendra la valeur réduite.
+   *
+   * Sur accélérateur, cette donnée est allouée sur le device.
+   * Sur CPU, il s'agit de l'adresse de \a m_local_value pour l'instance parente.
+   */
   DataType* m_managed_memory_value;
   impl::IReduceMemoryImpl::GridMemoryInfo m_grid_memory_info;
  private:

--- a/arcane/src/arcane/accelerator/core/IReduceMemoryImpl.h
+++ b/arcane/src/arcane/accelerator/core/IReduceMemoryImpl.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IReduceMemoryImpl.h                                         (C) 2000-2022 */
+/* IReduceMemoryImpl.h                                         (C) 2000-2023 */
 /*                                                                           */
 /* Interface de la gestion mémoire pour les réductions.                      */
 /*---------------------------------------------------------------------------*/
@@ -48,6 +48,8 @@ class ARCANE_ACCELERATOR_CORE_EXPORT IReduceMemoryImpl
     unsigned int* m_grid_device_count = nullptr;
     //! Politique de réduction
     eDeviceReducePolicy m_reduce_policy = eDeviceReducePolicy::Grid;
+    //! Pointeur vers la mémoire sur l'hôte contenant la valeur réduite.
+    void* m_host_memory_for_reduced_value = nullptr;
   };
 
  public:
@@ -70,6 +72,14 @@ class ARCANE_ACCELERATOR_CORE_EXPORT IReduceMemoryImpl
 
   //! Informations sur la mémoire utilisée par la réduction
   virtual GridMemoryInfo gridMemoryInfo() = 0;
+
+  /*!
+   * \brief Copie la valeur réduite depuis le device vers l'hote.
+   *
+   * La valeur sera copié de gridMemoryInfo().m_device_memory_for_reduced_value
+   * vers gridMemoryInfo().m_host_memory_for_reduced_value
+   */
+  virtual void copyReduceValueFromDevice() =0;
 
   //! Libère l'instance.
   virtual void release() = 0;

--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -49,7 +49,8 @@ class ReduceMemoryImpl
  public:
 
   ReduceMemoryImpl(RunCommandImpl* p)
-  : m_command(p), m_grid_buffer(eMemoryRessource::Device), m_grid_device_count(eMemoryRessource::Device)
+  : m_command(p), m_managed_memory_bytes(eMemoryRessource::Device), m_host_memory_bytes(eMemoryRessource::Host),
+    m_grid_buffer(eMemoryRessource::Device), m_grid_device_count(eMemoryRessource::Device)
   {
     _allocateMemoryForReduceData(128);
     _allocateMemoryForGridDeviceCount();
@@ -74,6 +75,7 @@ class ReduceMemoryImpl
   {
     return m_grid_memory_info;
   }
+  void copyReduceValueFromDevice() override;
   void release() override;
 
  private:
@@ -83,8 +85,11 @@ class ReduceMemoryImpl
   //! Pointeur vers la mémoire unifiée contenant la donnée réduite
   std::byte* m_managed_memory = nullptr;
 
-  //! Allocation pour la donnée réduite
+  //! Allocation pour la donnée réduite en mémoire managée
   NumArray<std::byte, MDDim1> m_managed_memory_bytes;
+
+  //! Allocation pour la donnée réduite en mémoire hôte
+  NumArray<std::byte, MDDim1> m_host_memory_bytes;
 
   //! Taille allouée pour \a m_managed_memory
   Int64 m_size = 0;
@@ -118,6 +123,10 @@ class ReduceMemoryImpl
   {
     m_managed_memory_bytes.resize(new_size);
     m_managed_memory = m_managed_memory_bytes.to1DSpan().data();
+
+    m_host_memory_bytes.resize(new_size);
+    m_grid_memory_info.m_host_memory_for_reduced_value = m_host_memory_bytes.to1DSpan().data();
+
     m_size = new_size;
   }
 };
@@ -380,11 +389,13 @@ allocateReduceDataMemory(ConstMemoryView identity_view)
   m_data_type_size = data_type_size;
   if (data_type_size > m_size)
     _allocateMemoryForReduceData(data_type_size);
+
   // Recopie \a identity_view dans un buffer car on utilise l'asynchronisme
   // et la zone pointée par \a identity_view n'est pas forcément conservée
   m_identity_buffer.copy(identity_view.bytes());
   MemoryCopyArgs copy_args(m_managed_memory, m_identity_buffer.span().data(), data_type_size);
   m_command->internalStream()->copyMemory(copy_args.addAsync());
+
   return m_managed_memory;
 }
 
@@ -401,17 +412,9 @@ _allocateGridDataMemory()
     return;
 
   m_grid_buffer.resize(total_size);
+
   auto mem_view = makeMutableMemoryView(m_grid_buffer.to1DSpan());
   m_grid_memory_info.m_grid_memory_values = mem_view;
-
-  // Indique qu'on va utiliser cette zone mémoire uniquement sur le device.
-  // Cela n'est utile que si on utilise la mémoire managée pour la grille.
-  if (m_grid_buffer.memoryRessource()!=eMemoryRessource::Device){
-    Runner* runner = m_command->runner();
-    runner->setMemoryAdvice(mem_view,eMemoryAdvice::PreferredLocationDevice);
-    runner->setMemoryAdvice(mem_view,eMemoryAdvice::AccessedByHost);
-  }
-  //std::cout << "RESIZE GRID t=" << total_size << "\n";
 }
 
 /*---------------------------------------------------------------------------*/
@@ -431,6 +434,18 @@ _allocateMemoryForGridDeviceCount()
 
   // Initialise cette zone mémoire avec 0.
   MemoryCopyArgs copy_args(ptr, &zero, size);
+  m_command->internalStream()->copyMemory(copy_args);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ReduceMemoryImpl::
+copyReduceValueFromDevice()
+{
+  void* destination = m_grid_memory_info.m_host_memory_for_reduced_value;
+  void* source = m_managed_memory;
+  MemoryCopyArgs copy_args(destination,source,m_data_type_size);
   m_command->internalStream()->copyMemory(copy_args);
 }
 


### PR DESCRIPTION
Use device memory to handle reduced value and use explicit memory transfer to get the result. 