### PR TITLE
Move dfinition of 'DynamicMesh::InternalApi' in source file

### DIFF
--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -58,6 +58,8 @@
 #include "arcane/core/internal/UnstructuredMeshAllocateBuildInfoInternal.h"
 #include "arcane/core/internal/IItemFamilyInternal.h"
 #include "arcane/core/internal/IVariableMngInternal.h"
+#include "arcane/core/internal/IMeshInternal.h"
+#include "arcane/core/internal/IMeshModifierInternal.h"
 
 #include "arcane/mesh/ExtraGhostCellsBuilder.h"
 #include "arcane/mesh/ExtraGhostParticlesBuilder.h"
@@ -148,6 +150,26 @@ const std::string DynamicMesh::PerfCounter::m_names[] = {
     "UPGHOSTLAYER7"
 } ;
 #endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class DynamicMesh::InternalApi
+: public IMeshInternal
+, public IMeshModifierInternal
+{
+ public:
+
+  InternalApi(DynamicMesh* mesh)
+  : m_mesh(mesh)
+  {
+  }
+
+ private:
+
+  DynamicMesh* m_mesh = nullptr;
+};
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -183,7 +205,7 @@ DynamicMesh(ISubDomain* sub_domain,const MeshBuildInfo& mbi, bool is_submesh)
 , m_extra_ghost_cells_builder(nullptr)
 , m_extra_ghost_particles_builder(nullptr)
 , m_initial_allocator(this)
-, m_internal_api(this)
+, m_internal_api(std::make_unique<InternalApi>(this))
 , m_is_amr_activated(mbi.meshKind().meshAMRKind()!=eMeshAMRKind::None)
 , m_amr_type(mbi.meshKind().meshAMRKind())
 , m_is_dynamic(false)
@@ -3335,6 +3357,24 @@ _updateItemFamilyDependencies(VariableScalarInteger connectivity)
       m_item_family_network->setIsStored(con);
     }
   }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+IMeshInternal* DynamicMesh::
+_internalApi()
+{
+  return m_internal_api.get();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+IMeshModifierInternal* DynamicMesh::
+_modifierInternalApi()
+{
+  return m_internal_api.get();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DynamicMesh.h
+++ b/arcane/src/arcane/mesh/DynamicMesh.h
@@ -29,8 +29,6 @@
 #include "arcane/core/MeshHandle.h"
 #include "arcane/core/IMeshInitialAllocator.h"
 #include "arcane/core/MeshKind.h"
-#include "arcane/core/internal/IMeshInternal.h"
-#include "arcane/core/internal/IMeshModifierInternal.h"
 
 #include "arcane/mesh/SubMeshTools.h"
 #include "arcane/mesh/MeshVariables.h"
@@ -97,6 +95,8 @@ class ARCANE_MESH_EXPORT DynamicMesh
 , public IUnstructuredMeshInitialAllocator
 , public ICartesianMeshInitialAllocator
 {
+  class InternalApi;
+
  private:
   // TEMPORAIRE
   friend DynamicMeshMergerHelper;
@@ -106,22 +106,6 @@ class ARCANE_MESH_EXPORT DynamicMesh
   typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
 
   typedef List<IItemFamily*> ItemFamilyList;
-
-  class InternalApi
-  : public IMeshInternal
-  , public IMeshModifierInternal
-  {
-   public:
-
-    InternalApi(DynamicMesh* mesh)
-    : m_mesh(mesh)
-    {
-    }
-
-   private:
-
-    DynamicMesh* m_mesh;
-  };
 
   class InitialAllocator
   : public IMeshInitialAllocator
@@ -555,8 +539,8 @@ public:
 
   const MeshKind meshKind() const override { return m_mesh_kind; }
 
-  IMeshInternal* _internalApi() override { return &m_internal_api; }
-  IMeshModifierInternal* _modifierInternalApi() override { return &m_internal_api; }
+  IMeshInternal* _internalApi() override;
+  IMeshModifierInternal* _modifierInternalApi() override;
 
  private:
 
@@ -576,7 +560,7 @@ public:
   ExtraGhostCellsBuilder* m_extra_ghost_cells_builder = nullptr;
   ExtraGhostParticlesBuilder* m_extra_ghost_particles_builder = nullptr;
   InitialAllocator m_initial_allocator;
-  InternalApi m_internal_api;
+  std::unique_ptr<InternalApi> m_internal_api;
 
  private:
   


### PR DESCRIPTION
This is needed if user code want to include `DynamicMesh.h`.