### PR TITLE
In DynamicMesh, save the value of the attribute 'need-compact' in a checkpoint

### DIFF
--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -1362,16 +1362,28 @@ _prepareForDump()
   bool want_dump = m_properties->getBool("dump");
   info(4) << "DynamicMesh::prepareForDump() name=" << name()
           << " need_compact?=" << m_need_compact
-          << " want_dump?=" << want_dump;
-
-  _saveProperties();
+          << " want_dump?=" << want_dump
+          << " timestamp=" << m_timestamp;
 
   // Si le maillage n'est pas sauvé, ne fait rien. Cela évite de compacter
   // et trier le maillage ce qui n'est pas souhaitable si les propriétés
   // 'sort' et 'compact' sont à 'false'.
-  if (!want_dump)
-    return;
+  if (want_dump)
+    _prepareForDumpReal();
 
+  // Sauve les propriétés. Il faut le faire à la fin car l'appel à
+  // prepareForDumpReal() peut modifier ces propriétés
+  _saveProperties();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Prépare les variables pour une protection.
+ */
+void DynamicMesh::
+_prepareForDumpReal()
+{
   if (m_need_compact){
     // Pour l'instant, il faut trier et compacter les entites
     // avant une sauvegarde

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -2597,6 +2597,10 @@ _compactItems(bool do_sort,bool compact_variables_and_groups)
   }
 
   m_need_compact = false;
+
+  // Considère le compactage comme une évolution du maillage car cela
+  // change les structures associées aux entités et leurs connectivités
+  ++m_timestamp;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DynamicMesh.h
+++ b/arcane/src/arcane/mesh/DynamicMesh.h
@@ -597,6 +597,7 @@ public:
   void _allocateCells2(DynamicMeshIncrementalBuilder* mib);
   void _itemsUniqueIdsToLocalIdsSorted(eItemKind item_kind,ArrayView<Integer> ids);
   void _prepareForDump();
+  void _prepareForDumpReal();
   void _readFromDump();
 
   void _setOwnersFromCells();

--- a/arcane/src/arcane/mesh/DynamicMesh.h
+++ b/arcane/src/arcane/mesh/DynamicMesh.h
@@ -582,6 +582,7 @@ public:
   ItemTypeMng* m_item_type_mng = nullptr;
   std::unique_ptr<IIndexedIncrementalItemConnectivityMng> m_indexed_connectivity_mng;
   MeshKind m_mesh_kind;
+  bool m_do_not_save_need_compact = false;
 
  private:
 


### PR DESCRIPTION
This is need to prevent a useless compacting after a restart. And this compacting may invalidate some structures like the cartesian connectivity information in `ICartesianMesh`.