### PR TITLE
Remove some compiler warnings in Alien

### DIFF
--- a/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/accessors/ItemVectorAccessorT.h
+++ b/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/accessors/ItemVectorAccessorT.h
@@ -51,8 +51,8 @@ namespace ArcaneTools {
   template <typename ValueT>
   typename ItemVectorAccessorT<ValueT>::VectorElement ItemVectorAccessorT<ValueT>::
   operator()(const IIndexManager::Entry& entry,
-      typename ItemVectorAccessorT<ValueT>::eSubBlockExtractingPolicyType policy
-          ALIEN_UNUSED_PARAM)
+      [[maybe_unused]] typename ItemVectorAccessorT<ValueT>::eSubBlockExtractingPolicyType policy
+          )
   {
     if (m_vblock)
       // XT (27/07/2016) : This is just to allow compilation

--- a/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.cc
+++ b/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.cc
@@ -948,7 +948,7 @@ namespace ArcaneTools {
           (fastReturnMap[nameString][origDomainId] != NULL), ("Inconsistency detected"));
       EntrySendRequest& request = *fastReturnMap[nameString][origDomainId];
       request.m_comm = *i; // Reconnection pour accès rapide depuis l'EntrySendRequest
-      const Integer idCount = sbuf->getInteger();
+      [[maybe_unused]] const Integer idCount = sbuf->getInteger();
       ALIEN_ASSERT((request.m_count == idCount), ("Inconsistency detected"));
     }
 

--- a/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.h
+++ b/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.h
@@ -198,8 +198,8 @@ namespace ArcaneTools {
     struct InternalEntryIndex
     {
       InternalEntryIndex(MyEntryImpl* e, Arccore::Integer lid, Arccore::Integer kind,
-          Arccore::Int64 uid, Arccore::Integer index,
-          Arccore::Integer creation_index ALIEN_UNUSED_PARAM, Arccore::Integer owner)
+                         Arccore::Int64 uid, Arccore::Integer index,
+                         [[maybe_unused]] Arccore::Integer creation_index, Arccore::Integer owner)
       : m_entry(e)
       , m_uid(uid)
       , m_localid(lid)

--- a/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/io/MatrixRowPrinter.cc
+++ b/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/io/MatrixRowPrinter.cc
@@ -199,8 +199,8 @@ namespace ArcaneTools {
       return oss.str();
     }
 
-    const PetscInt* cols = PETSC_NULL;
-    const PetscScalar* vals = PETSC_NULL;
+    const PetscInt* cols = nullptr;
+    const PetscScalar* vals = nullptr;
     PetscInt ncols = 0;
     checkError("Extract row", MatGetRow(m_petsc_matrix.internal()->m_internal,
                                   global_line_index, &ncols, &cols, &vals));
@@ -231,8 +231,8 @@ namespace ArcaneTools {
       return std::map<Arccore::Integer, Arccore::Real>();
     }
 
-    const PetscInt* cols = PETSC_NULL;
-    const PetscScalar* vals = PETSC_NULL;
+    const PetscInt* cols = nullptr;
+    const PetscScalar* vals = nullptr;
     PetscInt ncols = 0;
     checkError("Extract row", MatGetRow(m_petsc_matrix.internal()->m_internal,
                                   global_line_index, &ncols, &cols, &vals));

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/HypreBackEnd.h
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/HypreBackEnd.h
@@ -55,7 +55,7 @@ template <> struct AlgebraTraits<BackEnd::tag::hypre>
   typedef IInternalLinearAlgebra<matrix_type, vector_type> algebra_type;
   typedef IInternalLinearSolver<matrix_type, vector_type> solver_type;
   static algebra_type* algebra_factory(
-      Arccore::MessagePassing::IMessagePassingMng* p_mng = nullptr)
+      [[maybe_unused]] Arccore::MessagePassing::IMessagePassingMng* p_mng = nullptr)
   {
     return HypreInternalLinearAlgebraFactory();
   }

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/algebra/HypreInternalLinearAlgebra.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/algebra/HypreInternalLinearAlgebra.cc
@@ -69,7 +69,7 @@ HypreInternalLinearAlgebra::~HypreInternalLinearAlgebra()
 /*---------------------------------------------------------------------------*/
 
 Arccore::Real
-HypreInternalLinearAlgebra::norm0(const HypreVector& vx ALIEN_UNUSED_PARAM) const
+HypreInternalLinearAlgebra::norm0([[maybe_unused]] const HypreVector& vx) const
 {
   Arccore::Real result = 0;
   throw Arccore::NotImplementedException(
@@ -81,7 +81,7 @@ HypreInternalLinearAlgebra::norm0(const HypreVector& vx ALIEN_UNUSED_PARAM) cons
 /*---------------------------------------------------------------------------*/
 
 Arccore::Real
-HypreInternalLinearAlgebra::norm1(const HypreVector& vx ALIEN_UNUSED_PARAM) const
+HypreInternalLinearAlgebra::norm1([[maybe_unused]] const HypreVector& vx) const
 {
   Arccore::Real result = 0;
   throw Arccore::NotImplementedException(
@@ -111,8 +111,9 @@ HypreInternalLinearAlgebra::mult(
 /*---------------------------------------------------------------------------*/
 
 void
-HypreInternalLinearAlgebra::axpy(Real alpha ALIEN_UNUSED_PARAM,
-    const HypreVector& vx ALIEN_UNUSED_PARAM, HypreVector& vr ALIEN_UNUSED_PARAM) const
+HypreInternalLinearAlgebra::axpy([[maybe_unused]] Real alpha,
+                                 [[maybe_unused]] const HypreVector& vx,
+                                 [[maybe_unused]] HypreVector& vr) const
 {
   throw Arccore::NotImplementedException(
       A_FUNCINFO, "HypreLinearAlgebra::axpy not implemented");
@@ -138,8 +139,8 @@ HypreInternalLinearAlgebra::dot(const HypreVector& vx, const HypreVector& vy) co
 /*---------------------------------------------------------------------------*/
 
 void
-HypreInternalLinearAlgebra::diagonal(
-    HypreMatrix const& m ALIEN_UNUSED_PARAM, HypreVector& v ALIEN_UNUSED_PARAM) const
+HypreInternalLinearAlgebra::diagonal([[maybe_unused]] HypreMatrix const& m,
+                                     [[maybe_unused]] HypreVector& v) const
 {
   throw Arccore::NotImplementedException(
       A_FUNCINFO, "HypreLinearAlgebra::diagonal not implemented");
@@ -148,7 +149,7 @@ HypreInternalLinearAlgebra::diagonal(
 /*---------------------------------------------------------------------------*/
 
 void
-HypreInternalLinearAlgebra::reciprocal(HypreVector& v ALIEN_UNUSED_PARAM) const
+HypreInternalLinearAlgebra::reciprocal([[maybe_unused]] HypreVector& v) const
 {
   throw Arccore::NotImplementedException(
       A_FUNCINFO, "HypreLinearAlgebra::reciprocal not implemented");
@@ -157,8 +158,9 @@ HypreInternalLinearAlgebra::reciprocal(HypreVector& v ALIEN_UNUSED_PARAM) const
 /*---------------------------------------------------------------------------*/
 
 void
-HypreInternalLinearAlgebra::aypx(Real alpha ALIEN_UNUSED_PARAM,
-    HypreVector& y ALIEN_UNUSED_PARAM, const HypreVector& x ALIEN_UNUSED_PARAM) const
+HypreInternalLinearAlgebra::aypx([[maybe_unused]] Real alpha,
+                                 [[maybe_unused]] HypreVector& y,
+                                 [[maybe_unused]] const HypreVector& x) const
 {
   throw Arccore::NotImplementedException(
       A_FUNCINFO, "HypreLinearAlgebra::aypx not implemented");
@@ -167,8 +169,9 @@ HypreInternalLinearAlgebra::aypx(Real alpha ALIEN_UNUSED_PARAM,
 /*---------------------------------------------------------------------------*/
 
 void
-HypreInternalLinearAlgebra::pointwiseMult(const HypreVector& x ALIEN_UNUSED_PARAM,
-    const HypreVector& y ALIEN_UNUSED_PARAM, HypreVector& w ALIEN_UNUSED_PARAM) const
+HypreInternalLinearAlgebra::pointwiseMult([[maybe_unused]] const HypreVector& x,
+                                          [[maybe_unused]] const HypreVector& y,
+                                          [[maybe_unused]] HypreVector& w) const
 {
   throw Arccore::NotImplementedException(
       A_FUNCINFO, "HypreLinearAlgebra::pointwiseMult not implemented");
@@ -185,39 +188,45 @@ HypreInternalLinearAlgebra::scal(Real alpha, HypreVector& x) const
 /*---------------------------------------------------------------------------*/
 
 void
-HypreInternalLinearAlgebra::mult(
-    const Matrix& a, const UniqueArray<Real>& x, UniqueArray<Real>& r) const
+HypreInternalLinearAlgebra::mult([[maybe_unused]] const Matrix& a,
+                                 [[maybe_unused]] const UniqueArray<Real>& x,
+                                 [[maybe_unused]] UniqueArray<Real>& r) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::mult not implemented");
 }
 
 void
-HypreInternalLinearAlgebra::axpy(
-    Real alpha, const UniqueArray<Real>& x, UniqueArray<Real>& r) const
+HypreInternalLinearAlgebra::axpy([[maybe_unused]] Real alpha,
+                                 [[maybe_unused]] const UniqueArray<Real>& x,
+                                 [[maybe_unused]] UniqueArray<Real>& r) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::norm0 not implemented");
 }
 
 void
-HypreInternalLinearAlgebra::aypx(
-    Real alpha, UniqueArray<Real>& y, const UniqueArray<Real>& x) const
+HypreInternalLinearAlgebra::aypx([[maybe_unused]] Real alpha,
+                                 [[maybe_unused]] UniqueArray<Real>& y,
+                                 [[maybe_unused]] const UniqueArray<Real>& x) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::axpy not implemented");
 }
 void
-HypreInternalLinearAlgebra::copy(const UniqueArray<Real>& x, UniqueArray<Real>& r) const
+HypreInternalLinearAlgebra::copy([[maybe_unused]] const UniqueArray<Real>& x,
+                                 [[maybe_unused]] UniqueArray<Real>& r) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::copy not implemented");
 }
 Real
-HypreInternalLinearAlgebra::dot(
-    Integer local_size, const UniqueArray<Real>& x, const UniqueArray<Real>& y) const
+HypreInternalLinearAlgebra::dot([[maybe_unused]] Integer local_size,
+                                [[maybe_unused]] const UniqueArray<Real>& x,
+                                [[maybe_unused]] const UniqueArray<Real>& y) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::dot not implemented");
   return Real();
 }
 void
-HypreInternalLinearAlgebra::scal(Real alpha, UniqueArray<Real>& x) const
+HypreInternalLinearAlgebra::scal([[maybe_unused]] Real alpha,
+                                 [[maybe_unused]] UniqueArray<Real>& x) const
 {
   throw NotImplementedException(A_FUNCINFO, "HypreLinearAlgebra::scal not implemented");
 }

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/data_structure/HypreVector.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/data_structure/HypreVector.cc
@@ -83,7 +83,7 @@ HypreVector::setValues(const int nrow, const int* rows, const double* values)
 /*---------------------------------------------------------------------------*/
 
 bool
-HypreVector::setValues(const int nrow, const double* values)
+HypreVector::setValues([[maybe_unused]] const int nrow, const double* values)
 {
   if (m_internal == NULL)
     return false;
@@ -104,7 +104,7 @@ HypreVector::getValues(const int nrow, const int* rows, double* values) const
 /*---------------------------------------------------------------------------*/
 
 bool
-HypreVector::getValues(const int nrow, double* values) const
+HypreVector::getValues([[maybe_unused]] const int nrow, double* values) const
 {
   if (m_internal == NULL)
     return false;
@@ -125,7 +125,7 @@ HypreVector::assemble()
 /*---------------------------------------------------------------------------*/
 
 void
-HypreVector::update(const HypreVector& v)
+HypreVector::update([[maybe_unused]] const HypreVector& v)
 {
   ALIEN_ASSERT((this == &v), ("Unexpected error"));
 }

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/linear_solver/HypreInternalLinearSolver.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/linear_solver/HypreInternalLinearSolver.cc
@@ -206,8 +206,8 @@ HypreInternalLinearSolver::solve(
       int coarsening_opt = 8;
       int interpolation_type = 7;
       double StrongThreshold = 0.15;
-      int amg_debug_flag = 0;
-      int bicgs_debug_flag =0;
+      [[maybe_unused]] int amg_debug_flag = 0;
+      [[maybe_unused]] int bicgs_debug_flag =0;
       int ierr = 0;
       ierr = HYPRE_BoomerAMGSetMaxIter(preconditioner,2) ;//Sophie::
       if( ierr == HYPRE_ERROR_CONV){

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/algebra/PETScInternalLinearAlgebra.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/algebra/PETScInternalLinearAlgebra.cc
@@ -160,37 +160,32 @@ PETScInternalLinearAlgebra::pointwiseMult(
 /*---------------------------------------------------------------------------*/
 
 void
-PETScInternalLinearAlgebra::mult(
-    const Matrix& a, const UniqueArray<Real>& x, UniqueArray<Real>& r) const
+PETScInternalLinearAlgebra::mult(const Matrix&, const UniqueArray<Real>&, UniqueArray<Real>&) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::mult not implemented");
 }
 void
-PETScInternalLinearAlgebra::axpy(
-    Real alpha, const UniqueArray<Real>& x, UniqueArray<Real>& r) const
+PETScInternalLinearAlgebra::axpy(Real, const UniqueArray<Real>&, UniqueArray<Real>&) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::axpy not implemented");
 }
 void
-PETScInternalLinearAlgebra::aypx(
-    Real alpha, UniqueArray<Real>& y, const UniqueArray<Real>& x) const
+PETScInternalLinearAlgebra::aypx(Real, UniqueArray<Real>&, const UniqueArray<Real>&) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::aypx not implemented");
 }
 void
-PETScInternalLinearAlgebra::copy(const UniqueArray<Real>& x, UniqueArray<Real>& r) const
+PETScInternalLinearAlgebra::copy(const UniqueArray<Real>&, UniqueArray<Real>&) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::copy not implemented");
 }
 Real
-PETScInternalLinearAlgebra::dot(
-    Integer local_size, const UniqueArray<Real>& x, const UniqueArray<Real>& y) const
+PETScInternalLinearAlgebra::dot(Integer, const UniqueArray<Real>&, const UniqueArray<Real>&) const
 {
   throw NotImplementedException(A_FUNCINFO, "LinearAlgebra::dot not implemented");
-  return Real();
 }
 void
-PETScInternalLinearAlgebra::scal(Real alpha, UniqueArray<Real>& x) const
+PETScInternalLinearAlgebra::scal(Real, UniqueArray<Real>&) const
 {
   throw NotImplementedException(A_FUNCINFO, "HypreLinearAlgebra::scal not implemented");
 }

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/data_structure/PETScInternal.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/data_structure/PETScInternal.cc
@@ -23,7 +23,7 @@ VectorInternal::VectorInternal(const int local_size, const int local_offset,
     ierr += VecCreateSeq(PETSC_COMM_SELF, local_size, &m_internal);
   }
   int low;
-  ierr += VecGetOwnershipRange(m_internal, &low, PETSC_NULL);
+  ierr += VecGetOwnershipRange(m_internal, &low, nullptr);
 
   if (low != local_offset)
     throw Arccore::FatalErrorException(A_FUNCINFO, "Ill placed parallel vector");

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/data_structure/PETScMatrix.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/data_structure/PETScMatrix.cc
@@ -73,7 +73,7 @@ PETScMatrix::initMatrix(const int local_size, const int local_offset,
   // Offsets are implicit with PETSc, we can to check that
   // they are compatible with the expected behaviour
   PetscInt low;
-  ierr += MatGetOwnershipRange(m_internal->m_internal, &low, PETSC_NULL);
+  ierr += MatGetOwnershipRange(m_internal->m_internal, &low, nullptr);
   if (low != local_offset)
     return false;
 

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/data_structure/PETScVector.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/data_structure/PETScVector.cc
@@ -28,8 +28,8 @@ PETScVector::~PETScVector()
 /*---------------------------------------------------------------------------*/
 
 void
-PETScVector::init(const VectorDistribution& dist,
-    const bool need_allocate, Arccore::Integer block_size ALIEN_UNUSED_PARAM)
+PETScVector::init([[maybe_unused]] const VectorDistribution& dist,
+                  const bool need_allocate, Arccore::Integer block_size ALIEN_UNUSED_PARAM)
 {
   if (need_allocate)
     allocate();

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigAdditiveSchwarzService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigAdditiveSchwarzService.cc
@@ -68,7 +68,7 @@ PETScPrecConfigAdditiveSchwarzService::configure(
     });
   } else if (local_blocks > 1) {
     checkError("Set AdditiveSchwarz blocks",
-        PCASMSetLocalSubdomains(pc, local_blocks, PETSC_NULL, PETSC_NULL));
+        PCASMSetLocalSubdomains(pc, local_blocks, nullptr, nullptr));
   }
   // else 1 : default
   switch (options()->type()) {

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigDiagonalService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigDiagonalService.cc
@@ -42,8 +42,9 @@ PETScPrecConfigDiagonalService::needPrematureKSPSetUp() const
 /*---------------------------------------------------------------------------*/
 
 void
-PETScPrecConfigDiagonalService::configure(
-    PC& pc, const ISpace& space, const MatrixDistribution& distribution)
+PETScPrecConfigDiagonalService::configure(PC& pc,
+                                          [[maybe_unused]] const ISpace& space,
+                                          [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_debug([&] { cout() << "configure PETSc none preconditioner"; });
   checkError("Set preconditioner", PCSetType(pc, PCNONE));

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigJacobiService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigJacobiService.cc
@@ -38,8 +38,8 @@ PETScPrecConfigJacobiService::PETScPrecConfigJacobiService(
 
 //! Initialisation
 void
-PETScPrecConfigJacobiService::configure(
-    PC& pc, const ISpace& space, const MatrixDistribution& distribution)
+PETScPrecConfigJacobiService::configure(PC& pc, [[maybe_unused]] const ISpace& space,
+                                        [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_debug([&] { cout() << "configure PETSc block jacobi preconditioner"; });
   checkError("Set preconditioner", PCSetType(pc, PCBJACOBI));

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigNoPreconditionerService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScPrecConfigNoPreconditionerService.cc
@@ -37,8 +37,9 @@ PETScPrecConfigNoPreconditionerService::PETScPrecConfigNoPreconditionerService(
 
 //! Initialisation
 void
-PETScPrecConfigNoPreconditionerService::configure(
-    PC& pc, const ISpace& space, const MatrixDistribution& distribution)
+PETScPrecConfigNoPreconditionerService::configure(PC& pc,
+                                                  [[maybe_unused]] const ISpace& space,
+                                                  [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_debug([&] { cout() << "configure PETSc none preconditioner"; });
   checkError("Set preconditioner", PCSetType(pc, PCNONE));

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScSolverConfigCustomService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScSolverConfigCustomService.cc
@@ -38,8 +38,9 @@ PETScSolverConfigCustomService::PETScSolverConfigCustomService(
 
 //! Initialisation
 void
-PETScSolverConfigCustomService::configure(
-    KSP& ksp, const ISpace& space, const MatrixDistribution& distribution)
+PETScSolverConfigCustomService::configure(KSP& ksp,
+                                          [[maybe_unused]] const ISpace& space,
+                                          [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_debug([&] { cout() << "configure PETSc custom solver"; });
   Arccore::String prefix = Arccore::String::format("{0}_", this);

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScSolverConfigLUService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/arcane/PETScSolverConfigLUService.cc
@@ -34,8 +34,9 @@ PETScSolverConfigLUService::PETScSolverConfigLUService(
 
 //! Initialisation
 void
-PETScSolverConfigLUService::configure(
-    KSP& ksp, const ISpace& space, const MatrixDistribution& distribution)
+PETScSolverConfigLUService::configure(KSP& ksp,
+                                      [[maybe_unused]] const ISpace& space,
+                                      [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_debug([&] { cout() << "configure PETSc lu solver"; });
 

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/field_split/AdditiveFieldSplitTypeService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/field_split/AdditiveFieldSplitTypeService.cc
@@ -37,7 +37,7 @@ AdditiveFieldSplitTypeService::AdditiveFieldSplitTypeService(
 
 //! Configure FieldSplit type
 Arccore::Integer
-AdditiveFieldSplitTypeService::configure(PC& pc, const Arccore::Integer nbField)
+AdditiveFieldSplitTypeService::configure(PC& pc,[[maybe_unused]] const Arccore::Integer nbField)
 {
   alien_debug([&] { cout() << "configure PETSc additive FlieldSplit preconditioner"; });
   Arccore::Integer code = PCFieldSplitSetType(pc, PC_COMPOSITE_ADDITIVE);

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/field_split/MultiplicativeFieldSplitTypeService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/field_split/MultiplicativeFieldSplitTypeService.cc
@@ -37,7 +37,7 @@ MultiplicativeFieldSplitTypeService::MultiplicativeFieldSplitTypeService(
 //! Configure FieldSplit type
 
 Arccore::Integer
-MultiplicativeFieldSplitTypeService::configure(PC& pc, const Arccore::Integer nbField)
+MultiplicativeFieldSplitTypeService::configure(PC& pc,[[maybe_unused]] const Arccore::Integer nbField)
 {
   alien_debug(
       [&] { cout() << "configure PETSc multiplicative FlieldSplit preconditioner"; });

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/field_split/SymmetricMultiplicativeFieldSplitTypeService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/field_split/SymmetricMultiplicativeFieldSplitTypeService.cc
@@ -40,7 +40,7 @@ SymmetricMultiplicativeFieldSplitTypeService::
 
 Arccore::Integer
 SymmetricMultiplicativeFieldSplitTypeService::configure(
-    PC& pc, const Arccore::Integer nbField)
+    PC& pc, [[maybe_unused]] const Arccore::Integer nbField)
 {
   alien_debug([&] {
     cout() << "configure PETSc symmetric multiplicative FlieldSplit preconditioner";

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/hypre/PETScPrecConfigHypreEuclidService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/hypre/PETScPrecConfigHypreEuclidService.cc
@@ -37,8 +37,8 @@ PETScPrecConfigHypreEuclidService::PETScPrecConfigHypreEuclidService(
 
 //! Initialisation
 void
-PETScPrecConfigHypreEuclidService::configure(
-    PC& pc, const ISpace& space, const MatrixDistribution& distribution)
+PETScPrecConfigHypreEuclidService::configure(PC& pc, [[maybe_unused]] const ISpace& space,
+                                             [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_debug([&] { cout() << "configure PETSc euclid preconditioner"; });
   checkError("Set preconditioner", PCSetType(pc, PCHYPRE));

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/hypre/PETScPrecConfigHypreService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/hypre/PETScPrecConfigHypreService.cc
@@ -37,8 +37,8 @@ PETScPrecConfigHypreService::PETScPrecConfigHypreService(
 }
 
 void
-PETScPrecConfigHypreService::configure(
-    PC& pc, const ISpace& space, const MatrixDistribution& distribution)
+PETScPrecConfigHypreService::configure(PC& pc, [[maybe_unused]] const ISpace& space,
+                                       [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_debug([&] { cout() << "configure PETSc hypre preconditioner"; });
   // if(options()->fieldSplitMode())

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/spai/PETScPrecConfigSPAIService.cc
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/linear_solver/spai/PETScPrecConfigSPAIService.cc
@@ -35,8 +35,9 @@ PETScPrecConfigSPAIService::PETScPrecConfigSPAIService(
 }
 
 void
-PETScPrecConfigSPAIService::configure(
-    PC& pc, const ISpace& space, const MatrixDistribution& distribution)
+PETScPrecConfigSPAIService::configure([[maybe_unused]] PC& pc,
+                                      [[maybe_unused]] const ISpace& space,
+                                      [[maybe_unused]] const MatrixDistribution& distribution)
 {
   alien_fatal([&] { cout() << "configure SPAI not available need to be checked"; });
 }

--- a/alien/ArcaneInterface/modules/interface_c/src/alien/c/alienc.cc
+++ b/alien/ArcaneInterface/modules/interface_c/src/alien/c/alienc.cc
@@ -254,7 +254,7 @@ AlienManager::AlienManager()
 }
 
 void AlienManager::LinearSystem::
-init(int global_nrows,
+init([[maybe_unused]] int global_nrows,
      int local_nrows,
      uid_type* row_uids,
      int nb_ghosts,
@@ -540,7 +540,7 @@ extern "C" {
 
   #include "alien/c/alienc.h"
 
-  ALIEN_INTERFACE_C_EXPORT int ALIEN_init(int argc, char** argv)
+  ALIEN_INTERFACE_C_EXPORT int ALIEN_init([[maybe_unused]] int argc,[[maybe_unused]] char** argv)
   {
     AlienManager::initialize() ;
     return 0 ;

--- a/alien/ArcaneInterface/test/AlienBench/AlienBenchModule.cc
+++ b/alien/ArcaneInterface/test/AlienBench/AlienBenchModule.cc
@@ -800,7 +800,7 @@ AlienBenchModule::funck(Real3 p) const
 }
 
 Real
-AlienBenchModule::dii(const Cell& ci) const
+AlienBenchModule::dii([[maybe_unused]] const Cell& ci) const
 {
   return m_diag_coeff;
 }

--- a/alien/ArcaneInterface/test/AlienBench/AlienStokesModule.cc
+++ b/alien/ArcaneInterface/test/AlienBench/AlienStokesModule.cc
@@ -137,7 +137,7 @@ AlienStokesModule::init()
 
     if (m_h[dir] == 0 && iface->nbCell() == 2) {
       Real3 d = m_cell_center[iface->frontCell()] - m_cell_center[iface->backCell()];
-      m_h[dir] = d.abs();
+      m_h[dir] = d.normL2();
       m_h2[dir] = m_h[dir] * m_h[dir];
     }
   }
@@ -449,7 +449,7 @@ AlienStokesModule::test()
       const Integer iIndex = allPIndex[cell.localId()];
       assert(iIndex != -1);
       info() << "CELL[" << cell.localId() << "]";
-      if (m_cell_center[icell].abs() < m_h[0]) {
+      if (m_cell_center[icell].normL2() < m_h[0]) {
         profiler.addMatrixEntry(iIndex, iIndex);
       }
 
@@ -548,10 +548,10 @@ AlienStokesModule::test()
                 break;
               }
             } else {
-              builder(iIndex, allUIndex[face2->localId()]) += -1 / m_h2[face_type];
+              builder(iIndex, allUIndex[face2.localId()]) += -1 / m_h2[face_type];
               builder(iIndex, iIndex) += 1. / m_h2[face_type];
 
-              builderA(iIndexU, allUIndexA[face2->localId()]) += -1 / m_h2[face_type];
+              builderA(iIndexU, allUIndexA[face2.localId()]) += -1 / m_h2[face_type];
               builderA(iIndexU, iIndexU) += 1. / m_h2[face_type];
             }
           }
@@ -585,10 +585,10 @@ AlienStokesModule::test()
                 break;
               }
             } else {
-              builder(iIndex, allUIndex[face2->localId()]) += -1 / m_h2[face_type];
+              builder(iIndex, allUIndex[face2.localId()]) += -1 / m_h2[face_type];
               builder(iIndex, iIndex) += 1. / m_h2[face_type];
 
-              builderA(iIndexU, allUIndexA[face2->localId()]) += -1 / m_h2[face_type];
+              builderA(iIndexU, allUIndexA[face2.localId()]) += -1 / m_h2[face_type];
               builder(iIndexU, iIndexU) += 1. / m_h2[face_type];
             }
           }
@@ -645,7 +645,7 @@ AlienStokesModule::test()
       const Integer iIndexP = allPIndexB[cell.localId()];
       assert(iIndexP != -1);
 
-      if (m_cell_center[icell].abs() < m_h[0])
+      if (m_cell_center[icell].normL2() < m_h[0])
         builder(iIndex, iIndex) = 1000000;
 
       rhs[iIndex] += m_g[cell];
@@ -798,7 +798,7 @@ AlienStokesModule::ux(Real3 const& x) const
 }
 
 Real
-AlienStokesModule::duxdn(Real3 const& x, Integer dir) const
+AlienStokesModule::duxdn([[maybe_unused]] Real3 const& x, Integer dir) const
 {
   switch (dir) {
   case 0:
@@ -815,7 +815,7 @@ AlienStokesModule::uy(Real3 const& x) const
 }
 
 Real
-AlienStokesModule::duydn(Real3 const& x, Integer dir) const
+AlienStokesModule::duydn([[maybe_unused]] Real3 const& x, Integer dir) const
 {
   switch (dir) {
   case 1:
@@ -832,7 +832,7 @@ AlienStokesModule::uz(Real3 const& x) const
 }
 
 Real
-AlienStokesModule::duzdn(Real3 const& x, Integer dir) const
+AlienStokesModule::duzdn([[maybe_unused]] Real3 const& x, Integer dir) const
 {
   switch (dir) {
   case 2:
@@ -843,13 +843,13 @@ AlienStokesModule::duzdn(Real3 const& x, Integer dir) const
 }
 
 Real
-AlienStokesModule::div(Real3 const& xC) const
+AlienStokesModule::div([[maybe_unused]] Real3 const& xC) const
 {
   return 3;
 }
 
 Real
-AlienStokesModule::func(Real3 const& xC, Integer dir) const
+AlienStokesModule::func([[maybe_unused]] Real3 const& xC, Integer dir) const
 {
   switch (dir) {
   case 0:

--- a/alien/ArcaneInterface/test/AlienInterfaceC/Fortran/main.c
+++ b/alien/ArcaneInterface/test/AlienInterfaceC/Fortran/main.c
@@ -16,7 +16,7 @@
 
 extern void F2C(test)() ;
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc,[[maybe_unused]] char** argv)
 {
   F2C(test)() ;
 

--- a/alien/ArcaneInterface/test/AlienTest/AlienTestModule.cc
+++ b/alien/ArcaneInterface/test/AlienTest/AlienTestModule.cc
@@ -676,7 +676,7 @@ AlienTestModule::buildAndFillInBlockVector(Alien::Move::VectorData& vectorB,
 void
 AlienTestModule::buildAndFillInBlockVector(Alien::Move::VectorData& vectorB,
     ConstArrayView<Integer> allUIndex, ConstArray2View<Integer> allPIndex,
-    ConstArrayView<Integer> allXIndex ALIEN_UNUSED_PARAM, ConstArrayView<Real> value)
+    [[maybe_unused]] ConstArrayView<Integer> allXIndex, ConstArrayView<Real> value)
 {
   Alien::Move::LocalBlockVectorWriter b(std::move(vectorB));
   ENUMERATE_CELL (icell, m_areaT.own()) {
@@ -1224,7 +1224,7 @@ AlienTestModule::vectorVariableUpdate(Alien::Move::VectorData& vectorB,
 
 void
 AlienTestModule::checkDotProductWithManyAlgebra(Alien::IVector& vectorB,
-    Alien::IVector& vectorX, Alien::Space& space ALIEN_UNUSED_PARAM)
+    Alien::IVector& vectorX, [[maybe_unused]] Alien::Space& space)
 {
   info() << "Checking dot product using two linear algebra implementations";
 

--- a/alien/ArcaneInterface/test/Tests/RefSemantic/block/Profiled.cpp
+++ b/alien/ArcaneInterface/test/Tests/RefSemantic/block/Profiled.cpp
@@ -7,7 +7,8 @@ extern Alien::ITraceMng* traceMng();
 }
 
 void
-buildMatrix(Alien::BlockMatrix& A, std::string const& filename, std::string const& format)
+buildMatrix(Alien::BlockMatrix& A, [[maybe_unused]] std::string const& filename,
+            [[maybe_unused]] std::string const& format)
 {
   auto* tm = Environment::traceMng();
 

--- a/alien/ArcaneInterface/test/Tests/RefSemantic/block/Stream.cpp
+++ b/alien/ArcaneInterface/test/Tests/RefSemantic/block/Stream.cpp
@@ -7,7 +7,8 @@ extern Arccore::ITraceMng* traceMng();
 }
 
 void
-buildMatrix(Alien::BlockMatrix& A, std::string const& filename, std::string const& format)
+buildMatrix(Alien::BlockMatrix& A, [[maybe_unused]] std::string const& filename,
+            [[maybe_unused]] std::string const& format)
 {
   auto* tm = Environment::traceMng();
 

--- a/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/Direct.cpp
+++ b/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/Direct.cpp
@@ -6,7 +6,8 @@ extern Alien::ITraceMng* traceMng();
 }
 
 void
-buildMatrix(Alien::Matrix& A, std::string const& filename, std::string const& format)
+buildMatrix(Alien::Matrix& A, [[maybe_unused]] std::string const& filename,
+            [[maybe_unused]] std::string const& format)
 {
   auto* tm = Environment::traceMng();
 

--- a/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/DirectByDoK.cpp
+++ b/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/DirectByDoK.cpp
@@ -7,7 +7,8 @@ extern Alien::ITraceMng* traceMng();
 }
 
 void
-buildMatrix(Alien::Matrix& A, std::string const& filename, std::string const& format)
+buildMatrix(Alien::Matrix& A, [[maybe_unused]] std::string const& filename,
+            [[maybe_unused]] std::string const& format)
 {
   auto* tm = Environment::traceMng();
 

--- a/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/Profiled.cpp
+++ b/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/Profiled.cpp
@@ -5,7 +5,8 @@ extern Alien::ITraceMng* traceMng();
 }
 
 void
-buildMatrix(Alien::Matrix& A, std::string const& filename, std::string const& format)
+buildMatrix(Alien::Matrix& A, [[maybe_unused]] std::string const& filename,
+            [[maybe_unused]] std::string const& format)
 {
   auto* tm = Environment::traceMng();
 

--- a/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/RedistributorAlgebraTestFramework.cpp
+++ b/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/RedistributorAlgebraTestFramework.cpp
@@ -51,15 +51,15 @@ testAlgebra(algebraName algebra, const Alien::ILinearAlgebra& alg,
     for (int i = 0; i < lsize; ++i)
       assert(readerX[i] == readerB[i]);
   }
-  const double dot = alg.dot(basVector, xasVector);
+  [[maybe_unused]] const double dot = alg.dot(basVector, xasVector);
   assert(dot == gsize);
   if (algebra == algebraName::petsc) {
-    const double norm0 = alg.norm0(xasVector);
+    [[maybe_unused]] const double norm0 = alg.norm0(xasVector);
     assert(norm0 == 1.);
-    const double norm1 = alg.norm1(xasVector);
+    [[maybe_unused]] const double norm1 = alg.norm1(xasVector);
     assert(norm1 == gsize);
   }
-  const double norm2 = alg.norm2(x);
+  [[maybe_unused]] const double norm2 = alg.norm2(x);
   assert(norm2 == sqrt(dot));
   if (algebra != algebraName::hypre) {
     const double scal = 2.;

--- a/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/Stream.cpp
+++ b/alien/ArcaneInterface/test/Tests/RefSemantic/scalar/Stream.cpp
@@ -6,7 +6,8 @@ extern Arccore::ITraceMng* traceMng();
 } // namespace Environment
 
 void
-buildMatrix(Alien::Matrix& A, std::string const& filename, std::string const& format)
+buildMatrix(Alien::Matrix& A, [[maybe_unused]] std::string const& filename,
+            [[maybe_unused]] std::string const& format)
 {
   auto* tm = Environment::traceMng();
 

--- a/alien/standalone/src/core/alien/core/backend/IInternalLinearAlgebraExprT.h
+++ b/alien/standalone/src/core/alien/core/backend/IInternalLinearAlgebraExprT.h
@@ -199,7 +199,7 @@ class IInternalLinearAlgebraExpr
    * \param[in] filename The name of the file
    * \todo Implement this method
    */
-  virtual void dump(Matrix const& a, std::string const& filename) const
+  virtual void dump([[maybe_unused]] Matrix const& a, [[maybe_unused]] std::string const& filename) const
   {
     throw NotImplementedException(
     A_FUNCINFO, "IInternalLinearAlgebra::dump not implemented");
@@ -211,7 +211,7 @@ class IInternalLinearAlgebraExpr
    * \param[in] filename The name of the file
    * \todo Implement this method
    */
-  virtual void dump(Vector const& x, std::string const& filename) const
+  virtual void dump([[maybe_unused]] Vector const& x, [[maybe_unused]] std::string const& filename) const
   {
     throw NotImplementedException(
     A_FUNCINFO, "IInternalLinearAlgebra::dump not implemented");

--- a/alien/standalone/src/core/alien/core/backend/IInternalLinearAlgebraT.h
+++ b/alien/standalone/src/core/alien/core/backend/IInternalLinearAlgebraT.h
@@ -167,7 +167,7 @@ class IInternalLinearAlgebra
    * \param[in] filename The name of the file
    * \todo Implement this method
    */
-  virtual void dump(ALIEN_UNUSED_PARAM Matrix const& a, ALIEN_UNUSED_PARAM std::string const& filename) const
+  virtual void dump([[maybe_unused]] Matrix const& a, [[maybe_unused]] std::string const& filename) const
   {
     throw NotImplementedException(
     A_FUNCINFO, "IInternalLinearAlgebra::dump not implemented");
@@ -179,7 +179,7 @@ class IInternalLinearAlgebra
    * \param[in] filename The name of the file
    * \todo Implement this method
    */
-  virtual void dump(ALIEN_UNUSED_PARAM Vector const& x, ALIEN_UNUSED_PARAM std::string const& filename) const
+  virtual void dump([[maybe_unused]] Vector const& x, [[maybe_unused]] std::string const& filename) const
   {
     throw NotImplementedException(
     A_FUNCINFO, "IInternalLinearAlgebra::dump not implemented");

--- a/alien/standalone/src/core/alien/core/backend/IInternalLinearSolverT.h
+++ b/alien/standalone/src/core/alien/core/backend/IInternalLinearSolverT.h
@@ -70,7 +70,7 @@ class IInternalLinearSolver
    *
    * \param[in] pm The new parallel manager
    */
-  virtual void updateParallelMng(ALIEN_UNUSED_PARAM Arccore::MessagePassing::IMessagePassingMng* pm) {}
+  virtual void updateParallelMng([[maybe_unused]] Arccore::MessagePassing::IMessagePassingMng* pm) {}
 
   //! Initialize the linear solver
   virtual void init() {}

--- a/alien/standalone/src/core/alien/core/backend/IMatrixConverter.h
+++ b/alien/standalone/src/core/alien/core/backend/IMatrixConverter.h
@@ -89,7 +89,7 @@ class IMatrixConverter : public Alien::ObjectWithTrace
    * \todo Check backend using T
    */
   template <typename T>
-  static T& cast(IMatrixImpl* impl, BackEndId backend)
+  static T& cast(IMatrixImpl* impl,[[maybe_unused]] BackEndId backend)
   {
     ALIEN_ASSERT((impl != NULL), ("Null implementation"));
     ALIEN_ASSERT((impl->backend() == backend), ("Bad backend"));
@@ -107,7 +107,7 @@ class IMatrixConverter : public Alien::ObjectWithTrace
    * \todo Check backend using T
    */
   template <typename T>
-  static const T& cast(const IMatrixImpl* impl, BackEndId backend)
+  static const T& cast(const IMatrixImpl* impl,[[maybe_unused]] BackEndId backend)
   {
     ALIEN_ASSERT((impl != NULL), ("Null implementation"));
     ALIEN_ASSERT((impl->backend() == backend), ("Bad backend"));

--- a/alien/standalone/src/core/alien/core/backend/IVectorConverter.h
+++ b/alien/standalone/src/core/alien/core/backend/IVectorConverter.h
@@ -90,7 +90,7 @@ class IVectorConverter : public ObjectWithTrace
    * \todo Check backend using T
    */
   template <typename T>
-  static T& cast(IVectorImpl* impl, BackEndId backend)
+  static T& cast(IVectorImpl* impl, [[maybe_unused]] BackEndId backend)
   {
     ALIEN_ASSERT((impl != NULL), ("Null implementation"));
     ALIEN_ASSERT((impl->backend() == backend), ("Bad backend"));
@@ -108,7 +108,7 @@ class IVectorConverter : public ObjectWithTrace
    * \todo Check backend using T
    */
   template <typename T>
-  static const T& cast(const IVectorImpl* impl, BackEndId backend)
+  static const T& cast(const IVectorImpl* impl, [[maybe_unused]] BackEndId backend)
   {
     ALIEN_ASSERT((impl != NULL), ("Null implementation"));
     ALIEN_ASSERT((impl->backend() == backend), ("Bad backend"));

--- a/alien/standalone/src/core/alien/core/backend/LinearSolver.h
+++ b/alien/standalone/src/core/alien/core/backend/LinearSolver.h
@@ -157,7 +157,7 @@ class LinearSolver : public ILinearSolver
    *
    * \todo Implement this method
    */
-  virtual void setNullSpaceConstantOption(bool flag ALIEN_UNUSED_PARAM)
+  virtual void setNullSpaceConstantOption([[maybe_unused]] bool flag)
   {
     throw NotImplementedException(A_FUNCINFO);
   }

--- a/alien/standalone/src/core/alien/core/impl/IVectorImpl.h
+++ b/alien/standalone/src/core/alien/core/impl/IVectorImpl.h
@@ -91,7 +91,7 @@ class ALIEN_EXPORT IVectorImpl : public Timestamp
    *
    * \todo Fix this method : could be removed during the process of solver refactoring
    */
-  virtual void init(ALIEN_UNUSED_PARAM const VectorDistribution& dist, ALIEN_UNUSED_PARAM bool do_alloc) {}
+  virtual void init([[maybe_unused]] const VectorDistribution& dist, [[maybe_unused]] bool do_alloc) {}
 
   /*!
    * \brief Get the vector space

--- a/alien/standalone/src/core/alien/data/utils/Parameters.h
+++ b/alien/standalone/src/core/alien/data/utils/Parameters.h
@@ -67,8 +67,7 @@ struct LocalIndexer
    * \param[in] offset The offset
    * \returns The local id
    */
-  static Arccore::Integer index(
-  Arccore::Integer id, Arccore::Integer offset ALIEN_UNUSED_PARAM)
+  static Arccore::Integer index(Arccore::Integer id, [[maybe_unused]] Arccore::Integer offset)
   {
     return id;
   }

--- a/alien/standalone/src/core/alien/expression/krylov/BiCGStab.h
+++ b/alien/standalone/src/core/alien/expression/krylov/BiCGStab.h
@@ -154,7 +154,7 @@ class BiCGStab
   {
     if (iter.nullRhs())
       return 0;
-    ValueType rho(0), rho1(0), alpha(0), beta(0), gamma(0), omega(0);
+    ValueType rho(0), rho1(0), alpha(0), beta(0), omega(0);
     VectorType p, phat, s, shat, t, v, r, r0;
 
     m_algebra.allocate(AlgebraType::resource(A), p, phat, s, shat, t, v, r, r0);

--- a/alien/standalone/src/core/alien/expression/krylov/ChebyshevPreconditioner.h
+++ b/alien/standalone/src/core/alien/expression/krylov/ChebyshevPreconditioner.h
@@ -124,7 +124,7 @@ class ChebyshevPreconditioner
     std::mt19937 gen;
     std::uniform_real_distribution<> dis(-1., 1.);
 
-    m_algebra.assign(x, [&](std::size_t i) {
+    m_algebra.assign(x, [&]([[maybe_unused]] std::size_t i) {
       return dis(gen);
     });
     /*
@@ -171,7 +171,7 @@ class ChebyshevPreconditioner
         x[i] =dis(gen);
       }*/
 
-    m_algebra.assign(x, [&](std::size_t i) {
+    m_algebra.assign(x, [&]([[maybe_unused]] std::size_t i) {
       return dis(gen);
     });
     //m_algebra.assign(x,1.) ;
@@ -315,7 +315,7 @@ class ChebyshevPreconditioner
       solve2(x, y);
   }
 
-  void _algo1(AlgebraType& algebra,
+  void _algo1([[maybe_unused]] AlgebraType& algebra,
               VectorType const& x,
               VectorType& y) const
   {
@@ -389,7 +389,7 @@ class ChebyshevPreconditioner
     }
   }
 
-  void _algo2(AlgebraType& algebra,
+  void _algo2([[maybe_unused]] AlgebraType& algebra,
               VectorType const& x,
               VectorType& y) const
   {

--- a/alien/standalone/src/core/alien/expression/krylov/ILU0Preconditioner.h
+++ b/alien/standalone/src/core/alien/expression/krylov/ILU0Preconditioner.h
@@ -231,7 +231,7 @@ class LUFactorisationAlgo
   }
 
   template <typename AlgebraT>
-  void solve(AlgebraT& algebra, VectorType const& y, VectorType& x) const
+  void solve([[maybe_unused]] AlgebraT& algebra, VectorType const& y, VectorType& x) const
   {
 
     //////////////////////////////////////////////////////////////////////////

--- a/alien/standalone/src/core/alien/expression/krylov/NeumannPolyPreconditioner.h
+++ b/alien/standalone/src/core/alien/expression/krylov/NeumannPolyPreconditioner.h
@@ -153,7 +153,7 @@ class NeumannPolyPreconditioner
       {
         x[i] =dis(gen);
       }*/
-    m_algebra.assign(x, [&](auto i) {
+    m_algebra.assign(x, [&]([[maybe_unused]] auto i) {
       return dis(gen);
     });
 

--- a/alien/standalone/src/core/alien/kernels/simple_csr/LUSendRecvOp.h
+++ b/alien/standalone/src/core/alien/kernels/simple_csr/LUSendRecvOp.h
@@ -72,12 +72,12 @@ class LUSendRecvOp
     // clang-format off
     auto nrows  = view.nrows() ;
     auto kcol   = view.kcol() ;
-    auto dcol   = view.dcol() ;
+    //auto dcol   = view.dcol() ;
     auto cols   = view.cols() ;
     // clang-format on
     auto& local_row_size = m_matrix.getDistStructInfo().m_local_row_size;
 
-    int my_rank = m_parallel_mng->commRank();
+    //int my_rank = m_parallel_mng->commRank();
 
     m_mpi_ext_inv_ids.resize(m_recv_info.m_first_upper_neighb);
     for (int ineighb = 0; ineighb < m_recv_info.m_first_upper_neighb; ++ineighb) {
@@ -118,7 +118,7 @@ class LUSendRecvOp
     CSRModifierViewT<MatrixType> modifier(m_matrix);
     // clang-format off
     auto nrows  = modifier.nrows() ;
-    auto nnz    = modifier.nnz() ;
+    //auto nnz    = modifier.nnz() ;
     auto kcol   = modifier.kcol() ;
     auto dcol   = modifier.dcol() ;
     auto cols   = modifier.cols() ;

--- a/alien/standalone/src/core/alien/kernels/simple_csr/SendRecvOp.h
+++ b/alien/standalone/src/core/alien/kernels/simple_csr/SendRecvOp.h
@@ -275,7 +275,7 @@ class SendRecvOp : public IASynchOp
           m_recv_buffer[m_recv_info.m_ids[i]] = m_rbuffer[i];
       else
         for (int i = 0; i < size; ++i)
-          for (std::size_t ui = 0; ui < m_unknowns_num; ++ui)
+          for (int ui = 0; ui < m_unknowns_num; ++ui)
             m_recv_buffer[m_recv_info.m_ids[i] * m_unknowns_num + ui] = m_rbuffer[i * m_unknowns_num + ui];
     }
   }
@@ -305,7 +305,7 @@ class SendRecvOp : public IASynchOp
           m_recv_buffer[m_recv_info.m_ids[i]] = m_rbuffer[i];
       else
         for (int i = 0; i < size; ++i)
-          for (std::size_t ui = 0; ui < m_unknowns_num; ++ui)
+          for (int ui = 0; ui < m_unknowns_num; ++ui)
             m_recv_buffer[m_recv_info.m_ids[i] * m_unknowns_num + ui] = m_rbuffer[i * m_unknowns_num + ui];
     }
   }
@@ -351,7 +351,7 @@ class SendRecvOp : public IASynchOp
         }
       else
         for (int i = 0; i < size; ++i)
-          for (std::size_t ui = 0; ui < m_unknowns_num; ++ui)
+          for (int ui = 0; ui < m_unknowns_num; ++ui)
             m_sbuffer[i * m_unknowns_num + ui] = m_send_buffer[m_send_info.m_ids[i] * m_unknowns_num + ui];
       sbuffer = &m_sbuffer[0];
     }
@@ -378,7 +378,7 @@ class SendRecvOp : public IASynchOp
         }
       else
         for (int i = 0; i < size; ++i)
-          for (std::size_t ui = 0; ui < m_unknowns_num; ++ui)
+          for (int ui = 0; ui < m_unknowns_num; ++ui)
             m_sbuffer[i * m_unknowns_num + ui] = m_send_buffer[m_send_info.m_ids[offset + i] * m_unknowns_num + ui];
       sbuffer = &m_sbuffer[0];
     }

--- a/alien/standalone/src/core/alien/kernels/simple_csr/SimpleCSRBackEnd.h
+++ b/alien/standalone/src/core/alien/kernels/simple_csr/SimpleCSRBackEnd.h
@@ -79,13 +79,11 @@ struct AlgebraTraits<BackEnd::tag::simplecsr>
   typedef SimpleCSRTraits<Real>::AlgebraExprType algebra_expr_type;
   // clang-format off
   
-  static algebra_type* algebra_factory(
-  IMessagePassingMng* p_mng ALIEN_UNUSED_PARAM = nullptr)
+  static algebra_type* algebra_factory([[maybe_unused]] IMessagePassingMng* p_mng = nullptr)
   {
     return SimpleCSRInternalLinearAlgebraFactory();
   }
-  static algebra_expr_type* algebra_expr_factory(
-  IMessagePassingMng* p_mng ALIEN_UNUSED_PARAM = nullptr)
+  static algebra_expr_type* algebra_expr_factory([[maybe_unused]] IMessagePassingMng* p_mng = nullptr)
   {
     return SimpleCSRInternalLinearAlgebraExprFactory();
   }

--- a/alien/standalone/src/refsemantic/alien/ref/mv_expr/MVExpr.h
+++ b/alien/standalone/src/refsemantic/alien/ref/mv_expr/MVExpr.h
@@ -535,7 +535,7 @@ namespace MVExpr
       return vectorMinus(csr_a.getArrayValues(), b);
     }
 
-    auto operator()(lazy::dot_tag, const VectorDistribution* distribution,
+    auto operator()(lazy::dot_tag, [[maybe_unused]] const VectorDistribution* distribution,
                     Vector const& a, Vector const& b)
     {
 #ifdef DEBUG


### PR DESCRIPTION
- The majority of warnings are for  `unused-parameters`
- Remove usage of deprecated functions
