### PR TITLE
Separate 'IIncrementalItemConnectivity' into source and target interface

### DIFF
--- a/arcane/src/arcane/core/ArcaneTypes.h
+++ b/arcane/src/arcane/core/ArcaneTypes.h
@@ -122,6 +122,8 @@ class IMeshInitialAllocator;
 class UnstructuredMeshAllocateBuildInfo;
 class CartesianMeshAllocateBuildInfo;
 class IIncrementalItemConnectivity;
+class IIncrementalItemTargetConnectivity;
+class IIncrementalItemSourceConnectivity;
 enum class eMeshStructure;
 enum class eMeshAMRKind;
 
@@ -533,7 +535,8 @@ ARCCORE_DECLARE_REFERENCE_COUNTED_CLASS(Arcane::ICaseFunction)
 ARCCORE_DECLARE_REFERENCE_COUNTED_CLASS(Arcane::ICaseOptions)
 ARCCORE_DECLARE_REFERENCE_COUNTED_CLASS(Arcane::ICaseMng)
 ARCCORE_DECLARE_REFERENCE_COUNTED_CLASS(Arcane::ICaseOptionList)
-ARCCORE_DECLARE_REFERENCE_COUNTED_CLASS(Arcane::IIncrementalItemConnectivity)
+ARCCORE_DECLARE_REFERENCE_COUNTED_CLASS(Arcane::IIncrementalItemSourceConnectivity)
+ARCCORE_DECLARE_REFERENCE_COUNTED_CLASS(Arcane::IIncrementalItemTargetConnectivity)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/IIncrementalItemConnectivity.h
+++ b/arcane/src/arcane/core/IIncrementalItemConnectivity.h
@@ -27,6 +27,71 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
+class ARCANE_CORE_EXPORT IIncrementalItemSourceConnectivity
+{
+  ARCCORE_DECLARE_REFERENCE_COUNTED_INCLASS_METHODS();
+
+ protected:
+
+  virtual ~IIncrementalItemSourceConnectivity() = default;
+
+ public:
+
+  //! Famille source
+  virtual IItemFamily* sourceFamily() const = 0;
+
+  //TODO: utiliser un mécanisme par évènement.
+  //! Notifie la connectivité que la famille source est compactée.
+  virtual void notifySourceFamilyLocalIdChanged(Int32ConstArrayView new_to_old_ids) = 0;
+
+  //! Notifie la connectivité qu'une entité a été ajoutée à la famille source.
+  virtual void notifySourceItemAdded(ItemLocalId item) = 0;
+
+  /*!
+   * \brief Réserve la mémoire pour \a n entités sources.
+   *
+   * L'appel à cette méthode est optionnel mais permet d'éviter de multiples
+   * réallocations lors d'appels successifs à notifySourceItemAdded().
+   *
+   * Si \a pre_alloc_connectivity est vrai, préalloue aussi les la liste des
+   * connectivités en fonction de la valeur de preAllocatedSize(). Par exemple
+   * si preAllocatedSize() vaut 4 et si \a n vaut 10000, on va préallouer
+   * pour 40000 connectivités. Pour éviter une surconsommation mémoire inutile,
+   * il ne faut préallouer les connectivités que si on est sur qu'on va les utiliser.
+   */
+  virtual void reserveMemoryForNbSourceItems(Int32 n, bool pre_alloc_connectivity);
+
+  //! Notifie la connectivité qu'on a effectué une relecture à partir d'une protection
+  virtual void notifyReadFromDump() = 0;
+
+  //! Retourne une référence sur l'instance
+  virtual Ref<IIncrementalItemSourceConnectivity> toSourceReference() = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class ARCANE_CORE_EXPORT IIncrementalItemTargetConnectivity
+{
+  ARCCORE_DECLARE_REFERENCE_COUNTED_INCLASS_METHODS();
+
+ protected:
+
+  virtual ~IIncrementalItemTargetConnectivity() = default;
+
+ public:
+
+  //TODO: utiliser un mécanisme par évènement.
+  //! Notifie la connectivité que la famille cible est compactée.
+  virtual void notifyTargetFamilyLocalIdChanged(Int32ConstArrayView old_to_new_ids) = 0;
+
+  //! Retourne une référence sur l'instance
+  virtual Ref<IIncrementalItemTargetConnectivity> toTargetReference() = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \brief Interface pour gérer une connectivité incrémentale.
  *
@@ -35,6 +100,8 @@ namespace Arcane
  */
 class ARCANE_CORE_EXPORT IIncrementalItemConnectivity
 : public IItemConnectivityAccessor
+, public IIncrementalItemSourceConnectivity
+, public IIncrementalItemTargetConnectivity
 {
   ARCCORE_DECLARE_REFERENCE_COUNTED_INCLASS_METHODS();
 
@@ -50,9 +117,6 @@ class ARCANE_CORE_EXPORT IIncrementalItemConnectivity
 
   //! Liste des familles (sourceFamily() + targetFamily())
   virtual ConstArrayView<IItemFamily*> families() const = 0;
-
-  //! Famille source
-  virtual IItemFamily* sourceFamily() const = 0;
 
   //! Famille cible
   virtual IItemFamily* targetFamily() const = 0;
@@ -75,19 +139,13 @@ class ARCANE_CORE_EXPORT IIncrementalItemConnectivity
   //! Test l'existence d'un connectivité entre \a source_item et l'entité de localId() \a target_local_id
   virtual bool hasConnectedItem(ItemLocalId source_item, ItemLocalId target_local_id) const = 0;
 
-  //TODO: utiliser un mécanisme par évènement.
-  //! Notifie la connectivité que la famille source est compactée.
-  virtual void notifySourceFamilyLocalIdChanged(Int32ConstArrayView new_to_old_ids) = 0;
-
-  //TODO: utiliser un mécanisme par évènement.
-  //! Notifie la connectivité que la famille cible est compactée.
-  virtual void notifyTargetFamilyLocalIdChanged(Int32ConstArrayView old_to_new_ids) = 0;
-
-  //! Notifie la connectivité qu'une entité a été ajoutée à la famille source.
-  virtual void notifySourceItemAdded(ItemLocalId item) = 0;
-
-  //! Notifie la connectivité qu'on a effectué une relecture à partir d'une protection
-  virtual void notifyReadFromDump() = 0;
+  /*!
+   * \brief Nombre maximum d'entités connectées à une entité source.
+   *
+   * Cette valeur peut être supérieure au nombre maximum actuel d'entités
+   * connectées s'il y a eu des appels à removeConnectedItem() et removeConnectedItems().
+   */
+  virtual Int32 maxNbConnectedItem() const = 0;
 
   //! Nombre d'entités préalloués pour la connectivité de chaque entité
   virtual Integer preAllocatedSize() const = 0;
@@ -97,31 +155,6 @@ class ARCANE_CORE_EXPORT IIncrementalItemConnectivity
 
   //! Sort sur le flot \a out des statistiques sur l'utilisation et la mémoire utilisée
   virtual void dumpStats(std::ostream& out) const = 0;
-
-  /*!
-   * \brief Nombre maximum d'entités connectées à une entité source.
-   *
-   * Cette valeur peut être supérieure au nombre maximum actuel d'entités
-   * connectées s'il y a eu des appels à removeConnectedItem() et removeConnectedItems().
-   */
-  virtual Int32 maxNbConnectedItem() const = 0;
-
-  /*!
-   * \brief Réserve la mémoire pour \a n entités sources.
-   *
-   * L'appel à cette méthode est optionnel mais permet d'éviter de multiples
-   * réallocations lors d'appels successifs à notifySourceItemAdded().
-   *
-   * Si \a pre_alloc_connectivity est vrai, préalloue aussi les la liste des
-   * connectivités en fonction de la valeur de preAllocatedSize(). Par exemple
-   * si preAllocatedSize() vaut 4 et si \a n vaut 10000, on va préallouer
-   * pour 40000 connectivités. Pour éviter une surconsommation mémoire inutile,
-   * il ne faut préallouer les connectivités que si on est sur qu'on va les utiliser.
-   */
-  virtual void reserveMemoryForNbSourceItems(Int32 n, bool pre_alloc_connectivity);
-
-  //! Retourne une référence sur l'instance
-  virtual Ref<IIncrementalItemConnectivity> toReference() = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/InterfaceImpl.cc
+++ b/arcane/src/arcane/core/InterfaceImpl.cc
@@ -207,7 +207,7 @@ findOrAllocOne(Int64 uid,ItemTypeInfo* type, mesh::MeshInfos& mesh_info, bool& i
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void IIncrementalItemConnectivity::
+void IIncrementalItemSourceConnectivity::
 reserveMemoryForNbSourceItems([[maybe_unused]] Int32 n,
                               [[maybe_unused]] bool pre_alloc_connectivity)
 {

--- a/arcane/src/arcane/core/internal/IItemFamilyInternal.h
+++ b/arcane/src/arcane/core/internal/IItemFamilyInternal.h
@@ -86,8 +86,8 @@ class ARCANE_CORE_EXPORT IItemFamilyInternal
    */
   virtual void resizeVariables(bool force_resize) = 0;
 
-  virtual void addSourceConnectivity(IIncrementalItemConnectivity* connectivity) = 0;
-  virtual void addTargetConnectivity(IIncrementalItemConnectivity* connectivity) = 0;
+  virtual void addSourceConnectivity(IIncrementalItemSourceConnectivity* connectivity) = 0;
+  virtual void addTargetConnectivity(IIncrementalItemTargetConnectivity* connectivity) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -79,10 +79,19 @@ AbstractIncrementalItemConnectivity(IItemFamily* source_family,
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-Ref<IIncrementalItemConnectivity> AbstractIncrementalItemConnectivity::
-toReference()
+Ref<IIncrementalItemSourceConnectivity> AbstractIncrementalItemConnectivity::
+toSourceReference()
 {
-  return Arccore::makeRef<IIncrementalItemConnectivity>(this);
+  return Arccore::makeRef<IIncrementalItemSourceConnectivity>(this);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+Ref<IIncrementalItemTargetConnectivity> AbstractIncrementalItemConnectivity::
+toTargetReference()
+{
+  return Arccore::makeRef<IIncrementalItemTargetConnectivity>(this);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
@@ -68,7 +68,8 @@ class ARCANE_MESH_EXPORT AbstractIncrementalItemConnectivity
   IItemFamily* sourceFamily() const override { return m_source_family;}
   IItemFamily* targetFamily() const override { return m_target_family;}
 
-  Ref<IIncrementalItemConnectivity> toReference() override;
+  Ref<IIncrementalItemSourceConnectivity> toSourceReference() override;
+  Ref<IIncrementalItemTargetConnectivity> toTargetReference() override;
 
  protected:
 

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -137,11 +137,11 @@ class ItemFamily::InternalApi
   {
     return m_family->commonItemSharedInfo();
   }
-  void addSourceConnectivity(IIncrementalItemConnectivity* connectivity) override
+  void addSourceConnectivity(IIncrementalItemSourceConnectivity* connectivity) override
   {
     m_family->_addSourceConnectivity(connectivity);
   }
-  void addTargetConnectivity(IIncrementalItemConnectivity* connectivity) override
+  void addTargetConnectivity(IIncrementalItemTargetConnectivity* connectivity) override
   {
     m_family->_addTargetConnectivity(connectivity);
   }
@@ -2334,18 +2334,18 @@ setConnectivityMng(IItemConnectivityMng* connectivity_mng)
 /*---------------------------------------------------------------------------*/
 
 void ItemFamily::
-_addSourceConnectivity(IIncrementalItemConnectivity* c)
+_addSourceConnectivity(IIncrementalItemSourceConnectivity* c)
 {
-  m_source_incremental_item_connectivities.add(c->toReference());
+  m_source_incremental_item_connectivities.add(c->toSourceReference());
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 void ItemFamily::
-_addTargetConnectivity(IIncrementalItemConnectivity* c)
+_addTargetConnectivity(IIncrementalItemTargetConnectivity* c)
 {
-  m_target_incremental_item_connectivities.add(c->toReference());
+  m_target_incremental_item_connectivities.add(c->toTargetReference());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -380,8 +380,8 @@ class ARCANE_MESH_EXPORT ItemFamily
 
  private:
 
-  UniqueArray<Ref<IIncrementalItemConnectivity>> m_source_incremental_item_connectivities;
-  UniqueArray<Ref<IIncrementalItemConnectivity>> m_target_incremental_item_connectivities;
+  UniqueArray<Ref<IIncrementalItemSourceConnectivity>> m_source_incremental_item_connectivities;
+  UniqueArray<Ref<IIncrementalItemTargetConnectivity>> m_target_incremental_item_connectivities;
 
  protected:
 
@@ -537,8 +537,8 @@ class ARCANE_MESH_EXPORT ItemFamily
   void _resizeItemVariables(Int32 new_size,bool force_resize);
   void _handleOldCheckpoint();
 
-  void _addSourceConnectivity(IIncrementalItemConnectivity* c);
-  void _addTargetConnectivity(IIncrementalItemConnectivity* c);
+  void _addSourceConnectivity(IIncrementalItemSourceConnectivity* c);
+  void _addTargetConnectivity(IIncrementalItemTargetConnectivity* c);
   void _addVariable(IVariable* var);
   void _removeVariable(IVariable* var);
   void _resizeVariables(bool force_resize);

--- a/arcane/src/arcane/mesh/NewWithLegacyConnectivity.h
+++ b/arcane/src/arcane/mesh/NewWithLegacyConnectivity.h
@@ -130,9 +130,13 @@ public:
   //! Nombre maximum d'entités connectées à une entité source.
   Int32 maxNbConnectedItem() const override { return Base::trueCustomConnectivity()->maxNbConnectedItem(); }
 
-  Ref<IIncrementalItemConnectivity> toReference() override
+  Ref<IIncrementalItemSourceConnectivity> toSourceReference() override
   {
-    return Arccore::makeRef<IIncrementalItemConnectivity>(this);
+    return Arccore::makeRef<IIncrementalItemSourceConnectivity>(this);
+  }
+  Ref<IIncrementalItemTargetConnectivity> toTargetReference() override
+  {
+    return Arccore::makeRef<IIncrementalItemTargetConnectivity>(this);
   }
 
   protected:


### PR DESCRIPTION
This will allow us to use connectivity without target connectivity.