### PR TITLE
Fix alien_legacy_plugins build on linux centos 7 and rocky 8

### DIFF
--- a/alien/ArcaneInterface/modules/trilinos/src/alien/kernels/trilinos/data_structure/TrilinosMatrix.cc
+++ b/alien/ArcaneInterface/modules/trilinos/src/alien/kernels/trilinos/data_structure/TrilinosMatrix.cc
@@ -160,16 +160,16 @@ TrilinosMatrix<ValueT, TagT>::dump(std::string const& filename) const
 }
 
 #ifdef KOKKOS_ENABLE_SERIAL
-template class TrilinosMatrix<double, BackEnd::tag::tpetraserial>;
+template class ALIEN_TRILINOS_EXPORT TrilinosMatrix<double, BackEnd::tag::tpetraserial>;
 #endif
 #ifdef KOKKOS_ENABLE_OPENMP
-template class TrilinosMatrix<double, BackEnd::tag::tpetraomp>;
+template class ALIEN_TRILINOS_EXPORT TrilinosMatrix<double, BackEnd::tag::tpetraomp>;
 #endif
 #ifdef KOKKOS_ENABLE_THREADS
-template class TrilinosMatrix<double, BackEnd::tag::tpetrapth>;
+template class ALIEN_TRILINOS_EXPORT TrilinosMatrix<double, BackEnd::tag::tpetrapth>;
 #endif
 #ifdef KOKKOS_ENABLE_CUDA
-template class TrilinosMatrix<double, BackEnd::tag::tpetracuda>;
+template class ALIEN_TRILINOS_EXPORT TrilinosMatrix<double, BackEnd::tag::tpetracuda>;
 #endif
 
 } // namespace Alien

--- a/alien/ArcaneInterface/modules/trilinos/src/alien/kernels/trilinos/data_structure/TrilinosMatrix.h
+++ b/alien/ArcaneInterface/modules/trilinos/src/alien/kernels/trilinos/data_structure/TrilinosMatrix.h
@@ -29,7 +29,7 @@ namespace Alien {
 template <typename ValueT, typename TagT> class TrilinosVector;
 
 /*---------------------------------------------------------------------------*/
-template <typename ValueT, typename TagT> class TrilinosMatrix : public IMatrixImpl
+template <typename ValueT, typename TagT> class ALIEN_TRILINOS_EXPORT  TrilinosMatrix : public IMatrixImpl
 {
  public:
   typedef TrilinosInternal::MatrixInternal<ValueT, TagT> MatrixInternal;

--- a/alien/standalone/src/core/alien/kernels/simple_csr/algebra/alien_cblas.h
+++ b/alien/standalone/src/core/alien/kernels/simple_csr/algebra/alien_cblas.h
@@ -28,53 +28,53 @@ double cblas_dnrm2(const int n, const double* x, const int incx);
 namespace cblas
 {
 
-float dot(const int n, const float* x, const int incx, const float* y,
+inline float dot(const int n, const float* x, const int incx, const float* y,
           const int incy)
 {
   return cblas_sdot(n, x, incx, y, incy);
 }
 
-double dot(const int n, const double* x, const int incx, const double* y, const int incy)
+inline double dot(const int n, const double* x, const int incx, const double* y, const int incy)
 {
   return cblas_ddot(n, x, incx, y, incy);
 }
 
-void axpy(const int n, const float alpha, const float* x, const int incx, float* y, const int incy)
+inline void axpy(const int n, const float alpha, const float* x, const int incx, float* y, const int incy)
 {
   return cblas_saxpy(n, alpha, x, incx, y, incy);
 }
 
-void axpy(const int n, const double alpha, const double* x, const int incx, double* y, const int incy)
+inline void axpy(const int n, const double alpha, const double* x, const int incx, double* y, const int incy)
 {
   return cblas_daxpy(n, alpha, x, incx, y, incy);
 }
 
-void copy(const int n, const float* x, const int incx, float* y, const int incy)
+inline void copy(const int n, const float* x, const int incx, float* y, const int incy)
 {
   return cblas_scopy(n, x, incx, y, incy);
 }
 
-void copy(const int n, const double* x, const int incx, double* y, const int incy)
+inline void copy(const int n, const double* x, const int incx, double* y, const int incy)
 {
   return cblas_dcopy(n, x, incx, y, incy);
 }
 
-void scal(const int n, const float alpha, float* x, const int incx)
+inline void scal(const int n, const float alpha, float* x, const int incx)
 {
   return cblas_sscal(n, alpha, x, incx);
 }
 
-void scal(const int n, const double alpha, double* x, const int incx)
+inline void scal(const int n, const double alpha, double* x, const int incx)
 {
   return cblas_dscal(n, alpha, x, incx);
 }
 
-double nrm1(const int n, const double* x, const int incx)
+inline double nrm1(const int n, const double* x, const int incx)
 {
   return cblas_dasum(n, x, incx);
 }
 
-double nrm2(const int n, const double* x, const int incx)
+inline double nrm2(const int n, const double* x, const int incx)
 {
   return cblas_dnrm2(n, x, incx);
 }


### PR DESCRIPTION
will use the new workflow on centos 7 and 8 with ALIEN_BUILD_COMPONENT= all