### PR TITLE
Pre-allocate hash table for mesh Item

### DIFF
--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1725,6 +1725,8 @@ _allocateInfos(ItemInternal* item,Int64 uid,ItemSharedInfoWithType* isi)
 void ItemFamily::
 _preAllocate(Int32 nb_item,bool pre_alloc_connectivity)
 {
+  if (nb_item>1000)
+    m_infos.itemsMap().resize(nb_item,true);
   _resizeItemVariables(nb_item,false);
   for( auto& c : m_source_incremental_item_connectivities )
     c->reserveMemoryForNbSourceItems(nb_item,pre_alloc_connectivity);


### PR DESCRIPTION
Using the estimation of the number of items in a family we can set the size the hash table of `ItemInternal` before add items. This will greatly reduce the number of rehash when the hash table is growing. 