### PR TITLE
Minor modifications in Arccore

### DIFF
--- a/arccore/src/base/arccore/base/ArrayView.h
+++ b/arccore/src/base/arccore/base/ArrayView.h
@@ -259,11 +259,13 @@ class ArrayView
  public:
 
   //! Intervalle d'itération du premier au dernièr élément.
+  ARCCORE_DEPRECATED_REASON("Y2023: Use begin()/end() instead")
   ArrayRange<pointer> range()
   {
     return ArrayRange<pointer>(m_ptr,m_ptr+m_size);
   }
   //! Intervalle d'itération du premier au dernièr élément.
+  ARCCORE_DEPRECATED_REASON("Y2023: Use begin()/end() instead")
   ArrayRange<const_pointer> range() const
   {
     return ArrayRange<const_pointer>(m_ptr,m_ptr+m_size);
@@ -763,6 +765,7 @@ class ConstArrayView
   constexpr const_pointer data() const noexcept { return m_ptr; }
 
   //! Intervalle d'itération du premier au dernièr élément.
+  ARCCORE_DEPRECATED_REASON("Y2023: Use begin()/end() instead")
   ArrayRange<const_pointer> range() const
   {
     return ArrayRange<const_pointer>(m_ptr,m_ptr+m_size);

--- a/arccore/src/base/arccore/base/CoreArray.h
+++ b/arccore/src/base/arccore/base/CoreArray.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CoreArray.h                                                 (C) 2000-2022 */
+/* CoreArray.h                                                 (C) 2000-2023 */
 /*                                                                           */
 /* Tableau simple pour Arccore.                                              */
 /*---------------------------------------------------------------------------*/
@@ -66,7 +66,7 @@ class CoreArray
   CoreArray(ConstArrayView<DataType> v)
   : m_p(v.range().begin(),v.range().end()) {}
   CoreArray(Span<const DataType> v)
-  : m_p(v.range().begin(),v.range().end()) {}
+  : m_p(v.begin(),v.end()) {}
  public:
 
   //! Conversion vers un ConstArrayView

--- a/arccore/src/base/arccore/base/Span.h
+++ b/arccore/src/base/arccore/base/Span.h
@@ -191,6 +191,7 @@ class SpanImpl
  public:
 
   //! Intervalle d'itération du premier au dernièr élément.
+  ARCCORE_DEPRECATED_REASON("Y2023: Use begin()/end() instead")
   ArrayRange<pointer> range() const
   {
     return ArrayRange<pointer>(m_ptr,m_ptr+m_size);

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -1409,11 +1409,14 @@ class Array
  public:
 
   //! Intervalle d'itération du premier au dernièr élément.
+  ARCCORE_DEPRECATED_REASON("Y2023: Use begin()/end() instead")
   ArrayRange<pointer> range()
   {
     return ArrayRange<pointer>(m_ptr,m_ptr+m_md->size);
   }
+
   //! Intervalle d'itération du premier au dernièr élément.
+  ARCCORE_DEPRECATED_REASON("Y2023: Use begin()/end() instead")
   ArrayRange<const_pointer> range() const
   {
     return ArrayRange<const_pointer>(m_ptr,m_ptr+m_md->size);

--- a/arccore/src/collections/arccore/collections/IMemoryAllocator.h
+++ b/arccore/src/collections/arccore/collections/IMemoryAllocator.h
@@ -260,6 +260,15 @@ class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator
 {
  public:
 
+  using IMemoryAllocator::adjustCapacity;
+  using IMemoryAllocator::allocate;
+  using IMemoryAllocator::deallocate;
+  using IMemoryAllocator::guarantedAlignment;
+  using IMemoryAllocator::hasRealloc;
+  using IMemoryAllocator::reallocate;
+
+ public:
+
   bool hasRealloc() const override;
   void* allocate(size_t new_size) override;
   void* reallocate(void* current_ptr, size_t new_size) override;
@@ -279,6 +288,15 @@ class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator3
 : public IMemoryAllocator3
 {
   friend class ArrayMetaData;
+
+ public:
+
+  using IMemoryAllocator::adjustCapacity;
+  using IMemoryAllocator::allocate;
+  using IMemoryAllocator::deallocate;
+  using IMemoryAllocator::guarantedAlignment;
+  using IMemoryAllocator::hasRealloc;
+  using IMemoryAllocator::reallocate;
 
  private:
 
@@ -318,6 +336,15 @@ namespace impl
 class ARCCORE_COLLECTIONS_EXPORT AlignedMemoryAllocator
 : public IMemoryAllocator
 {
+ public:
+
+  using IMemoryAllocator::adjustCapacity;
+  using IMemoryAllocator::allocate;
+  using IMemoryAllocator::deallocate;
+  using IMemoryAllocator::guarantedAlignment;
+  using IMemoryAllocator::hasRealloc;
+  using IMemoryAllocator::reallocate;
+
  private:
 
   static AlignedMemoryAllocator SimdAllocator;
@@ -396,6 +423,15 @@ class ARCCORE_COLLECTIONS_EXPORT AlignedMemoryAllocator
 class ARCCORE_COLLECTIONS_EXPORT AlignedMemoryAllocator3
 : public IMemoryAllocator3
 {
+ public:
+
+  using IMemoryAllocator::adjustCapacity;
+  using IMemoryAllocator::allocate;
+  using IMemoryAllocator::deallocate;
+  using IMemoryAllocator::guarantedAlignment;
+  using IMemoryAllocator::hasRealloc;
+  using IMemoryAllocator::reallocate;
+
  private:
 
   static AlignedMemoryAllocator3 SimdAllocator;
@@ -473,6 +509,12 @@ class ARCCORE_COLLECTIONS_EXPORT PrintableMemoryAllocator
 : public DefaultMemoryAllocator
 {
   using Base = DefaultMemoryAllocator;
+
+ public:
+
+  using IMemoryAllocator::allocate;
+  using IMemoryAllocator::deallocate;
+  using IMemoryAllocator::reallocate;
 
  public:
 

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -393,7 +393,6 @@ void _testArrayNewInternal()
   {
     UniqueArray<IntPtrSubClass> vx;
     vx.add(IntPtrSubClass(5));
-    [[maybe_unused]] auto range = vx.range();
     UniqueArray<IntPtrSubClass>::iterator i = vx.begin();
     UniqueArray<IntPtrSubClass>::const_iterator ci = i;
     std::cout << "V=" << i->m_v << " " << ci->m_v << '\n';
@@ -404,7 +403,6 @@ void _testArrayNewInternal()
   {
     UniqueArray<IntPtrSubClass> vx;
     vx.add(IntPtrSubClass(5));
-    [[maybe_unused]] auto r = vx.range();
     UniqueArray<IntPtrSubClass>::iterator i = std::begin(vx);
     UniqueArray<IntPtrSubClass>::iterator iend = std::end(vx);
     UniqueArray<IntPtrSubClass>::const_iterator ci = i;

--- a/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiSerializeMessageList.cc
+++ b/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiSerializeMessageList.cc
@@ -230,7 +230,7 @@ _waitMessages2(eWaitType wait_type)
   UniqueArray<Request> requests(nb_message);
   UniqueArray<bool> done_indexes(nb_message);
   done_indexes.fill(false);
-  if (msg->verbosityLevel()>=4)
+  if (msg->verbosityLevel()>=6)
     m_is_verbose = true;
 
   for( Integer z=0; z<nb_message; ++z ){
@@ -242,12 +242,12 @@ _waitMessages2(eWaitType wait_type)
 
     for( Integer z=0; z<nb_message; ++z ){
       BasicSerializeMessage* msm = m_messages_request[z].m_mpi_message;
-      msg->info(4) << "Waiting for message: "
-                   << " rank=" << comm_rank
-                   << " issend=" << msm->isSend()
-                   << " dest=" << msm->destination()
-                   << " tag=" << msm->internalTag()
-                   << " request=" << requests[z];
+      msg->info() << "Waiting for message: "
+                  << " rank=" << comm_rank
+                  << " issend=" << msm->isSend()
+                  << " dest=" << msm->destination()
+                  << " tag=" << msm->internalTag()
+                  << " request=" << requests[z];
     }
   }
 


### PR DESCRIPTION
- Make deprecated methods `range()` in `ArrayView`, `Array` and `Span`.
- Remove some compiler warnings with CUDA compiler `nvcc`
- Increase the verbosity level needed to display messages information during MPI serialiazation