### PR TITLE
Nettoyage des synchronisations des variables

### DIFF
--- a/arcane/src/arcane/impl/DataSynchronizeInfo.cc
+++ b/arcane/src/arcane/impl/DataSynchronizeInfo.cc
@@ -118,7 +118,7 @@ changeLocalIds(Int32ConstArrayView old_to_new_ids)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ItemGroupSynchronizeInfo::
+void DataSynchronizeInfo::
 recompute()
 {
   Integer nb_message = this->size();
@@ -150,7 +150,7 @@ recompute()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ItemGroupSynchronizeInfo::
+void DataSynchronizeInfo::
 changeLocalIds(Int32ConstArrayView old_to_new_ids)
 {
   for (VariableSyncInfo& vsi : m_ranks_info) {

--- a/arcane/src/arcane/impl/DataSynchronizeInfo.cc
+++ b/arcane/src/arcane/impl/DataSynchronizeInfo.cc
@@ -1,0 +1,171 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* DataSynchronizeInfo.cc                                      (C) 2000-2023 */
+/*                                                                           */
+/* Informations pour synchroniser les données.                               */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/impl/DataSynchronizeInfo.h"
+
+#include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/PlatformUtils.h"
+#include "arcane/utils/IMemoryRessourceMng.h"
+#include "arcane/utils/MemoryView.h"
+#include "arcane/utils/SmallArray.h"
+#include "arcane/utils/ITraceMng.h"
+#include "arcane/utils/TraceAccessor.h"
+#include "arcane/utils/ValueConvert.h"
+
+#include "arcane/core/VariableCollection.h"
+#include "arcane/core/ParallelMngUtils.h"
+#include "arcane/core/IParallelExchanger.h"
+#include "arcane/core/ISerializeMessage.h"
+#include "arcane/core/ISerializer.h"
+#include "arcane/core/IParallelMng.h"
+#include "arcane/core/IData.h"
+#include "arcane/core/internal/IParallelMngInternal.h"
+#include "arcane/core/internal/IDataInternal.h"
+
+#include "arcane/accelerator/core/Runner.h"
+
+#include "arcane/impl/IBufferCopier.h"
+#include "arcane/impl/IDataSynchronizeBuffer.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// TODO: plutôt que d'utiliser la mémoire managée, il est préférable d'avoir
+// une copie sur le device des IDs. Cela permettra d'éviter des transferts
+// potentiels si on mélange synchronisation de variables sur accélérateurs et
+// sur CPU.
+
+VariableSyncInfo::
+VariableSyncInfo()
+: m_share_ids(platform::getDefaultDataAllocator())
+, m_ghost_ids(platform::getDefaultDataAllocator())
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+VariableSyncInfo::
+VariableSyncInfo(Int32ConstArrayView share_ids, Int32ConstArrayView ghost_ids,
+                 Int32 rank)
+: VariableSyncInfo()
+{
+  m_target_rank = rank;
+  m_share_ids.copy(share_ids);
+  m_ghost_ids.copy(ghost_ids);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+VariableSyncInfo::
+VariableSyncInfo(const VariableSyncInfo& rhs)
+: VariableSyncInfo()
+{
+  // NOTE: pour l'instant (avril 2023) il faut un constructeur de recopie
+  // explicite pour spécifier l'allocateur
+  m_target_rank = rhs.m_target_rank;
+  m_share_ids.copy(rhs.m_share_ids);
+  m_ghost_ids.copy(rhs.m_ghost_ids);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableSyncInfo::
+_changeIds(Array<Int32>& ids, Int32ConstArrayView old_to_new_ids)
+{
+  UniqueArray<Int32> orig_ids(ids);
+  ids.clear();
+
+  for (Integer z = 0, zs = orig_ids.size(); z < zs; ++z) {
+    Int32 old_id = orig_ids[z];
+    Int32 new_id = old_to_new_ids[old_id];
+    if (new_id != NULL_ITEM_LOCAL_ID)
+      ids.add(new_id);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableSyncInfo::
+changeLocalIds(Int32ConstArrayView old_to_new_ids)
+{
+  _changeIds(m_share_ids, old_to_new_ids);
+  _changeIds(m_ghost_ids, old_to_new_ids);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemGroupSynchronizeInfo::
+recompute()
+{
+  Integer nb_message = this->size();
+
+  m_ghost_displacements_base.resize(nb_message);
+  m_share_displacements_base.resize(nb_message);
+
+  m_total_nb_ghost = 0;
+  m_total_nb_share = 0;
+
+  {
+    Integer ghost_displacement = 0;
+    Integer share_displacement = 0;
+    Int32 index = 0;
+    for (const VariableSyncInfo& vsi : m_ranks_info) {
+      Int32 ghost_size = vsi.nbGhost();
+      m_ghost_displacements_base[index] = ghost_displacement;
+      ghost_displacement += ghost_size;
+      Int32 share_size = vsi.nbShare();
+      m_share_displacements_base[index] = share_displacement;
+      share_displacement += share_size;
+      ++index;
+    }
+    m_total_nb_ghost = ghost_displacement;
+    m_total_nb_share = share_displacement;
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemGroupSynchronizeInfo::
+changeLocalIds(Int32ConstArrayView old_to_new_ids)
+{
+  for (VariableSyncInfo& vsi : m_ranks_info) {
+    vsi.changeLocalIds(old_to_new_ids);
+  }
+  recompute();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/DataSynchronizeInfo.h
+++ b/arcane/src/arcane/impl/DataSynchronizeInfo.h
@@ -23,7 +23,7 @@
 #include "arcane/core/Parallel.h"
 #include "arcane/core/VariableCollection.h"
 
-#include "arcane/impl/IGenericVariableSynchronizerDispatcher.h"
+#include "arcane/impl/IDataSynchronizeImplementation.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -89,25 +89,25 @@ class ARCANE_IMPL_EXPORT VariableSyncInfo
  * Il faut appeler recompute() après avoir ajouté ou modifier les instances
  * de VariableSyncInfo.
  */
-class ARCANE_IMPL_EXPORT ItemGroupSynchronizeInfo
+class ARCANE_IMPL_EXPORT DataSynchronizeInfo
 : private ReferenceCounterImpl
 {
  private:
 
-  ItemGroupSynchronizeInfo() = default;
+  DataSynchronizeInfo() = default;
 
  public:
 
-  ItemGroupSynchronizeInfo(const ItemGroupSynchronizeInfo&) = delete;
-  ItemGroupSynchronizeInfo operator=(const ItemGroupSynchronizeInfo&) = delete;
-  ItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo&&) = delete;
-  ItemGroupSynchronizeInfo operator=(ItemGroupSynchronizeInfo&&) = delete;
+  DataSynchronizeInfo(const DataSynchronizeInfo&) = delete;
+  DataSynchronizeInfo operator=(const DataSynchronizeInfo&) = delete;
+  DataSynchronizeInfo(DataSynchronizeInfo&&) = delete;
+  DataSynchronizeInfo operator=(DataSynchronizeInfo&&) = delete;
 
  public:
 
-  static Ref<ItemGroupSynchronizeInfo> create()
+  static Ref<DataSynchronizeInfo> create()
   {
-    return makeRef(new ItemGroupSynchronizeInfo());
+    return makeRef(new DataSynchronizeInfo());
   }
 
  public:

--- a/arcane/src/arcane/impl/DataSynchronizeInfo.h
+++ b/arcane/src/arcane/impl/DataSynchronizeInfo.h
@@ -1,0 +1,167 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* DataSynchronizeInfo.h                                       (C) 2000-2023 */
+/*                                                                           */
+/* Informations pour synchroniser les données.                               */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_IMPL_DATASYNCHRONIZERINFO_H
+#define ARCANE_IMPL_DATASYNCHRONIZERINFO_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/UniqueArray.h"
+#include "arcane/utils/Ref.h"
+#include "arccore/base/ReferenceCounterImpl.h"
+
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/Parallel.h"
+#include "arcane/core/VariableCollection.h"
+
+#include "arcane/impl/IGenericVariableSynchronizerDispatcher.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations sur la liste des entités partagées/fantômes pour
+ * un rang donné pour une synchronisation.
+ *
+ * TODO: Utiliser pour toutes les VariableSyncInfo un seul tableau pour les
+ *       entités partagées et un seul tableau pour les entités fantômes qui
+ *       sera géré par ItemGroupSynchronizeInfo.
+ */
+class ARCANE_IMPL_EXPORT VariableSyncInfo
+{
+ public:
+
+  VariableSyncInfo(Int32ConstArrayView share_ids, Int32ConstArrayView ghost_ids, Int32 rank);
+  VariableSyncInfo(const VariableSyncInfo& rhs);
+  VariableSyncInfo();
+
+ public:
+
+  //! Rang du processeur cible
+  Int32 targetRank() const { return m_target_rank; }
+
+  //! localIds() des entités à envoyer au rang targetRank()
+  ConstArrayView<Int32> shareIds() const { return m_share_ids; }
+  //! localIds() des entités à réceptionner du rang targetRank()
+  ConstArrayView<Int32> ghostIds() const { return m_ghost_ids; }
+
+  //! Nombre d'entités partagées
+  Int32 nbShare() const { return m_share_ids.size(); }
+  //! Nombre d'entités fantômes
+  Int32 nbGhost() const { return m_ghost_ids.size(); }
+
+  //! Met à jour les informations lorsque les localId() des entités changent
+  void changeLocalIds(Int32ConstArrayView old_to_new_ids);
+
+ private:
+
+  //! localIds() des entités à envoyer au processeur #m_rank
+  UniqueArray<Int32> m_share_ids;
+  //! localIds() des entités à réceptionner du processeur #m_rank
+  UniqueArray<Int32> m_ghost_ids;
+  //! Rang du processeur cible
+  Int32 m_target_rank = A_NULL_RANK;
+
+ private:
+
+  void _changeIds(Array<Int32>& ids, Int32ConstArrayView old_to_new_ids);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations nécessaires pour synchroniser les entités sur un groupe.
+ *
+ * Il faut appeler recompute() après avoir ajouté ou modifier les instances
+ * de VariableSyncInfo.
+ */
+class ARCANE_IMPL_EXPORT ItemGroupSynchronizeInfo
+: private ReferenceCounterImpl
+{
+ private:
+
+  ItemGroupSynchronizeInfo() = default;
+
+ public:
+
+  ItemGroupSynchronizeInfo(const ItemGroupSynchronizeInfo&) = delete;
+  ItemGroupSynchronizeInfo operator=(const ItemGroupSynchronizeInfo&) = delete;
+  ItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo&&) = delete;
+  ItemGroupSynchronizeInfo operator=(ItemGroupSynchronizeInfo&&) = delete;
+
+ public:
+
+  static Ref<ItemGroupSynchronizeInfo> create()
+  {
+    return makeRef(new ItemGroupSynchronizeInfo());
+  }
+
+ public:
+
+  VariableSyncInfo& operator[](Int32 i) { return m_ranks_info[i]; }
+  const VariableSyncInfo& operator[](Int32 i) const { return m_ranks_info[i]; }
+
+  VariableSyncInfo& rankInfo(Int32 i) { return m_ranks_info[i]; }
+  const VariableSyncInfo& rankInfo(Int32 i) const { return m_ranks_info[i]; }
+
+  void clear() { m_ranks_info.clear(); }
+  Int32 size() const { return m_ranks_info.size(); }
+  void add(const VariableSyncInfo& s) { m_ranks_info.add(s); }
+  Int64 shareDisplacement(Int32 index) const { return m_share_displacements_base[index]; }
+  Int64 ghostDisplacement(Int32 index) const { return m_ghost_displacements_base[index]; }
+  Int64 totalNbGhost() const { return m_total_nb_ghost; }
+  Int64 totalNbShare() const { return m_total_nb_share; }
+
+  //! Notifie l'instance que les indices locaux ont changé
+  void changeLocalIds(Int32ConstArrayView old_to_new_ids);
+
+  //! Notifie l'instance que les valeurs ont changé
+  void recompute();
+
+ public:
+
+  void addReference() { ReferenceCounterImpl::addReference(); }
+  void removeReference() { ReferenceCounterImpl::removeReference(); }
+
+ public:
+
+  ARCANE_DEPRECATED_REASON("Y2023: use operator[] instead")
+  ConstArrayView<VariableSyncInfo> infos() const { return m_ranks_info; }
+
+  ARCANE_DEPRECATED_REASON("Y2023: use operator[] instead")
+  ArrayView<VariableSyncInfo> infos() { return m_ranks_info; }
+
+ private:
+
+  UniqueArray<VariableSyncInfo> m_ranks_info;
+  //! Déplacement dans le buffer fantôme de chaque rang
+  UniqueArray<Int64> m_ghost_displacements_base;
+  //! Déplacement dans le buffer partagé de chaque rang
+  UniqueArray<Int64> m_share_displacements_base;
+  Int64 m_total_nb_ghost = 0;
+  Int64 m_total_nb_share = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/impl/IDataSynchronizeImplementation.h
+++ b/arcane/src/arcane/impl/IDataSynchronizeImplementation.h
@@ -23,8 +23,8 @@
 namespace Arcane
 {
 class IDataSynchronizeBuffer;
-class ItemGroupSynchronizeInfo;
 class IParallelMng;
+class DataSynchronizeInfo;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -41,6 +41,8 @@ ARCANE_DEPRECATED_REASON("Use 'IDataSynchronizeImplementationFactory' instead") 
 
 using AbstractGenericVariableSynchronizerDispatcher
 ARCANE_DEPRECATED_REASON("Use 'AbstractDataSynchronizeImplementation' instead") = AbstractDataSynchronizeImplementation;
+
+using ItemGroupSynchronizeInfo = DataSynchronizeInfo;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/IDataSynchronizeImplementation.h
+++ b/arcane/src/arcane/impl/IDataSynchronizeImplementation.h
@@ -42,7 +42,8 @@ ARCANE_DEPRECATED_REASON("Use 'IDataSynchronizeImplementationFactory' instead") 
 using AbstractGenericVariableSynchronizerDispatcher
 ARCANE_DEPRECATED_REASON("Use 'AbstractDataSynchronizeImplementation' instead") = AbstractDataSynchronizeImplementation;
 
-using ItemGroupSynchronizeInfo = DataSynchronizeInfo;
+using ItemGroupSynchronizeInfo
+ARCANE_DEPRECATED_REASON("Use 'DataSynchronizeInfo' instead") = DataSynchronizeInfo;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -57,7 +58,7 @@ class ARCANE_IMPL_EXPORT IDataSynchronizeImplementation
 
  public:
 
-  virtual void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) = 0;
+  virtual void setDataSynchronizeInfo(DataSynchronizeInfo* sync_info) = 0;
   virtual void compute() = 0;
   virtual void beginSynchronize(IDataSynchronizeBuffer* buf) = 0;
   virtual void endSynchronize(IDataSynchronizeBuffer* buf) = 0;
@@ -91,15 +92,15 @@ class AbstractDataSynchronizeImplementation
 {
  public:
 
-  void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) final { m_sync_info = sync_info; }
+  void setDataSynchronizeInfo(DataSynchronizeInfo* sync_info) final { m_sync_info = sync_info; }
 
  protected:
 
-  ItemGroupSynchronizeInfo* _syncInfo() const { return m_sync_info; }
+  DataSynchronizeInfo* _syncInfo() const { return m_sync_info; }
 
  private:
 
-  ItemGroupSynchronizeInfo* m_sync_info = nullptr;
+  DataSynchronizeInfo* m_sync_info = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -72,7 +72,7 @@ VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
 , m_allow_multi_sync(true)
 , m_trace_sync(false)
 {
-  m_sync_list = ItemGroupSynchronizeInfo::create();
+  m_sync_list = DataSynchronizeInfo::create();
   if (!implementation_factory.get())
     implementation_factory = arcaneCreateSimpleVariableSynchronizerFactory(pm);
   m_implementation_factory = implementation_factory;

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -80,11 +80,10 @@ VariableSynchronizer(IParallelMng* pm,const ItemGroup& group,
   GroupIndexTable* table = nullptr;
   if (!group.isAllItems())
     table = group.localIdToIndex().get();
-  VariableSynchronizeDispatcherBuildInfo bi(pm,table,implementation_factory);
+  VariableSynchronizeDispatcherBuildInfo bi(pm,table,implementation_factory,m_sync_list);
   m_dispatcher = IVariableSynchronizerDispatcher::create(bi);
   if (!m_dispatcher)
     ARCANE_FATAL("No synchronizer created");
-  m_dispatcher->setItemGroupSynchronizeInfo(m_sync_list.get());
   m_multi_dispatcher = IVariableSynchronizerMultiDispatcher::create(bi);
   if (!m_multi_dispatcher)
     ARCANE_FATAL("No multi synchronizer created");
@@ -774,7 +773,7 @@ _synchronizeMulti(VariableCollection vars)
     m_sync_timer = new Timer(pm->timerMng(),"SyncTimer",Timer::TimerReal);
   {
     Timer::Sentry ts2(m_sync_timer);
-    m_multi_dispatcher->synchronize(vars,m_sync_list.get());
+    m_multi_dispatcher->synchronize(vars);
     for( VariableCollection::Enumerator ivar(vars); ++ivar; ){
       (*ivar)->setIsSynchronized();
     }

--- a/arcane/src/arcane/impl/VariableSynchronizer.h
+++ b/arcane/src/arcane/impl/VariableSynchronizer.h
@@ -169,7 +169,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizer
 
   IParallelMng* m_parallel_mng = nullptr;
   ItemGroup m_item_group;
-  Ref<ItemGroupSynchronizeInfo> m_sync_list;
+  Ref<DataSynchronizeInfo> m_sync_list;
   Int32UniqueArray m_communicating_ranks;
   Ref<IVariableSynchronizerDispatcher> m_dispatcher;
   IVariableSynchronizerMultiDispatcher* m_multi_dispatcher = nullptr;

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.cc
@@ -88,7 +88,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeBufferBase
 
  public:
 
-  void compute(IBufferCopier* copier, ItemGroupSynchronizeInfo* sync_list, Int32 datatype_size);
+  void compute(IBufferCopier* copier, DataSynchronizeInfo* sync_list, Int32 datatype_size);
   IDataSynchronizeBuffer* genericBuffer() { return this; }
 
  protected:
@@ -97,7 +97,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeBufferBase
 
  protected:
 
-  ItemGroupSynchronizeInfo* m_sync_info = nullptr;
+  DataSynchronizeInfo* m_sync_info = nullptr;
   //! Buffer pour toutes les données des entités fantômes qui serviront en réception
   MutableMemoryView m_ghost_memory_view;
   //! Buffer pour toutes les données des entités partagées qui serviront en envoi
@@ -157,7 +157,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeBufferBase
  * terme de memoire.
  */
 void VariableSynchronizeBufferBase::
-compute(IBufferCopier* copier, ItemGroupSynchronizeInfo* sync_info, Int32 datatype_size)
+compute(IBufferCopier* copier, DataSynchronizeInfo* sync_info, Int32 datatype_size)
 {
   m_datatype_size = datatype_size;
   m_buffer_copier = copier;
@@ -286,7 +286,7 @@ VariableSynchronizerDispatcherBase(const VariableSynchronizeDispatcherBuildInfo&
 {
   ARCANE_CHECK_POINTER(bi.factory().get());
   m_implementation_instance = bi.factory()->createInstance();
-  m_implementation_instance->setItemGroupSynchronizeInfo(m_sync_info.get());
+  m_implementation_instance->setDataSynchronizeInfo(m_sync_info.get());
 
   if (bi.table())
     m_buffer_copier = new TableBufferCopier(bi.table());
@@ -416,7 +416,7 @@ void VariableSynchronizerDispatcher::
 compute()
 {
   if (!m_sync_info)
-    ARCANE_FATAL("The instance is not initialized. You need to call setItemGroupSynchronizeInfo() before");
+    ARCANE_FATAL("The instance is not initialized. You need to call setDataSynchronizeInfo() before");
   m_implementation_instance->compute();
 }
 
@@ -643,7 +643,7 @@ synchronize(VariableCollection vars)
 
   buffer.compute(m_buffer_copier,m_sync_info.get(),all_datatype_size);
 
-  m_implementation_instance->setItemGroupSynchronizeInfo(m_sync_info.get());
+  m_implementation_instance->setDataSynchronizeInfo(m_sync_info.get());
   m_implementation_instance->compute();
   m_implementation_instance->beginSynchronize(buffer.genericBuffer());
   m_implementation_instance->endSynchronize(buffer.genericBuffer());

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -84,7 +84,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcherBuildInfo
  * Il faut utiliser create() pour créer une implémentation pour cette
  * interface.
  *
- * Il faut appeler \a setItemGroupSynchronizeInfo() pour initialiser
+ * Il faut appeler \a setDataSynchronizeInfo() pour initialiser
  * l'instance.
  */
 class ARCANE_IMPL_EXPORT IVariableSynchronizerDispatcher
@@ -97,11 +97,11 @@ class ARCANE_IMPL_EXPORT IVariableSynchronizerDispatcher
 
  public:
 
-  virtual void setItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo* sync_info) = 0;
+  virtual void setItemGroupSynchronizeInfo(DataSynchronizeInfo* sync_info) = 0;
 
   /*!
    * \brief Recalcule les informations nécessaires après une mise à jour des informations
-   * de \a ItemGroupSynchronizeInfo.
+   * de \a DataSynchronizeInfo.
    */
   virtual void compute() = 0;
 
@@ -131,7 +131,7 @@ class ARCANE_IMPL_EXPORT IVariableSynchronizerMultiDispatcher
 
  public:
 
-  virtual void synchronize(VariableCollection vars, ItemGroupSynchronizeInfo* sync_info) = 0;
+  virtual void synchronize(VariableCollection vars, DataSynchronizeInfo* sync_info) = 0;
 
  public:
 

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -24,6 +24,7 @@
 #include "arcane/core/VariableCollection.h"
 
 #include "arcane/impl/IGenericVariableSynchronizerDispatcher.h"
+#include "arcane/impl/DataSynchronizeInfo.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -41,130 +42,6 @@ class GroupIndexTable;
 class INumericDataInternal;
 using IVariableSynchronizeDispatcher = IVariableSynchronizerDispatcher;
 
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Informations sur la liste des entités partagées/fantômes pour
- * un rang donné pour une synchronisation.
- *
- * TODO: Utiliser pour toutes les VariableSyncInfo un seul tableau pour les
- *       entités partagées et un seul tableau pour les entités fantômes qui
- *       sera géré par ItemGroupSynchronizeInfo.
- */
-class ARCANE_IMPL_EXPORT VariableSyncInfo
-{
- public:
-
-  VariableSyncInfo(Int32ConstArrayView share_ids, Int32ConstArrayView ghost_ids, Int32 rank);
-  VariableSyncInfo(const VariableSyncInfo& rhs);
-  VariableSyncInfo();
-
- public:
-
-  //! Rang du processeur cible
-  Int32 targetRank() const { return m_target_rank; }
-
-  //! localIds() des entités à envoyer au rang targetRank()
-  ConstArrayView<Int32> shareIds() const { return m_share_ids; }
-  //! localIds() des entités à réceptionner du rang targetRank()
-  ConstArrayView<Int32> ghostIds() const { return m_ghost_ids; }
-
-  //! Nombre d'entités partagées
-  Int32 nbShare() const { return m_share_ids.size(); }
-  //! Nombre d'entités fantômes
-  Int32 nbGhost() const { return m_ghost_ids.size(); }
-
-  //! Met à jour les informations lorsque les localId() des entités changent
-  void changeLocalIds(Int32ConstArrayView old_to_new_ids);
-
- private:
-
-  //! localIds() des entités à envoyer au processeur #m_rank
-  UniqueArray<Int32> m_share_ids;
-  //! localIds() des entités à réceptionner du processeur #m_rank
-  UniqueArray<Int32> m_ghost_ids;
-  //! Rang du processeur cible
-  Int32 m_target_rank = A_NULL_RANK;
-
- private:
-
-  void _changeIds(Array<Int32>& ids, Int32ConstArrayView old_to_new_ids);
-};
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Informations nécessaires pour synchroniser les entités sur un groupe.
- *
- * Il faut appeler recompute() après avoir ajouté ou modifier les instances
- * de VariableSyncInfo.
- */
-class ARCANE_IMPL_EXPORT ItemGroupSynchronizeInfo
-: private ReferenceCounterImpl
-{
- private:
-
-  ItemGroupSynchronizeInfo() = default;
-
- public:
-
-  ItemGroupSynchronizeInfo(const ItemGroupSynchronizeInfo&) = delete;
-  ItemGroupSynchronizeInfo operator=(const ItemGroupSynchronizeInfo&) = delete;
-  ItemGroupSynchronizeInfo(ItemGroupSynchronizeInfo&&) = delete;
-  ItemGroupSynchronizeInfo operator=(ItemGroupSynchronizeInfo&&) = delete;
-
- public:
-
-  static Ref<ItemGroupSynchronizeInfo> create()
-  {
-    return makeRef(new ItemGroupSynchronizeInfo());
-  }
-
- public:
-
-  VariableSyncInfo& operator[](Int32 i) { return m_ranks_info[i]; }
-  const VariableSyncInfo& operator[](Int32 i) const { return m_ranks_info[i]; }
-
-  VariableSyncInfo& rankInfo(Int32 i) { return m_ranks_info[i]; }
-  const VariableSyncInfo& rankInfo(Int32 i) const { return m_ranks_info[i]; }
-
-  void clear() { m_ranks_info.clear(); }
-  Int32 size() const { return m_ranks_info.size(); }
-  void add(const VariableSyncInfo& s) { m_ranks_info.add(s); }
-  Int64 shareDisplacement(Int32 index) const { return m_share_displacements_base[index]; }
-  Int64 ghostDisplacement(Int32 index) const { return m_ghost_displacements_base[index]; }
-  Int64 totalNbGhost() const { return m_total_nb_ghost; }
-  Int64 totalNbShare() const { return m_total_nb_share; }
-
-  //! Notifie l'instance que les indices locaux ont changé
-  void changeLocalIds(Int32ConstArrayView old_to_new_ids);
-
-  //! Notifie l'instance que les valeurs ont changé
-  void recompute();
-
- public:
-
-  void addReference() { ReferenceCounterImpl::addReference(); }
-  void removeReference() { ReferenceCounterImpl::removeReference(); }
-
- public:
-
-  ARCANE_DEPRECATED_REASON("Y2023: use operator[] instead")
-  ConstArrayView<VariableSyncInfo> infos() const { return m_ranks_info; }
-
-  ARCANE_DEPRECATED_REASON("Y2023: use operator[] instead")
-  ArrayView<VariableSyncInfo> infos() { return m_ranks_info; }
-
- private:
-
-  UniqueArray<VariableSyncInfo> m_ranks_info;
-  //! Déplacement dans le buffer fantôme de chaque rang
-  UniqueArray<Int64> m_ghost_displacements_base;
-  //! Déplacement dans le buffer partagé de chaque rang
-  UniqueArray<Int64> m_share_displacements_base;
-  Int64 m_total_nb_ghost = 0;
-  Int64 m_total_nb_share = 0;
-};
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
+++ b/arcane/src/arcane/impl/VariableSynchronizerDispatcher.h
@@ -23,7 +23,7 @@
 #include "arcane/core/Parallel.h"
 #include "arcane/core/VariableCollection.h"
 
-#include "arcane/impl/IGenericVariableSynchronizerDispatcher.h"
+#include "arcane/impl/IDataSynchronizeImplementation.h"
 #include "arcane/impl/DataSynchronizeInfo.h"
 
 /*---------------------------------------------------------------------------*/
@@ -42,7 +42,6 @@ class GroupIndexTable;
 class INumericDataInternal;
 using IVariableSynchronizeDispatcher = IVariableSynchronizerDispatcher;
 
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
@@ -53,10 +52,12 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcherBuildInfo
  public:
 
   VariableSynchronizeDispatcherBuildInfo(IParallelMng* pm, GroupIndexTable* table,
-                                         Ref<IDataSynchronizeImplementationFactory> factory)
+                                         Ref<IDataSynchronizeImplementationFactory> factory,
+                                         Ref<DataSynchronizeInfo> sync_info)
   : m_parallel_mng(pm)
   , m_table(table)
   , m_factory(factory)
+  , m_synchronize_info(sync_info)
   {}
 
  public:
@@ -68,12 +69,17 @@ class ARCANE_IMPL_EXPORT VariableSynchronizeDispatcherBuildInfo
   {
     return m_factory;
   }
+  Ref<DataSynchronizeInfo> synchronizeInfo() const
+  {
+    return m_synchronize_info;
+  }
 
  private:
 
   IParallelMng* m_parallel_mng;
   GroupIndexTable* m_table;
   Ref<IDataSynchronizeImplementationFactory> m_factory;
+  Ref<DataSynchronizeInfo> m_synchronize_info;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -96,8 +102,6 @@ class ARCANE_IMPL_EXPORT IVariableSynchronizerDispatcher
   virtual ~IVariableSynchronizerDispatcher() = default;
 
  public:
-
-  virtual void setItemGroupSynchronizeInfo(DataSynchronizeInfo* sync_info) = 0;
 
   /*!
    * \brief Recalcule les informations nécessaires après une mise à jour des informations
@@ -131,7 +135,7 @@ class ARCANE_IMPL_EXPORT IVariableSynchronizerMultiDispatcher
 
  public:
 
-  virtual void synchronize(VariableCollection vars, DataSynchronizeInfo* sync_info) = 0;
+  virtual void synchronize(VariableCollection vars) = 0;
 
  public:
 

--- a/arcane/src/arcane/impl/srcs.cmake
+++ b/arcane/src/arcane/impl/srcs.cmake
@@ -29,6 +29,8 @@ set( ARCANE_SOURCES
   DataFactoryMng.cc
   DataFactoryMng.h
   DataStorageFactory.h
+  DataSynchronizeInfo.h
+  DataSynchronizeInfo.cc
   EntryPointMng.cc
   ExecutionStatsDumper.h
   ExecutionStatsDumper.cc

--- a/arcane/src/arcane/parallel/mpi/MpiNeighborVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiNeighborVariableSynchronizeDispatcher.cc
@@ -201,7 +201,7 @@ endSynchronize(IDataSynchronizeBuffer* buf)
 void MpiNeighborVariableSynchronizerDispatcher::
 compute()
 {
-  ItemGroupSynchronizeInfo* sync_info = _syncInfo();
+  DataSynchronizeInfo* sync_info = _syncInfo();
   ARCANE_CHECK_POINTER(sync_info);
 
   auto* sync_communicator = m_synchronizer_communicator.get();

--- a/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiVariableSynchronizeDispatcher.cc
@@ -136,7 +136,7 @@ MpiVariableSynchronizeDispatcher(Factory* f)
 void MpiVariableSynchronizeDispatcher::
 beginSynchronize(IDataSynchronizeBuffer* ds_buf)
 {
-  ItemGroupSynchronizeInfo* sync_info = _syncInfo();
+  DataSynchronizeInfo* sync_info = _syncInfo();
   Integer nb_message = sync_info->size();
 
   m_send_request_list->clear();


### PR DESCRIPTION
Rename `ItemGroupSynchronizeInfo` to `DataSynchronizeInfo` and move it in its own file.