### PR TITLE
Implément 'IMemoryAllocator::reallocate()' for accelerator allocators

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -63,7 +63,7 @@ class CudaMemoryAllocatorBase
   : AlignedMemoryAllocator3(128)
   {}
 
-  bool hasRealloc(MemoryAllocationArgs) const final { return false; }
+  bool hasRealloc(MemoryAllocationArgs) const final { return true; }
   AllocatedMemoryInfo allocate(MemoryAllocationArgs args, Int64 new_size) final
   {
     void* out = nullptr;
@@ -75,8 +75,10 @@ class CudaMemoryAllocatorBase
   }
   AllocatedMemoryInfo reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size) final
   {
+    AllocatedMemoryInfo a = allocate(args, new_size);
+    ARCANE_CHECK_CUDA(cudaMemcpy(a.baseAddress(), current_ptr.baseAddress(), current_ptr.size(), cudaMemcpyDefault));
     deallocate(args, current_ptr);
-    return allocate(args, new_size);
+    return a;
   }
   void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo mem_info) final
   {

--- a/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
+++ b/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
@@ -61,7 +61,7 @@ class HipMemoryAllocatorBase
   : AlignedMemoryAllocator3(128)
   {}
 
-  bool hasRealloc(MemoryAllocationArgs) const override { return false; }
+  bool hasRealloc(MemoryAllocationArgs) const override { return true; }
   AllocatedMemoryInfo allocate(MemoryAllocationArgs args, Int64 new_size) override
   {
     void* out = nullptr;
@@ -73,8 +73,10 @@ class HipMemoryAllocatorBase
   }
   AllocatedMemoryInfo reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size) override
   {
+    AllocatedMemoryInfo a = allocate(args, new_size);
+    ARCANE_CHECK_HIP(hipMemcpy(a.baseAddress(), current_ptr.baseAddress(), current_ptr.size(), hipMemcpyDefault));
     deallocate(args, current_ptr);
-    return allocate(args, new_size);
+    return a;
   }
   void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr) override
   {


### PR DESCRIPTION
This is needed if we want to do reallocation with device memory for example because can not use `std::memcpy` in this case.