### PR TITLE
Remove C# wrapping of 'IMeshComponentInternal'

### DIFF
--- a/arcane/src/arcane/core/materials/ComponentItemVectorView.h
+++ b/arcane/src/arcane/core/materials/ComponentItemVectorView.h
@@ -61,6 +61,10 @@ class ARCANE_CORE_EXPORT ComponentItemVectorView
   template<typename DataType> friend class
   MaterialVariableArrayTraits;
 
+ public:
+
+  ComponentItemVectorView() = default;
+
  protected:
 
   //! Construit un vecteur contenant les entités de \a group pour le composant \a component
@@ -130,10 +134,13 @@ class ARCANE_CORE_EXPORT ComponentItemVectorView
 
  private:
 
+  // NOTE: Cette classe est wrappé directement en C#.
+  // Si on modifie les champs de cette classe il faut modifier le type correspondant
+  // dans le wrappeur.
   ConstArrayView<MatVarIndex> m_matvar_indexes_view;
   ConstArrayView<ComponentItemInternal*> m_items_internal_main_view;
   ConstArrayView<Int32> m_items_local_id_view;
-  IMeshComponent* m_component;
+  IMeshComponent* m_component = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -150,6 +157,10 @@ class ARCANE_CORE_EXPORT MatItemVectorView
   friend class MeshMaterial;
   template<typename ViewType,typename LambdaType>
   friend class LambdaMatItemRangeFunctorT;
+
+ public:
+
+  MatItemVectorView() = default;
 
  private:
 
@@ -200,6 +211,10 @@ class ARCANE_CORE_EXPORT EnvItemVectorView
   friend class MeshEnvironment;
   template<typename ViewType,typename LambdaType>
   friend class LambdaMatItemRangeFunctorT;
+
+ public:
+
+  EnvItemVectorView() = default;
 
  private:
 

--- a/arcane/src/arcane/core/materials/MatItemEnumerator.cc
+++ b/arcane/src/arcane/core/materials/MatItemEnumerator.cc
@@ -32,12 +32,49 @@ namespace Arcane::Materials
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+ComponentCellEnumerator::
+ComponentCellEnumerator(ConstArrayView<ComponentItemInternal*> items,
+                        ConstArrayView<MatVarIndex> matvar_indexes,
+                        IMeshComponent* component)
+: m_index(0)
+, m_size(items.size())
+, m_items(items)
+, m_matvar_indexes(matvar_indexes)
+, m_component(component)
+{
+#ifdef ARCANE_CHECK
+  if (m_index<m_size)
+    _check();
+#endif
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ComponentCellEnumerator::
+ComponentCellEnumerator(const ComponentItemVectorView& v)
+: ComponentCellEnumerator(v._itemsInternalView(),v._matvarIndexes(),v.component())
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+MatCellEnumerator::
+MatCellEnumerator(ConstArrayView<ComponentItemInternal*> items,
+                  ConstArrayView<MatVarIndex> matvar_indexes,
+                  IMeshComponent* component)
+: ComponentCellEnumerator(items,matvar_indexes,component)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 MatCellEnumerator MatCellEnumerator::
 create(IMeshMaterial* mat)
 {
-  IMeshComponentInternal* mci = mat->_internalApi();
-  return MatCellEnumerator(mci->itemsInternalView(),
-                           mci->variableIndexer()->matvarIndexes(),mat);
+  return MatCellEnumerator(mat->view());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -55,7 +92,7 @@ create(const MatCellVector& miv)
 MatCellEnumerator MatCellEnumerator::
 create(MatCellVectorView v)
 {
-  return MatCellEnumerator(v._itemsInternalView(),v._matvarIndexes(),v.component());
+  return MatCellEnumerator(v);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -64,11 +101,21 @@ create(MatCellVectorView v)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+EnvCellEnumerator::
+EnvCellEnumerator(ConstArrayView<ComponentItemInternal*> items,
+                  ConstArrayView<MatVarIndex> matvar_indexes,
+                  IMeshComponent* component)
+: ComponentCellEnumerator(items,matvar_indexes,component)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 EnvCellEnumerator EnvCellEnumerator::
 create(IMeshEnvironment* env)
 {
-  IMeshComponentInternal* mci = env->_internalApi();
-  return EnvCellEnumerator(mci->itemsInternalView(),mci->variableIndexer()->matvarIndexes(),env);
+  return EnvCellEnumerator(env->view());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -86,7 +133,7 @@ create(const EnvCellVector& miv)
 EnvCellEnumerator EnvCellEnumerator::
 create(EnvCellVectorView v)
 {
-  return EnvCellEnumerator(v._itemsInternalView(),v._matvarIndexes(),v.component());
+  return EnvCellEnumerator(v);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -173,10 +220,7 @@ create(const CellGroup& v)
 ComponentCellEnumerator ComponentCellEnumerator::
 create(IMeshComponent* component)
 {
-  IMeshComponentInternal* mci = component->_internalApi();
-  MeshMaterialVariableIndexer* vi = mci->variableIndexer();
-
-  return ComponentCellEnumerator(mci->itemsInternalView(),vi->matvarIndexes(),component);
+  return ComponentCellEnumerator(component->view());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -194,8 +238,7 @@ create(const ComponentItemVector& v)
 ComponentCellEnumerator ComponentCellEnumerator::
 create(ComponentItemVectorView v)
 {
-  return ComponentCellEnumerator(v._itemsInternalView(),v._matvarIndexes(),
-                                 v.component());
+  return ComponentCellEnumerator(v);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/MatItemEnumerator.h
+++ b/arcane/src/arcane/core/materials/MatItemEnumerator.h
@@ -22,7 +22,6 @@
 #include "arcane/utils/FatalErrorException.h"
 
 #include "arcane/core/materials/MatItem.h"
-#include "arcane/core/materials/MeshMaterialVariableIndexer.h"
 #include "arcane/core/materials/IEnumeratorTracer.h"
 
 #include "arcane/EnumeratorTraceWrapper.h"
@@ -114,23 +113,26 @@ class ARCANE_CORE_EXPORT AllEnvCellVectorView
 class ARCANE_CORE_EXPORT ComponentCellEnumerator
 {
   friend class EnumeratorTracer;
+
  protected:
+
+  ARCANE_DEPRECATED_REASON("Y2023: This method is internal to Arcane")
   ComponentCellEnumerator(ConstArrayView<ComponentItemInternal*> items,
                           ConstArrayView<MatVarIndex> matvar_indexes,
-                          IMeshComponent* component)
-  : m_index(0), m_size(items.size()), m_items(items)
-  , m_matvar_indexes(matvar_indexes), m_component(component)
-  {
-#ifdef ARCANE_CHECK
-    if (m_index<m_size)
-      _check();
-#endif
-  }
+                          IMeshComponent* component);
+
+ protected:
+
+  explicit ComponentCellEnumerator(const ComponentItemVectorView& v);
+
  public:
+
   static ComponentCellEnumerator create(IMeshComponent* component);
   static ComponentCellEnumerator create(const ComponentItemVector& v);
   static ComponentCellEnumerator create(ComponentItemVectorView v);
+
  public:
+
   void operator++()
   {
     ++m_index;
@@ -160,6 +162,7 @@ class ARCANE_CORE_EXPORT ComponentCellEnumerator
   Int32 _varValueIndex() const { return m_matvar_indexes[m_index].valueIndex(); }
 
  protected:
+
   void _check() const
   {
     ComponentItemInternal* ii = m_items[m_index];
@@ -175,9 +178,11 @@ class ARCANE_CORE_EXPORT ComponentCellEnumerator
       ARCANE_FATAL("Bad 'var_value_index' for ComponentCell matvar='{0}' registered='{1}' index={2}",
                    mvi,m_matvar_indexes[m_index],m_index);
   }
+
  protected:
-  Integer m_index;
-  Integer m_size;
+
+  Int32 m_index;
+  Int32 m_size;
   ConstArrayView<ComponentItemInternal*> m_items;
   ConstArrayView<MatVarIndex> m_matvar_indexes;
   IMeshComponent* m_component;
@@ -192,16 +197,25 @@ class ARCANE_CORE_EXPORT MatCellEnumerator
 : public ComponentCellEnumerator
 {
  protected:
+
+  ARCANE_DEPRECATED_REASON("Y2023: This method is internal to Arcane")
   MatCellEnumerator(ConstArrayView<ComponentItemInternal*> items,
                     ConstArrayView<MatVarIndex> matvar_indexes,
-                    IMeshComponent* component)
-  : ComponentCellEnumerator(items,matvar_indexes,component)
+                    IMeshComponent* component);
+
+ protected:
+
+  explicit MatCellEnumerator(const ComponentItemVectorView& v)
+  : ComponentCellEnumerator(v)
   {
   }
+
  public:
+
   static MatCellEnumerator create(IMeshMaterial* mat);
   static MatCellEnumerator create(const MatCellVector& miv);
   static MatCellEnumerator create(MatItemVectorView v);
+
  public:
 
   MatCell operator*() const
@@ -224,17 +238,27 @@ class ARCANE_CORE_EXPORT EnvCellEnumerator
 : public ComponentCellEnumerator
 {
  protected:
+
+  ARCANE_DEPRECATED_REASON("Y2023: This method is internal to Arcane")
   EnvCellEnumerator(ConstArrayView<ComponentItemInternal*> items,
                     ConstArrayView<MatVarIndex> matvar_indexes,
-                    IMeshComponent* component)
-  : ComponentCellEnumerator(items,matvar_indexes,component)
+                    IMeshComponent* component);
+
+ protected:
+
+  explicit EnvCellEnumerator(const ComponentItemVectorView& v)
+  : ComponentCellEnumerator(v)
   {
   }
+
  public:
+
   static EnvCellEnumerator create(IMeshEnvironment* mat);
   static EnvCellEnumerator create(const EnvCellVector& miv);
   static EnvCellEnumerator create(EnvItemVectorView v);
+
  public:
+
   EnvCell operator*() const
   {
 #ifdef ARCANE_CHECK

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -25,6 +25,7 @@
 #include "arcane/core/materials/MaterialVariableBuildInfo.h"
 #include "arcane/core/materials/IMeshMaterialMng.h"
 #include "arcane/core/materials/IMeshMaterialVariableFactoryMng.h"
+#include "arcane/core/materials/MeshMaterialVariableIndexer.h"
 
 #include "arcane/materials/MeshMaterialVariableRef.h"
 #include "arcane/materials/ComponentItemListBuilder.h"

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -26,6 +26,7 @@
 
 #include "arcane/core/materials/IMeshMaterial.h"
 #include "arcane/core/materials/ComponentItemVectorView.h"
+#include "arcane/core/materials/MeshMaterialVariableIndexer.h"
 
 #include "arcane/materials/MaterialVariableBuildInfo.h"
 #include "arcane/materials/MatItemEnumerator.h"

--- a/arcane/tools/wrapper/materials/Arcane.Cea.Materials.csproj.in
+++ b/arcane/tools/wrapper/materials/Arcane.Cea.Materials.csproj.in
@@ -16,13 +16,6 @@
     <Compile Include="@ARCANE_DOTNET_WRAPPER_OUTDIRECTORY@/out_cs_cea_materials/*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@/csharp/MatVarIndex.cs" />
-    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@/csharp/Component.cs" />
-    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@/csharp/ComponentItem.cs" />
-    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@/csharp/ComponentItemEnumerator.cs" />
-    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@/csharp/ComponentItemInternal.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="../Arcane.Core/Arcane.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/arcane/tools/wrapper/materials/ArcaneSwigCeaMaterials.i
+++ b/arcane/tools/wrapper/materials/ArcaneSwigCeaMaterials.i
@@ -18,8 +18,36 @@
 #include "arcane/core/materials/MeshMaterialVariableIndexer.h"
 #include "arcane/core/materials/internal/IMeshComponentInternal.h"
 
+namespace Arcane::Materials
+{
+  // Cette classe sert de type de retour pour wrapper la classe 'ComponentItemVectorView'
+  class ComponentItemVectorViewPOD
+  {
+   public:
+    ConstArrayView<MatVarIndex> m_matvar_indexes_view;
+    ConstArrayView<ComponentItemInternal*> m_items_internal_main_view;
+    ConstArrayView<Int32> m_items_local_id_view;
+    IMeshComponent* m_component;
+  };
+}
+
 using namespace Arcane;
 using namespace Arcane::Materials;
+
+namespace
+{
+  ComponentItemVectorViewPOD _createComponentItemVectorViewPOD(const ComponentItemVectorView& view)
+  {
+    ComponentItemVectorViewPOD pod;
+    size_t size1 = sizeof(ComponentItemVectorViewPOD);
+    size_t size2 = sizeof(ComponentItemVectorView);
+    if (size1!=size2)
+      ARCANE_FATAL("Bad size for POD copy size1={0} size2={1}",size1,size2);
+    std::memcpy(&pod,&view,size1);
+    return pod;
+  }
+}
+
 %}
 
 #define ARCANE_DOTNET

--- a/arcane/tools/wrapper/materials/ArcaneSwigCeaMaterials.i
+++ b/arcane/tools/wrapper/materials/ArcaneSwigCeaMaterials.i
@@ -15,6 +15,7 @@
 #include "arcane/core/materials/ComponentItemVectorView.h"
 #include "arcane/core/materials/CellToAllEnvCellConverter.h"
 #include "arcane/core/materials/MeshMaterialVariableRef.h"
+#include "arcane/core/materials/MeshMaterialVariableIndexer.h"
 #include "arcane/core/materials/internal/IMeshComponentInternal.h"
 
 using namespace Arcane;

--- a/arcane/tools/wrapper/materials/ArcaneSwigCeaMaterials.i
+++ b/arcane/tools/wrapper/materials/ArcaneSwigCeaMaterials.i
@@ -16,7 +16,6 @@
 #include "arcane/core/materials/CellToAllEnvCellConverter.h"
 #include "arcane/core/materials/MeshMaterialVariableRef.h"
 #include "arcane/core/materials/MeshMaterialVariableIndexer.h"
-#include "arcane/core/materials/internal/IMeshComponentInternal.h"
 
 namespace Arcane::Materials
 {
@@ -93,7 +92,6 @@ ARCANE_STD_EXHANDLER
 %include arcane/core/materials/IMeshEnvironment.h
 %include arcane/core/materials/IMeshMaterialMng.h
 %include arcane/core/materials/CellToAllEnvCellConverter.h
-%include arcane/core/materials/internal/IMeshComponentInternal.h
 %include MeshMaterialVariable.i
 %exception;
 

--- a/arcane/tools/wrapper/materials/CMakeLists.txt
+++ b/arcane/tools/wrapper/materials/CMakeLists.txt
@@ -9,6 +9,15 @@ set(ARCANE_SWIG_CEA_MATERIALS_FILES
   MeshMaterialVariable.i
 )
 
+set(ARCANE_SWIG_CEA_MATERIALS_CSHARP_FILES
+  Component
+  ComponentItem
+  ComponentItemEnumerator
+  ComponentItemInternal
+  ComponentItemVectorView
+  MatVarIndex
+)
+
 # ----------------------------------------------------------------------------
 
 install(FILES
@@ -21,6 +30,7 @@ arcane_wrapper_add_swig_target(NAME cea_materials
   NAMESPACE_NAME Arcane.Materials
   DLL_NAME Arcane.Cea.Materials
   SWIG_TARGET_DEPENDS core
+  CSHARP_SOURCES ${ARCANE_SWIG_CEA_MATERIALS_CSHARP_FILES}
   )
 
 target_link_libraries(arcane_dotnet_wrapper_cea_materials PUBLIC arcane_core)

--- a/arcane/tools/wrapper/materials/ComponentItemVector.i
+++ b/arcane/tools/wrapper/materials/ComponentItemVector.i
@@ -38,8 +38,39 @@ ARCANE_SWIG_SPECIALIZE_CONSTARRAYVIEW(Arcane::Materials::IMeshEnvironmentPtr,Arc
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+%define ARCANE_SWIG_MATERIAL_COMPONENTITEMVECTORVIEW(CTYPE,CSHARP_TYPE)
+
+%typemap(cstype) CTYPE %{ CSHARP_TYPE %}
+%typemap(imtype) CTYPE %{ CSHARP_TYPE %}
+%typemap(csin) CTYPE "$csinput"
+%typemap(csout) CTYPE {
+    CSHARP_TYPE ret = $imcall;$excode
+    return ret;
+  }
+%typemap(ctype, out="Arcane::Materials::ComponentItemVectorViewPOD") CTYPE %{ CSHARP_TYPE %}
+%typemap(out) CTYPE
+%{
+   Arcane::Materials::ComponentItemVectorView result_ref = ($1);
+   $result = _createComponentItemVectorViewPOD(result_ref);
+%}
+%typemap(in) CTYPE %{$1 = $input; %}
+
+%enddef
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ARCANE_SWIG_MATERIAL_COMPONENTITEMVECTORVIEW(Arcane::Materials::ComponentItemVectorView,Arcane.Materials.ComponentItemVectorView)
+ARCANE_SWIG_MATERIAL_COMPONENTITEMVECTORVIEW(Arcane::Materials::MatItemVectorView,Arcane.Materials.MatItemVectorView)
+ARCANE_SWIG_MATERIAL_COMPONENTITEMVECTORVIEW(Arcane::Materials::EnvItemVectorView,Arcane.Materials.EnvItemVectorView)
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 %include arcane/core/materials/ComponentPartItemVectorView.h
-%include arcane/core/materials/ComponentItemVectorView.h
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemEnumerator.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemEnumerator.cs
@@ -13,22 +13,17 @@ namespace Arcane.Materials
     internal MatVarIndex* m_matvar_indexes;
     internal IntPtr m_component; // IMeshComponent* m_component;
     internal T m_true_type;
-    internal ComponentItemEnumerator(ComponentItemInternal** items, MatVarIndex* matvar_indexes, Integer size, T true_type)
+    internal ComponentItemEnumerator(ComponentItemVectorView view, T true_type)
     {
-      m_items = items;
-      m_matvar_indexes = matvar_indexes;
+      m_items = view.m_items_internal_main_view.m_ptr;
+      m_matvar_indexes = view.m_matvar_indexes_view.m_ptr;
       m_index = -1;
-      m_size = size;
-      m_component = IntPtr.Zero; // TODO: mettre la bonne valeur
+      m_size = view.m_items_internal_main_view.m_size;
+      m_component = view.m_component;
       m_true_type = true_type;
     }
-    internal ComponentItemEnumerator(ComponentItemInternalPtrConstArrayView items, MatVarIndexConstArrayView matvar_indexes, T true_type)
-    : this(items.m_ptr,matvar_indexes.m_ptr,items.m_size,true_type)
-    {
-    }
-
     internal ComponentItemEnumerator(IMeshComponent mesh_component, T true_type)
-      : this(mesh_component._internalApi().ItemsInternalView(),mesh_component._internalApi().VariableIndexer().MatvarIndexes(),true_type)
+    : this(mesh_component.View(),true_type)
     {
     }
     public bool MoveNext()
@@ -51,9 +46,7 @@ namespace Arcane.Materials
   {
     public static ComponentItemEnumerator<ComponentItem> Create(IMeshComponent mesh_component)
     {
-      var indexes = mesh_component._internalApi().VariableIndexer().MatvarIndexes();
-      var items = mesh_component._internalApi().ItemsInternalView();
-      return new ComponentItemEnumerator<ComponentItem>(items.m_ptr, indexes.m_ptr, items.m_size, new ComponentItem(null));
+      return new ComponentItemEnumerator<ComponentItem>(mesh_component, new ComponentItem(null));
     }
 
     public static ComponentItemEnumerator<ComponentItem> Create(IMeshComponent mesh_component, ComponentItem item)

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemVectorView.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemVectorView.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+using System;
+using Arcane;
+
+namespace Arcane.Materials
+{
+  [StructLayout(LayoutKind.Sequential)]
+  public unsafe struct ComponentItemVectorView
+  {
+    MatVarIndexConstArrayView m_matvar_indexes_view;
+    ComponentItemInternalPtrConstArrayView m_items_internal_main_view;
+    Int32ConstArrayView m_items_local_id_view;
+    IntPtr m_component; //IMeshComponent*
+
+    public Int32 NbItem() { return m_matvar_indexes_view.m_size; }
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public unsafe struct MatItemVectorView
+  {
+    internal ComponentItemVectorView m_component_vector_view;
+    public Int32 NbItem() { return m_component_vector_view.NbItem(); }
+    public static implicit operator ComponentItemVectorView(MatItemVectorView c) => c.m_component_vector_view;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public unsafe struct EnvItemVectorView
+  {
+    internal ComponentItemVectorView m_component_vector_view;
+    public Int32 NbItem(){ return m_component_vector_view.NbItem(); }
+    public static implicit operator ComponentItemVectorView(EnvItemVectorView c) => c.m_component_vector_view;
+  }
+}

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemVectorView.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemVectorView.cs
@@ -7,10 +7,10 @@ namespace Arcane.Materials
   [StructLayout(LayoutKind.Sequential)]
   public unsafe struct ComponentItemVectorView
   {
-    MatVarIndexConstArrayView m_matvar_indexes_view;
-    ComponentItemInternalPtrConstArrayView m_items_internal_main_view;
-    Int32ConstArrayView m_items_local_id_view;
-    IntPtr m_component; //IMeshComponent*
+    internal MatVarIndexConstArrayView m_matvar_indexes_view;
+    internal ComponentItemInternalPtrConstArrayView m_items_internal_main_view;
+    internal Int32ConstArrayView m_items_local_id_view;
+    internal IntPtr m_component; //IMeshComponent*
 
     public Int32 NbItem() { return m_matvar_indexes_view.m_size; }
   }


### PR DESCRIPTION
This class is internal to Arcane and not exported so the wrapping should not use it.