### PR TITLE
Minor update in Alien build config

### DIFF
--- a/alien/ArcaneInterface/modules/external_packages/src/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/external_packages/src/CMakeLists.txt
@@ -71,3 +71,11 @@ install(DIRECTORY alien
         DESTINATION include
         FILES_MATCHING PATTERN "*.h"
         )
+
+# Explicitly force linking of dependent libraries.
+# This is needed on some platforms (ubuntu) to prevent linker from removing
+# library if its symbols are not explicitly used.
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  message(STATUS "Adding 'no-as-needed' to link option for 'alien_external_packages'")
+  target_link_options(alien_external_packages INTERFACE "-Wl,--no-as-needed")
+endif()

--- a/alien/standalone/src/core/CMakeLists.txt
+++ b/alien/standalone/src/core/CMakeLists.txt
@@ -179,6 +179,9 @@ target_link_libraries(alien_core PUBLIC
                       Arccore::arccore_base
                       Arccore::arccore_message_passing_mpi)
 
+# Compile avec les mêmes avertissements de compilation que 'Arccore'
+target_link_libraries(alien_core PUBLIC $<BUILD_INTERFACE:Arccore::arccore_build_compile_flags>)
+
 find_package(Boost COMPONENTS program_options REQUIRED)
 
 find_package(MPI REQUIRED)


### PR DESCRIPTION
- Use same generic compilation flags as `Arccore` to enable usage of `ccache` on Win32.
- Fix compilation of `Alien/ArcaneInterface` on ubuntu 22