### PR TITLE
Add method JSONValue::value() to return a String

### DIFF
--- a/arcane/src/arcane/impl/ConfigurationReader.cc
+++ b/arcane/src/arcane/impl/ConfigurationReader.cc
@@ -72,7 +72,7 @@ _addValuesFromJSON(const JSONValue& jv,Integer priority,const String& base_name)
       // pas supportés dans la configuration.
     }
     else{
-      String v_value = value.valueAsString();
+      String v_value = value.value();
       //info() << "B=" << base_name << " N=" << name << " V=" << v_value;
       m_configuration->addValue(base_name+name,v_value,priority);
     }

--- a/arcane/src/arcane/impl/ConfigurationReader.cc
+++ b/arcane/src/arcane/impl/ConfigurationReader.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ConfigurationReader.cc                                      (C) 2000-2020 */
+/* ConfigurationReader.cc                                      (C) 2000-2023 */
 /*                                                                           */
 /* Lecteurs de fichiers de configuration.                                    */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/std/BasicReaderWriter.cc
+++ b/arcane/src/arcane/std/BasicReaderWriter.cc
@@ -1231,10 +1231,8 @@ initialize()
     JSONValue jv_arcane_db = root.expectedChild(_getArcaneDBTag());
     m_version = jv_arcane_db.expectedChild("Version").valueAsInt32();
     m_nb_written_part = jv_arcane_db.expectedChild("NbPart").valueAsInt32();
-    data_compressor_name = jv_arcane_db.expectedChild("DataCompressor").valueAsString();
-    JSONValue hash_algo_json = jv_arcane_db.child("HashAlgorithm");
-    if (!hash_algo_json.null())
-      hash_algorithm_name = hash_algo_json.valueAsString();
+    data_compressor_name = jv_arcane_db.expectedChild("DataCompressor").value();
+    hash_algorithm_name = jv_arcane_db.child("HashAlgorithm").value();
     info() << "**--** Begin read using database version=" << m_version
            << " nb_part=" << m_nb_written_part
            << " compressor=" << data_compressor_name

--- a/arcane/src/arcane/std/BasicReaderWriterDatabase.cc
+++ b/arcane/src/arcane/std/BasicReaderWriterDatabase.cc
@@ -694,7 +694,7 @@ _readJSON()
     UniqueArray<Int64> extents;
     extents.reserve(12);
     for (JSONValue v : data.valueAsArray()) {
-      String name = v.child("Name").valueAsString();
+      String name = v.child("Name").value();
       Int64 file_offset = v.child("FileOffset").valueAsInt64();
       //std::cout << "Name=" << name << "\n";
       //std::cout << "FileOffset=" << file_offset << "\n";

--- a/arcane/src/arcane/tests/JSONUnitTest.cc
+++ b/arcane/src/arcane/tests/JSONUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* JSONUnitTest.cc                                             (C) 2000-2019 */
+/* JSONUnitTest.cc                                             (C) 2000-2023 */
 /*                                                                           */
 /* Test du lecteur/ecrivain JSON.                                            */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/JSONUnitTest.cc
+++ b/arcane/src/arcane/tests/JSONUnitTest.cc
@@ -163,6 +163,7 @@ void JSONUnitTest::
 _testJSON_Read_1()
 {
   info() << "TEST_JSON_Read_1!";
+  String str1("test1");
 
   IIOMng* io_mng = subDomain()->ioMng();
   UniqueArray<Byte> bytes;
@@ -175,9 +176,34 @@ _testJSON_Read_1()
 
   JSONValue doc_root = document.root();
   JSONKeyValue v1 = doc_root.keyValueChild("toto");
-  info() << "IS_V1?=" << v1.null() << " name=" << v1.name() << " values=" << v1.value().valueAsString();
+  info() << "IS_V1?=" << v1.null() << " name=" << v1.name() << " values=" << v1.value().valueAsStringView();
+  {
+    String strv = v1.value().value();
+    if (!strv.null())
+      ARCANE_FATAL("Value 'v1'  should be null (v={0})", strv);
+    String strview = v1.value().valueAsStringView();
+    if (!strview.empty())
+      ARCANE_FATAL("Value 'v1' should be empty (v={0})", strview);
+  }
   JSONKeyValue v2 = doc_root.keyValueChild("real_values");
-  info() << "IS_V2?=" << v2.null() << " name=" << v2.name() << " values=" << v2.value().valueAsString();
+  info() << "IS_V2?=" << v2.null() << " name=" << v2.name() << " values=" << v2.value().valueAsStringView();
+  {
+    String strv = v2.value().value();
+    if (strv.null())
+      ARCANE_FATAL("Value 'v2' should not be null (v={0})", strv);
+    String strview = v2.value().valueAsStringView();
+    if (strview.empty())
+      ARCANE_FATAL("Value 'v2' should not be empty (v={0})", strview);
+  }
+  {
+    JSONValue json_str = doc_root.expectedChild("string_value");
+    String strv = json_str.value();
+    if (strv!=str1)
+      ARCANE_FATAL("Bad value for 'strv' v='{0}' expected='{1}'", strv, str1);
+    String strview = json_str.valueAsStringView();
+    if (strview!=str1)
+      ARCANE_FATAL("Bad value for 'strview' v='{0}' expected='{1}'", strview, str1);
+  }
   {
     JSONValue v3 = doc_root.child("int64_value");
     Int64 v = v3.valueAsInt64();

--- a/arcane/src/arcane/utils/JSONReader.cc
+++ b/arcane/src/arcane/utils/JSONReader.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* JSONReader.cc                                               (C) 2000-2021 */
+/* JSONReader.cc                                               (C) 2000-2023 */
 /*                                                                           */
 /* Lecteur au format JSON.                                                  */
 /*---------------------------------------------------------------------------*/
@@ -154,6 +154,20 @@ valueAsInt64() const
   if (x->IsInt64())
     return x->GetInt64();
   return 0;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool JSONValue::
+valueAsBool() const
+{
+  if (!m_p)
+    return false;
+  auto x = m_p->toValue();
+  if (x->IsBool())
+    return x->GetBool();
+  return false;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/JSONReader.cc
+++ b/arcane/src/arcane/utils/JSONReader.cc
@@ -108,8 +108,22 @@ value() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+String JSONValue::
+value() const
+{
+  if (!m_p)
+    return String();
+  auto x = m_p->toValue();
+  if (x->IsString())
+    return String(Span<const Byte>((const Byte*)x->GetString(),x->GetStringLength()));
+  return String();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 StringView JSONValue::
-valueAsString() const
+valueAsStringView() const
 {
   if (!m_p)
     return StringView();
@@ -117,6 +131,15 @@ valueAsString() const
   if (x->IsString())
     return StringView(Span<const Byte>((const Byte*)x->GetString(),x->GetStringLength()));
   return StringView();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+StringView JSONValue::
+valueAsString() const
+{
+  return valueAsStringView();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -157,7 +180,7 @@ valueAsReal() const
     return x->GetDouble();
   if (x->GetType()==rapidjson::kStringType){
     // Convertie la chaîne de caractères en un réél
-    StringView s = this->valueAsString();
+    StringView s = this->valueAsStringView();
     Real r = 0.0;
     if (!builtInGetValue(r,s))
       return r;

--- a/arcane/src/arcane/utils/JSONReader.h
+++ b/arcane/src/arcane/utils/JSONReader.h
@@ -44,10 +44,19 @@ class ARCANE_UTILS_EXPORT JSONValue
   class Impl;
   friend JSONWrapperUtils;
   friend JSONKeyValue;
+
  private:
-  explicit JSONValue(Impl* p) : m_p(p){}
+
+  explicit JSONValue(Impl* p)
+  : m_p(p)
+  {}
+
  public:
-  JSONValue() : m_p(nullptr){}
+
+  JSONValue()
+  : m_p(nullptr)
+  {}
+
  public:
 
   //! Vrai si le noeud est nul
@@ -88,10 +97,14 @@ class ARCANE_UTILS_EXPORT JSONValue
   // Liste des objects fils de cet objet. L'instance doit être un objet
   JSONValueList children() const;
   JSONKeyValueList keyValueChildren() const;
+
  public:
+
   bool isArray() const;
   bool isObject() const;
+
  private:
+
   Impl* m_p;
 };
 
@@ -110,18 +123,32 @@ class ARCANE_UTILS_EXPORT JSONKeyValue
 {
   class Impl;
   friend JSONWrapperUtils;
+
  private:
-  explicit JSONKeyValue(Impl* p) : m_p(p){}
+
+  explicit JSONKeyValue(Impl* p)
+  : m_p(p)
+  {}
+
  public:
-  JSONKeyValue() : m_p(nullptr){}
+
+  JSONKeyValue()
+  : m_p(nullptr)
+  {}
+
  public:
+
   //! Vrai si le noeud est nul
   bool null() const { return !m_p; }
   bool operator!() const { return null(); }
+
  public:
+
   StringView name() const;
   JSONValue value() const;
+
  private:
+
   Impl* m_p;
 };
 
@@ -138,17 +165,23 @@ class ARCANE_UTILS_EXPORT JSONKeyValue
 class ARCANE_UTILS_EXPORT JSONKeyValueList
 {
   typedef std::vector<JSONKeyValue> ContainerType;
+
  public:
+
   typedef ContainerType::const_iterator const_iterator;
   typedef ContainerType::iterator iterator;
+
  public:
+
   void add(JSONKeyValue v)
   {
     m_values.push_back(v);
   }
   const_iterator begin() const { return m_values.begin(); }
   const_iterator end() const { return m_values.end(); }
+
  private:
+
   std::vector<JSONKeyValue> m_values;
 };
 
@@ -165,17 +198,23 @@ class ARCANE_UTILS_EXPORT JSONKeyValueList
 class ARCANE_UTILS_EXPORT JSONValueList
 {
   typedef std::vector<JSONValue> ContainerType;
+
  public:
+
   typedef ContainerType::const_iterator const_iterator;
   typedef ContainerType::iterator iterator;
+
  public:
+
   void add(JSONValue v)
   {
     m_values.push_back(v);
   }
   const_iterator begin() const { return m_values.begin(); }
   const_iterator end() const { return m_values.end(); }
+
  private:
+
   std::vector<JSONValue> m_values;
 };
 
@@ -190,31 +229,36 @@ class ARCANE_UTILS_EXPORT JSONValueList
 class ARCANE_UTILS_EXPORT JSONDocument
 {
   class Impl;
+
  public:
+
   JSONDocument();
   ~JSONDocument();
+
  public:
+
   //! Lit le fichier au format UTF-8.
   void parse(Span<const Byte> bytes);
   //! Lit le fichier au format UTF-8.
   void parse(Span<const std::byte> bytes);
   //! Lit le fichier au format UTF-8.
-  void parse(Span<const Byte> bytes,StringView file_name);
+  void parse(Span<const Byte> bytes, StringView file_name);
   //! Lit le fichier au format UTF-8.
-  void parse(Span<const std::byte> bytes,StringView file_name);
+  void parse(Span<const std::byte> bytes, StringView file_name);
   //! Elément racine
   JSONValue root() const;
+
  private:
+
   Impl* m_p;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #endif
-

--- a/arcane/src/arcane/utils/JSONReader.h
+++ b/arcane/src/arcane/utils/JSONReader.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* JSONReader.h                                                (C) 2000-2020 */
+/* JSONReader.h                                                (C) 2000-2023 */
 /*                                                                           */
 /* Lecteur au format JSON.                                                   */
 /*---------------------------------------------------------------------------*/
@@ -74,6 +74,8 @@ class ARCANE_UTILS_EXPORT JSONValue
   Int64 valueAsInt64() const;
   //! Valeur sous forme de Int64. Retourn 0 si 'null()' est vrai.
   Int32 valueAsInt32() const;
+  //! Valeur sous forme de booléen. Retourn false si 'null()' est vrai.
+  bool valueAsBool() const;
   JSONValueList valueAsArray() const;
 
  public:

--- a/arcane/src/arcane/utils/JSONReader.h
+++ b/arcane/src/arcane/utils/JSONReader.h
@@ -49,16 +49,35 @@ class ARCANE_UTILS_EXPORT JSONValue
  public:
   JSONValue() : m_p(nullptr){}
  public:
+
   //! Vrai si le noeud est nul
   bool null() const { return !m_p; }
   bool operator!() const { return null(); }
+
  public:
+
+  ARCANE_DEPRECATED_REASON("Y2023: Use valueAsStringView() or value() instead")
   StringView valueAsString() const;
+
+  //! Valeur sous forme de String. La chaîne retournée est nulle si 'null()' est vrai.
+  String value() const;
+  /*!
+   * \brief Valeur sous forme de StringView.
+   * La chaîne est vide si 'null()' est vrai.
+   * \note Si on veut faire la distinction entre la valeur nulle et une chaîne
+   * de caractères vide, il faut utiliser value().
+   */
+  StringView valueAsStringView() const;
+  //! Valeur sous forme de Real. Retourn 0.0 si 'null()' est vrai.
   Real valueAsReal() const;
+  //! Valeur sous forme de Int64. Retourn 0 si 'null()' est vrai.
   Int64 valueAsInt64() const;
+  //! Valeur sous forme de Int64. Retourn 0 si 'null()' est vrai.
   Int32 valueAsInt32() const;
   JSONValueList valueAsArray() const;
+
  public:
+
   JSONKeyValue keyValueChild(StringView name) const;
   //! Valeur fille de nom \a name. Retourne une valeur nulle si non trouvé.
   JSONValue child(StringView name) const;

--- a/arcane/src/arcane/utils/JSONWriter.h
+++ b/arcane/src/arcane/utils/JSONWriter.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* JSONWriter.h                                                (C) 2000-2020 */
+/* JSONWriter.h                                                (C) 2000-2023 */
 /*                                                                           */
 /* Ecrivain au format JSON.                                                  */
 /*---------------------------------------------------------------------------*/
@@ -32,16 +32,19 @@ namespace Arcane
 class ARCANE_UTILS_EXPORT JSONWriter
 {
   class Impl;
+
  public:
+
   class Object
   {
    public:
+
     Object(JSONWriter& writer)
     : m_writer(writer)
     {
       m_writer.beginObject();
     }
-    Object(JSONWriter& writer,StringView str)
+    Object(JSONWriter& writer, StringView str)
     : m_writer(writer)
     {
       m_writer.writeKey(str);
@@ -51,13 +54,16 @@ class ARCANE_UTILS_EXPORT JSONWriter
     {
       m_writer.endObject();
     }
+
    private:
+
     JSONWriter& m_writer;
   };
   class Array
   {
    public:
-    Array(JSONWriter& writer,StringView name)
+
+    Array(JSONWriter& writer, StringView name)
     : m_writer(writer)
     {
       m_writer.writeKey(name);
@@ -67,10 +73,14 @@ class ARCANE_UTILS_EXPORT JSONWriter
     {
       m_writer.endArray();
     }
+
    private:
+
     JSONWriter& m_writer;
   };
+
  public:
+
   enum class FormatFlags
   {
     None = 0,
@@ -79,40 +89,47 @@ class ARCANE_UTILS_EXPORT JSONWriter
 
     Default = HexFloat
   };
+
  public:
+
   JSONWriter(FormatFlags format_flags = FormatFlags::Default);
   ~JSONWriter();
+
  public:
+
   void beginObject();
   void endObject();
   void beginArray();
   void endArray();
   void writeKey(StringView key);
   void writeValue(StringView str);
-  void write(StringView key,const char* v);
-  void write(StringView key,std::string_view v);
-  void write(StringView key,bool v);
-  void write(StringView key,Int64 v);
-  void write(StringView key,UInt64 v);
-  void write(StringView key,Real v);
-  void write(StringView key,StringView str);
-  void writeIfNotNull(StringView key,const String& str);
-  void write(StringView key,Span<const Int32> view);
-  void write(StringView key,Span<const Int64> view);
-  void write(StringView key,Span<const Real> view);
+  void write(StringView key, const char* v);
+  void write(StringView key, std::string_view v);
+  void write(StringView key, bool v);
+  void write(StringView key, Int64 v);
+  void write(StringView key, UInt64 v);
+  void write(StringView key, Real v);
+  void write(StringView key, StringView str);
+  void writeIfNotNull(StringView key, const String& str);
+  void write(StringView key, Span<const Int32> view);
+  void write(StringView key, Span<const Int64> view);
+  void write(StringView key, Span<const Real> view);
+
  public:
+
   StringView getBuffer() const;
+
  private:
+
   Impl* m_p;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace Arcane
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #endif
-

--- a/arcane/src/arcane/utils/Property.cc
+++ b/arcane/src/arcane/utils/Property.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Property.cc                                                 (C) 2000-2021 */
+/* Property.cc                                                 (C) 2000-2023 */
 /*                                                                           */
 /* Gestion des propriétés.                                                   */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/Property.cc
+++ b/arcane/src/arcane/utils/Property.cc
@@ -34,7 +34,7 @@ namespace Arcane::properties
 auto PropertySettingTraits<String>::
 fromJSON(const JSONValue& jv) -> InputType
 {
-  return jv.valueAsString();
+  return jv.value();
 }
 
 auto PropertySettingTraits<String>::
@@ -57,7 +57,7 @@ fromJSON(const JSONValue& jv) -> InputType
 {
   StringList string_list;
   for(JSONValue jv2 : jv.valueAsArray())
-    string_list.add(jv2.valueAsString());
+    string_list.add(jv2.value());
   return string_list;
 }
 


### PR DESCRIPTION
Before there was only `JSONValue::valueAsString()` which return a `StringView`. We need a method which return a `String` to make the difference between empty `String` and null `String` (when `JSONValue::null()` is true for the current instance). 