### PR TITLE
Add class to print material constituents information

### DIFF
--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -261,7 +261,7 @@ arcane_add_test(material_heat3 testMaterialHeat-3.arc)
 arcane_add_test(material_heat_incremental testMaterialHeat-1-incremental.arc)
 arcane_add_test(material_heat2_incremental testMaterialHeat-2-incremental.arc)
 arcane_add_test(material_heat3_incremental testMaterialHeat-3-incremental.arc)
-arcane_add_test_sequential(material_heat2_incremental_small testMaterialHeat-2-incremental-small.arc)
+arcane_add_test_sequential(material_heat2_incremental_small testMaterialHeat-2-incremental-small.arc "-We,ARCANE_DEBUG_MATERIAL_MODIFIER,2")
 
 ###################
 # WRAPPING '.Net' #

--- a/arcane/src/arcane/materials/ConstituentListPrinter.cc
+++ b/arcane/src/arcane/materials/ConstituentListPrinter.cc
@@ -1,0 +1,104 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ConstituentListPrinter.cc                                   (C) 2000-2023 */
+/*                                                                           */
+/* Fonctions utilitaires d'affichage des constituants.                       */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/materials/internal/ConstituentListPrinter.h"
+
+#include "arcane/materials/internal/MeshMaterialMng.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Materials
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ConstituentListPrinter::
+ConstituentListPrinter(MeshMaterialMng* mm)
+: TraceAccessor(mm->traceMng())
+, m_material_mng(mm)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ConstituentListPrinter::
+print()
+{
+  IMesh* mesh = m_material_mng->mesh();
+  _printConstituentsPerCell(mesh->allCells().view());
+  _printConstituents();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ConstituentListPrinter::
+_printConstituentsPerCell(ItemVectorView items)
+{
+  info() << "ConstituentsPerCell:";
+  CellToAllEnvCellConverter all_env_cell_converter(m_material_mng);
+  ENUMERATE_ (Cell, icell, items) {
+    AllEnvCell all_env_cell = all_env_cell_converter[icell];
+    Cell global_cell = all_env_cell.globalCell();
+    info() << "Cell=" << global_cell.uniqueId();
+    ENUMERATE_CELL_ENVCELL (ienvcell, all_env_cell) {
+      EnvCell ec = *ienvcell;
+      info() << " EnvCell mv=" << ec._varIndex()
+             << " env=" << ec.component()->name();
+      ENUMERATE_CELL_MATCELL (imatcell, (*ienvcell)) {
+        MatCell mc = *imatcell;
+        info() << "  MatCell mv=" << mc._varIndex()
+               << " mat=" << mc.component()->name();
+      }
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ConstituentListPrinter::
+_printConstituents()
+{
+  info() << "Constituents:";
+  ENUMERATE_ENV (ienv, m_material_mng) {
+    IMeshEnvironment* env = *ienv;
+    info() << "ENV name=" << env->name();
+    ENUMERATE_ENVCELL (icell, env) {
+      EnvCell ev = *icell;
+      info() << "EnvCell mv=" << ev._varIndex();
+    }
+    ENUMERATE_MAT (imat, env) {
+      Materials::IMeshMaterial* mat = *imat;
+      info() << "MAT name=" << mat->name();
+      ENUMERATE_MATCELL (icell, mat) {
+        MatCell mc = *icell;
+        info() << "MatCell mv=" << mc._varIndex();
+      }
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Materials
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/ConstituentListPrinter.h
+++ b/arcane/src/arcane/materials/internal/ConstituentListPrinter.h
@@ -1,0 +1,71 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ConstituentListPrinter.h                                    (C) 2000-2023 */
+/*                                                                           */
+/* Fonctions utilitaires d'affichage des constituants.                       */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_MATERIALS_INTERNAL_COMPONENTLISTPRINTER_H
+#define ARCANE_MATERIALS_INTERNAL_COMPONENTLISTPRINTER_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/TraceAccessor.h"
+#include "arcane/utils/Array.h"
+
+#include "arcane/core/VariableTypes.h"
+
+#include "arcane/materials/MaterialsGlobal.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Materials
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Fonctions utilitaires d'affichage des constituants.
+ */
+class ARCANE_MATERIALS_EXPORT ConstituentListPrinter
+: public TraceAccessor
+{
+ public:
+
+  explicit ConstituentListPrinter(MeshMaterialMng* mm);
+
+ public:
+
+  ConstituentListPrinter(ConstituentListPrinter&&) = delete;
+  ConstituentListPrinter(const ConstituentListPrinter&) = delete;
+  ConstituentListPrinter& operator=(ConstituentListPrinter&&) = delete;
+  ConstituentListPrinter& operator=(const ConstituentListPrinter&) = delete;
+
+ public:
+
+  void print();
+
+ private:
+
+  MeshMaterialMng* m_material_mng = nullptr;
+
+ private:
+
+  void _printConstituentsPerCell(ItemVectorView items);
+  void _printConstituents();
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Materials
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/materials/internal/MeshMaterialModifierImpl.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialModifierImpl.h
@@ -83,15 +83,21 @@ class MeshMaterialModifierImpl
 
   MeshMaterialMng* m_material_mng = nullptr;
   OperationList m_operations;
-  Integer nb_update = 0;
-  Integer nb_save_restore = 0;
-  Integer nb_optimize_add = 0;
-  Integer nb_optimize_remove = 0;
+  Int32 nb_update = 0;
+  Int32 nb_save_restore = 0;
+  Int32 nb_optimize_add = 0;
+  Int32 nb_optimize_remove = 0;
+  Int32 m_modification_id = 0;
 
   bool m_allow_optimization = false;
   bool m_allow_optimize_multiple_operation = false;
   bool m_allow_optimize_multiple_material = false;
   bool m_use_incremental_recompute = false;
+  bool m_print_component_list = false;
+
+ private:
+
+  void _endUpdate();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/srcs.cmake
+++ b/arcane/src/arcane/materials/srcs.cmake
@@ -12,6 +12,7 @@ set(ARCANE_SOURCES
   ComponentSimd.h
   ComponentConnectivityList.cc
   ComponentItemInternalData.cc
+  ConstituentListPrinter.cc
   ComponentModifierWorkInfo.cc
   EnumeratorTracer.cc
   EnumeratorTracer.h
@@ -120,6 +121,7 @@ set(ARCANE_SOURCES
   internal/ComponentConnectivityList.h
   internal/ComponentItemInternalData.h
   internal/ComponentItemListBuilder.h
+  internal/ConstituentListPrinter.h
   internal/ComponentModifierWorkInfo.h
   internal/IncrementalComponentModifier.h
   internal/IMeshMaterialModifierImpl.h


### PR DESCRIPTION
This class is currently used in `MeshMaterialModifier` to print information before and after modification of constituents.