### PR TITLE
[CI] Update create release workflow

### DIFF
--- a/.github/workflows/create-release-arcane.yml
+++ b/.github/workflows/create-release-arcane.yml
@@ -75,12 +75,11 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
+          name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
           body: |
             Release ${{ env.FRAMEWORK_TAG_VERSION }}
           draft: false

--- a/.github/workflows/create-release-arccon.yml
+++ b/.github/workflows/create-release-arccon.yml
@@ -49,12 +49,11 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
+          name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
           body: |
             Release ${{ env.FRAMEWORK_TAG_VERSION }}
           draft: false

--- a/.github/workflows/create-release-arccore.yml
+++ b/.github/workflows/create-release-arccore.yml
@@ -49,12 +49,11 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
+          name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
           body: |
             Release ${{ env.FRAMEWORK_TAG_VERSION }}
           draft: false

--- a/.github/workflows/create-release-axlstar.yml
+++ b/.github/workflows/create-release-axlstar.yml
@@ -49,12 +49,11 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
+          name: ${{ env.COMPONENT_NAME_UPPER }} Version ${{ env.FRAMEWORK_TAG_VERSION }}
           body: |
             Release ${{ env.FRAMEWORK_TAG_VERSION }}
           draft: false


### PR DESCRIPTION
The current version does not work because it used `node v12` which is no longer supported.