### PR TITLE
Make optional the use of material value when transforming a partial cell to a pure cell

### DIFF
--- a/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
+++ b/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
@@ -170,7 +170,7 @@ buildInit()
 
   m_material_mng->setModificationFlags(flags);
   m_material_mng->setMeshModificationNotified(true);
-
+  m_material_mng->setUseMaterialValueWhenRemovingPartialValue(true);
   if (subDomain()->isContinue()) {
     mm->recreateFromDump();
   }

--- a/arcane/src/arcane/core/materials/IMeshMaterialMng.h
+++ b/arcane/src/arcane/core/materials/IMeshMaterialMng.h
@@ -425,6 +425,22 @@ class ARCANE_CORE_EXPORT IMeshMaterialMng
   virtual void enableCellToAllEnvCellForRunCommand(bool is_enable, bool force_create=false) =0;
   virtual bool isCellToAllEnvCellForRunCommand() const =0;
 
+  /*!
+   * \brief Indique si on utilise la valeur matériau ou milieu lorsqu'on transforme une maille
+   * partielle en maille pure.
+   *
+   * Lors du passage d'une maille partielle en maille pure, il faut recopier la valeur
+   * partielle dans la valeur globale. Par défaut, le comportement n'est pas le même
+   * suivant que les optimisations sont actives ou non (\sa modificationFlags()).
+   * Sans optimisation, c'est la valeur matériau qui est utilisée. Si l'optimisation
+   * eModificationFlags::GenericOptimize est active, c'est la valeur milieu.
+   *
+   * Cette propriété, si elle vrai, permet d'utiliser la valeur matériau
+   * dans tous les cas.
+   */
+  virtual void setUseMaterialValueWhenRemovingPartialValue(bool v) =0;
+  virtual bool isUseMaterialValueWhenRemovingPartialValue() const =0;
+
  public:
 
   //!\internal

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -520,6 +520,12 @@ _switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env,bool i
 
   bool is_verbose = traceMng()->verbosityLevel()>=5;
 
+  // Ne copie pas les valeurs partielles des milieux vers les valeurs globales
+  // en cas de suppression de mailles car cela sera fait avec la valeur matériau
+  // correspondante. Cela permet d'avoir le même comportement que sans
+  // optimisation. Ce n'est pas actif par défaut pour compatibilité avec l'existant.
+  bool is_copy = is_add_operation || !(m_material_mng->isUseMaterialValueWhenRemovingPartialValue());
+
   for( const MeshEnvironment* env : m_material_mng->trueEnvironments() ){
     // Ne traite pas le milieu en cours de modification.
     if (env==modified_env)
@@ -540,11 +546,7 @@ _switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env,bool i
     info(4) << "NB_ENV_TRANSFORM=" << pure_local_ids.size()
             << " name=" << env->name();
 
-    // Ne copie pas les valeurs partielles des milieux vers les valeurs globales
-    // en cas de suppression de mailles car cela sera fait avec la valeur matériau
-    // correspondante. Cela permet d'avoir le même comportement que sans
-    // optimisation.
-    if (is_add_operation)
+    if (is_copy)
       _copyBetweenPartialsAndGlobals(pure_local_ids,partial_indexes,
                                      indexer->index(),is_add_operation);
   }

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -263,6 +263,12 @@ _switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env)
 {
   const bool is_add = m_work_info.isAdd();
 
+  // Ne copie pas les valeurs partielles des milieux vers les valeurs globales
+  // en cas de suppression de mailles car cela sera fait avec la valeur matériau
+  // correspondante. Cela permet d'avoir le même comportement que sans
+  // optimisation. Ce n'est pas actif par défaut pour compatibilité avec l'existant.
+  const bool is_copy = is_add || !(m_material_mng->isUseMaterialValueWhenRemovingPartialValue());
+
   for (const MeshEnvironment* env : m_material_mng->trueEnvironments()) {
     // Ne traite pas le milieu en cours de modification.
     if (env == modified_env)
@@ -281,11 +287,7 @@ _switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env)
     info(4) << "NB_ENV_TRANSFORM=" << m_work_info.pure_local_ids.size()
             << " name=" << env->name();
 
-    // Ne copie pas les valeurs partielles des milieux vers les valeurs globales
-    // en cas de suppression de mailles car cela sera fait avec la valeur matériau
-    // correspondante. Cela permet d'avoir le même comportement que sans
-    // optimisation.
-    if (is_add)
+    if (is_copy)
       m_all_env_data->_copyBetweenPartialsAndGlobals(m_work_info.pure_local_ids,
                                                      m_work_info.partial_indexes,
                                                      indexer->index(), is_add);

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -227,6 +227,15 @@ class MeshMaterialMng
     return m_variable_factory_mng;
   }
 
+  void setUseMaterialValueWhenRemovingPartialValue(bool v) override
+  {
+    m_is_use_material_value_when_removing_partial_value = v;
+  }
+  bool isUseMaterialValueWhenRemovingPartialValue() const override
+  {
+    return m_is_use_material_value_when_removing_partial_value;
+  }
+
  public:
 
   AllEnvData* allEnvData() { return m_all_env_data; }
@@ -278,6 +287,7 @@ class MeshMaterialMng
   bool m_is_data_initialisation_with_zero = false;
   bool m_is_mesh_modification_notified = false;
   bool m_is_allocate_scalar_environment_variable_as_material = false;
+  bool m_is_use_material_value_when_removing_partial_value = false;
   int m_modification_flags = 0;
 
   Mutex m_variable_lock;


### PR DESCRIPTION
This will allow to have the same behavior than version 3.10 and before.