### PR TITLE
Optimize method 'ItemGroup::applyOperation()'

### DIFF
--- a/arcane/src/arcane/core/ItemGroupImpl.h
+++ b/arcane/src/arcane/core/ItemGroupImpl.h
@@ -449,6 +449,10 @@ class ARCANE_CORE_EXPORT ItemGroupImpl
   void _initChildrenByType();
   //! Méthode de calcul des sous-groupes par type
   void _computeChildrenByType();
+  //! Initialisation des sous-groupes par types
+  void _initChildrenByTypeV2();
+  //! Méthode de calcul des sous-groupes par type
+  void _computeChildrenByTypeV2();
   //! Invalidation des sous-groupes
   void _executeExtend(const Int32ConstArrayView * info);
   //! Invalidation des sous-groupes

--- a/arcane/src/arcane/core/ItemTypeMng.cc
+++ b/arcane/src/arcane/core/ItemTypeMng.cc
@@ -1132,6 +1132,15 @@ typeName(Integer id) const
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
+String ItemTypeMng::
+typeName(ItemTypeId id) const
+{
+  return typeFromId(id)->typeName();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 // Recopie de la fonction obsolète Item::typeName().
 // TODO: voir pourquoi il y a un test sur nBasicItemType().
 String ItemTypeMng::

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -12,10 +12,8 @@ if(ARCANE_HAS_SOLVERS)
   set(TEST_LIBS ${TEST_LIBS} arcane_solvers)
 endif()
 
-if(ARCANE_HAS_GEOMETRY)
-  set(TEST_DIRS ${TEST_DIRS} geometry)
-  set(TEST_LIBS ${TEST_LIBS} arcane_geometry)
-endif()
+list(APPEND TEST_DIRS geometry)
+list(APPEND TEST_LIBS arcane_geometry)
 
 if(GEOMETRYKERNEL_FOUND)
   set(TEST_DIRS ${TEST_DIRS} corefinement)
@@ -659,10 +657,9 @@ arcane_add_test_sequential(pdes_random_number_generator_service testPDESRandomNu
 arcane_add_test_sequential(simple_csv_output_service testSimpleCsvOutputService.arc)
 arcane_add_test_sequential(simple_csv_comparator_service testSimpleCsvComparatorService.arc)
 
+arcane_add_test(geometry testGeom.arc)
+arcane_add_test(geometry_applyoperation_v2 testGeom.arc -We,ARCANE_APPLYOPERATION_VERSION,2 -We,ARCANE_DEBUG_APPLYOPERATION,1)
 
-if(ARCANE_HAS_GEOMETRY)
-  ARCANE_ADD_TEST(geometry testGeom.arc)
-endif()
 if(ARCANE_HAS_SOLVERS)
   ARCANE_ADD_TEST_PARALLEL(solver testSolver.arc 1)
   ARCANE_ADD_TEST_PARALLEL(solver testSolver.arc 4)


### PR DESCRIPTION
Two optimizations:
- use `UniqueArray<Int32>` to keep local ids by type instead of using a child `ItemGroup`.
- use directly the group if all the items in the group are of the same type.

At the moment, this is only active is the environment variable `ARCANE_APPLYOPERATION_VERSION` is equal to `2`.
