### PR TITLE
Add sentinel type to iterator on Items

### DIFF
--- a/arcane/src/arcane/cartesianmesh/CartesianMeshPatchListView.h
+++ b/arcane/src/arcane/cartesianmesh/CartesianMeshPatchListView.h
@@ -34,6 +34,10 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianMeshPatchListView
 
  public:
 
+  //! Sentinelle pour l'itération pour une liste de patchs.
+  class Sentinel
+  {};
+
   //! Itérateur pour une liste de patchs.
   class Iterator
   {
@@ -41,7 +45,7 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianMeshPatchListView
 
    public:
 
-    typedef std::random_access_iterator_tag iterator_category;
+    typedef std::forward_iterator_tag iterator_category;
     typedef ICartesianMeshPatch value_type;
     typedef Int32 size_type;
 
@@ -62,6 +66,14 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianMeshPatchListView
       return (a.m_patches.data() + a.m_index) == (b.m_patches.data() + b.m_index);
     }
     friend bool operator!=(const Iterator& a, const Iterator& b)
+    {
+      return !(operator==(a, b));
+    }
+    friend bool operator==(const Iterator& a, const Sentinel&)
+    {
+      return a.m_patches.size() != a.m_index;
+    }
+    friend bool operator!=(const Iterator& a, const Sentinel& b)
     {
       return !(operator==(a, b));
     }
@@ -93,7 +105,8 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianMeshPatchListView
  public:
 
   Iterator begin() const { return Iterator(m_patches, 0); }
-  Iterator end() const { return Iterator(m_patches, m_patches.size()); }
+  Sentinel end() const { return {}; }
+  Iterator endIterator() const { return Iterator(m_patches, m_patches.size()); }
   Int32 size() const { return m_patches.size(); }
 
  private:

--- a/arcane/src/arcane/core/ItemConnectedListView.h
+++ b/arcane/src/arcane/core/ItemConnectedListView.h
@@ -237,6 +237,8 @@ class ItemConnectedListView
   using value_type = Item;
   using reference_type = Item&;
   using const_reference_type = const Item&;
+  // TODO: Créér le type 'Sentinel' lorsqu'on sera en C++20
+  using SentinelType = const_iterator;
 
  public:
 
@@ -271,7 +273,13 @@ class ItemConnectedListView
   }
 
   //! Itérateur sur après la dernière entité connectée
-  const_iterator end() const
+  SentinelType end() const
+  {
+    return endIterator();
+  }
+
+  //! Itérateur sur après la dernière entité connectée
+  const_iterator endIterator() const
   {
     return const_iterator(m_shared_info, (m_index_view._data() + this->size()), _localIdOffset());
   }
@@ -357,6 +365,8 @@ class ItemConnectedListViewT
   using const_iterator = ItemConnectedListViewConstIteratorT<ItemType>;
   using difference_type = std::ptrdiff_t;
   using value_type = ItemType;
+  // TODO: Créér le type 'Sentinel' lorsqu'on sera en C++20
+  using SentinelType = const_iterator;
 
  private:
 
@@ -390,7 +400,12 @@ class ItemConnectedListViewT
     return const_iterator(m_shared_info, this->_localIdsData(), this->_localIdOffset());
   }
   //! Itérateur sur après la dernière entité connectée
-  inline const_iterator end() const
+  inline SentinelType end() const
+  {
+    return endIterator();
+  }
+  //! Itérateur sur après la dernière entité connectée
+  inline const_iterator endIterator() const
   {
     return const_iterator(m_shared_info, (this->_localIdsData() + this->size()), this->_localIdOffset());
   }

--- a/arcane/src/arcane/core/ItemLocalIdListView.h
+++ b/arcane/src/arcane/core/ItemLocalIdListView.h
@@ -154,12 +154,12 @@ class ItemLocalIdListViewConstIteratorT
   friend constexpr ARCCORE_HOST_DEVICE ThatClass operator-(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr - v;
-    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
+    return ThatClass(ptr, a.m_local_id_offset);
   }
   friend constexpr ARCCORE_HOST_DEVICE ThatClass operator+(const ThatClass& a, difference_type v)
   {
     const Int32* ptr = a.m_local_id_ptr + v;
-    return ThatClass(a.m_shared_info, ptr, a.m_local_id_offset);
+    return ThatClass(ptr, a.m_local_id_offset);
   }
 };
 
@@ -237,6 +237,8 @@ class ItemLocalIdListViewT
 
   using LocalIdType = typename ItemLocalIdTraitsT<ItemType>::LocalIdType;
   using const_iterator = ItemLocalIdListViewConstIteratorT<ItemType>;
+  // TODO: Créér le type 'Sentinel' lorsqu'on sera en C++20
+  using SentinelType = const_iterator;
 
  public:
 
@@ -259,7 +261,11 @@ class ItemLocalIdListViewT
   {
     return const_iterator(m_local_ids, m_local_id_offset);
   }
-  constexpr ARCCORE_HOST_DEVICE const_iterator end() const
+  constexpr ARCCORE_HOST_DEVICE SentinelType end() const
+  {
+    return endIterator();
+  }
+  constexpr ARCCORE_HOST_DEVICE const_iterator endIterator() const
   {
     return const_iterator(m_local_ids + m_size, m_local_id_offset);
   }

--- a/arcane/src/arcane/core/ItemVectorView.h
+++ b/arcane/src/arcane/core/ItemVectorView.h
@@ -234,6 +234,8 @@ class ARCANE_CORE_EXPORT ItemVectorView
   using value_type = Item;
   using reference_type = Item&;
   using const_reference_type = const Item&;
+  // TODO: Créér le type 'Sentinel' lorsqu'on sera en C++20
+  using SentinelType = const_iterator;
 
  public:
 
@@ -349,7 +351,11 @@ class ARCANE_CORE_EXPORT ItemVectorView
   {
     return const_iterator(m_shared_info, m_index_view._data(), _localIdOffset());
   }
-  const_iterator end() const
+  SentinelType end() const
+  {
+    return endIterator();
+  }
+  const_iterator endIterator() const
   {
     return const_iterator(m_shared_info, (m_index_view._data() + this->size()), _localIdOffset());
   }
@@ -400,6 +406,8 @@ class ItemVectorViewT
   using reference_type = ItemType&;
   //TODO a supprimer avec le C++20
   using const_reference_type = const ItemType&;
+  // TODO: Créér le type 'Sentinel' lorsqu'on sera en C++20
+  using SentinelType = const_iterator;
 
  public:
 
@@ -456,7 +464,11 @@ class ItemVectorViewT
   {
     return const_iterator(m_shared_info, _localIdsData(), _localIdOffset());
   }
-  inline const_iterator end() const
+  inline SentinelType end() const
+  {
+    return const_iterator(m_shared_info, _localIdsData() + this->size(), _localIdOffset());
+  }
+  inline const_iterator endIterator() const
   {
     return const_iterator(m_shared_info, _localIdsData() + this->size(), _localIdOffset());
   }


### PR DESCRIPTION
At the moment it is only a typedef for `const_iterator` type. With C++20 and ranges, it will be a true sentinel type (see [sentinel_for](https://en.cppreference.com/w/cpp/iterator/sentinel_for))