### PR TITLE
Make operators (==,!=,<<,<) as friend of class

### DIFF
--- a/arccore/src/base/arccore/base/ArrayView.cc
+++ b/arccore/src/base/arccore/base/ArrayView.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayView.cc                                                (C) 2000-2018 */
+/* ArrayView.cc                                                (C) 2000-2023 */
 /*                                                                           */
 /* Déclarations générales de Arccore.                                        */
 /*---------------------------------------------------------------------------*/
@@ -16,7 +16,7 @@
 #include "arccore/base/TraceInfo.h"
 
 // On n'utilise pas directement ces fichiers mais on les inclus pour tester
-// la compilation. Lorsque les tests seront en place on pourra supprmer
+// la compilation. Lorsque les tests seront en place on pourra supprimer
 // ces inclusions
 #include "arccore/base/Array2View.h"
 #include "arccore/base/Array3View.h"
@@ -51,6 +51,26 @@ ARCCORE_BASE_EXPORT void impl::
 arccoreThrowNegativeSize [[noreturn]] (Int64 size)
 {
   ARCCORE_THROW(ArgumentException,"invalid negative value '{0}' for Array size",size);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void
+binaryWrite(std::ostream& ostr,const Span<const std::byte>& bytes)
+{
+  auto* ptr = reinterpret_cast<const char*>(bytes.data());
+  ostr.write(ptr,bytes.size());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void
+binaryRead(std::istream& istr,const Span<std::byte>& bytes)
+{
+  auto* ptr = reinterpret_cast<char*>(bytes.data());
+  istr.read(ptr,bytes.size());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/ArrayView.h
+++ b/arccore/src/base/arccore/base/ArrayView.h
@@ -448,6 +448,24 @@ class ArrayView
    */
   constexpr pointer data() noexcept { return m_ptr; }
 
+ public:
+
+  friend inline bool operator==(const ArrayView<T>& rhs, const ArrayView<T>& lhs)
+  {
+    return impl::areEqual(rhs,lhs);
+  }
+
+  friend inline bool operator!=(const ArrayView<T>& rhs, const ArrayView<T>& lhs)
+  {
+    return !(rhs==lhs);
+  }
+
+  friend std::ostream& operator<<(std::ostream& o, const ArrayView<T>& val)
+  {
+    impl::dumpArray(o,val,500);
+    return o;
+  }
+
  protected:
 
   /*!
@@ -750,6 +768,24 @@ class ConstArrayView
     return ArrayRange<const_pointer>(m_ptr,m_ptr+m_size);
   }
 
+ public:
+
+  friend inline bool operator==(const ConstArrayView<T>& rhs, const ConstArrayView<T>& lhs)
+  {
+    return impl::areEqual(rhs,lhs);
+  }
+
+  friend inline bool operator!=(const ConstArrayView<T>& rhs, const ConstArrayView<T>& lhs)
+  {
+    return !(rhs==lhs);
+  }
+
+  friend std::ostream& operator<<(std::ostream& o, const ConstArrayView<T>& val)
+  {
+    impl::dumpArray(o,val,500);
+    return o;
+  }
+
  private:
 
   Integer m_size; //!< Nombre d'éléments 
@@ -765,36 +801,6 @@ class ConstArrayView
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-template<typename T> inline bool
-operator==(ConstArrayView<T> rhs, ConstArrayView<T> lhs)
-{
-  return impl::areEqual(rhs,lhs);
-}
-
-template<typename T> inline bool
-operator!=(ConstArrayView<T> rhs, ConstArrayView<T> lhs)
-{
-  return !(rhs==lhs);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline bool
-operator==(ArrayView<T> rhs, ArrayView<T> lhs)
-{
-  return operator==(rhs.constView(),lhs.constView());
-}
-
-template<typename T> inline bool
-operator!=(ArrayView<T> rhs,ArrayView<T> lhs)
-{
-  return !(rhs==lhs);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 /*!
  * \brief Affiche sur le flot \a o les valeurs du tableau \a val.
  *
@@ -807,26 +813,6 @@ template<typename T> inline void
 dumpArray(std::ostream& o,ConstArrayView<T> val,int max_print)
 {
   impl::dumpArray(o,val,max_print);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline std::ostream&
-operator<<(std::ostream& o, ConstArrayView<T> val)
-{
-  dumpArray(o,val,500);
-  return o;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline std::ostream&
-operator<<(std::ostream& o, ArrayView<T> val)
-{
-  o << val.constView();
-  return o;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/CheckedPointer.h
+++ b/arccore/src/base/arccore/base/CheckedPointer.h
@@ -5,13 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CheckedPointer.h                                            (C) 2000-2019 */
+/* CheckedPointer.h                                            (C) 2000-2023 */
 /*                                                                           */
 /* Classes encapsulant un pointeur permettant de vérifier l'utilisation.     */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCCORE_BASE_CHECKEDPOINTER_H
 #define ARCCORE_BASE_CHECKEDPOINTER_H
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -121,38 +120,35 @@ class CheckedPointer
     return (!m_value);
   }
 
+
+  /*!
+   * \brief Compare les objets référencés par \a v1 et \a v2
+   * La comparaison se fait pointeur par pointeur.
+   * \retval true s'ils sont égaux
+   * \retval false sinon
+   */
+  template<typename T2> friend bool
+  operator==(const CheckedPointer<T>& v1,const CheckedPointer<T2>& v2)
+  {
+    return v1.get() == v2.get();
+  }
+
+  /*!
+   * \brief Compare les objets référencés par \a v1 et \a v2
+   * La comparaison se fait pointeur par pointeur.
+   * \retval false s'ils sont égaux
+   * \retval true sinon
+   */
+  template<typename T2> friend bool
+  operator!=(const CheckedPointer<T>& v1,const CheckedPointer<T2>& v2)
+  {
+    return v1.get() != v2.get();
+  }
+
  protected:
   
   T* m_value; //!< Pointeur sur l'objet référencé
 };
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Compare les objets référencés par \a v1 et \a v2
- * La comparaison se fait pointeur par pointeur.
- * \retval true s'ils sont égaux
- * \retval false sinon
- */
-template<class T1,class T2> inline bool
-operator==(const CheckedPointer<T1>& v1,const CheckedPointer<T2>& v2)
-{
-  return v1.get() == v2.get();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Compare les objets référencés par \a v1 et \a v2
- * La comparaison se fait pointeur par pointeur.
- * \retval false s'ils sont égaux
- * \retval true sinon
- */
-template<class T1,class T2> inline bool
-operator!=(const CheckedPointer<T1>& v1,const CheckedPointer<T2>& v2)
-{
-  return v1.get() != v2.get();
-}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/Ref.h
+++ b/arccore/src/base/arccore/base/Ref.h
@@ -179,6 +179,7 @@ class Ref
   ~Ref() = default;
   
  public:
+
   /*!
    * \internal
    * \brief Créé une référence à partir de l'instance \a t.
@@ -217,6 +218,29 @@ class Ref
   }
 
  public:
+
+  friend inline bool operator==(const ThatClass& a,const ThatClass& b)
+  {
+    return a.get()==b.get();
+  }
+
+  friend inline bool operator!=(const ThatClass& a,const ThatClass& b)
+  {
+    return a.get()!=b.get();
+  }
+
+  friend inline bool operator<(const ThatClass& a,const ThatClass& b)
+  {
+    return a.get()<b.get();
+  }
+
+  friend inline bool operator!(const ThatClass& a)
+  {
+    return a.isNull();
+  }
+
+ public:
+
   //! Instance associée ou `nullptr` si aucune
   InstanceType* get() const { return m_instance.get(); }
   //! Indique si le compteur référence une instance non nulle.
@@ -242,36 +266,14 @@ class Ref
     return t;
   }
   const ImplType& _internalInstance() const { return m_instance; }
+
  private:
+
   ImplType m_instance;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-template<typename InstanceType,int TagId>
-inline bool operator==(const Ref<InstanceType,TagId>& a,const Ref<InstanceType,TagId>& b)
-{
-  return a.get()==b.get();
-}
-
-template<typename InstanceType,int TagId>
-inline bool operator!=(const Ref<InstanceType,TagId>& a,const Ref<InstanceType,TagId>& b)
-{
-  return a.get()!=b.get();
-}
-
-template<typename InstanceType,int TagId>
-inline bool operator<(const Ref<InstanceType,TagId>& a,const Ref<InstanceType,TagId>& b)
-{
-  return a.get()<b.get();
-}
-
-template<typename InstanceType,int TagId>
-inline bool operator!(const Ref<InstanceType,TagId>& a)
-{
-  return a.isNull();
-}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/Span.h
+++ b/arccore/src/base/arccore/base/Span.h
@@ -380,6 +380,40 @@ class SpanImpl
    */
   constexpr ARCCORE_HOST_DEVICE pointer data() const noexcept { return m_ptr; }
 
+  //! Opérateur d'égalité (valide si T est const mais pas X)
+  template<typename X,SizeType Extent2,typename = std::enable_if_t<std::is_same_v<X,value_type>>> friend bool
+  operator==(const SpanImpl<T,SizeType,Extent>& rhs, const SpanImpl<X,SizeType,Extent2>& lhs)
+  {
+    return impl::areEqual(SpanImpl<T,SizeType>(rhs),SpanImpl<T,SizeType>(lhs));
+  }
+
+  //! Opérateur d'inégalité (valide si T est const mais pas X)
+  template<typename X,SizeType Extent2,typename = std::enable_if_t<std::is_same_v<X,value_type>>> friend bool
+  operator!=(const SpanImpl<T,SizeType,Extent>& rhs, const SpanImpl<X,SizeType,Extent2>& lhs)
+  {
+    return !operator==(rhs,lhs);
+  }
+
+  //! Opérateur d'égalité
+  template<SizeType Extent2> friend bool
+  operator==(const SpanImpl<T,SizeType,Extent>& rhs, const SpanImpl<T,SizeType,Extent2>& lhs)
+  {
+    return impl::areEqual(SpanImpl<T,SizeType>(rhs),SpanImpl<T,SizeType>(lhs));
+  }
+
+  //! Opérateur d'inégalité
+  template<SizeType Extent2> friend bool
+  operator!=(const SpanImpl<T,SizeType,Extent>& rhs, const SpanImpl<T,SizeType,Extent2>& lhs)
+  {
+    return !operator==(rhs,lhs);
+  }
+
+  friend inline std::ostream& operator<<(std::ostream& o, const ThatClass& val)
+  {
+    impl::dumpArray(o,Span<const T>(val),500);
+    return o;
+  }
+
  protected:
   
   /*!
@@ -707,60 +741,8 @@ class SmallSpan
   {
     return impl::subViewInterval<ThatClass>(*this,index,nb_interval);
   }
+
 };
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T,typename SizeType> inline bool
-operator==(SpanImpl<const T,SizeType> rhs, SpanImpl<const T,SizeType> lhs)
-{
-  return impl::areEqual(rhs,lhs);
-}
-
-template<typename T> inline bool
-operator==(Span<const T> rhs, Span<const T> lhs)
-{
-  SpanImpl<const T,Int64> a = rhs;
-  SpanImpl<const T,Int64> b = lhs;
-  return a==b;
-}
-
-template<typename T> inline bool
-operator!=(Span<const T> rhs, Span<const T> lhs)
-{
-  return !(rhs==lhs);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline bool
-operator==(Span<T> rhs, Span<T> lhs)
-{
-  return impl::areEqual(rhs,lhs);
-}
-
-template<typename T> inline bool
-operator!=(Span<T> rhs, Span<T> lhs)
-{
-  return !(rhs==lhs);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline bool
-operator==(SmallSpan<T> rhs, SmallSpan<T> lhs)
-{
-  return operator==(Span<const T>(rhs),Span<const T>(lhs));
-}
-
-template<typename T> inline bool
-operator!=(SmallSpan<T> rhs, SmallSpan<T> lhs)
-{
-  return !(rhs==lhs);
-}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -838,8 +820,8 @@ sampleSpan(Span<const DataType> values,Span<const Int32> indexes,Span<DataType> 
 /*!
  * \brief Converti la vue en un tableau d'octets non modifiables.
  */
-template<typename DataType,typename SizeType,Int64 Extent> inline Span<const std::byte,Extent>
-asBytes(SpanImpl<DataType,SizeType,Extent> s)
+template<typename DataType,typename SizeType,SizeType Extent> inline Span<const std::byte>
+asBytes(const SpanImpl<DataType,SizeType,Extent>& s)
 {
   return {reinterpret_cast<const std::byte*>(s.data()), s.sizeBytes()};
 }
@@ -851,13 +833,17 @@ asBytes(SpanImpl<DataType,SizeType,Extent> s)
  *
  * Cette méthode n'est accessible que si \a DataType n'est pas `const`.
  */
-template<typename DataType,typename SizeType,Int64 Extent,
+template<typename DataType,typename SizeType,SizeType Extent,
          typename std::enable_if_t<!std::is_const<DataType>::value, int> = 0>
-inline Span<std::byte,Extent>
-asWritableBytes(SpanImpl<DataType,SizeType,Extent> s)
+inline Span<std::byte>
+asWritableBytes(const SpanImpl<DataType,SizeType,Extent>& s)
 {
   return {reinterpret_cast<std::byte*>(s.data()), s.sizeBytes()};
 }
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 namespace impl
 {
 
@@ -907,26 +893,6 @@ asSpan(std::array<DataType,SizeType>& s)
 {
   Int64 size = static_cast<Int64>(s.size());
   return { s.data(), size };
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline std::ostream&
-operator<<(std::ostream& o, Span<T> val)
-{
-  dumpArray(o,Span<const T>(val),500);
-  return o;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline std::ostream&
-operator<<(std::ostream& o, SmallSpan<T> val)
-{
-  o << Span<T>(val);
-  return o;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/Span.h
+++ b/arccore/src/base/arccore/base/Span.h
@@ -897,6 +897,24 @@ asSpan(std::array<DataType,SizeType>& s)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Ecrit en binaire le contenu de \a bytes sur le flot \a ostr.
+ *
+ * Cela revient à faire ostr.write(bytes.data(),bytes.size());
+ */
+extern "C++" ARCCORE_BASE_EXPORT void
+binaryWrite(std::ostream& ostr,const Span<const std::byte>& bytes);
+
+/*!
+ * \brief Lit en binaire le contenu de \a bytes depuis le flot \a istr.
+ *
+ * Cela revient à faire ostr.read(bytes.data(),bytes.size());
+ */
+extern "C++" ARCCORE_BASE_EXPORT void
+binaryRead(std::istream& istr,const Span<std::byte>& bytes);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 } // End namespace Arccore
 

--- a/arccore/src/base/arccore/base/Span2.h
+++ b/arccore/src/base/arccore/base/Span2.h
@@ -62,6 +62,8 @@ class View2TypeT<const T>
 template<typename T,typename SizeType,SizeType Extent1,SizeType Extent2>
 class Span2Impl
 {
+  using ThatClass = Span2Impl<T,SizeType,Extent1,Extent2>;
+
  public:
 
   using ElementType = T;
@@ -180,6 +182,33 @@ class Span2Impl
 
   //! Pointeur sur la mémoire allouée.
   constexpr ARCCORE_HOST_DEVICE const ElementType* data() const { return m_ptr; }
+
+ public:
+
+  //! Opérateur d'égalité (valide si T est const mais pas X)
+  template<typename X,SizeType XExtent1,SizeType XExtent2, typename = std::enable_if_t<std::is_same_v<X,value_type>>>
+  friend bool operator==(const ThatClass& lhs, const Span2Impl<X,SizeType,XExtent1,XExtent2>& rhs)
+  {
+    return impl::areEqual2D(rhs,lhs);
+  }
+  //! Opérateur d'inégalité (valide si T est const mais pas X)
+  template<typename X,SizeType XExtent1,SizeType XExtent2, typename = std::enable_if_t<std::is_same_v<X,value_type>>>
+  friend bool operator!=(const ThatClass& lhs, const Span2Impl<X,SizeType,XExtent1,XExtent2>& rhs)
+  {
+    return !impl::areEqual2D(rhs,lhs);
+  }
+  //! Opérateur d'égalité
+  template<SizeType XExtent1,SizeType XExtent2>
+  friend bool operator==(const ThatClass& lhs, const Span2Impl<T,SizeType,XExtent1,XExtent2>& rhs)
+  {
+    return impl::areEqual2D(rhs,lhs);
+  }
+  //! Opérateur d'inégalité
+  template<SizeType XExtent1,SizeType XExtent2>
+  friend bool operator!=(const ThatClass& lhs, const Span2Impl<T,SizeType,XExtent1,XExtent2>& rhs)
+  {
+    return !impl::areEqual2D(rhs,lhs);
+  }
 
  protected:
 
@@ -331,59 +360,6 @@ class Span2
     return Span<ElementType>(m_ptr + (m_dim2_size*i),m_dim2_size);
   }
 };
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T,typename SizeType> inline bool
-operator==(Span2Impl<const T,SizeType> rhs, Span2Impl<const T,SizeType> lhs)
-{
-  return impl::areEqual2D(rhs,lhs);
-}
-
-template<typename T> inline bool
-operator==(Span2<const T> rhs, Span2<const T> lhs)
-{
-  Span2Impl<const T,Int64> a = rhs;
-  Span2Impl<const T,Int64> b = lhs;
-  return impl::areEqual2D(a,b);
-}
-
-template<typename T> inline bool
-operator!=(Span2<const T> rhs, Span2<const T> lhs)
-{
-  return !(rhs==lhs);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline bool
-operator==(Span2<T> rhs, Span2<T> lhs)
-{
-  return impl::areEqual2D(rhs,lhs);
-}
-
-template<typename T> inline bool
-operator!=(Span2<T> rhs, Span2<T> lhs)
-{
-  return !(rhs==lhs);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename T> inline bool
-operator==(SmallSpan2<T> rhs, SmallSpan2<T> lhs)
-{
-  return operator==(Span2<const T>(rhs),Span2<const T>(lhs));
-}
-
-template<typename T> inline bool
-operator!=(SmallSpan2<T> rhs, SmallSpan2<T> lhs)
-{
-  return !(rhs==lhs);
-}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/String.h
+++ b/arccore/src/base/arccore/base/String.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* String.h                                                    (C) 2000-2022 */
+/* String.h                                                    (C) 2000-2023 */
 /*                                                                           */
 /* Chaîne de caractère unicode.                                              */
 /*---------------------------------------------------------------------------*/
@@ -70,7 +70,6 @@ class ARCCORE_BASE_EXPORT String
 {
  public:
 
-  friend ARCCORE_BASE_EXPORT bool operator==(const String& a,const String& b);
   friend ARCCORE_BASE_EXPORT bool operator<(const String& a,const String& b);
   friend class StringBuilder;
   friend class StringUtilsImpl;
@@ -304,6 +303,71 @@ class ARCCORE_BASE_EXPORT String
 
  public:
 
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont égales,
+   * \retval false sinon.
+   * \relate String
+   */
+  friend ARCCORE_BASE_EXPORT bool operator==(const String& a,const String& b);
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont différentes,
+   * \retval false si elles sont égales.
+   * \relate String
+   */
+  friend bool operator!=(const String& a,const String& b)
+  {
+    return !operator==(a,b);
+  }
+
+  //! Opérateur d'écriture d'une String
+  friend ARCCORE_BASE_EXPORT std::ostream& operator<<(std::ostream& o,const String&);
+  //! Opérateur de lecture d'une String
+  friend ARCCORE_BASE_EXPORT std::istream& operator>>(std::istream& o,String&);
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont égales,
+   * \retval false sinon.
+   */
+  friend ARCCORE_BASE_EXPORT bool operator==(const char* a,const String& b);
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont différentes,
+   * \retval false si elles sont égales.
+   */
+  inline friend bool operator!=(const char* a,const String& b)
+  {
+    return !operator==(a,b);
+  }
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont égales,
+   * \retval false sinon.
+   */
+  friend ARCCORE_BASE_EXPORT bool operator==(const String& a,const char* b);
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont différentes,
+   * \retval false si elles sont égales.
+   */
+  inline friend bool operator!=(const String& a,const char* b)
+  {
+    return !operator==(a,b);
+  }
+
+  //! Ajoute deux chaînes.
+  friend ARCCORE_BASE_EXPORT String operator+(const char* a,const String& b);
+
+  friend ARCCORE_BASE_EXPORT bool operator<(const String& a,const String& b);
+
+ public:
+
   //! Retourne la concaténation de cette chaîne avec la chaîne \a str encodée en UTF-8
   String operator+(const char* str) const
   {
@@ -504,84 +568,6 @@ class ARCCORE_BASE_EXPORT String
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-//! Opérateur d'écriture d'une String
-ARCCORE_BASE_EXPORT std::ostream& operator<<(std::ostream& o,const String&);
-//! Opérateur de lecture d'une String
-ARCCORE_BASE_EXPORT std::istream& operator>>(std::istream& o,String&);
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont égales,
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator==(const String& a,const String& b);
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont différentes,
- * \retval false si elles sont égales.
- * \relate String
- */
-inline bool operator!=(const String& a,const String& b)
-{
-  return !operator==(a,b);
-}
-
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont égales,
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator==(const char* a,const String& b);
-
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont différentes,
- * \retval false si elles sont égales.
- * \relate String
- */
-inline bool operator!=(const char* a,const String& b)
-{
-  return !operator==(a,b);
-}
-
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont égales,
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator==(const String& a,const char* b);
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont différentes,
- * \retval false si elles sont égales.
- * \relate String
- */
-inline bool operator!=(const String& a,const char* b)
-{
-  return !operator==(a,b);
-}
-
-//! Ajoute deux chaînes.
-extern "C++" ARCCORE_BASE_EXPORT String operator+(const char* a,const String& b);
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si a<b
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator<(const String& a,const String& b);
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 template<typename U>
 class StringFormatterArgToString
 {
@@ -594,6 +580,8 @@ class StringFormatterArgToString
   }
 };
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \internal
  * \brief Classe utilisée pour formatter une chaîne de caractères.
@@ -621,6 +609,15 @@ class ARCCORE_BASE_EXPORT StringFormatterArg
  private:
   void _formatReal(Real avalue);
 };
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+inline Span<const std::byte>
+asBytes(const String& v)
+{
+  return asBytes(v.bytes());
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/StringBuilder.cc
+++ b/arccore/src/base/arccore/base/StringBuilder.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StringBuilder.cc                                            (C) 2000-2018 */
+/* StringBuilder.cc                                            (C) 2000-2023 */
 /*                                                                           */
 /* Constructeur de chaîne de caractère unicode.                              */
 /*---------------------------------------------------------------------------*/
@@ -28,7 +28,6 @@ namespace Arccore
 StringBuilder::
 StringBuilder(const std::string& str)
 : m_p(new StringImpl(str))
-, m_const_ptr(0)
 {
   m_p->addReference();
 }
@@ -39,7 +38,6 @@ StringBuilder(const std::string& str)
 StringBuilder::
 StringBuilder(const UCharConstArrayView& ustr)
 : m_p(new StringImpl(ustr.data()))
-, m_const_ptr(0)
 {
   m_p->addReference();
 }
@@ -50,7 +48,6 @@ StringBuilder(const UCharConstArrayView& ustr)
 StringBuilder::
 StringBuilder(const ByteConstArrayView& ustr)
 : m_p(new StringImpl(ustr))
-, m_const_ptr(0)
 {
   m_p->addReference();
 }
@@ -61,7 +58,6 @@ StringBuilder(const ByteConstArrayView& ustr)
 StringBuilder::
 StringBuilder(StringImpl* impl)
 : m_p(impl)
-, m_const_ptr(0)
 {
   if (m_p)
     m_p->addReference();
@@ -73,7 +69,6 @@ StringBuilder(StringImpl* impl)
 StringBuilder::
 StringBuilder(const char* str,Integer len)
 : m_p(new StringImpl(std::string_view(str,len)))
-, m_const_ptr(0)
 {
   m_p->addReference();
 }
@@ -84,7 +79,6 @@ StringBuilder(const char* str,Integer len)
 StringBuilder::
 StringBuilder(const char* str)
 : m_p(0)
-, m_const_ptr(0)
 {
   const bool do_alloc = true;
   if (do_alloc){
@@ -400,6 +394,15 @@ operator<<(std::ostream& o,const StringBuilder& str)
   String s = str.toString();
   o << s.localstr();
   return o;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool
+operator==(const StringBuilder& a,const StringBuilder& b)
+{
+  return a.toString()==b.toString();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/StringBuilder.h
+++ b/arccore/src/base/arccore/base/StringBuilder.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StringBuilder.h                                             (C) 2000-2018 */
+/* StringBuilder.h                                             (C) 2000-2023 */
 /*                                                                           */
 /* Constructeur de chaîne de caractère unicode.                              */
 /*---------------------------------------------------------------------------*/
@@ -47,10 +47,8 @@ class ARCCORE_BASE_EXPORT StringBuilder
 {
  public:
 
- public:
-
   //! Crée une chaîne nulle
-  StringBuilder() : m_p(0), m_const_ptr(0) {}
+  StringBuilder() : m_p(nullptr), m_const_ptr(nullptr) {}
   //! Créé une chaîne à partir de \a str dans l'encodage local
   StringBuilder(const char* str);
   //! Créé une chaîne à partir de \a str dans l'encodage local
@@ -79,8 +77,6 @@ class ARCCORE_BASE_EXPORT StringBuilder
 
  public:
 
- public:
-
   /*!
    * \brief Retourne la chaîne de caractères construite.
    */
@@ -90,8 +86,6 @@ class ARCCORE_BASE_EXPORT StringBuilder
    * \brief Retourne la chaîne de caractères construite.
    */
   String toString() const;
-
- public:
 
  public:
 
@@ -136,6 +130,15 @@ class ARCCORE_BASE_EXPORT StringBuilder
   void operator+=(const APReal& v);
 
  public:
+
+  friend ARCCORE_BASE_EXPORT bool operator==(const StringBuilder& a,const StringBuilder& b);
+  friend bool operator!=(const StringBuilder& a,const StringBuilder& b)
+  {
+    return !operator==(a,b);
+  }
+
+ public:
+
   /*!
    * \brief Affiche les infos internes de la classe.
    *
@@ -145,8 +148,8 @@ class ARCCORE_BASE_EXPORT StringBuilder
 
  private:
 
-  mutable StringImpl* m_p; //!< Implémentation de la classe
-  mutable const char* m_const_ptr;
+  mutable StringImpl* m_p = nullptr; //!< Implémentation de la classe
+  mutable const char* m_const_ptr = nullptr;
 
   void _checkClone() const;
 };

--- a/arccore/src/base/arccore/base/StringView.cc
+++ b/arccore/src/base/arccore/base/StringView.cc
@@ -44,7 +44,7 @@ operator<<(std::ostream& o,const StringView& str)
 /*---------------------------------------------------------------------------*/
 
 bool
-operator==(StringView a,StringView b)
+operator==(const StringView& a,const StringView& b)
 {
   bool is_equal = (a.toStdStringView()==b.toStdStringView());
   //std::cout << "COMPARE: a=" << a.length() << " '" << a << "'"
@@ -55,7 +55,7 @@ operator==(StringView a,StringView b)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-bool operator==(const char* a,StringView b)
+bool operator==(const char* a,const StringView& b)
 {
   return operator==(StringView(a),b);
 }
@@ -63,7 +63,7 @@ bool operator==(const char* a,StringView b)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-bool operator==(StringView a,const char* b)
+bool operator==(const StringView& a,const char* b)
 {
   return operator==(a,StringView(b));
 }
@@ -71,7 +71,7 @@ bool operator==(StringView a,const char* b)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-bool operator<(StringView a,StringView b)
+bool operator<(const StringView& a,const StringView& b)
 {
   return a.toStdStringView()<b.toStdStringView();
 }

--- a/arccore/src/base/arccore/base/StringView.h
+++ b/arccore/src/base/arccore/base/StringView.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StringView.h                                                (C) 2000-2022 */
+/* StringView.h                                                (C) 2000-2023 */
 /*                                                                           */
 /* Vue sur une chaîne de caractères UTF-8.                                   */
 /*---------------------------------------------------------------------------*/
@@ -47,11 +47,6 @@ class ARCCORE_BASE_EXPORT StringView
 {
  public:
 
-  friend ARCCORE_BASE_EXPORT bool operator==(StringView a,StringView b);
-  friend ARCCORE_BASE_EXPORT bool operator<(StringView a,StringView b);
-
- public:
-
   //! Crée une vue sur une chaîne vide
   StringView() = default;
   //! Créé une vue à partir de \a str codé en UTF-8. \a str peut être nul.
@@ -90,8 +85,6 @@ class ARCCORE_BASE_EXPORT StringView
 
  public:
 
- public:
-
   /*!
    * \brief Retourne la conversion de l'instance dans l'encodage UTF-8.
    *
@@ -121,95 +114,79 @@ class ARCCORE_BASE_EXPORT StringView
     return std::string_view(reinterpret_cast<const char*>(m_v.data()),m_v.size());
   }
 
+  //! Opérateur d'écriture d'une StringView
+  friend ARCCORE_BASE_EXPORT std::ostream& operator<<(std::ostream& o,const StringView&);
+
+  /*!
+   * \brief Compare deux vues.
+   * \retval true si elles sont égales,
+   * \retval false sinon.
+   */
+  friend ARCCORE_BASE_EXPORT bool operator==(const StringView& a,const StringView& b);
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont différentes,
+   * \retval false si elles sont égales.
+   * \relate String
+   */
+  friend inline bool operator!=(const StringView& a,const StringView& b)
+  {
+    return !operator==(a,b);
+  }
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont égales,
+   * \retval false sinon.
+   * \relate String
+   */
+  friend ARCCORE_BASE_EXPORT bool operator==(const char* a,const StringView& b);
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont différentes,
+   * \retval false si elles sont égales.
+   * \relate String
+   */
+  friend bool operator!=(const char* a,const StringView& b){ return !operator==(a,b); }
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont égales,
+   * \retval false sinon.
+   * \relate String
+   */
+  friend ARCCORE_BASE_EXPORT bool operator==(const StringView& a,const char* b);
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si elles sont différentes,
+   * \retval false si elles sont égales.
+   * \relate String
+   */
+  friend inline bool operator!=(const StringView& a,const char* b)
+  {
+    return !operator==(a,b);
+  }
+
+  /*!
+   * \brief Compare deux chaînes unicode.
+   * \retval true si a<b
+   * \retval false sinon.
+   * \relate String
+   */
+  friend ARCCORE_BASE_EXPORT bool operator<(const StringView& a,const StringView& b);
+
  public:
 
   //! Écrit la chaîne au format UTF-8 sur le flot \a o
   void writeBytes(std::ostream& o) const;
 
- public:
-
  private:
 
   Span<const Byte> m_v;
-
- private:
 };
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-//! Opérateur d'écriture d'une StringView
-ARCCORE_BASE_EXPORT std::ostream& operator<<(std::ostream& o,const StringView&);
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Compare deux vues.
- * \retval true si elles sont égales,
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator==(StringView a,StringView b);
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont différentes,
- * \retval false si elles sont égales.
- * \relate String
- */
-inline bool operator!=(StringView a,StringView b)
-{
-  return !operator==(a,b);
-}
-
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont égales,
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator==(const char* a,StringView b);
-
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont différentes,
- * \retval false si elles sont égales.
- * \relate String
- */
-inline bool operator!=(const char* a,StringView b)
-{
-  return !operator==(a,b);
-}
-
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont égales,
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator==(StringView a,const char* b);
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si elles sont différentes,
- * \retval false si elles sont égales.
- * \relate String
- */
-inline bool operator!=(StringView a,const char* b)
-{
-  return !operator==(a,b);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Compare deux chaînes unicode.
- * \retval true si a<b
- * \retval false sinon.
- * \relate String
- */
-extern "C++" ARCCORE_BASE_EXPORT bool operator<(StringView a,StringView b);
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/tests/TestArrayView.cc
+++ b/arccore/src/base/tests/TestArrayView.cc
@@ -337,6 +337,15 @@ _testSpanStdArray()
     span1 = v3;
     _checkSame(span1,v3,"const span1==v3");
   }
+  {
+    SpanType span1 { v1 };
+    ConstSpanType const_span1 { v1 };
+    ASSERT_TRUE(span1==const_span1);
+
+    SpanType span2 { v2 };
+    ConstSpanType const_span3 { v3 };
+    ASSERT_TRUE(span2!=const_span3);
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -377,6 +386,24 @@ TEST(Span, StdArray)
     _checkSame(x, v2, "x==v2");
     x[2] = 5;
     ASSERT_EQ(v2[2], 5);
+  }
+
+  {
+    std::array<Int64,2> v1 { 5, 7 };
+    std::array<Int64,3> v2 { 2, 4, -2 };
+    Span<Int64,2> fixed_s1(v1);
+    Span<Int64,3> fixed_s2(v2);
+    ASSERT_FALSE(fixed_s1==fixed_s2);
+    ASSERT_TRUE(fixed_s1!=fixed_s2);
+
+    Span<const Int64> s1_a(s1);
+    Span<const std::byte> fb1(asBytes(s1_a));
+    Span<std::byte> fb2(asWritableBytes(s2));
+    ASSERT_FALSE(fb1==fb2);
+
+    std::array<Real, 3> v2r{ 2.0, 4.1, -2.3 };
+    SmallSpan<const Real> small2(v2r);
+    Span<const std::byte> small_fb2(asBytes(small2));
   }
 }
 

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -505,6 +505,44 @@ class AbstractArray
     m_md->_setMemoryLocationHint(new_hint,m_ptr,sizeof(T));
   }
 
+ public:
+
+  friend bool operator==(const AbstractArray<T>& rhs, const AbstractArray<T>& lhs)
+  {
+    return operator==(Span<const T>(rhs),Span<const T>(lhs));
+  }
+
+  friend bool operator!=(const AbstractArray<T>& rhs, const AbstractArray<T>& lhs)
+  {
+    return !(rhs==lhs);
+  }
+
+  friend bool operator==(const AbstractArray<T>& rhs, const Span<const T>& lhs)
+  {
+    return operator==(Span<const T>(rhs),lhs);
+  }
+
+  friend bool operator!=(const AbstractArray<T>& rhs, const Span<const T>& lhs)
+  {
+    return !(rhs==lhs);
+  }
+
+  friend bool operator==(const Span<const T>& rhs, const AbstractArray<T>& lhs)
+  {
+    return operator==(rhs,Span<const T>(lhs));
+  }
+
+  friend bool operator!=(const Span<const T>& rhs, const AbstractArray<T>& lhs)
+  {
+    return !(rhs==lhs);
+  }
+
+  friend std::ostream& operator<<(std::ostream& o, const AbstractArray<T>& val)
+  {
+    o << Span<const T>(val);
+    return o;
+  }
+
  private:
 
   using AbstractArrayBase::m_meta_data;
@@ -1916,27 +1954,26 @@ operator=(const UniqueArray<T>& rhs)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-template<typename T> inline std::ostream&
-operator<<(std::ostream& o, const AbstractArray<T>& val)
+/*!
+ * \brief Converti la vue en un tableau d'octets non modifiables.
+ */
+template<typename T> inline Span<const std::byte>
+asBytes(const Array<T>& v)
 {
-  o << Span<const T>(val);
-  return o;
+  return asBytes(v.constSpan());
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-template<typename T> inline bool
-operator==(const AbstractArray<T>& rhs, const AbstractArray<T>& lhs)
+/*!
+ * \brief Converti la vue en un tableau d'octets modifiables.
+ *
+ * Cela ne doit être que si T est un type POD.
+ */
+template<typename T> inline Span<std::byte>
+asWritableBytes(Array<T>& v)
 {
-  return operator==(Span<const T>(rhs),Span<const T>(lhs));
-}
-
-template<typename T> inline bool
-operator!=(const AbstractArray<T>& rhs, const AbstractArray<T>& lhs)
-{
-  return !(rhs==lhs);
+  return asWritableBytes(v.span());
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
They will no longer participate in general overloads.
Also improve some conversions for `asBytes()`  and `asWritableBytes()`.