### PR TITLE
[CI] Fix errors in some MPI test in CI for ifpen/GIMKL

### DIFF
--- a/.github/workflows/ifpen_el7_gimkl-2018b.yml
+++ b/.github/workflows/ifpen_el7_gimkl-2018b.yml
@@ -48,6 +48,8 @@ env:
   CM_CCACHE_OPTS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
   # CTest
   CT_OPTS: "--timeout 300 --output-on-failure"
+  # For intel MPI to fix errors appearing in July 2023
+  I_MPI_SHM_LMT: shm
 
 jobs:
   arccon-install:

--- a/.github/workflows/ifpen_el8_gimkl-2018b.yml
+++ b/.github/workflows/ifpen_el8_gimkl-2018b.yml
@@ -48,6 +48,8 @@ env:
   CM_CCACHE_OPTS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
   # CTest
   CT_OPTS: "--timeout 300 --output-on-failure"
+  # For intel MPI to fix errors appearing in July 2023
+  I_MPI_SHM_LMT: shm
 
 jobs:
   arccon-install:


### PR DESCRIPTION
It seems to be due to a change in github runners.

The error messages were:
```
Fatal error in MPI_Waitsome: Other MPI error, error stack:
MPI_Waitsome(325)...............: MPI_Waitsome(count=1, req_array=0x1b038d0, out_count=0x7ffc21b9414c, indices=0x1b07f40, status_array=0x1b06b00) failed
PMPIDI_CH3I_Progress(658).......: fail failed
MPID_nem_handle_pkt(1450).......: fail failed
pkt_RTS_handler(317)............: fail failed
do_cts(662).....................: fail failed
MPID_nem_lmt_dcp_start_recv(302): fail failed
dcp_recv(165)...................: Internal MPI error!  Cannot read from remote process
 Two workarounds have been identified for this issue:
 1) Enable ptrace for non-root users with:
    echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 2) Or, use:
    I_MPI_SHM_LMT=shm
```

Adding environment variable `I_MPI_SHM_LMT=shm` seems to fix the errors