### PR TITLE
Make CMake option ARCANE_ADD_RPATH_TO_LIBS off by default

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 # dynamiques. Ce mode existe historiquement pour contourner des problèmes avec
 # d'anciennes versions de CMake (pré 3.10) mais ne devrait plus être nécessaire.
 # Il faudrait donc le supprimer.
-option(ARCANE_ADD_RPATH_TO_LIBS "True if we automatically add rpath in target_link_libraries" ON)
+option(ARCANE_ADD_RPATH_TO_LIBS "True if we automatically add rpath in target_link_libraries" OFF)
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This option was used to automatically add 'rpath' arguments for linker from target libname.
This is not needed with modern CMake and it does not work with 'generator expression'.
It will be removed next year.