### PR TITLE
Improve C# tools

### DIFF
--- a/arcane/tools/Arcane.UnifiedDriver/Arcane.UnifiedDriver.csproj
+++ b/arcane/tools/Arcane.UnifiedDriver/Arcane.UnifiedDriver.csproj
@@ -3,6 +3,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Arcane.Templates\Arcane.Templates.csproj" />
     <ProjectReference Include="..\Arcane.ExecDrivers\Arcane.ExecDrivers.csproj" />
-    <ProjectReference Include="..\Arcane.DotNetCompile\Arcane.DotNetCompile.csproj" />
   </ItemGroup>
 </Project>

--- a/arcane/tools/Arcane.Utils.Generator/Array.txt
+++ b/arcane/tools/Arcane.Utils.Generator/Array.txt
@@ -343,6 +343,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public @CTYPE@* _UnguardedBasePointer() { return m_ptr; }
+    internal @CTYPE@* _InternalData() { return m_ptr; }
     public @CTYPE@[] ToArray()
     {
       @CTYPE@[] a = new @CTYPE@[m_size];
@@ -550,6 +551,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public @CTYPE@* _UnguardedBasePointer() { return m_ptr; }
+    internal @CTYPE@* _InternalData() { return m_ptr; }
     public @CTYPE@[] ToArray()
     {
       @CTYPE@[] a = new @CTYPE@[m_size];
@@ -622,6 +624,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public @CTYPE@* _UnguardedBasePointer() { return m_ptr; }
+    internal @CTYPE@* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -664,6 +667,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public @CTYPE@* _UnguardedBasePointer() { return m_ptr; }
+    internal @CTYPE@* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/ArrayImplBase.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/ArrayImplBase.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 #if ARCANE_64BIT
 using Integer = System.Int64;
@@ -13,6 +14,8 @@ using Integer = System.Int64;
 using Integer = System.Int32;
 #endif
 using Real = System.Double;
+
+[assembly: InternalsVisibleTo("Arcane.Core")]
 
 namespace Arcane
 {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/ByteArray.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/ByteArray.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Byte* _UnguardedBasePointer() { return m_ptr; }
+    internal Byte* _InternalData() { return m_ptr; }
     public Byte[] ToArray()
     {
       Byte[] a = new Byte[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Byte* _UnguardedBasePointer() { return m_ptr; }
+    internal Byte* _InternalData() { return m_ptr; }
     public Byte[] ToArray()
     {
       Byte[] a = new Byte[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Byte* _UnguardedBasePointer() { return m_ptr; }
+    internal Byte* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Byte* _UnguardedBasePointer() { return m_ptr; }
+    internal Byte* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/Int16Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/Int16Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Int16* _UnguardedBasePointer() { return m_ptr; }
+    internal Int16* _InternalData() { return m_ptr; }
     public Int16[] ToArray()
     {
       Int16[] a = new Int16[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Int16* _UnguardedBasePointer() { return m_ptr; }
+    internal Int16* _InternalData() { return m_ptr; }
     public Int16[] ToArray()
     {
       Int16[] a = new Int16[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Int16* _UnguardedBasePointer() { return m_ptr; }
+    internal Int16* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Int16* _UnguardedBasePointer() { return m_ptr; }
+    internal Int16* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/Int32Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/Int32Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Int32* _UnguardedBasePointer() { return m_ptr; }
+    internal Int32* _InternalData() { return m_ptr; }
     public Int32[] ToArray()
     {
       Int32[] a = new Int32[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Int32* _UnguardedBasePointer() { return m_ptr; }
+    internal Int32* _InternalData() { return m_ptr; }
     public Int32[] ToArray()
     {
       Int32[] a = new Int32[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Int32* _UnguardedBasePointer() { return m_ptr; }
+    internal Int32* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Int32* _UnguardedBasePointer() { return m_ptr; }
+    internal Int32* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/Int64Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/Int64Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Int64* _UnguardedBasePointer() { return m_ptr; }
+    internal Int64* _InternalData() { return m_ptr; }
     public Int64[] ToArray()
     {
       Int64[] a = new Int64[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Int64* _UnguardedBasePointer() { return m_ptr; }
+    internal Int64* _InternalData() { return m_ptr; }
     public Int64[] ToArray()
     {
       Int64[] a = new Int64[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Int64* _UnguardedBasePointer() { return m_ptr; }
+    internal Int64* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Int64* _UnguardedBasePointer() { return m_ptr; }
+    internal Int64* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/Real2Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/Real2Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2* _InternalData() { return m_ptr; }
     public Real2[] ToArray()
     {
       Real2[] a = new Real2[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2* _InternalData() { return m_ptr; }
     public Real2[] ToArray()
     {
       Real2[] a = new Real2[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/Real2x2Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/Real2x2Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real2x2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2x2* _InternalData() { return m_ptr; }
     public Real2x2[] ToArray()
     {
       Real2x2[] a = new Real2x2[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real2x2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2x2* _InternalData() { return m_ptr; }
     public Real2x2[] ToArray()
     {
       Real2x2[] a = new Real2x2[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real2x2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2x2* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real2x2* _UnguardedBasePointer() { return m_ptr; }
+    internal Real2x2* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/Real3Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/Real3Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3* _InternalData() { return m_ptr; }
     public Real3[] ToArray()
     {
       Real3[] a = new Real3[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3* _InternalData() { return m_ptr; }
     public Real3[] ToArray()
     {
       Real3[] a = new Real3[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/Real3x3Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/Real3x3Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real3x3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3x3* _InternalData() { return m_ptr; }
     public Real3x3[] ToArray()
     {
       Real3x3[] a = new Real3x3[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real3x3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3x3* _InternalData() { return m_ptr; }
     public Real3x3[] ToArray()
     {
       Real3x3[] a = new Real3x3[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real3x3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3x3* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real3x3* _UnguardedBasePointer() { return m_ptr; }
+    internal Real3x3* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/RealArray.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/RealArray.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real* _UnguardedBasePointer() { return m_ptr; }
+    internal Real* _InternalData() { return m_ptr; }
     public Real[] ToArray()
     {
       Real[] a = new Real[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public Real* _UnguardedBasePointer() { return m_ptr; }
+    internal Real* _InternalData() { return m_ptr; }
     public Real[] ToArray()
     {
       Real[] a = new Real[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real* _UnguardedBasePointer() { return m_ptr; }
+    internal Real* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public Real* _UnguardedBasePointer() { return m_ptr; }
+    internal Real* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/UInt16Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/UInt16Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public UInt16* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt16* _InternalData() { return m_ptr; }
     public UInt16[] ToArray()
     {
       UInt16[] a = new UInt16[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public UInt16* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt16* _InternalData() { return m_ptr; }
     public UInt16[] ToArray()
     {
       UInt16[] a = new UInt16[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public UInt16* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt16* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public UInt16* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt16* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/UInt32Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/UInt32Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public UInt32* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt32* _InternalData() { return m_ptr; }
     public UInt32[] ToArray()
     {
       UInt32[] a = new UInt32[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public UInt32* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt32* _InternalData() { return m_ptr; }
     public UInt32[] ToArray()
     {
       UInt32[] a = new UInt32[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public UInt32* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt32* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public UInt32* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt32* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/Arcane.Utils/Arcane.Utils/UInt64Array.cs
+++ b/arcane/tools/Arcane.Utils/Arcane.Utils/UInt64Array.cs
@@ -1,5 +1,5 @@
 //WARNING: this file is generated. Do not Edit
-//Date 1/13/2020 12:20:40 PM
+//Date 7/19/2023 1:42:56 PM
 // -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 using System;
 using System.Collections;
@@ -345,6 +345,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public UInt64* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt64* _InternalData() { return m_ptr; }
     public UInt64[] ToArray()
     {
       UInt64[] a = new UInt64[m_size];
@@ -552,6 +553,7 @@ namespace Arcane
     { return new Enumerator(m_ptr,m_size); }
     [Obsolete]
     public UInt64* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt64* _InternalData() { return m_ptr; }
     public UInt64[] ToArray()
     {
       UInt64[] a = new UInt64[m_size];
@@ -624,6 +626,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public UInt64* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt64* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {
@@ -666,6 +669,7 @@ namespace Arcane
     public Integer Dim2Size { get { return m_dim2_size; } }
     [Obsolete]
     public UInt64* _UnguardedBasePointer() { return m_ptr; }
+    internal UInt64* _InternalData() { return m_ptr; }
     [Obsolete]
     public IntPtr _Base()
     {

--- a/arcane/tools/CMakeLists.txt
+++ b/arcane/tools/CMakeLists.txt
@@ -1,36 +1,36 @@
 ﻿# ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
-# Configuration des runtimes 'mono', 'dotnet' et de l'outils 'msbuild'
+# Configuration du runtime 'dotnet' et de l'outil 'msbuild'
 
 message(STATUS "[.Net] Checking '.Net' configuration (using 'dependencies' for nuget packages")
 message(STATUS "[.Net] Wanted runtime ARCANE_DOTNET_RUNTIME=${ARCANE_DOTNET_RUNTIME}")
 
-# Indique si on souhaite utiliser 'coreclr' (.NetCore) ou 'mono'.
+# Indique si on souhaite utiliser 'coreclr' (.NetCore).
 # Par défaut, on prend 'coreclr'
 if (NOT ARCANE_DOTNET_RUNTIME)
   if(ARCCON_DOTNET_HAS_RUNTIME_coreclr)
     set(ARCANE_DOTNET_RUNTIME "coreclr")
   elseif (ARCCON_DOTNET_HAS_RUNTIME_mono)
     set(ARCANE_DOTNET_RUNTIME "mono")
+    message(FATAL_ERROR "'Mono' runtime for '.Net' is no longer supported in Arcane. Install '.Net' 6.0+ (coreclr)")
   else()
-    message(FATAL_ERROR "No '.Net' runtime available. Install '.NetCore 3.0+ (coreclr)' or 'mono 5.16+'")
+    message(FATAL_ERROR "No '.Net' runtime available. Install '.Net' 6.0+ (coreclr)")
   endif()
 endif()
 
 if (NOT ARCCON_DOTNET_HAS_RUNTIME_${ARCANE_DOTNET_RUNTIME})
   message(FATAL_ERROR
     "'.Net' runtime '${ARCANE_DOTNET_RUNTIME}' is not available."
-    "Choose another runtime ('coreclr' or 'mono')"
     )
 endif()
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
 
-# Vérifie qu'on a au moins la version 3.0 de 'dotnet'.
+# Vérifie qu'on a au moins la version 6.0 de 'dotnet'.
 if (ARCANE_DOTNET_RUNTIME STREQUAL coreclr)
-  if(CORECLR_VERSION VERSION_LESS "3.0")
-    message(FATAL_ERROR "Version of 'dotnet' ${CORECLR_VERSION} is too old. Version 3.0+ is required")
+  if(CORECLR_VERSION VERSION_LESS "6.0")
+    message(FATAL_ERROR "Version of 'dotnet' ${CORECLR_VERSION} is too old. Version 6.0+ is required")
   endif()
 endif()
 set(ARCANE_CORECLR_VERSION ${CORECLR_VERSION} CACHE STRING ".Net coreclr version" FORCE)
@@ -231,9 +231,7 @@ arccon_add_csharp_target(dotnet_arcane_utils
   PACK
   )
 
-# TODO: renommer la cible 'dotnet_xbuild' en 'dotnet_tools'.
-#
-arccon_add_csharp_target(dotnet_xbuild
+arccon_add_csharp_target(dotnet_tools
   DOTNET_RUNTIME ${ARCANE_DOTNET_RUNTIME}
   BUILD_DIR ${ARCANE_DOTNET_PUBLISH_BUILD_DIR}
   ASSEMBLY_NAME Arcane.ExecDrivers.dll
@@ -242,6 +240,10 @@ arccon_add_csharp_target(dotnet_xbuild
   MSBUILD_ARGS ${ARCANE_MSBUILD_ARGS}
   DOTNET_TARGET_DEPENDS dotnet_arcane_utils
   )
+
+# Pour compatibilité avec l'existant (versions 3.11 et antérieures)
+add_custom_target(dotnet_xbuild DEPENDS dotnet_tools)
+add_custom_target(force_dotnet_xbuild DEPENDS force_dotnet_tools)
 
 # Indique qu'il faut recopier à l'installation tout le répertoire où a été
 # publié le code compilé.

--- a/arcane/tools/wrapper/core/Variables.i
+++ b/arcane/tools/wrapper/core/Variables.i
@@ -180,7 +180,7 @@ namespace Arcane
     _InitMeshVariableBase();
     DATATYPE##ArrayView v = this._asArray();
     m_view = v;
-    m_values = v._UnguardedBasePointer();
+    m_values = v._InternalData();
     m_size = v.Size;
     //Console.WriteLine("BUILD ARRAY name={0} size={1} ptr={2}",name(),m_size,(IntPtr)m_values);
   }
@@ -213,7 +213,7 @@ namespace Arcane
    {
 		 DATATYPE##ArrayView v = _asArray();
      m_view = v;
-     m_values = v._UnguardedBasePointer();
+     m_values = v._InternalData();
      m_size = v.Size;
      //Console.WriteLine("GET ARRAY name={0} size={1} ptr={2}",Name,m_size,(IntPtr)m_values);
    }

--- a/arcane/tools/wrapper/core/csharp/ItemEnumerator.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemEnumerator.cs
@@ -326,7 +326,7 @@ namespace Arcane
 
     public IndexedItemEnumerator<_ItemKind> GetEnumerator()
     {
-      return new IndexedItemEnumerator<_ItemKind>(m_items.m_ptr,m_local_ids.m_local_ids._UnguardedBasePointer(),m_local_ids.Length);
+      return new IndexedItemEnumerator<_ItemKind>(m_items.m_ptr,m_local_ids.m_local_ids._InternalData(),m_local_ids.Length);
     }
 
     public ItemVectorView<_ItemKind> SubViewInterval(Integer interval,Integer nb_interval)
@@ -445,7 +445,7 @@ namespace Arcane
       ++m_current;
       if (m_current>=m_end)
         return false;
-      m_pair.m_sub_local_ids = m_sub_items_local_id._UnguardedBasePointer()+m_indexes[m_current];
+      m_pair.m_sub_local_ids = m_sub_items_local_id._InternalData()+m_indexes[m_current];
       m_pair.m_nb_sub_item = m_indexes[m_current+1]-m_indexes[m_current];
       m_pair.m_index = m_current;
       m_pair.m_item.Internal = m_items_internal.m_ptr[m_current];

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -73,7 +73,7 @@ namespace Arcane
     public NodeList Nodes(Int32 local_id)
     {
       int nb_node = m_container_node.m_nb_item[local_id];
-      return new NodeList(m_items->nodes.m_ptr,m_container_node.m_list._UnguardedBasePointer()+m_container_node.m_indexes[local_id],nb_node);
+      return new NodeList(m_items->nodes.m_ptr,m_container_node.m_list._InternalData()+m_container_node.m_indexes[local_id],nb_node);
     }
     public Int32 NbNode(Int32 local_id)
     {
@@ -91,7 +91,7 @@ namespace Arcane
     public ItemList<Face> Faces(Int32 local_id)
     {
       int nb_face = m_container_face.m_nb_item[local_id];
-      return new ItemList<Face>(m_items->faces.m_ptr,m_container_face.m_list._UnguardedBasePointer()+m_container_face.m_indexes[local_id],nb_face);
+      return new ItemList<Face>(m_items->faces.m_ptr,m_container_face.m_list._InternalData()+m_container_face.m_indexes[local_id],nb_face);
     }
     public Int32 NbFace(Int32 local_id)
     {
@@ -109,7 +109,7 @@ namespace Arcane
     public ItemList<Cell> Cells(Int32 local_id)
     {
       int nb_cell = m_container_node.m_nb_item[local_id];
-      return new ItemList<Cell>(m_items->cells.m_ptr,m_container_cell.m_list._UnguardedBasePointer()+m_container_cell.m_indexes[local_id],nb_cell);
+      return new ItemList<Cell>(m_items->cells.m_ptr,m_container_cell.m_list._InternalData()+m_container_cell.m_indexes[local_id],nb_cell);
     }
     public Int32 NbCell(Int32 local_id)
     {


### PR DESCRIPTION
- Add method `ArrayView::_InternalData()` to replace the deprecated `_UnguardedBasePointer()` method. This method is internal to Arcane.
- Remove support for compiling C# tools with `mono`
- Rename target `dotnet_xbuild` to `dotnet_tools`
