### PR TITLE
Change return value of 'IMeshMaterialMng::synchronizeMaterialsInCells()'

### DIFF
--- a/arcane/src/arcane/core/materials/IMeshMaterialMng.h
+++ b/arcane/src/arcane/core/materials/IMeshMaterialMng.h
@@ -410,8 +410,11 @@ class ARCANE_CORE_EXPORT IMeshMaterialMng
    * matériaux et milieux que cells du sous-domaine qui est propriétaire
    * de ces mailles. Il est notamment possible de synchroniser des variables
    * via MeshMaterialVariableRef::synchronize().
+   *
+   * Retourne \a true si les matériaux de ce sous-domaine ont été modifiés suite
+   * à la synchronisation, \a false sinon.
    */
-  virtual void synchronizeMaterialsInCells() =0;
+  virtual bool synchronizeMaterialsInCells() =0;
 
   /*!
    * \brief Vérifie que les mailles des matériaux sont cohérentes entre

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -896,11 +896,11 @@ dumpInfos2(std::ostream& o)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MeshMaterialMng::
+bool MeshMaterialMng::
 synchronizeMaterialsInCells()
 {
   MeshMaterialSynchronizer mms(this);
-  mms.synchronizeMaterialsInCells();
+  return mms.synchronizeMaterialsInCells();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -145,7 +145,7 @@ class MeshMaterialMng
     return &m_variable_lock;
   }
 
-  void synchronizeMaterialsInCells() override;
+  bool synchronizeMaterialsInCells() override;
   void checkMaterialsInCells(Integer max_print) override;
 
   Int64 timestamp() const override { return m_timestamp; }


### PR DESCRIPTION
Return a `bool` instead of `void`. The return value is `true` if materials have beed modified during the synchronization.

close #455 