### PR TITLE
Use only one buffer for variable synchronization and remove specific instance for each datatype

### DIFF
--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -74,14 +74,14 @@ VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
 , m_allow_multi_sync(true)
 , m_trace_sync(false)
 {
-  typedef DataTypeDispatchingDataVisitor<IVariableSynchronizeDispatcher> DispatcherType;
+  //typedef DataTypeDispatchingDataVisitor<IVariableSynchronizeDispatcher> DispatcherType;
   if (!m_dispatcher){
     auto generic_factory = arcaneCreateSimpleVariableSynchronizerFactory(pm);
     GroupIndexTable* table = nullptr;
     if (!group.isAllItems())
       table = group.localIdToIndex().get();
     VariableSynchronizeDispatcherBuildInfo bi(pm,table,generic_factory);
-    m_dispatcher = new VariableSynchronizerDispatcher(pm,DispatcherType::create<VariableSynchronizeDispatcher>(bi));
+    m_dispatcher = new VariableSynchronizerDispatcher(pm,bi);
   }
   m_dispatcher->setItemGroupSynchronizeInfo(&m_sync_list);
   m_multi_dispatcher = new VariableSynchronizerMultiDispatcher(pm);
@@ -675,7 +675,7 @@ synchronize(VariableCollection vars)
 void VariableSynchronizer::
 _synchronize(IVariable* var)
 {
-  var->data()->visit(m_dispatcher->visitor());
+  m_dispatcher->applyDispatch(var->data());
   var->setIsSynchronized();
 }
 
@@ -685,7 +685,7 @@ _synchronize(IVariable* var)
 void VariableSynchronizer::
 synchronizeData(IData* data)
 {
-  data->visit(m_dispatcher->visitor());
+  m_dispatcher->applyDispatch(data);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -81,7 +81,7 @@ VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
     if (!group.isAllItems())
       table = group.localIdToIndex().get();
     VariableSynchronizeDispatcherBuildInfo bi(pm,table,generic_factory);
-    m_dispatcher = new VariableSynchronizerDispatcher(pm,bi);
+    m_dispatcher = new VariableSynchronizerDispatcher(bi);
   }
   m_dispatcher->setItemGroupSynchronizeInfo(&m_sync_list);
   m_multi_dispatcher = new VariableSynchronizerMultiDispatcher(pm);

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -63,7 +63,7 @@ arcaneCreateSimpleVariableSynchronizerFactory(IParallelMng* pm);
 
 VariableSynchronizer::
 VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
-                     VariableSynchronizerDispatcher* dispatcher)
+                     IVariableSynchronizerDispatcher* dispatcher)
 : TraceAccessor(pm->traceMng())
 , m_parallel_mng(pm)
 , m_item_group(group)
@@ -74,14 +74,13 @@ VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
 , m_allow_multi_sync(true)
 , m_trace_sync(false)
 {
-  //typedef DataTypeDispatchingDataVisitor<IVariableSynchronizeDispatcher> DispatcherType;
   if (!m_dispatcher){
     auto generic_factory = arcaneCreateSimpleVariableSynchronizerFactory(pm);
     GroupIndexTable* table = nullptr;
     if (!group.isAllItems())
       table = group.localIdToIndex().get();
     VariableSynchronizeDispatcherBuildInfo bi(pm,table,generic_factory);
-    m_dispatcher = new VariableSynchronizerDispatcher(bi);
+    m_dispatcher = IVariableSynchronizerDispatcher::create(bi);
   }
   m_dispatcher->setItemGroupSynchronizeInfo(&m_sync_list);
   m_multi_dispatcher = new VariableSynchronizerMultiDispatcher(pm);

--- a/arcane/src/arcane/impl/VariableSynchronizer.h
+++ b/arcane/src/arcane/impl/VariableSynchronizer.h
@@ -35,6 +35,7 @@
 
 namespace Arcane
 {
+class Timer;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -126,7 +127,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizer
  public:
 
   VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
-                       VariableSynchronizerDispatcher* dispatcher);
+                       IVariableSynchronizerDispatcher* dispatcher);
   virtual ~VariableSynchronizer();
 
  public:
@@ -168,7 +169,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizer
   ItemGroup m_item_group;
   ItemGroupSynchronizeInfo m_sync_list;
   Int32UniqueArray m_communicating_ranks;
-  VariableSynchronizerDispatcher* m_dispatcher;
+  IVariableSynchronizerDispatcher* m_dispatcher;
   VariableSynchronizerMultiDispatcher* m_multi_dispatcher;
   Timer* m_sync_timer;
   bool m_is_verbose;

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
@@ -181,7 +181,7 @@ template <typename SimpleType> VariableSynchronizeDispatcher<SimpleType>::
 /*---------------------------------------------------------------------------*/
 
 template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
-_applyDispatch(IData* data,SyncBuffer& sync_buffer)
+_applyDispatch(IData* data)
 {
   INumericDataInternal* numapi = data->_commonInternal()->numericData();
   if (!numapi)
@@ -195,10 +195,10 @@ _applyDispatch(IData* data,SyncBuffer& sync_buffer)
   if (m_is_in_sync)
     ARCANE_FATAL("Only one pending serialisation is supported");
   m_is_in_sync = true;
-  sync_buffer.compute(m_buffer_copier, m_sync_info, full_datatype_size);
-  sync_buffer.setDataView(mem_view);
-  _beginSynchronize(sync_buffer);
-  _endSynchronize(sync_buffer);
+  m_sync_buffer.compute(m_buffer_copier, m_sync_info, full_datatype_size);
+  m_sync_buffer.setDataView(mem_view);
+  _beginSynchronize(m_sync_buffer);
+  _endSynchronize(m_sync_buffer);
   m_is_in_sync = false;
 }
 
@@ -208,7 +208,7 @@ _applyDispatch(IData* data,SyncBuffer& sync_buffer)
 template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 applyDispatch(IArrayDataT<SimpleType>* data)
 {
-  _applyDispatch(data,m_1d_buffer);
+  _applyDispatch(data);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -217,7 +217,7 @@ applyDispatch(IArrayDataT<SimpleType>* data)
 template <typename SimpleType> void VariableSynchronizeDispatcher<SimpleType>::
 applyDispatch(IArray2DataT<SimpleType>* data)
 {
-  _applyDispatch(data,m_2d_buffer);
+  _applyDispatch(data);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
@@ -13,29 +13,27 @@
 
 #include "arcane/impl/VariableSynchronizerDispatcher.h"
 
-#include "arcane/utils/ArrayView.h"
-#include "arcane/utils/Array2View.h"
 #include "arcane/utils/FatalErrorException.h"
-#include "arcane/utils/Real2.h"
-#include "arcane/utils/Real3.h"
-#include "arcane/utils/Real2x2.h"
-#include "arcane/utils/Real3x3.h"
-
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/IMemoryRessourceMng.h"
+#include "arcane/utils/MemoryView.h"
 
 #include "arcane/core/VariableCollection.h"
 #include "arcane/core/ParallelMngUtils.h"
 #include "arcane/core/IParallelExchanger.h"
 #include "arcane/core/ISerializeMessage.h"
 #include "arcane/core/ISerializer.h"
+#include "arcane/core/IParallelMng.h"
 #include "arcane/core/IData.h"
-#include "arcane/core/datatype/DataStorageTypeInfo.h"
-#include "arcane/core/datatype/DataTypeTraits.h"
+//#include "arcane/core/datatype/DataStorageTypeInfo.h"
+//#include "arcane/core/datatype/DataTypeTraits.h"
 #include "arcane/core/internal/IParallelMngInternal.h"
 #include "arcane/core/internal/IDataInternal.h"
 
 #include "arcane/accelerator/core/Runner.h"
+
+#include "arcane/impl/IBufferCopier.h"
+#include "arcane/impl/IDataSynchronizeBuffer.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
@@ -133,6 +133,152 @@ recompute()
   }
 }
 
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Implémentation de IDataSynchronizeBuffer pour les variables
+ */
+class ARCANE_IMPL_EXPORT VariableSynchronizeBufferBase
+: public IDataSynchronizeBuffer
+{
+ public:
+
+  Int32 nbRank() const final { return m_nb_rank; }
+  bool hasGlobalBuffer() const final { return true; }
+
+  MutableMemoryView receiveBuffer(Int32 index) final { return _ghostLocalBuffer(index); }
+  MutableMemoryView sendBuffer(Int32 index) final { return _shareLocalBuffer(index); }
+
+  Int64 receiveDisplacement(Int32 index) const final { return _ghostDisplacementBase(index) * m_datatype_size; }
+  Int64 sendDisplacement(Int32 index) const final { return _shareDisplacementBase(index) * m_datatype_size; }
+
+  MutableMemoryView globalReceiveBuffer() final { return m_ghost_memory_view; }
+  MutableMemoryView globalSendBuffer() final { return m_share_memory_view; }
+
+  void copyReceiveAsync(Integer index) final;
+  void copySendAsync(Integer index) final;
+  Int64 totalReceiveSize() const final { return m_ghost_memory_view.bytes().size(); }
+  Int64 totalSendSize() const final { return m_share_memory_view.bytes().size(); }
+
+  void barrier() final { m_buffer_copier->barrier(); }
+
+ public:
+
+  void compute(IBufferCopier* copier, ItemGroupSynchronizeInfo* sync_list, Int32 datatype_size);
+  IDataSynchronizeBuffer* genericBuffer() { return this; }
+  void setDataView(MutableMemoryView v) { m_data_view = v; }
+  MutableMemoryView dataMemoryView() { return m_data_view; }
+
+ protected:
+
+  void _allocateBuffers(Int32 datatype_size);
+
+ protected:
+
+  ItemGroupSynchronizeInfo* m_sync_info = nullptr;
+  //! Buffer pour toutes les données des entités fantômes qui serviront en réception
+  MutableMemoryView m_ghost_memory_view;
+  //! Buffer pour toutes les données des entités partagées qui serviront en envoi
+  MutableMemoryView m_share_memory_view;
+
+ private:
+
+  Int32 m_nb_rank = 0;
+  //! Vue sur les données de la variable
+  MutableMemoryView m_data_view;
+  IBufferCopier* m_buffer_copier = nullptr;
+
+  //! Buffer contenant les données concaténées en envoi et réception
+  UniqueArray<std::byte> m_buffer;
+
+  Int32 m_datatype_size = 0;
+
+ private:
+
+  Int64 _ghostDisplacementBase(Int32 index) const
+  {
+    return m_sync_info->ghostDisplacement(index);
+  }
+  Int64 _shareDisplacementBase(Int32 index) const
+  {
+    return m_sync_info->shareDisplacement(index);
+  }
+
+  Int32 _nbGhost(Int32 index) const
+  {
+    return m_sync_info->rankInfo(index).nbGhost();
+  }
+
+  Int32 _nbShare(Int32 index) const
+  {
+    return m_sync_info->rankInfo(index).nbShare();
+  }
+
+  MutableMemoryView _shareLocalBuffer(Int32 index) const
+  {
+    Int64 displacement = _shareDisplacementBase(index);
+    Int32 local_size = _nbShare(index);
+    return m_share_memory_view.subView(displacement, local_size);
+  }
+  MutableMemoryView _ghostLocalBuffer(Int32 index) const
+  {
+    Int64 displacement = _ghostDisplacementBase(index);
+    Int32 local_size = _nbGhost(index);
+    return m_ghost_memory_view.subView(displacement, local_size);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Gestion de la synchronisation.
+ */
+class ARCANE_IMPL_EXPORT VariableSynchronizerDispatcher
+: public IVariableSynchronizeDispatcher
+{
+ public:
+
+  //! Gère les buffers d'envoi et réception pour la synchronisation
+  using SyncBuffer = VariableSynchronizeBufferBase;
+
+ public:
+
+  explicit VariableSynchronizerDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi);
+  ~VariableSynchronizerDispatcher() override;
+
+ public:
+
+  void applyDispatch(IData* data) override;
+  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) final;
+  void compute() final;
+
+ protected:
+
+  void _beginSynchronize(VariableSynchronizeBufferBase& sync_buffer)
+  {
+    m_generic_instance->beginSynchronize(sync_buffer.genericBuffer());
+  }
+  void _endSynchronize(VariableSynchronizeBufferBase& sync_buffer)
+  {
+    m_generic_instance->endSynchronize(sync_buffer.genericBuffer());
+  }
+
+ private:
+
+  IParallelMng* m_parallel_mng = nullptr;
+  IBufferCopier* m_buffer_copier = nullptr;
+  ItemGroupSynchronizeInfo* m_sync_info = nullptr;
+  SyncBuffer m_sync_buffer;
+  bool m_is_in_sync = false;
+  Ref<IGenericVariableSynchronizerDispatcherFactory> m_factory;
+  Ref<IGenericVariableSynchronizerDispatcher> m_generic_instance;
+
+ private:
+
+  void _applyDispatch(IData* data);
+};
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -233,6 +379,18 @@ compute()
   if (!m_sync_info)
     ARCANE_FATAL("The instance is not initialized. You need to call setItemGroupSynchronizeInfo() before");
   m_generic_instance->compute();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+IVariableSynchronizeDispatcher* IVariableSynchronizeDispatcher::
+create(const VariableSynchronizeDispatcherBuildInfo& build_info)
+{
+  return new VariableSynchronizerDispatcher(build_info);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
@@ -139,8 +139,8 @@ recompute()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-VariableSynchronizeDispatcher::
-VariableSynchronizeDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi)
+VariableSynchronizerDispatcher::
+VariableSynchronizerDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi)
 : m_parallel_mng(bi.parallelMng())
 , m_factory(bi.factory())
 {
@@ -171,8 +171,8 @@ VariableSynchronizeDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-VariableSynchronizeDispatcher::
-~VariableSynchronizeDispatcher()
+VariableSynchronizerDispatcher::
+~VariableSynchronizerDispatcher()
 {
   delete m_buffer_copier;
 }
@@ -180,7 +180,7 @@ VariableSynchronizeDispatcher::
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void VariableSynchronizeDispatcher::
+void VariableSynchronizerDispatcher::
 _applyDispatch(IData* data)
 {
   INumericDataInternal* numapi = data->_commonInternal()->numericData();
@@ -205,7 +205,7 @@ _applyDispatch(IData* data)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void VariableSynchronizeDispatcher::
+void VariableSynchronizerDispatcher::
 applyDispatch(IData* data)
 {
   _applyDispatch(data);
@@ -214,7 +214,7 @@ applyDispatch(IData* data)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void VariableSynchronizeDispatcher::
+void VariableSynchronizerDispatcher::
 setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info)
 {
   m_sync_info = sync_info;
@@ -227,7 +227,7 @@ setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info)
  * \brief Calcule et alloue les tampons nécessaire aux envois et réceptions
  * pour les synchronisations des variables 1D.
  */
-void VariableSynchronizeDispatcher::
+void VariableSynchronizerDispatcher::
 compute()
 {
   if (!m_sync_info)
@@ -362,47 +362,6 @@ synchronize(VariableCollection vars, ConstArrayView<VariableSyncInfo> sync_infos
       (*ivar)->serialize(sbuf, ghost_ids, nullptr);
     }
   }
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-VariableSynchronizerDispatcher::
-VariableSynchronizerDispatcher(IParallelMng* pm,const VariableSynchronizeDispatcherBuildInfo& bi)
-: m_parallel_mng(pm)
-, m_dispatcher(new VariableSynchronizeDispatcher(bi))
-{
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-VariableSynchronizerDispatcher::
-~VariableSynchronizerDispatcher()
-{
-  delete m_dispatcher;
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void VariableSynchronizerDispatcher::
-setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info)
-{
-  m_dispatcher->setItemGroupSynchronizeInfo(sync_info);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void VariableSynchronizerDispatcher::
-compute()
-{
-  m_parallel_mng->traceMng()->info(4) << "DISPATCH RECOMPUTE";
-  m_dispatcher->compute();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -324,15 +324,14 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
   IParallelMng* m_parallel_mng = nullptr;
   IBufferCopier* m_buffer_copier = nullptr;
   ItemGroupSynchronizeInfo* m_sync_info = nullptr;
-  SyncBuffer m_1d_buffer;
-  SyncBuffer m_2d_buffer;
+  SyncBuffer m_sync_buffer;
   bool m_is_in_sync = false;
   Ref<IGenericVariableSynchronizerDispatcherFactory> m_factory;
   Ref<IGenericVariableSynchronizerDispatcher> m_generic_instance;
 
  private:
 
-  void _applyDispatch(IData* data,SyncBuffer& sync_buffer);
+  void _applyDispatch(IData* data);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -146,6 +146,7 @@ class ARCANE_IMPL_EXPORT IVariableSynchronizeDispatcher
  public:
   virtual void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) =0;
   virtual void compute() =0;
+  virtual void applyDispatch(IData* data) =0;
  protected:
 };
 
@@ -280,12 +281,10 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeBufferBase
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Gestion de la synchronisation pour un type de donnée \a SimpleType.
+ * \brief Gestion de la synchronisation.
  */
-template <class SimpleType>
 class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
-: public IDataTypeDataDispatcherT<SimpleType>
-, public IVariableSynchronizeDispatcher
+: public IVariableSynchronizeDispatcher
 {
  public:
 
@@ -299,9 +298,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
 
  public:
 
-  void applyDispatch(IScalarDataT<SimpleType>* data) override;
-  void applyDispatch(IArrayDataT<SimpleType>* data) override;
-  void applyDispatch(IArray2DataT<SimpleType>* data) override;
+  void applyDispatch(IData* data) override;
 
  public:
 
@@ -340,19 +337,21 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
 class ARCANE_IMPL_EXPORT VariableSynchronizerDispatcher
 {
  public:
-  typedef DataTypeDispatchingDataVisitor<IVariableSynchronizeDispatcher> DispatcherType;
+
+ using DispatcherType = VariableSynchronizeDispatcher;
+
  public:
-  VariableSynchronizerDispatcher(IParallelMng* pm,DispatcherType* dispatcher)
-  : m_parallel_mng(pm), m_dispatcher(dispatcher)
-  {
-  }
+
+ VariableSynchronizerDispatcher(IParallelMng* pm,const VariableSynchronizeDispatcherBuildInfo& bi);
   ~VariableSynchronizerDispatcher();
   void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info);
   void compute();
-  IDataVisitor* visitor() { return m_dispatcher; }
+  void applyDispatch(IData* data) { m_dispatcher->applyDispatch(data); }
+
  private:
-  IParallelMng* m_parallel_mng;
-  DispatcherType* m_dispatcher;
+
+  IParallelMng* m_parallel_mng = nullptr;
+  DispatcherType* m_dispatcher = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -371,7 +370,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizerMultiDispatcher
 
   void synchronize(VariableCollection vars,ConstArrayView<VariableSyncInfo> sync_infos);
  private:
-  IParallelMng* m_parallel_mng;
+  IParallelMng* m_parallel_mng = nullptr;
 };
   
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -15,21 +15,13 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/TraceAccessor.h"
-#include "arcane/utils/NotSupportedException.h"
-#include "arcane/utils/ITraceMng.h"
-#include "arcane/utils/Event.h"
+#include "arcane/utils/UniqueArray.h"
 
-#include "arcane/Parallel.h"
-#include "arcane/ItemGroup.h"
-#include "arcane/IVariableSynchronizer.h"
-#include "arcane/IParallelMng.h"
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/Parallel.h"
+#include "arcane/core/VariableCollection.h"
 
-#include "arcane/impl/IBufferCopier.h"
-#include "arcane/impl/IDataSynchronizeBuffer.h"
 #include "arcane/impl/IGenericVariableSynchronizerDispatcher.h"
-
-#include "arcane/DataTypeDispatchingDataVisitor.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -40,7 +32,6 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-//class VariableSynchronizer;
 class VariableSynchronizerDispatcher;
 class VariableSynchronizerMultiDispatcher;
 class IVariableSynchronizerDispatcher;
@@ -176,7 +167,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcherBuildInfo
  * interface.
  *
  * Il faut appeler \a setItemGroupSynchronizeInfo() pour initialiser
- * l'instance. I
+ * l'instance.
  */
 class ARCANE_IMPL_EXPORT IVariableSynchronizerDispatcher
 {

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -41,6 +41,7 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 class VariableSynchronizer;
+class VariableSynchronizerDispatcher;
 class VariableSynchronizerMultiDispatcher;
 class Timer;
 
@@ -139,8 +140,6 @@ class ARCANE_IMPL_EXPORT ItemGroupSynchronizeInfo
  */
 class ARCANE_IMPL_EXPORT IVariableSynchronizeDispatcher
 {
- public:
-  typedef FalseType HasStringDispatch;
  public:
   virtual ~IVariableSynchronizeDispatcher() = default;
  public:
@@ -283,7 +282,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeBufferBase
 /*!
  * \brief Gestion de la synchronisation.
  */
-class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
+class ARCANE_IMPL_EXPORT VariableSynchronizerDispatcher
 : public IVariableSynchronizeDispatcher
 {
  public:
@@ -293,15 +292,12 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
 
  public:
 
-  explicit VariableSynchronizeDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi);
-  ~VariableSynchronizeDispatcher() override;
+  explicit VariableSynchronizerDispatcher(const VariableSynchronizeDispatcherBuildInfo& bi);
+  ~VariableSynchronizerDispatcher() override;
 
  public:
 
   void applyDispatch(IData* data) override;
-
- public:
-
   void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) final;
   void compute() final;
 
@@ -329,29 +325,6 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcher
  private:
 
   void _applyDispatch(IData* data);
-};
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-class ARCANE_IMPL_EXPORT VariableSynchronizerDispatcher
-{
- public:
-
- using DispatcherType = VariableSynchronizeDispatcher;
-
- public:
-
- VariableSynchronizerDispatcher(IParallelMng* pm,const VariableSynchronizeDispatcherBuildInfo& bi);
-  ~VariableSynchronizerDispatcher();
-  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info);
-  void compute();
-  void applyDispatch(IData* data) { m_dispatcher->applyDispatch(data); }
-
- private:
-
-  IParallelMng* m_parallel_mng = nullptr;
-  DispatcherType* m_dispatcher = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiBlockVariableSynchronizeDispatcher.cc
@@ -1,17 +1,18 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MpiBlockVariableSynchronizeDispatcher.cc                    (C) 2000-2022 */
+/* MpiBlockVariableSynchronizeDispatcher.cc                    (C) 2000-2023 */
 /*                                                                           */
 /* Gestion spécifique MPI des synchronisations des variables.                */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/MemoryView.h"
 
 #include "arcane/parallel/mpi/MpiParallelMng.h"
 #include "arcane/parallel/mpi/MpiAdapter.h"

--- a/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiDirectSendrecvVariableSynchronizeDispatcher.cc
@@ -11,6 +11,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arcane/utils/MemoryView.h"
+
 #include "arcane/parallel/mpi/MpiParallelMng.h"
 #include "arcane/parallel/mpi/MpiAdapter.h"
 #include "arcane/parallel/mpi/MpiDatatypeList.h"

--- a/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiLegacyVariableSynchronizeDispatcher.cc
@@ -11,6 +11,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arcane/utils/MemoryView.h"
+
 #include "arcane/parallel/mpi/MpiParallelMng.h"
 #include "arcane/parallel/mpi/MpiAdapter.h"
 #include "arcane/parallel/mpi/MpiDatatypeList.h"

--- a/arcane/src/arcane/parallel/mpi/MpiNeighborVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiNeighborVariableSynchronizeDispatcher.cc
@@ -1,18 +1,20 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MpiNeighborVariableSynchronizeDispatcher.cc                 (C) 2000-2022 */
+/* MpiNeighborVariableSynchronizeDispatcher.cc                 (C) 2000-2023 */
 /*                                                                           */
 /* Synchronisations des variables via MPI_Neighbor_alltoallv.                */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/NotSupportedException.h"
 #include "arcane/utils/CheckedConvert.h"
+#include "arcane/utils/MemoryView.h"
 
 #include "arcane/parallel/mpi/MpiParallelMng.h"
 #include "arcane/parallel/mpi/MpiAdapter.h"

--- a/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
@@ -286,7 +286,6 @@ class MpiParallelMngUtilsFactory
   {
     Ref<IVariableSynchronizerMpiCommunicator> topology_info;
     MpiParallelMng* mpi_pm = ARCANE_CHECK_POINTER(dynamic_cast<MpiParallelMng*>(pm));
-    typedef DataTypeDispatchingDataVisitor<IVariableSynchronizeDispatcher> DispatcherType;
     ITraceMng* tm = pm->traceMng();
     Ref<IGenericVariableSynchronizerDispatcherFactory> generic_factory;
     // N'affiche les informations que pour le groupe de toutes les mailles pour éviter d'afficher
@@ -326,7 +325,7 @@ class MpiParallelMngUtilsFactory
     VariableSynchronizerDispatcher* vd = nullptr;
     if (generic_factory.get()){
       VariableSynchronizeDispatcherBuildInfo bi(mpi_pm,table,generic_factory);
-      vd = new VariableSynchronizerDispatcher(pm,DispatcherType::create<VariableSynchronizeDispatcher>(bi));
+      vd = new VariableSynchronizerDispatcher(pm,bi);
     }
     if (!vd)
       ARCANE_FATAL("No synchronizer created");

--- a/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
@@ -213,7 +213,7 @@ class MpiVariableSynchronizer
 {
  public:
   MpiVariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
-                          VariableSynchronizerDispatcher* dispatcher,
+                          IVariableSynchronizerDispatcher* dispatcher,
                           Ref<IVariableSynchronizerMpiCommunicator> topology_info)
   : VariableSynchronizer(pm,group,dispatcher)
   , m_topology_info(topology_info)
@@ -322,10 +322,10 @@ class MpiParallelMngUtilsFactory
         tm->info() << "Using MpiSynchronizer V1";
       generic_factory = arcaneCreateMpiLegacyVariableSynchronizerFactory(mpi_pm);
     }
-    VariableSynchronizerDispatcher* vd = nullptr;
+    IVariableSynchronizerDispatcher* vd = nullptr;
     if (generic_factory.get()){
       VariableSynchronizeDispatcherBuildInfo bi(mpi_pm,table,generic_factory);
-      vd = new VariableSynchronizerDispatcher(bi);
+      vd = IVariableSynchronizerDispatcher::create(bi);
     }
     if (!vd)
       ARCANE_FATAL("No synchronizer created");

--- a/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
@@ -325,7 +325,7 @@ class MpiParallelMngUtilsFactory
     VariableSynchronizerDispatcher* vd = nullptr;
     if (generic_factory.get()){
       VariableSynchronizeDispatcherBuildInfo bi(mpi_pm,table,generic_factory);
-      vd = new VariableSynchronizerDispatcher(pm,bi);
+      vd = new VariableSynchronizerDispatcher(bi);
     }
     if (!vd)
       ARCANE_FATAL("No synchronizer created");

--- a/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
@@ -1,17 +1,18 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MpiVariableSynchronizeDispatcher.cc                         (C) 2000-2022 */
+/* MpiVariableSynchronizeDispatcher.cc                         (C) 2000-2023 */
 /*                                                                           */
 /* Gestion spécifique MPI des synchronisations des variables.                */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/MemoryView.h"
 
 #include "arcane/parallel/mpi/MpiParallelMng.h"
 #include "arcane/parallel/mpi/MpiAdapter.h"


### PR DESCRIPTION
Before there was one buffer per datatype (`Int32`, `Real`, ...) and one buffer per dimension of the variable.
Now there is only one buffer per synchronizer.