### PR TITLE
Add method 'IMemoryAllocator::copyMemory()' to handle memory copy

### DIFF
--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -153,10 +153,11 @@ _reallocate(Int64 new_capacity, Int64 sizeof_true_type, MemoryPointer current)
       p = a->reallocate(alloc_args, current_info, elem_size).baseAddress();
     }
     else {
-      p = a->allocate(alloc_args, elem_size).baseAddress();
+      AllocatedMemoryInfo new_alloc_info = a->allocate(alloc_args, elem_size);
+      p = new_alloc_info.baseAddress();
       //GG: TODO: regarder si 'current' peut être nul (a priori je ne pense pas...)
       if (p && current) {
-        ::memcpy(p, current, current_size);
+        a->copyMemory(alloc_args, new_alloc_info, current_info);
         a->deallocate(alloc_args, current_info);
       }
     }

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -98,24 +98,37 @@ _setMemoryLocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+void ArrayMetaData::
+_copyFromMemory(MemoryPointer destination, ConstMemoryPointer source, Int64 sizeof_true_type)
+{
+  MemoryAllocationArgs args = _getAllocationArgs();
+  Int64 full_size = size * sizeof_true_type;
+  AllocatedMemoryInfo source_info(const_cast<void*>(source), full_size, full_size);
+  AllocatedMemoryInfo destination_info(destination, full_size, full_size);
+  _allocator()->copyMemory(args, destination_info, source_info);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 ArrayMetaData::MemoryPointer ArrayMetaData::
-_allocate(Int64 new_capacity,Int64 sizeof_true_type)
+_allocate(Int64 new_capacity, Int64 sizeof_true_type)
 {
   _checkAllocator();
   MemoryAllocationArgs alloc_args = _getAllocationArgs();
   IMemoryAllocator* a = _allocator();
   size_t s_new_capacity = (size_t)new_capacity;
-  s_new_capacity = a->adjustedCapacity(alloc_args,s_new_capacity,sizeof_true_type);
+  s_new_capacity = a->adjustedCapacity(alloc_args, s_new_capacity, sizeof_true_type);
   size_t s_sizeof_true_type = (size_t)sizeof_true_type;
   size_t elem_size = s_new_capacity * s_sizeof_true_type;
-  MemoryPointer p = a->allocate(alloc_args,elem_size).baseAddress();
+  MemoryPointer p = a->allocate(alloc_args, elem_size).baseAddress();
 #ifdef ARCCORE_DEBUG_ARRAY
   std::cout << "ArrayImplBase::ALLOCATE: elemsize=" << elem_size
             << " typesize=" << sizeof_true_type
             << " size=" << new_capacity << " datasize=" << sizeof_true_impl
             << " p=" << p << '\n';
 #endif
-  if (!p){
+  if (!p) {
     std::ostringstream ostr;
     ostr << " Bad ArrayImplBase::allocate() size=" << elem_size << " capacity=" << new_capacity
          << " sizeof_true_type=" << sizeof_true_type << '\n';

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -106,11 +106,12 @@ class ARCCORE_COLLECTIONS_EXPORT ArrayMetaData
  protected:
 
   using MemoryPointer = void*;
-
+  using ConstMemoryPointer = const void*;
   MemoryPointer _allocate(Int64 nb,Int64 sizeof_true_type);
   MemoryPointer _reallocate(Int64 nb,Int64 sizeof_true_type,MemoryPointer current);
   void _deallocate(MemoryPointer current,Int64 sizeof_true_type) ARCCORE_NOEXCEPT;
   void _setMemoryLocationHint(eMemoryLocationHint new_hint,void* ptr,Int64 sizeof_true_type);
+  void _copyFromMemory(MemoryPointer destination,ConstMemoryPointer source,Int64 sizeof_true_type);
 
  private:
 
@@ -634,6 +635,11 @@ class AbstractArray
     _updateReferences();
   }
 
+  void _copyFromMemory(const T* source)
+  {
+    m_md->_copyFromMemory(m_ptr,source,sizeof(T));
+  }
+
  private:
 
   void _directFirstAllocateWithAllocator(Int64 new_capacity,MemoryAllocationOptions options)
@@ -676,6 +682,7 @@ class AbstractArray
   {
     _setMP(reinterpret_cast<TrueImpl*>(m_md->_reallocate(new_capacity,sizeof(T),m_ptr)));
   }
+
  public:
 
   void printInfos(std::ostream& o)
@@ -831,11 +838,11 @@ class AbstractArray
   }
   void _copy(const T* rhs_begin,TrueType)
   {
-    std::memcpy(m_ptr,rhs_begin,((size_t)m_md->size)*sizeof(T));
+    _copyFromMemory(rhs_begin);
   }
   void _copy(const T* rhs_begin,FalseType)
   {
-    for( Int64 i=0, is=m_md->size; i<is; ++i )
+    for( Int64 i=0, n=m_md->size; i<n; ++i )
       m_ptr[i] = rhs_begin[i];
   }
   void _copy(const T* rhs_begin)

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -18,20 +18,6 @@
 #include "arccore/base/Span.h"
 #include "arccore/collections/MemoryAllocationOptions.h"
 
-// TODO (Mai 2023) Supprimer l'inclusion de ce fichier fin 2023
-// NOTE Le fichier 'IMemoryAllocator.h' n'est pas utilisé
-// par ce fichier d'en-tête.
-// On le garde néanmoins temporairement pour rester compatible
-// avec l'existant.
-// Cependant, depuis l'ajout des arguments 'MemoryAllocationArgs' le
-// compilateur 'nvcc' génère des avertissements qui sont des faux positifs lors
-// de l'inclusion de ce fichier dont on le désactive dans ce cas.
-// (les avertissements sont sur les méthode virtuelles partiellement surchargées).
-#if defined(__CUDACC__) || defined(__HIP__)
-#else
-#include "arccore/collections/IMemoryAllocator.h"
-#endif
-
 #include <memory>
 #include <initializer_list>
 #include <cstring>

--- a/arccore/src/collections/arccore/collections/IMemoryAllocator.h
+++ b/arccore/src/collections/arccore/collections/IMemoryAllocator.h
@@ -21,7 +21,6 @@
 
 namespace Arccore
 {
-// TODO: retourner infos sur pointeur + taille dans allocate()
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -123,11 +122,22 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
   /*!
    * \brief Notifie du changement des arguments spécifiques à l'instance.
    *
-   * \param Zone mémoire allouée
+   * \param ptr zone mémoire allouée
    * \param old_args ancienne valeur des arguments
    * \param new_args nouvelle valeur des arguments
    */
   virtual void notifyMemoryArgsChanged(MemoryAllocationArgs old_args, MemoryAllocationArgs new_args, AllocatedMemoryInfo ptr);
+
+  /*!
+   * \brief Copie la mémoire entre deux zones.
+   *
+   * L'implémentation par défaut utilise std::memcpy().
+   *
+   * \param args arguments de la zone mémoire
+   * \param destination destination de la copie
+   * \param destination source de la copie
+   */
+  virtual void copyMemory(MemoryAllocationArgs args, AllocatedMemoryInfo destination, AllocatedMemoryInfo source);
 
  public:
 

--- a/arccore/src/collections/arccore/collections/MemoryAllocator.cc
+++ b/arccore/src/collections/arccore/collections/MemoryAllocator.cc
@@ -19,6 +19,7 @@
 #include "arccore/collections/IMemoryAllocator.h"
 
 #include <cstdlib>
+#include <cstring>
 #include <errno.h>
 
 #if defined(ARCCORE_OS_WIN32)
@@ -47,6 +48,16 @@ DefaultMemoryAllocator3 DefaultMemoryAllocator3::shared_null_instance;
 void IMemoryAllocator::
 notifyMemoryArgsChanged(MemoryAllocationArgs, MemoryAllocationArgs, AllocatedMemoryInfo)
 {
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IMemoryAllocator::
+copyMemory([[maybe_unused]] MemoryAllocationArgs args, AllocatedMemoryInfo destination,
+           AllocatedMemoryInfo source)
+{
+  std::memcpy(destination.baseAddress(), source.baseAddress(), source.size());
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This is needed for specific memory allocator on device for example because `std::memcpy` is not available on device.