### PR TITLE
Add support to print synchronization statistics without comparing

### DIFF
--- a/arcane/src/arcane/impl/TimeLoopMng.cc
+++ b/arcane/src/arcane/impl/TimeLoopMng.cc
@@ -1611,16 +1611,18 @@ _dumpTimeInfos(JSONWriter& json_writer)
     o << '\n';
   }
   o.flags(f);
-  //o << '\0';
+
   info() << o.str();
 
   {
-    JSONWriter::Object jo(json_writer,"MessagePassingStats");
     IParallelMng* pm = m_sub_domain->parallelMng();
-    Parallel::IStat* s = pm->stat();
-    if (s){
-      s->printCollective(pm);
-      s->dumpJSON(json_writer);
+    if (pm->isParallel()){
+      JSONWriter::Object jo(json_writer,"MessagePassingStats");
+      Parallel::IStat* s = pm->stat();
+      if (s){
+        s->printCollective(pm);
+        s->dumpJSON(json_writer);
+      }
     }
   }
   {

--- a/arcane/src/arcane/impl/VariableSynchronizerMng.cc
+++ b/arcane/src/arcane/impl/VariableSynchronizerMng.cc
@@ -267,6 +267,8 @@ initialize()
 void VariableSynchronizerMng::
 dumpStats(std::ostream& ostr) const
 {
+  if (!m_parallel_mng->isParallel())
+    return;
   m_stats->dumpStats(ostr);
   m_internal_api.dumpStats(ostr);
 }

--- a/arcane/src/arcane/impl/internal/VariableSynchronizerMng.h
+++ b/arcane/src/arcane/impl/internal/VariableSynchronizerMng.h
@@ -90,6 +90,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizerMng
   void dumpStats(std::ostream& ostr) const override;
   void flushPendingStats() override;
   IVariableSynchronizerMngInternal* _internalApi() { return &m_internal_api; }
+  bool isDoingStats() const { return m_is_doing_stats || m_synchronize_compare_level > 0; }
 
  private:
 
@@ -99,7 +100,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizerMng
   EventObservable<const VariableSynchronizerEventArgs&> m_on_synchronized;
   VariableSynchronizerStats* m_stats = nullptr;
   Int32 m_synchronize_compare_level = 0;
-  bool m_is_do_stats = false;
+  bool m_is_doing_stats = false;
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Also, don't print statistics when not running in parallel.