### PR TITLE
[CI] Remove usage of C++20 when compiling Arcane on ubuntu 20

### DIFF
--- a/.github/workflows/build_tests_all.yml
+++ b/.github/workflows/build_tests_all.yml
@@ -21,7 +21,6 @@ jobs:
           - image_short: 'U20_G11_C13'
             image_long: 'ubuntu-2004:gcc-11_clang-13'
             image_date: '20230808'
-            image_args: '-DARCCORE_CXX_STANDARD=20'
             image_cuda: false
 
           - image_short: 'U22_G12_C16'

--- a/.github/workflows/build_tests_rand.yml
+++ b/.github/workflows/build_tests_rand.yml
@@ -19,7 +19,6 @@ jobs:
           - image_short: 'U20_G11_C13'
             image_long: 'ubuntu-2004:gcc-11_clang-13'
             image_date: '20230808'
-            image_args: '-DARCCORE_CXX_STANDARD=20'
             image_cuda: false
 
           - image_short: 'U22_G12_C16'

--- a/.github/workflows/build_tests_release.yml
+++ b/.github/workflows/build_tests_release.yml
@@ -41,7 +41,6 @@ jobs:
           - image_short: 'U20_G11_C13'
             image_long: 'ubuntu-2004:gcc-11_clang-13'
             image_date: '20230808'
-            image_args: '-DARCCORE_CXX_STANDARD=20'
             image_cuda: false
 
           - image_short: 'U22_G12_C16'


### PR DESCRIPTION
Use of `std::atomic_ref` do not compile on this platform.