### PR TITLE
Add class to keep statistics about variables synchronizations

### DIFF
--- a/arcane/src/arcane/core/IVariableSynchronizerMng.h
+++ b/arcane/src/arcane/core/IVariableSynchronizerMng.h
@@ -50,6 +50,9 @@ class ARCANE_CORE_EXPORT IVariableSynchronizerMng
 
   //! Indique si on effecture les comparaisons des valeurs avant et après synchronisation
   virtual bool isCompareSynchronize() const = 0;
+
+  //! Affiche les statistiques sur le flot \a ostr
+  virtual void dumpStats(std::ostream& ostr) const = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableSynchronizerEventArgs.cc
+++ b/arcane/src/arcane/core/VariableSynchronizerEventArgs.cc
@@ -84,8 +84,11 @@ initialize(const VariableCollection& vars)
 {
   _reset();
   m_variables.reserve(vars.count());
-  for( VariableCollectionEnumerator v(vars); ++v; )
+  m_compare_status_list.reserve(vars.count());
+  for( VariableCollectionEnumerator v(vars); ++v; ){
     m_variables.add(*v);
+    m_compare_status_list.add(CompareStatus::Unknown);
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -94,8 +97,9 @@ initialize(const VariableCollection& vars)
 void VariableSynchronizerEventArgs::
 initialize(IVariable* var)
 {
-  m_variables.clear();
+  _reset();
   m_variables.add(var);
+  m_compare_status_list.add(CompareStatus::Unknown);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -107,6 +111,7 @@ _reset()
   m_elapsed_time = 0.0;
   m_state = State::BeginSynchronize;
   m_variables.clear();
+  m_compare_status_list.clear();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableSynchronizerEventArgs.h
+++ b/arcane/src/arcane/core/VariableSynchronizerEventArgs.h
@@ -47,6 +47,19 @@ class ARCANE_CORE_EXPORT VariableSynchronizerEventArgs
     EndSynchronize
   };
 
+  //! Comparaison des valeurs des entités fantômes avant/après une synchronisation
+  enum class CompareStatus
+  {
+    //! Pas de comparaison ou résultat inconnue
+    Unknown,
+    //! Même valeurs avant et après la synchronisation
+    Same,
+    //! Valeurs différentes avant et après la synchronisation
+    Different
+  };
+
+ public:
+
   ARCANE_DEPRECATED_REASON("Y2023: Use VariableSynchronizerEventArgs(IVariableSynchronizer* vs) and call initialize() instead")
   VariableSynchronizerEventArgs(VariableCollection vars, IVariableSynchronizer* vs,
                                 Real elapsed_time, State state = State::EndSynchronize);
@@ -75,6 +88,20 @@ class ARCANE_CORE_EXPORT VariableSynchronizerEventArgs
   //! Liste des variables synchronisées.
   ConstArrayView<IVariable*> variables() const;
 
+  /*!
+   * \brief Liste de l'état de comparaison.
+   *
+   * La valeur du i-ème élément de compareStatus() indique l'état
+   * de comparaison pour la i-ème variable de variables().
+   *
+   * Cette liste n'est valide que pour les évènements de fin de synchronisation
+   * (state()==State::EndSynchronize).
+   */
+  ConstArrayView<CompareStatus> compareStatusList() const { return m_compare_status_list; }
+
+  //! Positionne l'état de comparaison de la i-ème variable.
+  void setCompareStatus(Int32 i, CompareStatus v) { m_compare_status_list[i] = v; }
+
   //! Temps passé dans la synchronisation.
   Real elapsedTime() const { return m_elapsed_time; }
   void setElapsedTime(Real v) { m_elapsed_time = v; }
@@ -87,6 +114,7 @@ class ARCANE_CORE_EXPORT VariableSynchronizerEventArgs
 
   IVariableSynchronizer* m_var_syncer = nullptr;
   UniqueArray<IVariable*> m_variables;
+  UniqueArray<CompareStatus> m_compare_status_list;
   Real m_elapsed_time = 0.0;
   State m_state = State::BeginSynchronize;
 

--- a/arcane/src/arcane/impl/ExecutionStatsDumper.cc
+++ b/arcane/src/arcane/impl/ExecutionStatsDumper.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExecutionStatsDumper.cc                                     (C) 2000-2022 */
+/* ExecutionStatsDumper.cc                                     (C) 2000-2023 */
 /*                                                                           */
 /* Ecriture des statistiques d'exécution.                                    */
 /*---------------------------------------------------------------------------*/
@@ -22,16 +22,17 @@
 
 #include "arcane/utils/internal/ProfilingInternal.h"
 
-#include "arcane/ISubDomain.h"
-#include "arcane/IVariableMng.h"
-#include "arcane/IPropertyMng.h"
-#include "arcane/ITimeLoopMng.h"
-#include "arcane/IMesh.h"
-#include "arcane/ITimeStats.h"
-#include "arcane/Directory.h"
-#include "arcane/IParallelMng.h"
-#include "arcane/ServiceBuilder.h"
-#include "arcane/ISimpleTableOutput.h"
+#include "arcane/core/ISubDomain.h"
+#include "arcane/core/IVariableMng.h"
+#include "arcane/core/IVariableSynchronizerMng.h"
+#include "arcane/core/IPropertyMng.h"
+#include "arcane/core/ITimeLoopMng.h"
+#include "arcane/core/IMesh.h"
+#include "arcane/core/ITimeStats.h"
+#include "arcane/core/Directory.h"
+#include "arcane/core/IParallelMng.h"
+#include "arcane/core/ServiceBuilder.h"
+#include "arcane/core/ISimpleTableOutput.h"
 
 #include <iostream>
 #include <iomanip>
@@ -251,8 +252,13 @@ dumpStats(ISubDomain* sd, ITimeStats* time_stat)
       sd->propertyMng()->print(postr());
       plog() << postr.str();
     }
-    // Affiche les statistiques sur les variables
     IVariableMng* vm = sd->variableMng();
+    // Affiche les statistiques sur les synchronisations
+    IVariableSynchronizerMng* vsm = vm->synchronizerMng();
+    OStringStream ostr_vsm;
+    vsm->dumpStats(ostr_vsm());
+    info() << ostr_vsm.str();
+    // Affiche les statistiques sur les variables
     OStringStream ostr_full;
     vm->dumpStats(ostr_full(), true);
     OStringStream ostr;

--- a/arcane/src/arcane/impl/VariableMng.cc
+++ b/arcane/src/arcane/impl/VariableMng.cc
@@ -150,6 +150,8 @@ initialize()
             << " addr=" << vf;
     vff = vff->nextVariableFactory();
   }
+
+  m_variable_synchronizer_mng->initialize();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableSynchronizer.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizer.cc
@@ -289,10 +289,14 @@ _doSynchronize(SyncMessage* message)
   if (nb_var == 1 && m_variable_synchronizer_mng->isCompareSynchronize()) {
     IVariable* var = message->variables()[0];
     eDataSynchronizeCompareStatus s = message->result().compareStatus();
-    if (s == eDataSynchronizeCompareStatus::Different)
+    if (s == eDataSynchronizeCompareStatus::Different) {
+      event_args.setCompareStatus(0, VariableSynchronizerEventArgs::CompareStatus::Different);
       info() << "Different values name=" << var->name();
-    else if (s == eDataSynchronizeCompareStatus::Same)
+    }
+    else if (s == eDataSynchronizeCompareStatus::Same) {
+      event_args.setCompareStatus(0, VariableSynchronizerEventArgs::CompareStatus::Same);
       info() << "Same values name=" << var->name();
+    }
     else
       info() << "Unknown values name=" << var->name();
   }

--- a/arcane/src/arcane/impl/VariableSynchronizerMng.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerMng.cc
@@ -16,6 +16,10 @@
 #include "arcane/utils/ValueConvert.h"
 
 #include "arcane/core/IVariableMng.h"
+#include "arcane/core/VariableSynchronizerEventArgs.h"
+#include "arcane/core/IVariable.h"
+
+#include <map>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -26,13 +30,128 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+class VariableSynchronizerStats
+: public TraceAccessor
+{
+ public:
+
+  class StatInfo
+  {
+   public:
+
+    Int32 m_count = 0;
+    Int32 m_nb_same = 0;
+    Int32 m_nb_different = 0;
+  };
+
+ public:
+
+  explicit VariableSynchronizerStats(ITraceMng* tm)
+  : TraceAccessor(tm)
+  {}
+
+ public:
+
+  void init(VariableSynchronizerMng* vsm)
+  {
+    auto handler = [&](const VariableSynchronizerEventArgs& args) {
+      _handleEvent(args);
+    };
+    vsm->onSynchronized().attach(m_observer_pool, handler);
+    m_is_event_registered = true;
+  }
+
+  void dumpStats(std::ostream& ostr)
+  {
+    ostr.precision(20);
+    ostr << "Synchronization Stats\n";
+    ostr << Trace::Width(40) << "Variable name"
+         << Trace::Width(8) << "Count"
+         << Trace::Width(8) << "NbSame"
+         << Trace::Width(8) << "NbDiff"
+         << "\n";
+    for (auto p : m_stats) {
+      ostr << Trace::Width(40) << p.first
+           << " " << Trace::Width(7) << p.second.m_count
+           << " " << Trace::Width(7) << p.second.m_nb_same
+           << " " << Trace::Width(7) << p.second.m_nb_different
+           << "\n";
+    }
+  }
+
+ private:
+
+  EventObserverPool m_observer_pool;
+  std::map<String, StatInfo> m_stats;
+  bool m_is_event_registered = false;
+
+ private:
+
+  void _handleEvent(const VariableSynchronizerEventArgs& args)
+  {
+    // On ne traite que les évènements de fin de synchronisation
+    if (args.state() != VariableSynchronizerEventArgs::State::EndSynchronize)
+      return;
+    auto compare_status_list = args.compareStatusList();
+    {
+      Int32 index = 0;
+      for (IVariable* var : args.variables()) {
+        auto& v = m_stats[var->fullName()];
+        ++v.m_count;
+        VariableSynchronizerEventArgs::CompareStatus s = compare_status_list[index];
+        if (s == VariableSynchronizerEventArgs::CompareStatus::Same)
+          ++v.m_nb_same;
+        else if (s == VariableSynchronizerEventArgs::CompareStatus::Different)
+          ++v.m_nb_different;
+        ++index;
+      }
+    }
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 VariableSynchronizerMng::
 VariableSynchronizerMng(IVariableMng* vm)
 : TraceAccessor(vm->traceMng())
 , m_variable_mng(vm)
+, m_stats(new VariableSynchronizerStats(vm->traceMng()))
 {
-  if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_AUTO_COMPARE_SYNCHRONIZE", true))
+  if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_AUTO_COMPARE_SYNCHRONIZE", true)) {
     m_is_compare_synchronize = (v.value() != 0);
+    // Si on active la comparaison, on active aussi les statistiques
+    m_is_do_stats = m_is_compare_synchronize;
+  }
+  if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_SYNCHRONIZE_STATS", true))
+    m_is_do_stats = (v.value() != 0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+VariableSynchronizerMng::
+~VariableSynchronizerMng()
+{
+  delete m_stats;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableSynchronizerMng::
+initialize()
+{
+  m_stats->init(this);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableSynchronizerMng::
+dumpStats(std::ostream& ostr) const
+{
+  m_stats->dumpStats(ostr);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/VariableSynchronizerMng.h
+++ b/arcane/src/arcane/impl/internal/VariableSynchronizerMng.h
@@ -25,6 +25,7 @@
 
 namespace Arcane
 {
+class VariableSynchronizerStats;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -38,6 +39,11 @@ class ARCANE_IMPL_EXPORT VariableSynchronizerMng
  public:
 
   explicit VariableSynchronizerMng(IVariableMng* vm);
+  ~VariableSynchronizerMng();
+
+ public:
+
+  void initialize();
 
  public:
 
@@ -49,11 +55,15 @@ class ARCANE_IMPL_EXPORT VariableSynchronizerMng
   void setCompareSynchronize(bool v) { m_is_compare_synchronize = v; }
   bool isCompareSynchronize() const { return m_is_compare_synchronize; }
 
+  void dumpStats(std::ostream& ostr) const override;
+
  private:
 
   IVariableMng* m_variable_mng = nullptr;
   EventObservable<const VariableSynchronizerEventArgs&> m_on_synchronized;
+  VariableSynchronizerStats* m_stats = nullptr;
   bool m_is_compare_synchronize = false;
+  bool m_is_do_stats = false;
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
If activated, some statistics are displayed at the end of the execution.
At the moment, these statistics are not enabled by default.