### PR TITLE
Cleanup VariableSynchronizer

### DIFF
--- a/arcane/src/arcane/impl/DataSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/impl/DataSynchronizeDispatcher.cc
@@ -149,7 +149,7 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcher
 
   explicit DataSynchronizeDispatcher(const DataSynchronizeDispatcherBuildInfo& bi)
   : DataSynchronizeDispatcherBase(bi)
-  , m_sync_buffer(m_sync_info.get(), bi.synchronizeMemory())
+  , m_sync_buffer(m_sync_info.get(), bi.synchronizeMemory(), bi.bufferCopier())
   {
   }
 
@@ -279,7 +279,7 @@ class ARCANE_IMPL_EXPORT DataSynchronizeMultiDispatcherV2
 
   explicit DataSynchronizeMultiDispatcherV2(const DataSynchronizeDispatcherBuildInfo& bi)
   : DataSynchronizeDispatcherBase(bi)
-  , m_sync_buffer(bi.parallelMng()->traceMng(), m_sync_info.get(), bi.synchronizeMemory())
+  , m_sync_buffer(bi.parallelMng()->traceMng(), m_sync_info.get(), bi.synchronizeMemory(), bi.bufferCopier())
   {
   }
 

--- a/arcane/src/arcane/impl/DataSynchronizeDispatcher.cc
+++ b/arcane/src/arcane/impl/DataSynchronizeDispatcher.cc
@@ -379,13 +379,13 @@ synchronize(ConstArrayView<IVariable*> vars)
  *
  * Cette implémentation est faite à partir de send/receive suivi de 'wait'.
  */
-class SimpleDataSynchronizeDispatcher
+class SimpleDataSynchronizeImplementation
 : public AbstractDataSynchronizeImplementation
 {
  public:
 
   class Factory;
-  explicit SimpleDataSynchronizeDispatcher(Factory* f);
+  explicit SimpleDataSynchronizeImplementation(Factory* f);
 
  protected:
 
@@ -402,7 +402,7 @@ class SimpleDataSynchronizeDispatcher
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-class SimpleDataSynchronizeDispatcher::Factory
+class SimpleDataSynchronizeImplementation::Factory
 : public IDataSynchronizeImplementationFactory
 {
  public:
@@ -413,7 +413,7 @@ class SimpleDataSynchronizeDispatcher::Factory
 
   Ref<IDataSynchronizeImplementation> createInstance() override
   {
-    auto* x = new SimpleDataSynchronizeDispatcher(this);
+    auto* x = new SimpleDataSynchronizeImplementation(this);
     return makeRef<IDataSynchronizeImplementation>(x);
   }
 
@@ -425,8 +425,8 @@ class SimpleDataSynchronizeDispatcher::Factory
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-SimpleDataSynchronizeDispatcher::
-SimpleDataSynchronizeDispatcher(Factory* f)
+SimpleDataSynchronizeImplementation::
+SimpleDataSynchronizeImplementation(Factory* f)
 : m_parallel_mng(f->m_parallel_mng)
 {
 }
@@ -437,14 +437,14 @@ SimpleDataSynchronizeDispatcher(Factory* f)
 extern "C++" Ref<IDataSynchronizeImplementationFactory>
 arcaneCreateSimpleVariableSynchronizerFactory(IParallelMng* pm)
 {
-  auto* x = new SimpleDataSynchronizeDispatcher::Factory(pm);
+  auto* x = new SimpleDataSynchronizeImplementation::Factory(pm);
   return makeRef<IDataSynchronizeImplementationFactory>(x);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void SimpleDataSynchronizeDispatcher::
+void SimpleDataSynchronizeImplementation::
 beginSynchronize(IDataSynchronizeBuffer* vs_buf)
 {
   ARCANE_CHECK_POINTER(vs_buf);
@@ -489,7 +489,7 @@ beginSynchronize(IDataSynchronizeBuffer* vs_buf)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void SimpleDataSynchronizeDispatcher::
+void SimpleDataSynchronizeImplementation::
 endSynchronize(IDataSynchronizeBuffer* vs_buf)
 {
   IParallelMng* pm = m_parallel_mng;

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -242,7 +242,11 @@ _buildMessage()
   DataSynchronizeMemory* memory = new DataSynchronizeMemory(allocator);
   Ref<DataSynchronizeMemory> ref_memory = makeRef<DataSynchronizeMemory>(memory);
 
-  DataSynchronizeDispatcherBuildInfo bi(m_parallel_mng, m_implementation_factory, m_sync_info, ref_memory, buffer_copier, runner);
+  // Créé une instance de l'implémentation
+  Ref<IDataSynchronizeImplementation> sync_impl = m_implementation_factory->createInstance();
+  sync_impl->setDataSynchronizeInfo(m_sync_info.get());
+
+  DataSynchronizeDispatcherBuildInfo bi(m_parallel_mng, sync_impl, m_sync_info, ref_memory, buffer_copier, runner);
   return new SyncMessage(bi, this);
 }
 

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -239,10 +239,10 @@ _buildMessage()
     allocator = platform::getDataMemoryRessourceMng()->getAllocator(eMemoryRessource::Device);
   }
 
-  DataSynchronizeMemory* memory = new DataSynchronizeMemory(buffer_copier, allocator);
+  DataSynchronizeMemory* memory = new DataSynchronizeMemory(allocator);
   Ref<DataSynchronizeMemory> ref_memory = makeRef<DataSynchronizeMemory>(memory);
 
-  DataSynchronizeDispatcherBuildInfo bi(m_parallel_mng, m_implementation_factory, m_sync_info, ref_memory, runner);
+  DataSynchronizeDispatcherBuildInfo bi(m_parallel_mng, m_implementation_factory, m_sync_info, ref_memory, buffer_copier, runner);
   return new SyncMessage(bi, this);
 }
 

--- a/arcane/src/arcane/impl/internal/DataSynchronizeBuffer.h
+++ b/arcane/src/arcane/impl/internal/DataSynchronizeBuffer.h
@@ -96,7 +96,8 @@ class ARCANE_IMPL_EXPORT DataSynchronizeBufferBase
 
  public:
 
-  DataSynchronizeBufferBase(DataSynchronizeInfo* sync_info, Ref<DataSynchronizeMemory> memory);
+  DataSynchronizeBufferBase(DataSynchronizeInfo* sync_info, Ref<DataSynchronizeMemory> memory,
+                            Ref<IBufferCopier> copier);
 
  public:
 
@@ -136,6 +137,8 @@ class ARCANE_IMPL_EXPORT DataSynchronizeBufferBase
 
   //! Buffer contenant les données concaténées en envoi et réception
   Ref<DataSynchronizeMemory> m_memory;
+
+  Ref<IBufferCopier> m_buffer_copier;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -148,8 +151,9 @@ class ARCANE_IMPL_EXPORT SingleDataSynchronizeBuffer
 {
  public:
 
-  SingleDataSynchronizeBuffer(DataSynchronizeInfo* sync_info, Ref<DataSynchronizeMemory> memory)
-  : DataSynchronizeBufferBase(sync_info, memory)
+  SingleDataSynchronizeBuffer(DataSynchronizeInfo* sync_info, Ref<DataSynchronizeMemory> memory,
+                              Ref<IBufferCopier> copier)
+  : DataSynchronizeBufferBase(sync_info, memory, copier)
   {}
 
  public:
@@ -187,9 +191,11 @@ class ARCANE_IMPL_EXPORT MultiDataSynchronizeBuffer
 
  public:
 
-  MultiDataSynchronizeBuffer(ITraceMng* tm, DataSynchronizeInfo* sync_info, Ref<DataSynchronizeMemory> memory)
+  MultiDataSynchronizeBuffer(ITraceMng* tm, DataSynchronizeInfo* sync_info,
+                             Ref<DataSynchronizeMemory> memory,
+                             Ref<IBufferCopier> copier)
   : TraceAccessor(tm)
-  , DataSynchronizeBufferBase(sync_info, memory)
+  , DataSynchronizeBufferBase(sync_info, memory, copier)
   {}
 
  public:

--- a/arcane/src/arcane/impl/internal/DataSynchronizeMemory.h
+++ b/arcane/src/arcane/impl/internal/DataSynchronizeMemory.h
@@ -33,9 +33,8 @@ class ARCANE_IMPL_EXPORT DataSynchronizeMemory
 {
  public:
 
-  DataSynchronizeMemory(Ref<IBufferCopier> copier, IMemoryAllocator* allocator)
-  : m_buffer_copier(copier)
-  , m_buffer(allocator)
+  explicit DataSynchronizeMemory(IMemoryAllocator* allocator)
+  : m_buffer(allocator)
   {}
 
  public:
@@ -44,11 +43,9 @@ class ARCANE_IMPL_EXPORT DataSynchronizeMemory
   Span<const std::byte> bytes() const { return m_buffer; }
   Span<std::byte> bytes() { return m_buffer; }
   IMemoryAllocator* allocator() const { return m_buffer.allocator(); }
-  IBufferCopier* copier() const { return m_buffer_copier.get(); }
 
  private:
 
-  Ref<IBufferCopier> m_buffer_copier;
   //! Buffer contenant les données.
   UniqueArray<std::byte> m_buffer;
 };

--- a/arcane/src/arcane/impl/internal/IDataSynchronizeDispatcher.h
+++ b/arcane/src/arcane/impl/internal/IDataSynchronizeDispatcher.h
@@ -50,13 +50,13 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
  public:
 
   DataSynchronizeDispatcherBuildInfo(IParallelMng* pm,
-                                     Ref<IDataSynchronizeImplementationFactory> factory,
+                                     Ref<IDataSynchronizeImplementation> sync_impl,
                                      Ref<DataSynchronizeInfo> sync_info,
                                      Ref<DataSynchronizeMemory> memory,
                                      Ref<IBufferCopier> copier,
                                      Runner* runner)
   : m_parallel_mng(pm)
-  , m_factory(factory)
+  , m_synchronize_implementation(sync_impl)
   , m_synchronize_info(sync_info)
   , m_synchronize_memory(memory)
   , m_buffer_copier(copier)
@@ -66,7 +66,7 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
  public:
 
   IParallelMng* parallelMng() const { return m_parallel_mng; }
-  Ref<IDataSynchronizeImplementationFactory> factory() const { return m_factory; }
+  Ref<IDataSynchronizeImplementation> synchronizeImplementation() const { return m_synchronize_implementation; }
   Ref<DataSynchronizeInfo> synchronizeInfo() const { return m_synchronize_info; }
   Ref<DataSynchronizeMemory> synchronizeMemory() const { return m_synchronize_memory; }
   Ref<IBufferCopier> bufferCopier() const { return m_buffer_copier; }
@@ -75,7 +75,7 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
  private:
 
   IParallelMng* m_parallel_mng = nullptr;
-  Ref<IDataSynchronizeImplementationFactory> m_factory;
+  Ref<IDataSynchronizeImplementation> m_synchronize_implementation;
   Ref<DataSynchronizeInfo> m_synchronize_info;
   Ref<DataSynchronizeMemory> m_synchronize_memory;
   Ref<IBufferCopier> m_buffer_copier;

--- a/arcane/src/arcane/impl/internal/IDataSynchronizeDispatcher.h
+++ b/arcane/src/arcane/impl/internal/IDataSynchronizeDispatcher.h
@@ -38,6 +38,7 @@ class DataSynchronizeResult;
 class DataSynchronizeMemory;
 class IVariableSynchronizerDispatcher;
 class INumericDataInternal;
+class IBufferCopier;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -52,11 +53,13 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
                                      Ref<IDataSynchronizeImplementationFactory> factory,
                                      Ref<DataSynchronizeInfo> sync_info,
                                      Ref<DataSynchronizeMemory> memory,
+                                     Ref<IBufferCopier> copier,
                                      Runner* runner)
   : m_parallel_mng(pm)
   , m_factory(factory)
   , m_synchronize_info(sync_info)
   , m_synchronize_memory(memory)
+  , m_buffer_copier(copier)
   , m_runner(runner)
   {}
 
@@ -66,6 +69,7 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
   Ref<IDataSynchronizeImplementationFactory> factory() const { return m_factory; }
   Ref<DataSynchronizeInfo> synchronizeInfo() const { return m_synchronize_info; }
   Ref<DataSynchronizeMemory> synchronizeMemory() const { return m_synchronize_memory; }
+  Ref<IBufferCopier> bufferCopier() const { return m_buffer_copier; }
   Runner* runner() const { return m_runner; }
 
  private:
@@ -74,6 +78,7 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
   Ref<IDataSynchronizeImplementationFactory> m_factory;
   Ref<DataSynchronizeInfo> m_synchronize_info;
   Ref<DataSynchronizeMemory> m_synchronize_memory;
+  Ref<IBufferCopier> m_buffer_copier;
   Runner* m_runner = nullptr;
 };
 

--- a/arcane/src/arcane/impl/internal/IDataSynchronizeDispatcher.h
+++ b/arcane/src/arcane/impl/internal/IDataSynchronizeDispatcher.h
@@ -53,14 +53,12 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
                                      Ref<IDataSynchronizeImplementation> sync_impl,
                                      Ref<DataSynchronizeInfo> sync_info,
                                      Ref<DataSynchronizeMemory> memory,
-                                     Ref<IBufferCopier> copier,
-                                     Runner* runner)
+                                     Ref<IBufferCopier> copier)
   : m_parallel_mng(pm)
   , m_synchronize_implementation(sync_impl)
   , m_synchronize_info(sync_info)
   , m_synchronize_memory(memory)
   , m_buffer_copier(copier)
-  , m_runner(runner)
   {}
 
  public:
@@ -70,7 +68,6 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
   Ref<DataSynchronizeInfo> synchronizeInfo() const { return m_synchronize_info; }
   Ref<DataSynchronizeMemory> synchronizeMemory() const { return m_synchronize_memory; }
   Ref<IBufferCopier> bufferCopier() const { return m_buffer_copier; }
-  Runner* runner() const { return m_runner; }
 
  private:
 
@@ -79,7 +76,6 @@ class ARCANE_IMPL_EXPORT DataSynchronizeDispatcherBuildInfo
   Ref<DataSynchronizeInfo> m_synchronize_info;
   Ref<DataSynchronizeMemory> m_synchronize_memory;
   Ref<IBufferCopier> m_buffer_copier;
-  Runner* m_runner = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/VariableSynchronizer.h
+++ b/arcane/src/arcane/impl/internal/VariableSynchronizer.h
@@ -108,6 +108,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizer
   Ref<IDataSynchronizeImplementationFactory> m_implementation_factory;
   IVariableSynchronizerMng* m_variable_synchronizer_mng = nullptr;
   SyncMessage* m_default_message = nullptr;
+  Runner* m_runner = nullptr;
 
  private:
 
@@ -120,6 +121,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizer
   void _sendEvent(VariableSynchronizerEventArgs& args);
   void _checkCreateTimer();
   void _doSynchronize(SyncMessage* message);
+  void _setCurrentDevice();
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
- Rename `SimpleDataSynchronizeDispatcher` to `SimpleDataSynchronizeImplementation` 
- Remove instance of `IBufferCopier` in `DataSynchronizeMemory`
- Move instance of `Runner` from `DataSynchronizeDispatcher` to `VariableSynchronizer`.