### PR TITLE
Update global README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ Project(ArcaneRepo LANGUAGES NONE)
 enable_testing()
 
 # Obsolète: permet de choisir quel composant on compile
-# Il faut maintenant utiliser ARCANEFRAMEWORK_COMPONENTS
+# Il faut maintenant utiliser ARCANEFRAMEWORK_BUILD_COMPONENTS
 # qui est utilisé dans _common/build_all/CMakeLists.txt
 if (NOT FRAMEWORK_BUILD_COMPONENT)
   set (FRAMEWORK_BUILD_COMPONENT all)

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ La documentation en ligne est accessible depuis internet :
 
 ### Changelog
 
-Les dernières modifications sont dans le fichier suivant: [Changelog](arcane/doc/doc_common/changelog.md)
+Les dernières modifications de Arcane sont dans le fichier suivant: [Changelog](arcane/doc/doc_common/changelog.md)
 
 ## Compilation
 
-Ce dépôt permet de compiler directement Arcane et ses dépendances
+Ce dépôt permet de compiler directement Arcane et/ou Alien et ses dépendances
 (Arrcon, Axlstar et Arccore)
 
 La compilation doit se faire dans un répertoire différent de celui
 contenant les sources.
 
-Pour les prérequis, voir les répertoires [Arcane](arcane/README.md) et [Arccore](arccore/README.md):
+Pour les prérequis, voir les répertoires [Arcane](arcane/README.md) et [Alien](alien/standalone/README.md):
 
 - [Linux](#linux)
 
@@ -50,21 +50,17 @@ git clone /path/to/git
 cd framework && git submodule update --init --recursive
 ~~~
 
-Il existe deux modes de compilations:
-1. soit on compile Arcane et les projets associées (Arccon, Axlstar et
-   Arccore) en même temps
-2. soit on ne compile qu'un seul composant.
+Par défaut, on compile Arcane et Alien si les pré-requis sont disponibles
+La variable CMake `ARCANEFRAMEWORK_BUILD_COMPONENTS` contient la liste
+des composants du dépôt à compiler. Cette liste peut contenir les
+valeurs suivantes:
 
-Le défaut est de tout compiler. La variable cmake
-`FRAMEWORK_BUILD_COMPONENT` permet de choisir le mode de
-compilation. Par défaut, la valeur est `all` et cela signifie qu'on
-compile tout. Si la valeur est `arcane`, `arccon`, `arccore` ou
-`axlstar` alors on ne compile que ces derniers. Il faut donc dans ce
-cas que les dépendences éventuelles soient déjà installées (par
-exemple pour Arcane il faut que Arccore soit déjà installé et
-spécifier son chemin via CMAKE_PREFIX_PATH par exemple).
+- `Arcane`
+- `Alien`
 
-Pour compiler Arcane et les composantes dont il dépend (arccore, axlstar, arccon)::
+Par défaut la valeur est `Arcane;Alien` et donc on compile les deux composants.
+
+Pour compiler Arcane et Alien , il faut procéder comme suit:
 
 ~~~{sh}
 mkdir /path/to/build
@@ -72,13 +68,16 @@ cmake -S /path/to/sources -B /path/to/build
 cmake --build /path/to/build
 ~~~
 
-Pour compiler uniquement Arcane en considérant que les dépendances
-Arccore, Arccon, Axlstar et ArcDependencies sont déjà installées:
+Si on ne souhaite compiler que Arcane :
 
 ~~~{sh}
-mkdir /path/to/build
-cmake -S /path/to/sources -B /path/to/build -DFRAMEWORK_BUILD_COMPONENT=arcane -DArccon_ROOT=... -DArccore_ROOT=... -DAxlstar_ROOT=... -DArcDependencies_ROOT=...
-cmake --build /path/to/build
+cmake -S /path/to/sources -B /path/to/build -DARCANEFRAMEWORK_BUILD_COMPONENTS=Arcane
+~~~
+
+Si on ne souhaite compiler que Alien :
+
+~~~{sh}
+cmake -S /path/to/sources -B /path/to/build -DARCANEFRAMEWORK_BUILD_COMPONENTS=Alien
 ~~~
 
 ## Linux
@@ -110,10 +109,11 @@ sudo snap install --classic cmake
 
 ### Environnement `.Net`
 
-L'environnement `.Net` est accessible via `apt` mais vous pouvez aussi
-directement télécharger un fichier `tar` contenant le binaire et les
-fichiers nécessaires. Pour l'architecture `x64`, les commandes
-suivantes installent l'environnement dans le répertoire `$HOME/dotnet`.
+L'environnement [.Net](https://dotnet.microsoft.com) est nécessaire pour compiler Arcane. Il est
+accessible via `apt` mais vous pouvez aussi directement télécharger un
+fichier `tar` contenant le binaire et les fichiers nécessaires. Pour
+l'architecture `x64`, les commandes suivantes installent
+l'environnement dans le répertoire `$HOME/dotnet`.
 
 ~~~{sh}
 wget https://download.visualstudio.microsoft.com/download/pr/372b11de-1321-44f3-aad7-040842babe62/c5925f9f856c3a299e97c80283317275/dotnet-sdk-6.0.304-linux-x64.tar.gz


### PR DESCRIPTION
We now need to use CMake variable `ARCANEFRAMEWORK_BUILD_COMPONENTS` to specify if we want to compile Arcane and/or Alien. The old CMake variable `FRAMEWORK_BUILD_COMPONENT` is deprecated.

Fix #949 
