### PR TITLE
Add offset for localId in all internal connectivities and item views

### DIFF
--- a/arcane/src/arcane/core/ItemConnectedListView.h
+++ b/arcane/src/arcane/core/ItemConnectedListView.h
@@ -228,8 +228,8 @@ class ItemConnectedListView
 
   ItemConnectedListView(const impl::ItemIndexedListView<DynExtent>& view)
   : m_local_ids(view.constLocalIds()), m_shared_info(view.m_shared_info) { }
-  ItemConnectedListView(ItemSharedInfo* shared_info,ConstArrayView<Int32> local_ids)
-  : m_local_ids(local_ids), m_shared_info(shared_info) { }
+  ItemConnectedListView(ItemSharedInfo* shared_info,ConstArrayView<Int32> local_ids,Int32 local_id_offset)
+  : m_local_ids(local_ids), m_shared_info(shared_info), m_local_id_offset(local_id_offset) { }
 
  public:
 
@@ -340,8 +340,8 @@ class ItemConnectedListViewT
 
  protected:
 
-  ItemConnectedListViewT(ItemSharedInfo* shared_info,ConstArrayView<Int32> local_ids)
-  : BaseClass(shared_info,local_ids) { }
+  ItemConnectedListViewT(ItemSharedInfo* shared_info,ConstArrayView<Int32> local_ids, Int32 local_id_offset)
+  : BaseClass(shared_info,local_ids,local_id_offset) { }
 
  public:
 

--- a/arcane/src/arcane/core/ItemConnectedListView.h
+++ b/arcane/src/arcane/core/ItemConnectedListView.h
@@ -21,14 +21,6 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
-#define ARCANE_LOCALID_ADD_OFFSET(a) (this->m_local_id_offset + (a))
-#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b,c
-#else
-#define ARCANE_LOCALID_ADD_OFFSET(a) (a)
-#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b
-#endif
-
 namespace Arcane
 {
 
@@ -50,19 +42,17 @@ class ItemConnectedListViewConstIterator
 {
  protected:
 
-  template<int Extent> friend class ItemConnectedListView;
+  template <int Extent> friend class ItemConnectedListView;
   friend class ItemVectorViewConstIterator;
 
  protected:
 
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
-  ItemConnectedListViewConstIterator(ItemSharedInfo* shared_info,const Int32* local_id_ptr,
+  ItemConnectedListViewConstIterator(ItemSharedInfo* shared_info, const Int32* local_id_ptr,
                                      Int32 local_id_offset)
-  : m_shared_info(shared_info), m_local_id_ptr(local_id_ptr), m_local_id_offset(local_id_offset){}
-#else
-  ItemConnectedListViewConstIterator(ItemSharedInfo* shared_info,const Int32* local_id_ptr)
-  : m_shared_info(shared_info), m_local_id_ptr(local_id_ptr){}
-#endif
+  : m_shared_info(shared_info)
+  , m_local_id_ptr(local_id_ptr)
+  , m_local_id_offset(local_id_offset)
+  {}
 
  public:
 
@@ -84,62 +74,80 @@ class ItemConnectedListViewConstIterator
 
  public:
 
-  Item operator*() const { return Item(*m_local_id_ptr,m_shared_info); }
-  ThatClass& operator++() { ++m_local_id_ptr; return (*this); }
-  ThatClass& operator--() { --m_local_id_ptr; return (*this); }
-  void operator+=(difference_type v) { m_local_id_ptr += v; }
-  void operator-=(difference_type v) { m_local_id_ptr -= v; }
+  Item operator*() const
+  {
+    return Item(*m_local_id_ptr, m_shared_info);
+  }
+  ThatClass& operator++()
+  {
+    ++m_local_id_ptr;
+    return (*this);
+  }
+  ThatClass& operator--()
+  {
+    --m_local_id_ptr;
+    return (*this);
+  }
+  void operator+=(difference_type v)
+  {
+    m_local_id_ptr += v;
+  }
+  void operator-=(difference_type v)
+  {
+    m_local_id_ptr -= v;
+  }
   difference_type operator-(const ThatClass& b) const
   {
     return this->m_local_id_ptr - b.m_local_id_ptr;
   }
-  friend ThatClass operator-(const ThatClass& a,difference_type v)
+  friend ThatClass operator-(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr - v;
-    return ThatClass(ARCANE_ARGS_AND_OFFSET(a.m_shared_info,ptr,a.m_local_id_offset));
+    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
   }
-  friend ThatClass operator+(const ThatClass& a,difference_type v)
+  friend ThatClass operator+(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr + v;
-    return ThatClass(ARCANE_ARGS_AND_OFFSET(a.m_shared_info,ptr,a.m_local_id_offset));
+    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
   }
-  friend bool operator<(const ThatClass& lhs,const ThatClass& rhs)
+  friend bool operator<(const ThatClass& lhs, const ThatClass& rhs)
   {
     return lhs.m_local_id_ptr <= rhs.m_local_id_ptr;
   }
   //! Compare les indices d'itération de deux instances
-  friend bool operator==(const ThatClass& lhs,const ThatClass& rhs)
+  friend bool operator==(const ThatClass& lhs, const ThatClass& rhs)
   {
     return lhs.m_local_id_ptr == rhs.m_local_id_ptr;
   }
-  friend bool operator!=(const ThatClass& lhs,const ThatClass& rhs)
+  friend bool operator!=(const ThatClass& lhs, const ThatClass& rhs)
   {
-    return !(lhs==rhs);
+    return !(lhs == rhs);
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: This method returns a temporary. Use 'operator*' instead")
-  Item operator->() const { return _itemInternal(); }
+  Item operator->() const
+  {
+    return _itemInternal();
+  }
 
  protected:
 
   ItemSharedInfo* m_shared_info;
   const Int32* m_local_id_ptr;
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
   Int32 m_local_id_offset = 0;
-#endif
 
  protected:
 
   inline ItemInternal* _itemInternal() const
   {
-    return m_shared_info->m_items_internal[ ARCANE_LOCALID_ADD_OFFSET((*m_local_id_ptr)) ];
+    return m_shared_info->m_items_internal[m_local_id_offset + (*m_local_id_ptr)];
   }
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename ItemType>
+template <typename ItemType>
 class ItemConnectedListViewConstIteratorT
 : public ItemConnectedListViewConstIterator
 {
@@ -147,14 +155,10 @@ class ItemConnectedListViewConstIteratorT
 
  private:
 
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
-  ItemConnectedListViewConstIteratorT(ItemSharedInfo* shared_info,const Int32* ARCANE_RESTRICT local_id_ptr,
+  ItemConnectedListViewConstIteratorT(ItemSharedInfo* shared_info, const Int32* ARCANE_RESTRICT local_id_ptr,
                                       Int32 local_id_offset)
-  : ItemConnectedListViewConstIterator(shared_info,local_id_ptr,local_id_offset){}
-#else
-  ItemConnectedListViewConstIteratorT(ItemSharedInfo* shared_info,const Int32* ARCANE_RESTRICT local_id_ptr)
-  : ItemConnectedListViewConstIterator(shared_info,local_id_ptr){}
-#endif
+  : ItemConnectedListViewConstIterator(shared_info, local_id_ptr, local_id_offset)
+  {}
 
  public:
 
@@ -170,28 +174,42 @@ class ItemConnectedListViewConstIteratorT
 
  public:
 
-  ItemType operator*() const { return ItemType(*m_local_id_ptr,m_shared_info); }
-  ThatClass& operator++() { ++m_local_id_ptr; return (*this); }
-  ThatClass& operator--() { --m_local_id_ptr; return (*this); }
+  ItemType operator*() const
+  {
+    return ItemType(*m_local_id_ptr, m_shared_info);
+  }
+  ThatClass& operator++()
+  {
+    ++m_local_id_ptr;
+    return (*this);
+  }
+  ThatClass& operator--()
+  {
+    --m_local_id_ptr;
+    return (*this);
+  }
   difference_type operator-(const ThatClass& b) const
   {
     return this->m_local_id_ptr - b.m_local_id_ptr;
   }
-  friend ThatClass operator-(const ThatClass& a,difference_type v)
+  friend ThatClass operator-(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr - v;
-    return ThatClass(a.m_shared_info,ptr);
+    return ThatClass(a.m_shared_info, ptr);
   }
-  friend ThatClass operator+(const ThatClass& a,difference_type v)
+  friend ThatClass operator+(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr + v;
-    return ThatClass(a.m_shared_info,ptr);
+    return ThatClass(a.m_shared_info, ptr);
   }
 
  public:
 
   ARCANE_DEPRECATED_REASON("Y2022: This method returns a temporary. Use 'operator*' instead")
-  ItemType operator->() const { return this->_itemInternal(); }
+  ItemType operator->() const
+  {
+    return this->_itemInternal();
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -203,14 +221,14 @@ class ItemConnectedListViewConstIteratorT
  * pas modifié et que la famille d'entité associée à ce tableau n'est
  * elle même pas modifiée.
  */
-template<int Extent>
+template <int Extent>
 class ItemConnectedListView
 {
   friend ItemVector;
   friend class ItemEnumeratorBase;
   friend class ItemVectorView;
   friend class ItemConnectedEnumeratorBase;
-  template<typename ItemType> friend class ItemEnumeratorBaseT;
+  template <typename ItemType> friend class ItemEnumeratorBaseT;
 
  public:
 
@@ -227,16 +245,21 @@ class ItemConnectedListView
  protected:
 
   ItemConnectedListView(const impl::ItemIndexedListView<DynExtent>& view)
-  : m_local_ids(view.constLocalIds()), m_shared_info(view.m_shared_info) { }
-  ItemConnectedListView(ItemSharedInfo* shared_info,ConstArrayView<Int32> local_ids,Int32 local_id_offset)
-  : m_local_ids(local_ids), m_shared_info(shared_info), m_local_id_offset(local_id_offset) { }
+  : m_local_ids(view.constLocalIds())
+  , m_shared_info(view.m_shared_info)
+  {}
+  ItemConnectedListView(ItemSharedInfo* shared_info, ConstArrayView<Int32> local_ids, Int32 local_id_offset)
+  : m_local_ids(local_ids)
+  , m_shared_info(shared_info)
+  , m_local_id_offset(local_id_offset)
+  {}
 
  public:
 
   //! Accède au \a i-ème élément du vecteur
   Item operator[](Integer index) const
   {
-    return Item(ARCANE_LOCALID_ADD_OFFSET(m_local_ids[index]),m_shared_info);
+    return Item(m_local_id_offset + m_local_ids[index], m_shared_info);
   }
 
   //! Nombre d'éléments du vecteur
@@ -245,16 +268,16 @@ class ItemConnectedListView
   // TODO: changer le type de l'iterateur
   const_iterator begin() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,m_local_ids.data(),m_local_id_offset));
+    return const_iterator(m_shared_info, m_local_ids.data(), m_local_id_offset);
   }
 
   // TODO: changer le type de l'iterateur
   const_iterator end() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,(m_local_ids.data()+this->size()),m_local_id_offset));
+    return const_iterator(m_shared_info, (m_local_ids.data() + this->size()), m_local_id_offset);
   }
 
-  friend std::ostream& operator<<(std::ostream& o,const ItemConnectedListView<Extent>& a)
+  friend std::ostream& operator<<(std::ostream& o, const ItemConnectedListView<Extent>& a)
   {
     o << a.m_local_ids.localIds();
     return o;
@@ -265,6 +288,7 @@ class ItemConnectedListView
 
 #ifdef ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
  private:
+
 #else
  public:
 #endif
@@ -272,7 +296,7 @@ class ItemConnectedListView
   // Temporaire pour rendre les sources compatibles
   operator ItemInternalVectorView() const
   {
-    return ItemInternalVectorView(m_shared_info,m_local_ids);
+    return ItemInternalVectorView(m_shared_info, m_local_ids, m_local_id_offset);
   }
 
   // TODO: rendre obsolète
@@ -281,18 +305,22 @@ class ItemConnectedListView
  private:
 
   //! Vue sur le tableau des indices
-  ItemIndexArrayView indexes() const { return m_local_ids; }
+  ItemIndexArrayView indexes() const
+  {
+    return m_local_ids;
+  }
 
   //! Vue sur le tableau des indices
-  Int32ConstArrayView _localIds() const { return m_local_ids; }
+  Int32ConstArrayView _localIds() const
+  {
+    return m_local_ids;
+  }
 
  protected:
-  
+
   ItemIndexArrayView m_local_ids;
   ItemSharedInfo* m_shared_info = ItemSharedInfo::nullInstance();
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
   Int32 m_local_id_offset = 0;
-#endif
 };
 
 /*---------------------------------------------------------------------------*/
@@ -300,7 +328,7 @@ class ItemConnectedListView
 /*!
  * \brief Vue sur une liste d'entités connectées à une autre.
  */
-template<typename ItemType,int Extent>
+template <typename ItemType, int Extent>
 class ItemConnectedListViewT
 : public ItemConnectedListView<Extent>
 {
@@ -318,11 +346,9 @@ class ItemConnectedListViewT
   template <typename T> friend class ItemConnectedEnumeratorBaseT;
 
   using BaseClass = ItemConnectedListView<Extent>;
-  using BaseClass::m_shared_info;
-  using BaseClass::m_local_ids;
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
   using BaseClass::m_local_id_offset;
-#endif
+  using BaseClass::m_local_ids;
+  using BaseClass::m_shared_info;
 
  public:
 
@@ -334,35 +360,39 @@ class ItemConnectedListViewT
 
   ItemConnectedListViewT() = default;
   ItemConnectedListViewT(const ItemConnectedListView<Extent>& rhs)
-  : BaseClass(rhs) {}
+  : BaseClass(rhs)
+  {}
   ItemConnectedListViewT(const impl::ItemIndexedListView<DynExtent>& rhs)
-  : BaseClass(rhs) {}
+  : BaseClass(rhs)
+  {}
 
  protected:
 
-  ItemConnectedListViewT(ItemSharedInfo* shared_info,ConstArrayView<Int32> local_ids, Int32 local_id_offset)
-  : BaseClass(shared_info,local_ids,local_id_offset) { }
+  ItemConnectedListViewT(ItemSharedInfo* shared_info, ConstArrayView<Int32> local_ids, Int32 local_id_offset)
+  : BaseClass(shared_info, local_ids, local_id_offset)
+  {}
 
  public:
 
   ItemType operator[](Integer index) const
   {
-    return ItemType(ARCANE_LOCALID_ADD_OFFSET(m_local_ids[index]),m_shared_info);
+    return ItemType(m_local_id_offset + m_local_ids[index], m_shared_info);
   }
 
  public:
-  
+
   inline const_iterator begin() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,m_local_ids.data(),m_local_id_offset));
+    return const_iterator(m_shared_info, m_local_ids.data(), m_local_id_offset);
   }
   inline const_iterator end() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,(m_local_ids.data()+this->size()),m_local_id_offset));
+    return const_iterator(m_shared_info, (m_local_ids.data() + this->size()), m_local_id_offset);
   }
 
 #ifdef ARCANE_HIDE_ITEM_CONNECTIVITY_STRUCTURE
  private:
+
 #else
  public:
 #endif
@@ -370,7 +400,7 @@ class ItemConnectedListViewT
   // TODO: rendre obsolète
   inline ItemEnumeratorT<ItemType> enumerator() const
   {
-    return ItemEnumeratorT<ItemType>(m_shared_info,m_local_ids.localIds());
+    return ItemEnumeratorT<ItemType>(m_shared_info, m_local_ids.localIds());
   }
 };
 
@@ -378,9 +408,6 @@ class ItemConnectedListViewT
 /*---------------------------------------------------------------------------*/
 
 } // End namespace Arcane
-
-#undef ARCANE_LOCALID_ADD_OFFSET
-#undef ARCANE_THAT_CLASS_AND_OFFSET
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemIndexedListView.h
+++ b/arcane/src/arcane/core/ItemIndexedListView.h
@@ -55,16 +55,18 @@ class ARCANE_CORE_EXPORT ItemIndexedListView
 
  private:
 
-  constexpr ItemIndexedListView(ItemSharedInfo* si, SmallSpan<const Int32> local_ids)
+  constexpr ItemIndexedListView(ItemSharedInfo* si, SmallSpan<const Int32> local_ids, Int32 local_id_offset)
   : m_local_ids(local_ids)
   , m_shared_info(si)
+  , m_local_id_offset(local_id_offset)
   {
     ARCANE_ASSERT(m_shared_info, ("null shared_info"));
   }
 
-  constexpr ItemIndexedListView(ItemSharedInfo* si, const Int32* local_ids, Int32 count)
+  constexpr ItemIndexedListView(ItemSharedInfo* si, const Int32* local_ids, Int32 count, Int32 local_id_offset)
   : m_local_ids(local_ids, count)
   , m_shared_info(si)
+  , m_local_id_offset(local_id_offset)
   {
     ARCANE_ASSERT(m_shared_info, ("null shared info"));
   }
@@ -84,6 +86,7 @@ class ARCANE_CORE_EXPORT ItemIndexedListView
 
   SmallSpan<const Int32, Extent> m_local_ids;
   ItemSharedInfo* m_shared_info = ItemSharedInfo::nullInstance();
+  Int32 m_local_id_offset;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemInternal.cc
+++ b/arcane/src/arcane/core/ItemInternal.cc
@@ -172,7 +172,7 @@ _internalActiveCells(Int32Array& local_ids) const
       local_ids.add(local_id);
     }
   }
-  return ItemInternalVectorView(m_shared_info->m_items->m_cell_shared_info,local_ids);
+  return ItemInternalVectorView(m_shared_info->m_items->m_cell_shared_info,local_ids,0);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemInternalVectorView.h
+++ b/arcane/src/arcane/core/ItemInternalVectorView.h
@@ -24,6 +24,17 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
+#define ARCANE_LOCALID_ADD_OFFSET(a) (m_local_id_offset + (a))
+#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b,c
+#else
+#define ARCANE_LOCALID_ADD_OFFSET(a) (a)
+#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 namespace Arcane
 {
 
@@ -44,8 +55,8 @@ class ItemInternalVectorViewConstIterator
 
   ItemInternalVectorViewConstIterator(const ItemInternalPtr* items,
                                       const Int32* ARCANE_RESTRICT local_ids,
-                                      Integer index)
-  : m_items(items), m_local_ids(local_ids), m_index(index){}
+                                      Integer index,Int32 local_id_offset)
+  : m_items(items), m_local_ids(local_ids), m_index(index), m_local_id_offset(local_id_offset){}
 
  public:
 
@@ -64,8 +75,8 @@ class ItemInternalVectorViewConstIterator
   //! Type d'une distance entre itérateur éléments du tableau
   typedef Integer difference_type;
  public:
-  value_type operator*() const { return m_items[ m_local_ids[m_index] ]; }
-  value_type operator->() const { return m_items[ m_local_ids[m_index] ]; }
+  value_type operator*() const { return m_items[ ARCANE_LOCALID_ADD_OFFSET(m_local_ids[m_index]) ]; }
+  value_type operator->() const { return m_items[ ARCANE_LOCALID_ADD_OFFSET(m_local_ids[m_index]) ]; }
   ThatClass& operator++() { ++m_index; return (*this); }
   ThatClass& operator--() { --m_index; return (*this); }
   void operator+=(difference_type v) { m_index += v; }
@@ -77,12 +88,12 @@ class ItemInternalVectorViewConstIterator
   friend ThatClass operator-(const ThatClass& a,difference_type v)
   {
     Integer index = a.m_index - v;
-    return ThatClass(a.m_items,a.m_local_ids,index);
+    return ThatClass(a.m_items,a.m_local_ids,index,a.m_local_id_offset);
   }
   friend ThatClass operator+(const ThatClass& a,difference_type v)
   {
     Integer index = a.m_index + v;
-    return ThatClass(a.m_items,a.m_local_ids,index);
+    return ThatClass(a.m_items,a.m_local_ids,index,a.m_local_id_offset);
   }
   friend bool operator<(const ThatClass& lhs,const ThatClass& rhs)
   {
@@ -104,7 +115,8 @@ class ItemInternalVectorViewConstIterator
 
   const ItemInternalPtr* m_items;
   const Int32* ARCANE_RESTRICT m_local_ids;
-  Integer m_index;
+  Int32 m_index;
+  Int32 m_local_id_offset = 0;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -140,16 +152,18 @@ class ARCANE_CORE_EXPORT ItemInternalVectorView
 
  private:
 
-  ItemInternalVectorView(ItemSharedInfo* si, Int32ConstArrayView local_ids)
+  ItemInternalVectorView(ItemSharedInfo* si, Int32ConstArrayView local_ids, Int32 local_id_offset)
   : m_local_ids(local_ids)
   , m_shared_info(si)
+  , m_local_id_offset(local_id_offset)
   {
     ARCANE_ASSERT(_isValid(), ("Bad ItemInternalVectorView"));
   }
 
-  ItemInternalVectorView(ItemSharedInfo* si, const Int32* local_ids, Integer count)
+  ItemInternalVectorView(ItemSharedInfo* si, const Int32* local_ids, Integer count, Int32 local_id_offset)
   : m_local_ids(count, local_ids)
   , m_shared_info(si)
+  , m_local_id_offset(local_id_offset)
   {
     ARCANE_ASSERT(_isValid(), ("Bad ItemInternalVectorView"));
   }
@@ -157,6 +171,7 @@ class ARCANE_CORE_EXPORT ItemInternalVectorView
   ItemInternalVectorView(const impl::ItemIndexedListView<DynExtent>& view)
   : m_local_ids(view.constLocalIds())
   , m_shared_info(view.m_shared_info)
+  , m_local_id_offset(view.m_local_id_offset)
   {}
 
  public:
@@ -185,19 +200,24 @@ class ARCANE_CORE_EXPORT ItemInternalVectorView
   ARCANE_DEPRECATED_REASON("Y2022: Use ItemVectorView to iterate")
   const_iterator begin() const
   {
-    return const_iterator(_items().data(), m_local_ids.data(), 0);
+    return const_iterator(_items().data(), m_local_ids.data(), 0, m_local_id_offset);
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: Use ItemVectorView to iterate")
   const_iterator end() const
   {
-    return const_iterator(_items().data(), m_local_ids.data(), this->size());
+    return const_iterator(_items().data(), m_local_ids.data(), this->size(), m_local_id_offset);
   }
+
+ protected:
+
+  Int32 localIdOffset() const { return m_local_id_offset; }
 
  protected:
 
   Int32ConstArrayView m_local_ids;
   ItemSharedInfo* m_shared_info = ItemSharedInfo::nullInstance();
+  Int32 m_local_id_offset = 0;
 
  private:
 
@@ -209,6 +229,9 @@ class ARCANE_CORE_EXPORT ItemInternalVectorView
 /*---------------------------------------------------------------------------*/
 
 } // End namespace Arcane
+
+#undef ARCANE_LOCALID_ADD_OFFSET
+#undef ARCANE_ARGS_AND_OFFSET
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemInternalVectorView.h
+++ b/arcane/src/arcane/core/ItemInternalVectorView.h
@@ -24,17 +24,6 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
-#define ARCANE_LOCALID_ADD_OFFSET(a) (m_local_id_offset + (a))
-#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b,c
-#else
-#define ARCANE_LOCALID_ADD_OFFSET(a) (a)
-#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b
-#endif
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 namespace Arcane
 {
 
@@ -75,8 +64,8 @@ class ItemInternalVectorViewConstIterator
   //! Type d'une distance entre itérateur éléments du tableau
   typedef Integer difference_type;
  public:
-  value_type operator*() const { return m_items[ ARCANE_LOCALID_ADD_OFFSET(m_local_ids[m_index]) ]; }
-  value_type operator->() const { return m_items[ ARCANE_LOCALID_ADD_OFFSET(m_local_ids[m_index]) ]; }
+  value_type operator*() const { return m_items[ m_local_id_offset + m_local_ids[m_index] ]; }
+  value_type operator->() const { return m_items[ m_local_id_offset + m_local_ids[m_index] ]; }
   ThatClass& operator++() { ++m_index; return (*this); }
   ThatClass& operator--() { --m_index; return (*this); }
   void operator+=(difference_type v) { m_index += v; }

--- a/arcane/src/arcane/core/ItemVectorView.h
+++ b/arcane/src/arcane/core/ItemVectorView.h
@@ -22,13 +22,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
-#define ARCANE_LOCALID_ADD_OFFSET(a) (m_local_id_offset + (a))
-#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b,c
-#else
-#define ARCANE_LOCALID_ADD_OFFSET(a) (a)
-#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b
-#endif
+//#define ARCANE_LOCALID_ADD_OFFSET(a) (m_local_id_offset + (a))
+//#define ARCANE_ARGS_AND_OFFSET(a,b,c) a,b,c
 
 namespace Arcane
 {
@@ -52,25 +47,27 @@ class ItemVectorViewConstIterator
  protected:
 
   friend class ItemVectorView;
-  template<int Extent> friend class ItemConnectedListView;
+  template <int Extent> friend class ItemConnectedListView;
 
  protected:
 
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
-  ItemVectorViewConstIterator(ItemSharedInfo* shared_info,const Int32* local_id_ptr,Int32 local_id_offset)
-  : m_shared_info(shared_info), m_local_id_ptr(local_id_ptr), m_local_id_offset(local_id_offset){}
-#endif
-  ItemVectorViewConstIterator(ItemSharedInfo* shared_info,const Int32* local_id_ptr)
-  : m_shared_info(shared_info), m_local_id_ptr(local_id_ptr){}
+  ItemVectorViewConstIterator(ItemSharedInfo* shared_info, const Int32* local_id_ptr, Int32 local_id_offset)
+  : m_shared_info(shared_info)
+  , m_local_id_ptr(local_id_ptr)
+  , m_local_id_offset(local_id_offset)
+  {}
+  ItemVectorViewConstIterator(ItemSharedInfo* shared_info, const Int32* local_id_ptr)
+  : m_shared_info(shared_info)
+  , m_local_id_ptr(local_id_ptr)
+  {}
 
  public:
 
   // Temporaire (01/2023) pour conversion avec nouveau type ItemConnectedListView
   ItemVectorViewConstIterator(const ItemConnectedListViewConstIterator& v)
-  : m_shared_info(v.m_shared_info), m_local_id_ptr(v.m_local_id_ptr)
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
-    , m_local_id_offset(v.m_local_id_offset)
-  #endif
+  : m_shared_info(v.m_shared_info)
+  , m_local_id_ptr(v.m_local_id_ptr)
+  , m_local_id_offset(v.m_local_id_offset)
   {}
 
  public:
@@ -93,38 +90,46 @@ class ItemVectorViewConstIterator
 
  public:
 
-  Item operator*() const { return Item(ARCANE_LOCALID_ADD_OFFSET((*m_local_id_ptr)),m_shared_info); }
+  Item operator*() const { return Item(m_local_id_offset + (*m_local_id_ptr), m_shared_info); }
 
-  ThatClass& operator++() { ++m_local_id_ptr; return (*this); }
-  ThatClass& operator--() { --m_local_id_ptr; return (*this); }
+  ThatClass& operator++()
+  {
+    ++m_local_id_ptr;
+    return (*this);
+  }
+  ThatClass& operator--()
+  {
+    --m_local_id_ptr;
+    return (*this);
+  }
   void operator+=(difference_type v) { m_local_id_ptr += v; }
   void operator-=(difference_type v) { m_local_id_ptr -= v; }
   difference_type operator-(const ThatClass& b) const
   {
     return this->m_local_id_ptr - b.m_local_id_ptr;
   }
-  friend ThatClass operator-(const ThatClass& a,difference_type v)
+  friend ThatClass operator-(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr - v;
-    return ThatClass(ARCANE_ARGS_AND_OFFSET(a.m_shared_info,ptr,a.m_local_id_offset));
+    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
   }
-  friend ThatClass operator+(const ThatClass& a,difference_type v)
+  friend ThatClass operator+(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr + v;
-    return ThatClass(ARCANE_ARGS_AND_OFFSET(a.m_shared_info,ptr,a.m_local_id_offset));
+    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
   }
-  friend bool operator<(const ThatClass& lhs,const ThatClass& rhs)
+  friend bool operator<(const ThatClass& lhs, const ThatClass& rhs)
   {
     return lhs.m_local_id_ptr <= rhs.m_local_id_ptr;
   }
   //! Compare les indices d'itération de deux instances
-  friend bool operator==(const ThatClass& lhs,const ThatClass& rhs)
+  friend bool operator==(const ThatClass& lhs, const ThatClass& rhs)
   {
     return lhs.m_local_id_ptr == rhs.m_local_id_ptr;
   }
-  friend bool operator!=(const ThatClass& lhs,const ThatClass& rhs)
+  friend bool operator!=(const ThatClass& lhs, const ThatClass& rhs)
   {
-    return !(lhs==rhs);
+    return !(lhs == rhs);
   }
 
   ARCANE_DEPRECATED_REASON("Y2022: This method returns a temporary. Use 'operator*' instead")
@@ -134,15 +139,13 @@ class ItemVectorViewConstIterator
 
   ItemSharedInfo* m_shared_info;
   const Int32* m_local_id_ptr;
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
   Int32 m_local_id_offset = 0;
-#endif
 
  protected:
 
   inline ItemInternal* _itemInternal() const
   {
-    return m_shared_info->m_items_internal[ ARCANE_LOCALID_ADD_OFFSET((*m_local_id_ptr)) ];
+    return m_shared_info->m_items_internal[m_local_id_offset + (*m_local_id_ptr)];
   }
 };
 
@@ -158,11 +161,9 @@ class ItemVectorViewConstIteratorT
 
  private:
 
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
   ItemVectorViewConstIteratorT(ItemSharedInfo* shared_info,const Int32* ARCANE_RESTRICT local_id_ptr,
                                Int32 local_id_offset)
   : ItemVectorViewConstIterator(shared_info,local_id_ptr,local_id_offset){}
-#endif
   ItemVectorViewConstIteratorT(ItemSharedInfo* shared_info,const Int32* ARCANE_RESTRICT local_id_ptr)
   : ItemVectorViewConstIterator(shared_info,local_id_ptr){}
 
@@ -186,7 +187,7 @@ class ItemVectorViewConstIteratorT
 
  public:
 
-  ItemType operator*() const { return ItemType(ARCANE_LOCALID_ADD_OFFSET((*m_local_id_ptr)),m_shared_info); }
+  ItemType operator*() const { return ItemType(m_local_id_offset + (*m_local_id_ptr), m_shared_info); }
 
   ThatClass& operator++() { ++m_local_id_ptr; return (*this); }
   ThatClass& operator--() { --m_local_id_ptr; return (*this); }
@@ -194,15 +195,15 @@ class ItemVectorViewConstIteratorT
   {
     return this->m_local_id_ptr - b.m_local_id_ptr;
   }
-  friend ThatClass operator-(const ThatClass& a,difference_type v)
+  friend ThatClass operator-(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr - v;
-    return ThatClass(ARCANE_ARGS_AND_OFFSET(a.m_shared_info,ptr,a.m_local_id_offset));
+    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
   }
-  friend ThatClass operator+(const ThatClass& a,difference_type v)
+  friend ThatClass operator+(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr + v;
-    return ThatClass(ARCANE_ARGS_AND_OFFSET(a.m_shared_info,ptr,a.m_local_id_offset));
+    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
   }
 
  public:
@@ -235,59 +236,80 @@ class ARCANE_CORE_EXPORT ItemVectorView
  public:
 
   ARCANE_DEPRECATED_REASON("Y2022: Use constructor with ItemInfoListView instead")
-  ItemVectorView(const ItemInternalArrayView& aitems,const Int32ConstArrayView& local_ids)
-  : m_local_ids(local_ids) { _init(aitems); }
+  ItemVectorView(const ItemInternalArrayView& aitems, const Int32ConstArrayView& local_ids)
+  : m_local_ids(local_ids)
+  {
+    _init(aitems);
+  }
 
   ARCANE_DEPRECATED_REASON("Y2022: Use constructor with ItemInfoListView instead")
-  ItemVectorView(ItemInternalArrayView aitems,ItemIndexArrayView indexes)
-  : m_local_ids(indexes) { _init(aitems); }
+  ItemVectorView(ItemInternalArrayView aitems, ItemIndexArrayView indexes)
+  : m_local_ids(indexes)
+  {
+    _init(aitems);
+  }
 
  public:
 
   ItemVectorView() = default;
   ItemVectorView(const ItemInternalVectorView& view)
-  : m_local_ids(view.localIds()), m_shared_info(view.m_shared_info) { }
-  ItemVectorView(ItemInfoListView item_info_list_view,ConstArrayView<Int32> local_ids)
-  : m_local_ids(local_ids), m_shared_info(item_info_list_view.m_item_shared_info) { }
-  ItemVectorView(ItemInfoListView item_info_list_view,ItemIndexArrayView indexes)
-  : m_local_ids(indexes), m_shared_info(item_info_list_view.m_item_shared_info) { }
-  ItemVectorView(IItemFamily* family,ConstArrayView<Int32> local_ids);
-  ItemVectorView(IItemFamily* family,ItemIndexArrayView indexes);
+  : m_local_ids(view.localIds())
+  , m_shared_info(view.m_shared_info)
+  {}
+  ItemVectorView(ItemInfoListView item_info_list_view, ConstArrayView<Int32> local_ids)
+  : m_local_ids(local_ids)
+  , m_shared_info(item_info_list_view.m_item_shared_info)
+  {}
+  ItemVectorView(ItemInfoListView item_info_list_view, ItemIndexArrayView indexes)
+  : m_local_ids(indexes)
+  , m_shared_info(item_info_list_view.m_item_shared_info)
+  {}
+  ItemVectorView(IItemFamily* family, ConstArrayView<Int32> local_ids);
+  ItemVectorView(IItemFamily* family, ItemIndexArrayView indexes);
   ItemVectorView(const impl::ItemIndexedListView<DynExtent>& view)
-  : m_local_ids(view.constLocalIds()), m_shared_info(view.m_shared_info) { }
+  : m_local_ids(view.constLocalIds())
+  , m_shared_info(view.m_shared_info)
+  {}
 
   // Temporaire (01/2023) pour conversion avec nouveau type ItemConnectedListView
   ItemVectorView(const ItemConnectedListView<DynExtent>& v)
-  : m_local_ids(v.m_local_ids), m_shared_info(v.m_shared_info)
-  #ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
+  : m_local_ids(v.m_local_ids)
+  , m_shared_info(v.m_shared_info)
   , m_local_id_offset(v.m_local_id_offset)
-  #endif
-  { }
+  {}
 
  protected:
 
-  ItemVectorView(ItemSharedInfo* shared_info,ConstArrayView<Int32> local_ids)
-  : m_local_ids(local_ids), m_shared_info(shared_info) { }
+  ItemVectorView(ItemSharedInfo* shared_info, ConstArrayView<Int32> local_ids)
+  : m_local_ids(local_ids)
+  , m_shared_info(shared_info)
+  {}
 
   // Temporaire pour éviter un avertissement de compilation lorsqu'on utilise le
   // constructeur obsolète de ItemVectorViewT
-  ItemVectorView(const ItemInternalArrayView& aitems,const Int32ConstArrayView& local_ids,bool)
-  : m_local_ids(local_ids) { _init(aitems); }
+  ItemVectorView(const ItemInternalArrayView& aitems, const Int32ConstArrayView& local_ids, bool)
+  : m_local_ids(local_ids)
+  {
+    _init(aitems);
+  }
 
   // Temporaire pour éviter un avertissement de compilation lorsqu'on utilise le
   // constructeur obsolète de ItemVectorViewT
-  ItemVectorView(ItemInternalArrayView aitems,ItemIndexArrayView indexes,bool)
-  : m_local_ids(indexes) { _init(aitems); }
+  ItemVectorView(ItemInternalArrayView aitems, ItemIndexArrayView indexes, bool)
+  : m_local_ids(indexes)
+  {
+    _init(aitems);
+  }
 
  public:
 
   operator ItemInternalVectorView() const
   {
-    return ItemInternalVectorView(m_shared_info,m_local_ids, m_local_id_offset);
+    return ItemInternalVectorView(m_shared_info, m_local_ids, m_local_id_offset);
   }
 
   //! Accède au \a i-ème élément du vecteur
-  Item operator[](Integer index) const { return Item(ARCANE_LOCALID_ADD_OFFSET(m_local_ids[index]),m_shared_info); }
+  Item operator[](Integer index) const { return Item(m_local_id_offset + m_local_ids[index], m_shared_info); }
 
   //! Nombre d'éléments du vecteur
   Int32 size() const { return m_local_ids.size(); }
@@ -300,17 +322,17 @@ class ARCANE_CORE_EXPORT ItemVectorView
   Int32ConstArrayView localIds() const { return m_local_ids; }
 
   //! Sous-vue à partir de l'élément \a abegin et contenant \a asize éléments
-  ItemVectorView subView(Integer abegin,Integer asize) const
+  ItemVectorView subView(Integer abegin, Integer asize) const
   {
-    return ItemVectorView(m_shared_info,m_local_ids.subView(abegin,asize));
+    return ItemVectorView(m_shared_info, m_local_ids.subView(abegin, asize));
   }
   const_iterator begin() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,m_local_ids.data(),m_local_id_offset));
+    return const_iterator(m_shared_info, m_local_ids.data(), m_local_id_offset);
   }
   const_iterator end() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,(m_local_ids.data()+this->size()), m_local_id_offset));
+    return const_iterator(m_shared_info, (m_local_ids.data() + this->size()), m_local_id_offset);
   }
   //! Vue sur le tableau des indices
   ItemIndexArrayView indexes() const { return m_local_ids; }
@@ -320,18 +342,16 @@ class ARCANE_CORE_EXPORT ItemVectorView
   inline ItemEnumerator enumerator() const;
 
  protected:
-  
+
   ItemIndexArrayView m_local_ids;
   ItemSharedInfo* m_shared_info = ItemSharedInfo::nullInstance();
-#ifdef ARCANE_HAS_OFFSET_FOR_ITEMVECTORVIEW
   Int32 m_local_id_offset = 0;
-#endif
 
  private:
 
   void _init(ItemInternalArrayView items)
   {
-    m_shared_info = (size()>0 && !items.empty()) ? ItemInternalCompatibility::_getSharedInfo(items[0]) : ItemSharedInfo::nullInstance();
+    m_shared_info = (size() > 0 && !items.empty()) ? ItemInternalCompatibility::_getSharedInfo(items[0]) : ItemSharedInfo::nullInstance();
   }
   void _init2(IItemFamily* family);
 };
@@ -411,11 +431,11 @@ class ItemVectorViewT
   }
   inline const_iterator begin() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,m_local_ids.data(), m_local_id_offset));
+    return const_iterator(m_shared_info,m_local_ids.data(), m_local_id_offset);
   }
   inline const_iterator end() const
   {
-    return const_iterator(ARCANE_ARGS_AND_OFFSET(m_shared_info,m_local_ids.data()+this->size(), m_local_id_offset));
+    return const_iterator(m_shared_info, m_local_ids.data() + this->size(), m_local_id_offset);
   }
 };
 
@@ -423,9 +443,6 @@ class ItemVectorViewT
 /*---------------------------------------------------------------------------*/
 
 } // End namespace Arcane
-
-#undef ARCANE_LOCALID_ADD_OFFSET
-#undef ARCANE_ARGS_AND_OFFSET
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemVectorView.h
+++ b/arcane/src/arcane/core/ItemVectorView.h
@@ -283,7 +283,7 @@ class ARCANE_CORE_EXPORT ItemVectorView
 
   operator ItemInternalVectorView() const
   {
-    return ItemInternalVectorView(m_shared_info,m_local_ids);
+    return ItemInternalVectorView(m_shared_info,m_local_ids, m_local_id_offset);
   }
 
   //! Accède au \a i-ème élément du vecteur

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -140,6 +140,13 @@ namespace Arcane
     Int32ConstArrayView m_list_hparent;
     Int32ConstArrayView m_list_hchild;
 
+    Int32ConstArrayView m_offset_node;
+    Int32ConstArrayView m_offset_edge;
+    Int32ConstArrayView m_offset_face;
+    Int32ConstArrayView m_offset_cell;
+    Int32ConstArrayView m_offset_hparent;
+    Int32ConstArrayView m_offset_hchild;
+
     Int32 m_max_nb_item0;
     Int32 m_max_nb_item1;
     Int32 m_max_nb_item2;


### PR DESCRIPTION
At the moment the offset is always `0` so it is not used but the internals will be ready to change that in a future version.