### PR TITLE
Add support for sorting Faces and Edges connected to Nodes

### DIFF
--- a/arcane/src/arcane/mesh/NodeFamily.cc
+++ b/arcane/src/arcane/mesh/NodeFamily.cc
@@ -316,7 +316,7 @@ class NodeFamily::ItemCompare2
 {
  public:
 
-  ItemCompare2(const ItemInfoListView& items)
+  explicit ItemCompare2(const ItemInfoListView& items)
   : m_items(items)
   {
   }
@@ -339,7 +339,7 @@ class NodeFamily::ItemCompare2
 class NodeFamily::ItemCompare3
 {
  public:
-  ItemCompare3(ITraceMng* msg) : m_msg(msg) {}
+  explicit ItemCompare3(ITraceMng* msg) : m_msg(msg) {}
  public:
   ITraceMng* m_msg;
   ItemInternalArrayView m_items;

--- a/arcane/src/arcane/mesh/NodeFamily.cc
+++ b/arcane/src/arcane/mesh/NodeFamily.cc
@@ -16,21 +16,22 @@
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/ITraceMng.h"
+#include "arcane/utils/ValueConvert.h"
 
-#include "arcane/ISubDomain.h"
-#include "arcane/ItemPrinter.h"
-#include "arcane/VariableTypes.h"
-#include "arcane/IMesh.h"
-#include "arcane/MeshUtils.h"
+#include "arcane/core/ISubDomain.h"
+#include "arcane/core/ItemPrinter.h"
+#include "arcane/core/VariableTypes.h"
+#include "arcane/core/IMesh.h"
+#include "arcane/core/MeshUtils.h"
+#include "arcane/core/Connectivity.h"
+#include "arcane/core/ConnectivityItemVector.h"
+#include "arcane/core/Properties.h"
 
-#include "arcane/Connectivity.h"
-#include "arcane/ConnectivityItemVector.h"
 #include "arcane/mesh/IncrementalItemConnectivity.h"
 #include "arcane/mesh/CompactIncrementalItemConnectivity.h"
 #include "arcane/mesh/ItemConnectivitySelector.h"
 #include "arcane/mesh/AbstractItemFamilyTopologyModifier.h"
 #include "arcane/mesh/NewWithLegacyConnectivity.h"
-
 #include "arcane/mesh/FaceFamily.h"
 
 /*---------------------------------------------------------------------------*/
@@ -71,17 +72,11 @@ class NodeFamily::TopologyModifier
 NodeFamily::
 NodeFamily(IMesh* mesh,const String& name)
 : ItemFamily(mesh,IK_Node,name)
-, m_node_type(0)
-, m_edge_prealloc(0)
-, m_face_prealloc(0)
-, m_cell_prealloc(0)
-, m_mesh_connectivity(0)
-, m_no_face_connectivity(false)
-, m_nodes_coords(0)
-, m_edge_connectivity(nullptr)
-, m_face_connectivity(nullptr)
-, m_cell_connectivity(nullptr)
 {
+  if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_SORT_FACE_AND_EDGE_OF_NODE", true)){
+    m_is_sort_connected_faces_and_edges = v.value() !=0;
+    info() << "Set sort faces and edges of nodes v?=" << m_is_sort_connected_faces_and_edges;
+  }
   _setTopologyModifier(new TopologyModifier(this));
 }
 
@@ -320,12 +315,22 @@ setConnectivity(const Integer c)
 class NodeFamily::ItemCompare2
 {
  public:
-  ItemInfoListView m_items;
+
+  ItemCompare2(const ItemInfoListView& items)
+  : m_items(items)
+  {
+  }
+
  public:
+
   bool operator()(Int32 item1,Int32 item2) const
   {
     return m_items.uniqueId(item1) < m_items.uniqueId(item2);
   }
+
+ private:
+
+  ItemInfoListView m_items;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -354,21 +359,41 @@ class NodeFamily::ItemCompare3
 /*---------------------------------------------------------------------------*/
 
 void NodeFamily::
+_sortConnectedItems(IItemFamily* family, IncrementalItemConnectivity* connectivity)
+{
+  if (!connectivity)
+    return;
+
+  // Trie les entités connectées aux noeuds par uniqueId() croissant.
+  // Cela est utile pour garantir un ordre de parcours de ces entités
+  // identique quel que soit le découpage et ainsi améliorer
+  // la reproductibilité.
+  ItemInfoListView items_infos(family->itemInfoListView());
+  ItemCompare2 ic_items(items_infos);
+  ENUMERATE_ITEM(iitem,allItems()){
+    ItemLocalId lid(iitem.itemLocalId());
+    Int32ArrayView conn_lids = connectivity->_connectedItemsLocalId(lid);
+    std::sort(std::begin(conn_lids),std::end(conn_lids),ic_items);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void NodeFamily::
 sortInternalReferences()
 {
   // Trie les mailles connectées aux noeuds par uniqueId() croissant.
-  // Cela est utile pour garantir un ordre de parcours des mailles
-  // des noeuds identique quel que soit le découpage et ainsi améliorer
-  // la reproductibilité.
-  ItemCompare2 ic_cell;
-  ic_cell.m_items = mesh()->cellFamily()->itemInfoListView();
-  auto new_connectivity = m_cell_connectivity->trueCustomConnectivity();
-  if (new_connectivity){
-    ENUMERATE_ITEM(iitem,allItems()){
-      ItemLocalId lid(iitem.itemLocalId());
-      Int32ArrayView conn_lids = new_connectivity->_connectedItemsLocalId(lid);
-      std::sort(std::begin(conn_lids),std::end(conn_lids),ic_cell);
-    }
+  _sortConnectedItems(mesh()->cellFamily(),m_cell_connectivity->trueCustomConnectivity());
+
+  // Fait de même pour les faces et les arêtes.
+  // Pour des raisons historiques, cela n'est pas actif par défaut.
+  bool do_sort = properties()->getBoolWithDefault("sort-connected-faces-edges",m_is_sort_connected_faces_and_edges);
+  if (do_sort){
+    info(4) << "Sorting connected faces and edges family=" << fullName();
+    _sortConnectedItems(m_face_family,m_face_connectivity->trueCustomConnectivity());
+    if (Connectivity::hasConnectivity(m_mesh_connectivity,Connectivity::CT_NodeToEdge))
+      _sortConnectedItems(mesh()->edgeFamily(),m_edge_connectivity->trueCustomConnectivity());
   }
 }
 

--- a/arcane/src/arcane/mesh/NodeFamily.h
+++ b/arcane/src/arcane/mesh/NodeFamily.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* NodeFamily.h                                                (C) 2000-2022 */
+/* NodeFamily.h                                                (C) 2000-2023 */
 /*                                                                           */
 /* Famille de noeuds.                                                        */
 /*---------------------------------------------------------------------------*/
@@ -14,8 +14,9 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arcane/core/IItemFamilyModifier.h"
+
 #include "arcane/mesh/ItemFamily.h"
-#include "arcane/IItemFamilyModifier.h"
 #include "arcane/mesh/MeshInfos.h"
 #include "arcane/mesh/ItemInternalConnectivityIndex.h"
 
@@ -140,17 +141,23 @@ class ARCANE_MESH_EXPORT NodeFamily
  private:
   
   ItemTypeInfo* m_node_type = nullptr; //!< Instance contenant le type des noeuds
-  Integer m_edge_prealloc;
-  Integer m_face_prealloc;
-  Integer m_cell_prealloc;
-  Integer m_mesh_connectivity;
-  bool m_no_face_connectivity;
+  Integer m_edge_prealloc = 0;
+  Integer m_face_prealloc = 0;
+  Integer m_cell_prealloc = 0;
+  Integer m_mesh_connectivity = 0;
+  bool m_no_face_connectivity = false;
   VariableNodeReal3* m_nodes_coords = nullptr;
   EdgeConnectivity* m_edge_connectivity = nullptr;
   FaceConnectivity* m_face_connectivity = nullptr;
   CellConnectivity* m_cell_connectivity = nullptr;
   FaceFamily* m_face_family = nullptr;
+  //! Indique si on trie les faces et arêtes connectées aux noeuds
+  bool m_is_sort_connected_faces_and_edges = false;
+
+ private:
+
   inline void _removeNode(Node node);
+  void _sortConnectedItems(IItemFamily* family, IncrementalItemConnectivity* connectivity);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -456,6 +456,7 @@ if(PARTITIONER_FOUND)
 endif()
 
 ARCANE_ADD_TEST(mesh2 testMesh-2.arc)
+arcane_add_test_sequential(mesh2_sort_faces testMesh-2-sorted-faces.arc)
 ARCANE_ADD_TEST_PARALLEL(mesh2_5ghost testMesh-2-5ghost.arc 4)
 ARCANE_ADD_TEST_SEQUENTIAL(matvec testMatVec-1.arc)
 #ARCANE_ADD_TEST_SEQUENTIAL(amr2 testAMR-2.arc)

--- a/arcane/src/arcane/tests/MeshUnitTest.axl
+++ b/arcane/src/arcane/tests/MeshUnitTest.axl
@@ -116,5 +116,15 @@ Teste la désallocation du maillage
    </description>
   </simple>
 
+  <simple
+   name = "test-sort-node-faces-and-edges"
+   type = "bool"
+   default = "false"
+  >
+   <description>
+     Indique si on tri les faces et les arêtes connectées aux noeuds
+   </description>
+  </simple>
+
  </options>
 </service>

--- a/arcane/tests/testMesh-2-sorted-faces.arc
+++ b/arcane/tests/testMesh-2-sorted-faces.arc
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<cas codename="ArcaneTest" xml:lang="fr" codeversion="1.0">
+  <arcane>
+    <titre>Test Maillage 1</titre>
+    <description>Test Maillage 1</description>
+    <boucle-en-temps>UnitTest</boucle-en-temps>
+  </arcane>
+
+  <maillage>
+    <fichier internal-partition="true">sod.vtk</fichier>
+  </maillage>
+
+  <module-test-unitaire>
+    <test name="MeshUnitTest">
+      <maillage-additionnel>sod.vtk</maillage-additionnel>
+      <test-sort-node-faces-and-edges>true</test-sort-node-faces-and-edges>
+    </test>
+  </module-test-unitaire>
+
+</cas>


### PR DESCRIPTION
This is not enabled by default because it can change results.
To use it you can add the following lines in the code:

```
IMesh* mesh = ...;
mesh->nodeFamily()->properties()->setBool("sort-connected-faces-edges",true);
mesh->modifier()->endUpdate();
```

Or you can set the environment variable `ARCANE_SORT_FACE_AND_EDGE_OF_NODE` to `1`.