### PR TITLE
Deprecate 'IHashAlgorithm::computeHash()'

### DIFF
--- a/arcane/src/arcane/core/SerializedData.cc
+++ b/arcane/src/arcane/core/SerializedData.cc
@@ -239,11 +239,11 @@ void SerializedData::
 computeHash(IHashAlgorithm* algo, ByteArray& output) const
 {
   // TODO: faire avec le support 64 bits mais cela change le hash.
-  algo->computeHash(m_const_buffer.constSmallView(), output);
+  algo->computeHash64(m_const_buffer, output);
   const Byte* ptr = reinterpret_cast<const Byte*>(m_dimensions.data());
   Integer msize = CheckedConvert::multiply(m_dimensions.size(), (Integer)sizeof(Integer));
   ByteConstArrayView dim_bytes(msize, ptr);
-  algo->computeHash(dim_bytes, output);
+  algo->computeHash64(dim_bytes, output);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ScalarData.cc
+++ b/arcane/src/arcane/impl/ScalarData.cc
@@ -298,7 +298,7 @@ computeHash(IHashAlgorithm* algo, ByteArray& output) const
   Integer type_size = sizeof(DataType);
   const Byte* ptr = reinterpret_cast<const Byte*>(&m_value);
   ByteConstArrayView input(type_size, ptr);
-  algo->computeHash(input, output);
+  algo->computeHash64(input, output);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/StringScalarData.cc
+++ b/arcane/src/arcane/impl/StringScalarData.cc
@@ -268,7 +268,7 @@ void StringScalarData::
 computeHash(IHashAlgorithm* algo, ByteArray& output) const
 {
   ByteConstArrayView input = m_value.utf8();
-  algo->computeHash(input, output);
+  algo->computeHash64(input, output);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/std/MetisGraphDigest.cc
+++ b/arcane/src/arcane/std/MetisGraphDigest.cc
@@ -38,7 +38,7 @@ const Integer real_t_size = sizeof(real_t);
 void
 _computeHash(ConstArrayView<idx_t> data, ByteArray& output)
 {
-  hash_algo.computeHash(ConstArrayView<Byte>(idx_t_size * data.size(), (Byte*)data.data()), output);
+  hash_algo.computeHash64(ConstArrayView<Byte>(idx_t_size * data.size(), (Byte*)data.data()), output);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -47,7 +47,7 @@ _computeHash(ConstArrayView<idx_t> data, ByteArray& output)
 void
 _computeHash(const idx_t* data, const Integer nb, ByteArray& output)
 {
-  hash_algo.computeHash(ConstArrayView<Byte>(idx_t_size * nb, (const Byte*)data), output);
+  hash_algo.computeHash64(ConstArrayView<Byte>(idx_t_size * nb, (const Byte*)data), output);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -56,7 +56,7 @@ _computeHash(const idx_t* data, const Integer nb, ByteArray& output)
 void
 _computeHash(const real_t* data, const Integer nb, ByteArray& output)
 {
-  hash_algo.computeHash(ConstArrayView<Byte>(real_t_size * nb, (const Byte*)data), output);
+  hash_algo.computeHash64(ConstArrayView<Byte>(real_t_size * nb, (const Byte*)data), output);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -93,7 +93,7 @@ _digestString(MPI_Comm comm, const int my_rank, const int nb_rank, const int io_
 
   if (my_rank == io_rank) {
     UniqueArray<Byte> final_digest;
-    hash_algo.computeHash(concat_digest, final_digest);
+    hash_algo.computeHash64(concat_digest, final_digest);
     return Convert::toHexaString(final_digest);
   }
 

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -15,7 +15,6 @@
 #include "arcane/utils/StringBuilder.h"
 #include "arcane/utils/ScopedPtr.h"
 #include "arcane/utils/List.h"
-#include "arcane/utils/MD5HashAlgorithm.h"
 #include "arcane/utils/ArithmeticException.h"
 #include "arcane/utils/ValueChecker.h"
 #include "arcane/utils/TestLogger.h"
@@ -185,7 +184,6 @@ public:
   void _testVariableWriter();
   void _testItemArray();
   void _testProjection();
-  void _testMD5();
   void _dumpConnections();
   void _partitionMesh(Int32 nb_part);
   void _testUsedVariables();
@@ -291,7 +289,6 @@ executeTest()
     error() << "ArithmeticException 2 catched!";
   }
 #endif
-  _testMD5();
   _testUsedVariables();
   _testAdditionalMeshes();
   _testCustomMeshTools();
@@ -1226,40 +1223,6 @@ _testProjection()
   //info() << vt->toString() << '\n';
   //a1 = a[0].x / a[0].z;
   //info() << " A1=" << a1;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void MeshUnitTest::
-_testMD5()
-{
-  info() << " MD5 TEST";
-  Arcane::MD5HashAlgorithm md5;
-  ByteUniqueArray output;
-  ByteUniqueArray input;
-  String s;
-  String ref;
-
-  // Calcul le md5 pour un tableau vide
-  input.clear();
-  output.clear();
-  md5.computeHash64(input,output);
-  s = Convert::toHexaString(output);
-  ref = "d41d8cd98f00b204e9800998ecf8427e";
-  info() << " S=" << s;
-  if (s!=ref)
-    fatal() << "Bad value for empty array ref=" << ref << " new=" << s;
-
-  input.clear();
-  output.clear();
-  input.add('a');
-  md5.computeHash64(input,output);
-  s = Convert::toHexaString(output);
-  ref = "0cc175b9c0f1b6a831c399e269772661";
-  info() << " S=" << s;
-  if (s!=ref)
-    fatal() << "Bad value for simple array ref=" << ref << " new=" << s;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -1244,7 +1244,7 @@ _testMD5()
   // Calcul le md5 pour un tableau vide
   input.clear();
   output.clear();
-  md5.computeHash(input,output);
+  md5.computeHash64(input,output);
   s = Convert::toHexaString(output);
   ref = "d41d8cd98f00b204e9800998ecf8427e";
   info() << " S=" << s;
@@ -1254,7 +1254,7 @@ _testMD5()
   input.clear();
   output.clear();
   input.add('a');
-  md5.computeHash(input,output);
+  md5.computeHash64(input,output);
   s = Convert::toHexaString(output);
   ref = "0cc175b9c0f1b6a831c399e269772661";
   info() << " S=" << s;

--- a/arcane/src/arcane/utils/ArcaneGlobal.cc
+++ b/arcane/src/arcane/utils/ArcaneGlobal.cc
@@ -39,6 +39,7 @@
 #include "arcane/utils/IMessagePassingProfilingService.h"
 #include "arcane/utils/ISymbolizerService.h"
 #include "arcane/utils/IDataCompressor.h"
+#include "arcane/utils/IHashAlgorithm.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -229,6 +230,25 @@ arcaneSizeWithPadding(Integer size)
   // TODO: vérifier débordement.
   Integer padding_size = ((size / SIMD_PADDING_SIZE) + 1) * SIMD_PADDING_SIZE;
   return padding_size;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IHashAlgorithm::
+computeHash64(Span<const Byte> input,ByteArray& output)
+{
+  computeHash(input.smallView(),output);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IHashAlgorithm::
+computeHash64(Span<const std::byte> input,ByteArray& output)
+{
+  const Byte* x = reinterpret_cast<const Byte*>(input.data());
+  computeHash64(Span<const Byte>(x,input.size()),output);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/IHashAlgorithm.h
+++ b/arcane/src/arcane/utils/IHashAlgorithm.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IHashAlgorithm.h                                            (C) 2000-2020 */
+/* IHashAlgorithm.h                                            (C) 2000-2023 */
 /*                                                                           */
 /* Interface d'un algorithme de hashage.                                     */
 /*---------------------------------------------------------------------------*/
@@ -31,8 +31,8 @@ namespace Arcane
 class ARCANE_UTILS_EXPORT IHashAlgorithm
 {
  public:
-	
-  virtual ~IHashAlgorithm(){}
+
+  virtual ~IHashAlgorithm() = default;
 
  public:
 
@@ -42,7 +42,8 @@ class ARCANE_UTILS_EXPORT IHashAlgorithm
    * La fonction de hashage est <strong>ajoutée</string> dans \a output.
    * La longueur dépend de l'algorithme utilisé.
    */
-  virtual void computeHash(ByteConstArrayView input,ByteArray& output) =0;
+  ARCANE_DEPRECATED_REASON("Y2023: Use computeHash64(Span<const std::byte> input,ByteArray& output) instead")
+  virtual void computeHash(ByteConstArrayView input, ByteArray& output) = 0;
 
   /*!
    * \brief Calcule la fonction de hashage sur le tableau \a input.
@@ -50,10 +51,7 @@ class ARCANE_UTILS_EXPORT IHashAlgorithm
    * La fonction de hashage est <strong>ajoutée</string> dans \a output.
    * La longueur dépend de l'algorithme utilisé.
    */
-  virtual void computeHash64(Span<const Byte> input,ByteArray& output)
-  {
-    computeHash(input.smallView(),output);
-  }
+  virtual void computeHash64(Span<const Byte> input, ByteArray& output);
 
   /*!
    * \brief Calcule la fonction de hashage sur le tableau \a input.
@@ -61,19 +59,13 @@ class ARCANE_UTILS_EXPORT IHashAlgorithm
    * La fonction de hashage est <strong>ajoutée</string> dans \a output.
    * La longueur dépend de l'algorithme utilisé.
    */
-  virtual void computeHash64(Span<const std::byte> input,ByteArray& output)
-  {
-    const Byte* x = reinterpret_cast<const Byte*>(input.data());
-    computeHash64(Span<const Byte>(x,input.size()),output);
-  }
-
- private:
+  virtual void computeHash64(Span<const std::byte> input, ByteArray& output);
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namesapce Arcane
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MD5HashAlgorithm.cc
+++ b/arcane/src/arcane/utils/MD5HashAlgorithm.cc
@@ -1,25 +1,17 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MD5HashAlgorithm.cc                                         (C) 2000-2014 */
+/* MD5HashAlgorithm.cc                                         (C) 2000-2023 */
 /*                                                                           */
 /* Calcule la fonction de hashage MD5.                                       */
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/StdHeader.h"
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 #include "arcane/utils/MD5HashAlgorithm_Licensed.h"
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 #include "arcane/utils/MD5HashAlgorithm.h"
 #include "arcane/utils/Array.h"
 #include "arcane/utils/Iostream.h"
@@ -27,7 +19,24 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace
+{
+  void _computeHash64(Span<const std::byte> input, ByteArray& output)
+  {
+    unsigned char buf[16];
+    _md5_buffer((const char*)input.data(), input.size(), buf);
+
+    for (int i = 0; i < 16; ++i) {
+      output.add(buf[i]);
+    }
+  }
+} // namespace
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -41,20 +50,35 @@ MD5HashAlgorithm()
 /*---------------------------------------------------------------------------*/
 
 void MD5HashAlgorithm::
-computeHash(ByteConstArrayView input,ByteArray& output)
+computeHash(ByteConstArrayView input, ByteArray& output)
 {
-  unsigned char buf[16];
-  _md5_buffer((const char*)input.data(),input.size(),buf);
-
-  for( int i=0; i<16; ++i ){
-    output.add(buf[i]);
-  }
+  Span<const Byte> input64(input);
+  return _computeHash64(asBytes(input64), output);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+void MD5HashAlgorithm::
+computeHash64(Span<const Byte> input, ByteArray& output)
+{
+  Span<const std::byte> bytes(asBytes(input));
+  return _computeHash64(bytes, output);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MD5HashAlgorithm::
+computeHash64(Span<const std::byte> input, ByteArray& output)
+{
+  return _computeHash64(input, output);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MD5HashAlgorithm.h
+++ b/arcane/src/arcane/utils/MD5HashAlgorithm.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MD5HashAlgorithm.h                                          (C) 2000-2014 */
+/* MD5HashAlgorithm.h                                          (C) 2000-2023 */
 /*                                                                           */
 /* Calcule la fonction de hashage MD5.                                       */
 /*---------------------------------------------------------------------------*/
@@ -19,45 +19,36 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 /*!
- * \brief  Calcule la fonction de hashage MD5.
+ * \brief Calcule la fonction de hashage MD5 d'un tableau.
+ *
+ * Pour cet algorithme, la taille de la clé est de 16 octets.
  */
 class ARCANE_UTILS_EXPORT MD5HashAlgorithm
 : public IHashAlgorithm
 {
  public:
-	
+
   MD5HashAlgorithm();
 
  public:
 
-  /*!
-   * \brief Calcule la fonction de hashage sur le tableau \a input.
-   * Pour cet algorithme, la clé est de 16 octets.
-   */
-  void computeHash(ByteConstArrayView input,ByteArray& output);
-
- private:
+  void computeHash(ByteConstArrayView input, ByteArray& output) override;
+  void computeHash64(Span<const Byte> input, ByteArray& output) override;
+  void computeHash64(Span<const std::byte> input, ByteArray& output) override;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
-
+#endif


### PR DESCRIPTION
We have to use `computeHash64()` instead.