### PR TITLE
Use 'host pinned' memory for reduction on accelerator

### DIFF
--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -49,15 +49,14 @@ class ReduceMemoryImpl
  public:
 
   ReduceMemoryImpl(RunCommandImpl* p)
-  : m_command(p), m_device_memory_bytes(eMemoryRessource::Device), m_host_memory_bytes(eMemoryRessource::Host),
-    m_grid_buffer(eMemoryRessource::Device), m_grid_device_count(eMemoryRessource::Device)
+  : m_command(p)
+  , m_device_memory_bytes(eMemoryRessource::Device)
+  , m_host_memory_bytes(eMemoryRessource::HostPinned)
+  , m_grid_buffer(eMemoryRessource::Device)
+  , m_grid_device_count(eMemoryRessource::Device)
   {
     _allocateMemoryForReduceData(128);
     _allocateMemoryForGridDeviceCount();
-  }
-
-  ~ReduceMemoryImpl()
-  {
   }
 
  public:


### PR DESCRIPTION
Previously we used standard (`malloc`) memory for reduction. pinned memory should accelerator memory copy between the device and the host.
