### PR TITLE
Make class SpinLock deprecated

### DIFF
--- a/arccore/src/concurrency/arccore/concurrency/ConcurrencyGlobal.cc
+++ b/arccore/src/concurrency/arccore/concurrency/ConcurrencyGlobal.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ConcurrencyGlobal.h                                         (C) 2000-2018 */
+/* ConcurrencyGlobal.h                                         (C) 2000-2023 */
 /*                                                                           */
 /* Définitions globales de la composante 'Concurrency' de 'Arccore'.         */
 /*---------------------------------------------------------------------------*/
@@ -26,9 +26,9 @@ namespace Arccore
 
 namespace
 {
-NullThreadImplementation global_null_thread_implementation;
-ReferenceCounter<IThreadImplementation> global_thread_implementation{&global_null_thread_implementation};
-}
+  NullThreadImplementation global_null_thread_implementation;
+  ReferenceCounter<IThreadImplementation> global_thread_implementation{ &global_null_thread_implementation };
+} // namespace
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -50,6 +50,33 @@ setThreadImplementation(IThreadImplementation* service)
   if (!service)
     global_thread_implementation = &global_null_thread_implementation;
   return old_service;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IThreadImplementation::
+_deprecatedCreateSpinLock(Int64* spin_lock_addr)
+{
+  createSpinLock(spin_lock_addr);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IThreadImplementation::
+_deprecatedLockSpinLock(Int64* spin_lock_addr, Int64* scoped_spin_lock_addr)
+{
+  lockSpinLock(spin_lock_addr, scoped_spin_lock_addr);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IThreadImplementation::
+_deprecatedUnlockSpinLock(Int64* spin_lock_addr, Int64* scoped_spin_lock_addr)
+{
+  unlockSpinLock(spin_lock_addr, scoped_spin_lock_addr);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/concurrency/arccore/concurrency/IThreadImplementation.h
+++ b/arccore/src/concurrency/arccore/concurrency/IThreadImplementation.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IThreadImplementation.h                                     (C) 2000-2019 */
+/* IThreadImplementation.h                                     (C) 2000-2023 */
 /*                                                                           */
 /* Interface d'un service implémentant le support des threads.               */
 /*---------------------------------------------------------------------------*/
@@ -34,32 +34,57 @@ namespace Arccore
  */
 class ARCCORE_CONCURRENCY_EXPORT IThreadImplementation
 {
+  friend class SpinLock;
+  friend class ScopedLock;
+  friend class ManualLock;
+
  public:
+
   typedef ReferenceCounterTag ReferenceCounterTagType;
+
  protected:
+
   virtual ~IThreadImplementation() = default;
+
  public:
-  virtual void addReference() =0;
-  virtual void removeReference() =0;
+
+  virtual void addReference() = 0;
+  virtual void removeReference() = 0;
+
  public:
-  virtual void initialize() =0;
+
+  virtual void initialize() = 0;
+
  public:
-  virtual ThreadImpl* createThread(IFunctor* f) =0;
-  virtual void joinThread(ThreadImpl* t) =0;
-  virtual void destroyThread(ThreadImpl* t) =0;
 
-  virtual void createSpinLock(Int64* spin_lock_addr) =0;
-  virtual void lockSpinLock(Int64* spin_lock_addr,Int64* scoped_spin_lock_addr) =0;
-  virtual void unlockSpinLock(Int64* spin_lock_addr,Int64* scoped_spin_lock_addr) =0;
+  virtual ThreadImpl* createThread(IFunctor* f) = 0;
+  virtual void joinThread(ThreadImpl* t) = 0;
+  virtual void destroyThread(ThreadImpl* t) = 0;
 
-  virtual MutexImpl* createMutex() =0;
-  virtual void destroyMutex(MutexImpl*) =0;
-  virtual void lockMutex(MutexImpl* mutex) =0;
-  virtual void unlockMutex(MutexImpl* mutex) =0;
+  ARCCORE_DEPRECATED_REASON("Y2023: SpinLock are deprecated. Use std::atomic_flag instead")
+  virtual void createSpinLock(Int64* spin_lock_addr) = 0;
+  ARCCORE_DEPRECATED_REASON("Y2023: SpinLock are deprecated. Use std::atomic_flag instead")
+  virtual void lockSpinLock(Int64* spin_lock_addr, Int64* scoped_spin_lock_addr) = 0;
+  ARCCORE_DEPRECATED_REASON("Y2023: SpinLock are deprecated. Use std::atomic_flag instead")
+  virtual void unlockSpinLock(Int64* spin_lock_addr, Int64* scoped_spin_lock_addr) = 0;
 
-  virtual Int64 currentThread() =0;
+  virtual MutexImpl* createMutex() = 0;
+  virtual void destroyMutex(MutexImpl*) = 0;
+  virtual void lockMutex(MutexImpl* mutex) = 0;
+  virtual void unlockMutex(MutexImpl* mutex) = 0;
 
-  virtual IThreadBarrier* createBarrier() =0;
+  virtual Int64 currentThread() = 0;
+
+  virtual IThreadBarrier* createBarrier() = 0;
+
+ private:
+
+  // Définitions pour éviter d'affichier les messages d'avertissement
+  // à cause des méthodes obsolètes.
+
+  void _deprecatedCreateSpinLock(Int64* spin_lock_addr);
+  void _deprecatedLockSpinLock(Int64* spin_lock_addr, Int64* scoped_spin_lock_addr);
+  void _deprecatedUnlockSpinLock(Int64* spin_lock_addr, Int64* scoped_spin_lock_addr);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/concurrency/arccore/concurrency/SpinLock.h
+++ b/arccore/src/concurrency/arccore/concurrency/SpinLock.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SpinLock.h                                                  (C) 2000-2017 */
+/* SpinLock.h                                                  (C) 2000-2023 */
 /*                                                                           */
 /* SpinLock pour le multi-threading.                                         */
 /*---------------------------------------------------------------------------*/
@@ -35,19 +35,24 @@ class SpinLockImpl;
 class ARCCORE_CONCURRENCY_EXPORT SpinLock
 {
  public:
+
   class ScopedLock
   {
    public:
+
+    ARCCORE_DEPRECATED_REASON("Y2023: SpinLock are deprecated. Use std::atomic_flag instead")
     ScopedLock(SpinLock& sl)
     {
       spin_lock_addr = &sl.spin_lock;
-      Concurrency::getThreadImplementation()->lockSpinLock(spin_lock_addr,scoped_spin_lock);
+      Concurrency::getThreadImplementation()->_deprecatedLockSpinLock(spin_lock_addr, scoped_spin_lock);
     }
     ~ScopedLock()
     {
-      Concurrency::getThreadImplementation()->unlockSpinLock(spin_lock_addr,scoped_spin_lock);
+      Concurrency::getThreadImplementation()->_deprecatedUnlockSpinLock(spin_lock_addr, scoped_spin_lock);
     }
+
    private:
+
     Int64* spin_lock_addr;
     Int64 scoped_spin_lock[2];
   };
@@ -55,15 +60,20 @@ class ARCCORE_CONCURRENCY_EXPORT SpinLock
   class ManualLock
   {
    public:
+
+    ARCCORE_DEPRECATED_REASON("Y2023: SpinLock are deprecated. Use std::atomic_flag instead")
     void lock(SpinLock& sl)
     {
-      Concurrency::getThreadImplementation()->lockSpinLock(&sl.spin_lock,scoped_spin_lock);
+      Concurrency::getThreadImplementation()->_deprecatedLockSpinLock(&sl.spin_lock, scoped_spin_lock);
     }
+    ARCCORE_DEPRECATED_REASON("Y2023: SpinLock are deprecated. Use std::atomic_flag instead")
     void unlock(SpinLock& sl)
     {
-      Concurrency::getThreadImplementation()->unlockSpinLock(&sl.spin_lock,scoped_spin_lock);
+      Concurrency::getThreadImplementation()->_deprecatedUnlockSpinLock(&sl.spin_lock, scoped_spin_lock);
     }
+
    private:
+
     Int64 scoped_spin_lock[2];
   };
 
@@ -71,12 +81,17 @@ class ARCCORE_CONCURRENCY_EXPORT SpinLock
   friend class ManualLock;
 
  public:
+
+  ARCCORE_DEPRECATED_REASON("Y2023: SpinLock are deprecated. Use std::atomic_flag instead")
   SpinLock()
   {
-    Concurrency::getThreadImplementation()->createSpinLock(&spin_lock);
+    Concurrency::getThreadImplementation()->_deprecatedCreateSpinLock(&spin_lock);
   }
+
  private:
-  Int64 spin_lock;
+
+  Int64 spin_lock = 0;
+
  private:
 };
 


### PR DESCRIPTION
This class is no longer useful. If needed, use `std::atomic_flag` instead.