### PR TITLE
In bit to bit comparison, considers two NaNs as equal

### DIFF
--- a/arcane/src/arcane/core/Array2Variable.cc
+++ b/arcane/src/arcane/core/Array2Variable.cc
@@ -112,7 +112,7 @@ class Array2VariableDiff
         DataType diff = DataType();
         DataType dref = lref[z];
         DataType dcurrent = lcurrent[z];
-        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff)){
+        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff,true)){
           this->m_diffs_info.add(DiffInfo(dcurrent,dref,diff,item,z));
           ++nb_diff;
         }
@@ -209,7 +209,7 @@ class Array2VariableDiff
         DataType diff = DataType();
         DataType dref = lref[z];
         DataType dcurrent = lcurrent[z];
-        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff)){
+        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff,true)){
           this->m_diffs_info.add(DiffInfo(dcurrent,dref,diff,item,z));
           ++nb_diff;
         }

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -100,7 +100,7 @@ class ArrayVariableDiff
       else{
         DataType dref = ref[index];
         DataType dcurrent = current[index];
-        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff)){
+        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff,true)){
           this->m_diffs_info.add(DiffInfo(dcurrent,dref,diff,item,NULL_ITEM_ID));
           ++nb_diff;
         }
@@ -152,7 +152,7 @@ class ArrayVariableDiff
       else{
         DataType dref = ref[index];
         DataType dcurrent = current[index];
-        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff)){
+        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff,true)){
           this->m_diffs_info.add(DiffInfo(dcurrent,dref,diff,index,NULL_ITEM_ID));
           ++nb_diff;
         }
@@ -208,7 +208,7 @@ class ArrayVariableDiff
       DataType diff = DataType();
       DataType min_val = min_values[index];
       DataType max_val = max_values[index];
-      if (VarDataTypeTraits::verifDifferent(min_val,max_val,diff)){
+      if (VarDataTypeTraits::verifDifferent(min_val,max_val,diff,true)){
         this->m_diffs_info.add(DiffInfo(min_val,max_val,diff,index,NULL_ITEM_ID));
         ++nb_diff;
       }

--- a/arcane/src/arcane/core/VariableDataTypeTraits.h
+++ b/arcane/src/arcane/core/VariableDataTypeTraits.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableDataTypeTraits.h                                    (C) 2000-2018 */
+/* VariableDataTypeTraits.h                                    (C) 2000-2023 */
 /*                                                                           */
 /* Classes spécialisées pour caractériser les types de données.              */
 /*---------------------------------------------------------------------------*/
@@ -20,15 +20,16 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
  * \brief Ecriture dans la chaine \a s d'un type basique de valeur \a v.
  */
-template<typename DataType> inline void
-builtInDumpValue(String& s,const DataType& v)
+template <typename DataType> inline void
+builtInDumpValue(String& s, const DataType& v)
 {
   std::ostringstream sbuf;
   sbuf << v << '\0';
@@ -43,10 +44,11 @@ builtInDumpValue(String& s,const DataType& v)
  *
  * Cette classe doit être spécialisée pour chaque type.
  */
-template<typename DataType>
+template <typename DataType>
 class VariableDataTypeTraitsT
 {
  public:
+
   static eDataType type() { return DT_Unknown; }
 };
 
@@ -59,8 +61,8 @@ class VariableDataTypeTraitsT
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>byte</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Byte>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Byte>
 {
  public:
 
@@ -84,37 +86,36 @@ class VariableDataTypeTraitsT<Byte>
   static Integer nbBasicType() { return 1; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Byte"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Byte; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type& v)
-    { builtInDumpValue(s,v); }
+  static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Byte v1,Byte v2,Byte& diff)
-    {
-      if (v1!=v2){
-        if (math::isZero(v1))
-          diff = (Byte)(v1-v2);
-        else
-          diff = (Byte)((v1-v2)/v1);
-        return true;
-      }
-      return false;
+  static bool verifDifferent(Byte v1, Byte v2, Byte& diff)
+  {
+    if (v1 != v2) {
+      if (math::isZero(v1))
+        diff = (Byte)(v1 - v2);
+      else
+        diff = (Byte)((v1 - v2) / v1);
+      return true;
     }
+    return false;
+  }
 
   static Byte normeMax(Byte v)
-    {
-      return (Byte)math::abs(v);
-    }
+  {
+    return (Byte)math::abs(v);
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -123,8 +124,8 @@ class VariableDataTypeTraitsT<Byte>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type \c Real.
  */
-template<>
-class VariableDataTypeTraitsT<Real>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real>
 {
  public:
 
@@ -148,43 +149,42 @@ class VariableDataTypeTraitsT<Real>
   static Integer nbBasicType() { return 1; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Real"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Real; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type& v)
-    { builtInDumpValue(s,v); }
+  static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Real v1,Real v2,Real& diff)
-    {
-      // Vérifie avant de les comparer que les deux nombres sont valides
-      // pour éviter une exception flottante sur certaines plates-formes
-      if (platform::isDenormalized(v1) || platform::isDenormalized(v2)){
-        diff = 1.0;
-        return true;
-      }
-      if (v1!=v2){
-        if (math::abs(v1) < 1.e-100) // TH: plantait pour v1 tres petit(math::isZero(v1))
-          diff = v1-v2;
-        else
-          diff = (v1-v2)/v1;
-        return true;
-      }
-      return false;
+  static bool verifDifferent(Real v1, Real v2, Real& diff)
+  {
+    // Vérifie avant de les comparer que les deux nombres sont valides
+    // pour éviter une exception flottante sur certaines plates-formes
+    if (platform::isDenormalized(v1) || platform::isDenormalized(v2)) {
+      diff = 1.0;
+      return true;
     }
+    if (v1 != v2) {
+      if (math::abs(v1) < 1.e-100) // TH: plantait pour v1 tres petit(math::isZero(v1))
+        diff = v1 - v2;
+      else
+        diff = (v1 - v2) / v1;
+      return true;
+    }
+    return false;
+  }
 
   static Real normeMax(Real v)
-    {
-      return math::abs(v);
-    }
+  {
+    return math::abs(v);
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -193,8 +193,8 @@ class VariableDataTypeTraitsT<Real>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>Int16</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Int16>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int16>
 {
  public:
 
@@ -218,35 +218,34 @@ class VariableDataTypeTraitsT<Int16>
   static Integer nbBasicType() { return 1; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Int16"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Int16; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type& v)
-    { builtInDumpValue(s,v); }
+  static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
-  static bool verifDifferent(Int16 v1,Int16 v2,Int16& diff)
-    {
-      if (v1!=v2){
-        if (math::isZero(v1))
-          diff = (Int16)(v1-v2);
-        else
-          diff = (Int16)((v1-v2)/v1);
-        return true;
-      }
-      return false;
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
+  static bool verifDifferent(Int16 v1, Int16 v2, Int16& diff)
+  {
+    if (v1 != v2) {
+      if (math::isZero(v1))
+        diff = (Int16)(v1 - v2);
+      else
+        diff = (Int16)((v1 - v2) / v1);
+      return true;
     }
+    return false;
+  }
   static Int16 normeMax(Int16 v)
-    {
-      return math::abs(v);
-    }
+  {
+    return math::abs(v);
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -255,8 +254,8 @@ class VariableDataTypeTraitsT<Int16>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>Int32</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Int32>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int32>
 {
  public:
 
@@ -280,35 +279,34 @@ class VariableDataTypeTraitsT<Int32>
   static Integer nbBasicType() { return 1; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Int32"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Int32; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type& v)
-    { builtInDumpValue(s,v); }
+  static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
-  static bool verifDifferent(Int32 v1,Int32 v2,Int32& diff)
-    {
-      if (v1!=v2){
-        if (math::isZero(v1))
-          diff = v1-v2;
-        else
-          diff = (v1-v2)/v1;
-        return true;
-      }
-      return false;
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
+  static bool verifDifferent(Int32 v1, Int32 v2, Int32& diff)
+  {
+    if (v1 != v2) {
+      if (math::isZero(v1))
+        diff = v1 - v2;
+      else
+        diff = (v1 - v2) / v1;
+      return true;
     }
+    return false;
+  }
   static Int32 normeMax(Int32 v)
-    {
-      return math::abs(v);
-    }
+  {
+    return math::abs(v);
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -317,8 +315,8 @@ class VariableDataTypeTraitsT<Int32>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>Int64</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Int64>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int64>
 {
  public:
 
@@ -342,36 +340,35 @@ class VariableDataTypeTraitsT<Int64>
   static Integer nbBasicType() { return 1; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Int64"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Int64; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type& v)
-    { builtInDumpValue(s,v); }
+  static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Type v1,Type v2,Type& diff)
-    {
-      if (v1!=v2){
-        if (math::isZero(v1))
-          diff = v1-v2;
-        else
-          diff = (v1-v2)/v1;
-        return true;
-      }
-      return false;
+  static bool verifDifferent(Type v1, Type v2, Type& diff)
+  {
+    if (v1 != v2) {
+      if (math::isZero(v1))
+        diff = v1 - v2;
+      else
+        diff = (v1 - v2) / v1;
+      return true;
     }
+    return false;
+  }
   static Int64 normeMax(Int64 v)
-    {
-      return v;
-    }
+  {
+    return v;
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -380,8 +377,8 @@ class VariableDataTypeTraitsT<Int64>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>String</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<String>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<String>
 {
  public:
 
@@ -405,29 +402,28 @@ class VariableDataTypeTraitsT<String>
   static Integer nbBasicType() { return 1; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "String"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_String; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type& v)
-    { s = v; }
+  static void dumpValue(String& s, const Type& v) { s = v; }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(const Type v1,const Type& v2,Type&)
+  static bool verifDifferent(const Type v1, const Type& v2, Type&)
   {
-    return (v1!=v2);
+    return (v1 != v2);
   }
   static const char* normeMax(const char* v)
-    {
-      return v;
-    }
+  {
+    return v;
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -436,8 +432,8 @@ class VariableDataTypeTraitsT<String>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>Real2</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Real2>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2>
 {
  public:
 
@@ -461,35 +457,34 @@ class VariableDataTypeTraitsT<Real2>
   static Integer nbBasicType() { return 2; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Real2"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Real2; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type&)
-    { s = "N/A"; }
+  static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Real2 v1,Real2 v2,Real2& diff)
-    {
-      bool is_different = false;
-      is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.x,v2.x,diff.x);
-      is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.y,v2.y,diff.y);
-      return is_different;
-    }
-  
+  static bool verifDifferent(Real2 v1, Real2 v2, Real2& diff)
+  {
+    bool is_different = false;
+    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.y, v2.y, diff.y);
+    return is_different;
+  }
+
   static Real normeMax(const Real2& v)
-    {
-      Real vx = VariableDataTypeTraitsT<Real>::normeMax(v.x);
-      Real vy = VariableDataTypeTraitsT<Real>::normeMax(v.y);
-      return math::max(vx,vy);
-    }
+  {
+    Real vx = VariableDataTypeTraitsT<Real>::normeMax(v.x);
+    Real vy = VariableDataTypeTraitsT<Real>::normeMax(v.y);
+    return math::max(vx, vy);
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -498,8 +493,8 @@ class VariableDataTypeTraitsT<Real2>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>Real3</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Real3>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3>
 {
  public:
 
@@ -523,37 +518,36 @@ class VariableDataTypeTraitsT<Real3>
   static Integer nbBasicType() { return 3; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Real3"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Real3; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type&)
-    { s = "N/A"; }
+  static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type& v,const String& s)
-    { return builtInGetValue(v,s); }
+  static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Real3 v1,Real3 v2,Real3& diff)
-    {
-      bool is_different = false;
-      is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.x,v2.x,diff.x);
-      is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.y,v2.y,diff.y);
-      is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.z,v2.z,diff.z);
-      return is_different;
-    }
+  static bool verifDifferent(Real3 v1, Real3 v2, Real3& diff)
+  {
+    bool is_different = false;
+    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.z, v2.z, diff.z);
+    return is_different;
+  }
 
   static Real normeMax(const Real3& v)
-    {
-      Real vx = VariableDataTypeTraitsT<Real>::normeMax(v.x);
-      Real vy = VariableDataTypeTraitsT<Real>::normeMax(v.y);
-      Real vz = VariableDataTypeTraitsT<Real>::normeMax(v.z);
-      return math::max(vx,math::max(vy,vz));
-    }
+  {
+    Real vx = VariableDataTypeTraitsT<Real>::normeMax(v.x);
+    Real vy = VariableDataTypeTraitsT<Real>::normeMax(v.y);
+    Real vz = VariableDataTypeTraitsT<Real>::normeMax(v.z);
+    return math::max(vx, math::max(vy, vz));
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -562,8 +556,8 @@ class VariableDataTypeTraitsT<Real3>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>Real3x3</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Real2x2>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2x2>
 {
  public:
 
@@ -587,35 +581,34 @@ class VariableDataTypeTraitsT<Real2x2>
   static Integer nbBasicType() { return 4; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Real2x2"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Real2x2; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type&)
-    { s = "N/A"; }
+  static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type&,const String&)
-    { return true; }
+  static bool getValue(Type&, const String&) { return true; }
 
-  static bool verifDifferent(Real2x2 v1,Real2x2 v2,Real2x2& diff)
-    {
-      bool is_different = false;
-      is_different |= VariableDataTypeTraitsT<Real2>::verifDifferent(v1.x,v2.x,diff.x);
-      is_different |= VariableDataTypeTraitsT<Real2>::verifDifferent(v1.y,v2.y,diff.y);
-      return is_different;
-    }
+  static bool verifDifferent(Real2x2 v1, Real2x2 v2, Real2x2& diff)
+  {
+    bool is_different = false;
+    is_different |= VariableDataTypeTraitsT<Real2>::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= VariableDataTypeTraitsT<Real2>::verifDifferent(v1.y, v2.y, diff.y);
+    return is_different;
+  }
 
   static Real normeMax(const Real2x2& v)
-    {
-      Real vx = VariableDataTypeTraitsT<Real2>::normeMax(v.x);
-      Real vy = VariableDataTypeTraitsT<Real2>::normeMax(v.y);
-      return VariableDataTypeTraitsT<Real2>::normeMax(Real2(vx,vy));
-    }
+  {
+    Real vx = VariableDataTypeTraitsT<Real2>::normeMax(v.x);
+    Real vy = VariableDataTypeTraitsT<Real2>::normeMax(v.y);
+    return VariableDataTypeTraitsT<Real2>::normeMax(Real2(vx, vy));
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -624,8 +617,8 @@ class VariableDataTypeTraitsT<Real2x2>
  * \internal
  * \brief Spécialisation de VariableDataTypeTraitsT pour le type <tt>Real3x3</tt>.
  */
-template<>
-class VariableDataTypeTraitsT<Real3x3>
+template <>
+class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3x3>
 {
  public:
 
@@ -649,44 +642,42 @@ class VariableDataTypeTraitsT<Real3x3>
   static Integer nbBasicType() { return 9; }
 
  public:
+
   //! Retourne le nom du type de la variable
   static const char* typeName() { return "Real3x3"; }
   //! Retourne le type de la variable
   static eDataType type() { return DT_Real3x3; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
-  static void dumpValue(String& s,const Type&)
-    { s = "N/A"; }
+  static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
    * \brief Stocke la conversion de la chaîne \a s en le type #Type dans \a v
    * \retval true en cas d'échec,
    * \retval false si la conversion est un succès
    */
-  static bool getValue(Type&,const String&)
-    { return true; }
+  static bool getValue(Type&, const String&) { return true; }
 
-  static bool verifDifferent(Real3x3 v1,Real3x3 v2,Real3x3& diff)
-    {
-      bool is_different = false;
-      is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.x,v2.x,diff.x);
-      is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.y,v2.y,diff.y);
-      is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.z,v2.z,diff.z);
-      return is_different;
-    }
-  
+  static bool verifDifferent(Real3x3 v1, Real3x3 v2, Real3x3& diff)
+  {
+    bool is_different = false;
+    is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.z, v2.z, diff.z);
+    return is_different;
+  }
 
   static Real normeMax(const Real3x3& v)
-    {
-      Real vx = VariableDataTypeTraitsT<Real3>::normeMax(v.x);
-      Real vy = VariableDataTypeTraitsT<Real3>::normeMax(v.y);
-      Real vz = VariableDataTypeTraitsT<Real3>::normeMax(v.z);
-      return VariableDataTypeTraitsT<Real3>::normeMax(Real3(vx,vy,vz));
-    }
+  {
+    Real vx = VariableDataTypeTraitsT<Real3>::normeMax(v.x);
+    Real vy = VariableDataTypeTraitsT<Real3>::normeMax(v.y);
+    Real vz = VariableDataTypeTraitsT<Real3>::normeMax(v.z);
+    return VariableDataTypeTraitsT<Real3>::normeMax(Real3(vx, vy, vz));
+  }
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableDataTypeTraits.h
+++ b/arcane/src/arcane/core/VariableDataTypeTraits.h
@@ -17,6 +17,8 @@
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/ValueConvert.h"
 
+#include <cmath>
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -100,7 +102,8 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Byte>
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Byte v1, Byte v2, Byte& diff)
+  static bool verifDifferent(Byte v1, Byte v2, Byte& diff,
+                             [[maybe_unused]] bool is_nan_equal = false)
   {
     if (v1 != v2) {
       if (math::isZero(v1))
@@ -163,8 +166,12 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real>
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Real v1, Real v2, Real& diff)
+  static bool verifDifferent(Real v1, Real v2, Real& diff, bool is_nan_equal = false)
   {
+    if (is_nan_equal) {
+      if (std::isnan(v1) && std::isnan(v2))
+        return false;
+    }
     // Vérifie avant de les comparer que les deux nombres sont valides
     // pour éviter une exception flottante sur certaines plates-formes
     if (platform::isDenormalized(v1) || platform::isDenormalized(v2)) {
@@ -231,7 +238,8 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int16>
    * \retval false si la conversion est un succès
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
-  static bool verifDifferent(Int16 v1, Int16 v2, Int16& diff)
+  static bool verifDifferent(Int16 v1, Int16 v2, Int16& diff,
+                             [[maybe_unused]] bool is_nan_equal = false)
   {
     if (v1 != v2) {
       if (math::isZero(v1))
@@ -292,7 +300,8 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int32>
    * \retval false si la conversion est un succès
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
-  static bool verifDifferent(Int32 v1, Int32 v2, Int32& diff)
+  static bool verifDifferent(Int32 v1, Int32 v2, Int32& diff,
+                             [[maybe_unused]] bool is_nan_equal = false)
   {
     if (v1 != v2) {
       if (math::isZero(v1))
@@ -354,7 +363,8 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int64>
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Type v1, Type v2, Type& diff)
+  static bool verifDifferent(Type v1, Type v2, Type& diff,
+                             [[maybe_unused]] bool is_nan_equal = false)
   {
     if (v1 != v2) {
       if (math::isZero(v1))
@@ -416,7 +426,8 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<String>
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(const Type v1, const Type& v2, Type&)
+  static bool verifDifferent(const Type v1, const Type& v2, Type&,
+                             [[maybe_unused]] bool is_nan_equal = false)
   {
     return (v1 != v2);
   }
@@ -475,11 +486,11 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2>
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Real2 v1, Real2 v2, Real2& diff)
+  static bool verifDifferent(Real2 v1, Real2 v2, Real2& diff, bool is_nan_equal = false)
   {
     bool is_different = false;
-    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x, is_nan_equal);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y, is_nan_equal);
     return is_different;
   }
 
@@ -540,12 +551,12 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3>
    */
   static bool getValue(Type& v, const String& s) { return builtInGetValue(v, s); }
 
-  static bool verifDifferent(Real3 v1, Real3 v2, Real3& diff)
+  static bool verifDifferent(Real3 v1, Real3 v2, Real3& diff, bool is_nan_equal = false)
   {
     bool is_different = false;
-    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
-    is_different |= SubTraits::verifDifferent(v1.z, v2.z, diff.z);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x, is_nan_equal);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y, is_nan_equal);
+    is_different |= SubTraits::verifDifferent(v1.z, v2.z, diff.z, is_nan_equal);
     return is_different;
   }
 
@@ -607,11 +618,11 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2x2>
    */
   static bool getValue(Type&, const String&) { return true; }
 
-  static bool verifDifferent(Real2x2 v1, Real2x2 v2, Real2x2& diff)
+  static bool verifDifferent(Real2x2 v1, Real2x2 v2, Real2x2& diff, bool is_nan_equal = false)
   {
     bool is_different = false;
-    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x, is_nan_equal);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y, is_nan_equal);
     return is_different;
   }
 
@@ -672,12 +683,12 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3x3>
    */
   static bool getValue(Type&, const String&) { return true; }
 
-  static bool verifDifferent(Real3x3 v1, Real3x3 v2, Real3x3& diff)
+  static bool verifDifferent(Real3x3 v1, Real3x3 v2, Real3x3& diff, bool is_nan_equal = false)
   {
     bool is_different = false;
-    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
-    is_different |= SubTraits::verifDifferent(v1.z, v2.z, diff.z);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x, is_nan_equal);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y, is_nan_equal);
+    is_different |= SubTraits::verifDifferent(v1.z, v2.z, diff.z, is_nan_equal);
     return is_different;
   }
 

--- a/arcane/src/arcane/core/VariableDataTypeTraits.h
+++ b/arcane/src/arcane/core/VariableDataTypeTraits.h
@@ -83,14 +83,14 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Byte>
 
   typedef Byte BasicType;
 
-  static Integer nbBasicType() { return 1; }
+  static constexpr Integer nbBasicType() { return 1; }
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Byte"; }
+  static constexpr const char* typeName() { return "Byte"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Byte; }
+  static constexpr eDataType type() { return DT_Byte; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
@@ -146,14 +146,14 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real>
 
   typedef Real BasicType;
 
-  static Integer nbBasicType() { return 1; }
+  static constexpr Integer nbBasicType() { return 1; }
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Real"; }
+  static constexpr const char* typeName() { return "Real"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Real; }
+  static constexpr eDataType type() { return DT_Real; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
@@ -215,14 +215,14 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int16>
 
   typedef Int16 BasicType;
 
-  static Integer nbBasicType() { return 1; }
+  static constexpr Integer nbBasicType() { return 1; }
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Int16"; }
+  static constexpr const char* typeName() { return "Int16"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Int16; }
+  static constexpr eDataType type() { return DT_Int16; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
@@ -276,14 +276,14 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int32>
 
   typedef Int32 BasicType;
 
-  static Integer nbBasicType() { return 1; }
+  static constexpr Integer nbBasicType() { return 1; }
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Int32"; }
+  static constexpr const char* typeName() { return "Int32"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Int32; }
+  static constexpr eDataType type() { return DT_Int32; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
@@ -337,14 +337,14 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Int64>
 
   typedef Int64 BasicType;
 
-  static Integer nbBasicType() { return 1; }
+  static constexpr Integer nbBasicType() { return 1; }
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Int64"; }
+  static constexpr const char* typeName() { return "Int64"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Int64; }
+  static constexpr eDataType type() { return DT_Int64; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type& v) { builtInDumpValue(s, v); }
   /*!
@@ -399,14 +399,14 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<String>
 
   typedef String BasicType;
 
-  static Integer nbBasicType() { return 1; }
+  static constexpr Integer nbBasicType() { return 1; }
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "String"; }
+  static constexpr const char* typeName() { return "String"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_String; }
+  static constexpr eDataType type() { return DT_String; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type& v) { s = v; }
   /*!
@@ -454,14 +454,18 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2>
 
   typedef Real BasicType;
 
-  static Integer nbBasicType() { return 2; }
+  static constexpr Integer nbBasicType() { return 2; }
+
+ private:
+
+  using SubTraits = VariableDataTypeTraitsT<Real>;
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Real2"; }
+  static constexpr const char* typeName() { return "Real2"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Real2; }
+  static constexpr eDataType type() { return DT_Real2; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
@@ -474,15 +478,15 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2>
   static bool verifDifferent(Real2 v1, Real2 v2, Real2& diff)
   {
     bool is_different = false;
-    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
     return is_different;
   }
 
   static Real normeMax(const Real2& v)
   {
-    Real vx = VariableDataTypeTraitsT<Real>::normeMax(v.x);
-    Real vy = VariableDataTypeTraitsT<Real>::normeMax(v.y);
+    Real vx = SubTraits::normeMax(v.x);
+    Real vy = SubTraits::normeMax(v.y);
     return math::max(vx, vy);
   }
 };
@@ -515,14 +519,18 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3>
 
   typedef Real BasicType;
 
-  static Integer nbBasicType() { return 3; }
+  static constexpr Integer nbBasicType() { return 3; }
+
+ private:
+
+  using SubTraits = VariableDataTypeTraitsT<Real>;
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Real3"; }
+  static constexpr const char* typeName() { return "Real3"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Real3; }
+  static constexpr eDataType type() { return DT_Real3; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
@@ -535,17 +543,17 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3>
   static bool verifDifferent(Real3 v1, Real3 v2, Real3& diff)
   {
     bool is_different = false;
-    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.y, v2.y, diff.y);
-    is_different |= VariableDataTypeTraitsT<Real>::verifDifferent(v1.z, v2.z, diff.z);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= SubTraits::verifDifferent(v1.z, v2.z, diff.z);
     return is_different;
   }
 
   static Real normeMax(const Real3& v)
   {
-    Real vx = VariableDataTypeTraitsT<Real>::normeMax(v.x);
-    Real vy = VariableDataTypeTraitsT<Real>::normeMax(v.y);
-    Real vz = VariableDataTypeTraitsT<Real>::normeMax(v.z);
+    Real vx = SubTraits::normeMax(v.x);
+    Real vy = SubTraits::normeMax(v.y);
+    Real vz = SubTraits::normeMax(v.z);
     return math::max(vx, math::max(vy, vz));
   }
 };
@@ -578,14 +586,18 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2x2>
 
   typedef Real BasicType;
 
-  static Integer nbBasicType() { return 4; }
+  static constexpr Integer nbBasicType() { return 4; }
+
+ private:
+
+  using SubTraits = VariableDataTypeTraitsT<Real2>;
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Real2x2"; }
+  static constexpr const char* typeName() { return "Real2x2"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Real2x2; }
+  static constexpr eDataType type() { return DT_Real2x2; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
@@ -598,16 +610,16 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real2x2>
   static bool verifDifferent(Real2x2 v1, Real2x2 v2, Real2x2& diff)
   {
     bool is_different = false;
-    is_different |= VariableDataTypeTraitsT<Real2>::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= VariableDataTypeTraitsT<Real2>::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
     return is_different;
   }
 
   static Real normeMax(const Real2x2& v)
   {
-    Real vx = VariableDataTypeTraitsT<Real2>::normeMax(v.x);
-    Real vy = VariableDataTypeTraitsT<Real2>::normeMax(v.y);
-    return VariableDataTypeTraitsT<Real2>::normeMax(Real2(vx, vy));
+    Real vx = SubTraits::normeMax(v.x);
+    Real vy = SubTraits::normeMax(v.y);
+    return SubTraits::normeMax(Real2(vx, vy));
   }
 };
 
@@ -639,14 +651,18 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3x3>
 
   typedef Real BasicType;
 
-  static Integer nbBasicType() { return 9; }
+  static constexpr Integer nbBasicType() { return 9; }
+
+ private:
+
+  using SubTraits = VariableDataTypeTraitsT<Real3>;
 
  public:
 
   //! Retourne le nom du type de la variable
-  static const char* typeName() { return "Real3x3"; }
+  static constexpr const char* typeName() { return "Real3x3"; }
   //! Retourne le type de la variable
-  static eDataType type() { return DT_Real3x3; }
+  static constexpr eDataType type() { return DT_Real3x3; }
   //! Ecrit dans la chaîne \a s la valeur de \a v
   static void dumpValue(String& s, const Type&) { s = "N/A"; }
   /*!
@@ -659,17 +675,17 @@ class ARCANE_CORE_EXPORT VariableDataTypeTraitsT<Real3x3>
   static bool verifDifferent(Real3x3 v1, Real3x3 v2, Real3x3& diff)
   {
     bool is_different = false;
-    is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.x, v2.x, diff.x);
-    is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.y, v2.y, diff.y);
-    is_different |= VariableDataTypeTraitsT<Real3>::verifDifferent(v1.z, v2.z, diff.z);
+    is_different |= SubTraits::verifDifferent(v1.x, v2.x, diff.x);
+    is_different |= SubTraits::verifDifferent(v1.y, v2.y, diff.y);
+    is_different |= SubTraits::verifDifferent(v1.z, v2.z, diff.z);
     return is_different;
   }
 
   static Real normeMax(const Real3x3& v)
   {
-    Real vx = VariableDataTypeTraitsT<Real3>::normeMax(v.x);
-    Real vy = VariableDataTypeTraitsT<Real3>::normeMax(v.y);
-    Real vz = VariableDataTypeTraitsT<Real3>::normeMax(v.z);
+    Real vx = SubTraits::normeMax(v.x);
+    Real vy = SubTraits::normeMax(v.y);
+    Real vz = SubTraits::normeMax(v.z);
     return VariableDataTypeTraitsT<Real3>::normeMax(Real3(vx, vy, vz));
   }
 };

--- a/arcane/src/arcane/core/VariableScalar.cc
+++ b/arcane/src/arcane/core/VariableScalar.cc
@@ -92,7 +92,7 @@ class ScalarVariableDiff
       else{
         DataType dref = ref[index];
         DataType dcurrent = current[index];
-        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff)){
+        if (VarDataTypeTraits::verifDifferent(dref,dcurrent,diff,true)){
           this->m_diffs_info.add(DiffInfo(dcurrent,dref,diff,item,NULL_ITEM_ID));
           ++nb_diff;
         }
@@ -146,7 +146,7 @@ class ScalarVariableDiff
 
     Integer nb_diff = 0;
     DataType diff = DataType();
-    if (VarDataTypeTraits::verifDifferent(min_value,max_value,diff)){
+    if (VarDataTypeTraits::verifDifferent(min_value,max_value,diff,true)){
       this->m_diffs_info.add(DiffInfo(min_value,max_value,diff,0,NULL_ITEM_ID));
       ++nb_diff;
     }


### PR DESCRIPTION
Because Arcane is trapping floating point exceptions,  `NaN` values in variables are in general from initialization. To avoid displaying false positive in bit to bit comparison we consider two `NaN` are equal in this case.