### PR TITLE
Improve 'MaterialHeat' test

### DIFF
--- a/arcane/ceapart/tests/testMaterialHeat-1.arc
+++ b/arcane/ceapart/tests/testMaterialHeat-1.arc
@@ -7,7 +7,7 @@
  </arcane>
 
  <arcane-post-processing>
-   <output-period>1</output-period>
+   <output-period>5</output-period>
    <output>
     <variable>Temperature</variable>
     <variable>AllTemperatures</variable>


### PR DESCRIPTION
- separate the compute loop in several phases
- use only one `MeshMaterialModifier` instance to do all the updates
- add flag `OptimizeMultiMaterialPerEnvironment` to material modification optimization.