### PR TITLE
Begin support for dataset symbol substitution

### DIFF
--- a/arcane/src/arcane/core/StringVariableReplace.h
+++ b/arcane/src/arcane/core/StringVariableReplace.h
@@ -1,0 +1,81 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* StringVariableReplace.h                                     (C) 2000-2023 */
+/*                                                                           */
+/* TODO.                                                       */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_STRINGVARIABLEREPLACE_H
+#define ARCANE_STRINGVARIABLEREPLACE_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/ApplicationInfo.h"
+#include "arcane/utils/CommandLineArguments.h"
+#include "arcane/utils/UniqueArray.h"
+#include "arcane/utils/StringBuilder.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class StringVariableReplace
+{
+ public:
+
+  static String replaceWithCmdLineArgs(const ApplicationInfo& appinfo, const String& name){
+    if(name.empty()) return name;
+
+    String name_cpy = name;
+
+    // Permet de contourner le bug avec String::split() si le nom commence par '@'.
+    if (name_cpy.startsWith("@")) {
+      name_cpy = "@" + name_cpy;
+    }
+
+    StringUniqueArray string_splited;
+    // On découpe la string là où se trouve les @.
+    name_cpy.split(string_splited, '@');
+
+    if(string_splited.size() == 1) return name;
+
+    for(auto & elem : string_splited){
+      String reference_input = appinfo.commandLineArguments().getParameter(elem);
+      if(reference_input.null()) continue;
+      elem = reference_input;
+    }
+
+    // On recombine la chaine.
+    StringBuilder combined = "";
+    for (const String& str : string_splited) {
+      // Permet de contourner le bug avec String::split() s'il y a '@@@' dans le nom ou si le
+      // nom commence par '@' (en complément des premières lignes de la méthode).
+      if (str == "@")
+        continue;
+      combined.append(str);
+    }
+
+    return combined.toString();
+  }
+
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif  
+

--- a/arcane/src/arcane/core/internal/StringVariableReplace.cc
+++ b/arcane/src/arcane/core/internal/StringVariableReplace.cc
@@ -1,4 +1,4 @@
-// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
 // Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.

--- a/arcane/src/arcane/core/internal/StringVariableReplace.cc
+++ b/arcane/src/arcane/core/internal/StringVariableReplace.cc
@@ -1,0 +1,79 @@
+// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* StringVariableReplace.h                                     (C) 2000-2023 */
+/*                                                                           */
+/* Classe permettant de remplacer les symboles d'une chaine de caractères    */
+/* par une autre chaine de caractères définie dans les arguments de          */
+/* lancement.                                                                */
+/* Un symbole est défini par une chaine de caractères entourée de @.         */
+/* Exemple : @mon_symbole@                                                   */
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/core/internal/StringVariableReplace.h"
+#include "arcane/utils/PlatformUtils.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+String StringVariableReplace::
+replaceWithCmdLineArgs(const ParameterList& parameter_list, const String& name)
+{
+  // Si la variable d'environnement ARCANE_REPLACE_SYMBOLS_IN_DATASET n'est pas
+  // définie, on ne touche pas à la chaine de caractères.
+  if (platform::getEnvironmentVariable("ARCANE_REPLACE_SYMBOLS_IN_DATASET").null()) {
+    return name;
+  }
+
+  if(name.empty()) return name;
+
+  String name_cpy = name;
+
+  // Permet de contourner le bug avec String::split() si le nom commence par '@'.
+  if (name_cpy.startsWith("@")) {
+    name_cpy = "@" + name_cpy;
+  }
+
+  StringUniqueArray string_splited;
+  // On découpe la string là où se trouve les @.
+  name_cpy.split(string_splited, '@');
+
+  // S'il n'y a aucun @, on retourne la chaine d'origine.
+  if(string_splited.size() == 1) return name;
+
+  for(auto & elem : string_splited){
+    String reference_input = parameter_list.getParameterOrNull(elem);
+    if(reference_input.null()) continue;
+    elem = reference_input;
+  }
+
+  // On recombine la chaine de caractères.
+  StringBuilder combined = "";
+  for (const String& str : string_splited) {
+    // Permet de contourner le bug avec String::split() s'il y a '@@@' dans le nom ou si le
+    // nom commence par '@' (en complément des premières lignes de la méthode).
+    if (str == "@")
+      continue;
+    combined.append(str);
+  }
+
+  return combined.toString();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/StringVariableReplace.cc
+++ b/arcane/src/arcane/core/internal/StringVariableReplace.cc
@@ -26,49 +26,146 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*!
+ * Méthode permettant de remplacer les symboles de la chaine de caractères name
+ * par leurs valeurs définies dans la liste des paramètres.
+ *
+ * Pour l'instant, un symbole est représenté par une chaine de caractères entourée
+ * de deux "\@".
+ *
+ * Exemple : "\@mesh_dir\@/cube.msh"
+ * avec un paramètre "mesh_dir=~/mesh"
+ * donnera : "~/mesh/cube.msh".
+ *
+ * À noter que les @ ne seront pas supprimés s'ils ne correspondent pas à un symbole.
+ *
+ * Exemple : "\@mesh_dir\@/cube.msh"
+ * sans paramètres
+ * donnera : "\@mesh_dir\@/cube.msh".
+ *
+ * @param parameter_list La liste des paramètres à considérer.
+ * @param string_with_symbols La chaine de caractères avec les symboles à remplacer.
+ * @return La chaine de caractères avec les symboles remplacés par leurs valeurs.
+ */
 String StringVariableReplace::
-replaceWithCmdLineArgs(const ParameterList& parameter_list, const String& name)
+replaceWithCmdLineArgs(const ParameterList& parameter_list, const String& string_with_symbols)
 {
   // Si la variable d'environnement ARCANE_REPLACE_SYMBOLS_IN_DATASET n'est pas
   // définie, on ne touche pas à la chaine de caractères.
-  if (platform::getEnvironmentVariable("ARCANE_REPLACE_SYMBOLS_IN_DATASET").null()) {
-    return name;
+  if (platform::getEnvironmentVariable("ARCANE_REPLACE_SYMBOLS_IN_DATASET").null() &&
+      parameter_list.getParameterOrNull("ARCANE_REPLACE_SYMBOLS_IN_DATASET").null()) {
+    return string_with_symbols;
   }
 
-  if(name.empty()) return name;
+  if(string_with_symbols.empty()) return string_with_symbols;
 
-  String name_cpy = name;
+  UniqueArray<String> string_splited;
+  UniqueArray<Integer> symbol_pos;
+  Integer nb_at;
 
-  // Permet de contourner le bug avec String::split() si le nom commence par '@'.
-  if (name_cpy.startsWith("@")) {
-    name_cpy = "@" + name_cpy;
-  }
-
-  StringUniqueArray string_splited;
   // On découpe la string là où se trouve les @.
-  name_cpy.split(string_splited, '@');
+  // On récupère la position des symboles et le nombre de @.
+  _splitString(string_with_symbols, string_splited, symbol_pos, nb_at, '@');
 
-  // S'il n'y a aucun @, on retourne la chaine d'origine.
-  if(string_splited.size() == 1) return name;
+  // S'il n'y a aucun symbole, on retourne la chaine d'origine.
+  if(symbol_pos.empty()) return string_with_symbols;
 
-  for(auto & elem : string_splited){
-    String reference_input = parameter_list.getParameterOrNull(elem);
-    if(reference_input.null()) continue;
-    elem = reference_input;
+  for(Integer pos : symbol_pos){
+    String& symbol = string_splited[pos];
+    String reference_input = parameter_list.getParameterOrNull(symbol);
+    if(reference_input.null()) {
+      symbol = "@" + symbol + "@";
+    }
+    else {
+      symbol = reference_input;
+    }
   }
 
   // On recombine la chaine de caractères.
   StringBuilder combined = "";
-  for (const String& str : string_splited) {
-    // Permet de contourner le bug avec String::split() s'il y a '@@@' dans le nom ou si le
-    // nom commence par '@' (en complément des premières lignes de la méthode).
-    if (str == "@")
-      continue;
+  for(Integer i = 0; i < string_splited.size() - 1; ++i){
+    const String& str = string_splited[i];
     combined.append(str);
+  }
+
+  // Si le nombre de @ est impair, alors il faut rajouter un @ avant le dernier element pour reproduire
+  // la chaine d'origine.
+  if(nb_at % 2 != 0){
+    combined.append("@" + string_splited[string_splited.size()-1]);
+  }
+  else{
+    combined.append(string_splited[string_splited.size()-1]);
   }
 
   return combined.toString();
 }
+
+/*!
+ * Méthode permettant de splitter la chaine "str" en plusieurs morceaux.
+ * Les splits seront entre les chars "c".
+ * Les morceaux seront ajoutés dans le tableau "str_array".
+ * Les positions des morceaux correspondant à un symbole seront ajoutées
+ * dans le tableau "int_array".
+ * Le nombre de char "c" sera mis dans le paramètre nb_c.
+ *
+ * @param str [IN] La chaine de caractères à split.
+ * @param str_array [OUT] Le tableau qui contiendra les morceaux.
+ * @param int_array [OUT] Le tableau avec les positions des symboles dans le tableau "str_array".
+ * @param nb_c [OUT] Le nombre de char "c".
+ * @param c Le char délimitant les morceaux.
+ */
+void StringVariableReplace::_splitString(const String& str, UniqueArray<String>& str_array, UniqueArray<Integer>& int_array, Integer& nb_c, char c)
+{
+  Span<const Byte> str_str = str.bytes();
+
+  Int64 offset = 0;
+  bool is_symbol = false;
+  Int64 len = str.length();
+  nb_c = 0;
+
+  for(Int64 i = 0; i < len; ++i) {
+
+    if (str_str[i] == c) {
+      nb_c++;
+      str_array.add(str.substring(offset, i - offset));
+      offset = i+1;
+
+      if(is_symbol){
+        int_array.add(str_array.size() - 1);
+        is_symbol = false;
+      }
+      else{
+        is_symbol = true;
+      }
+    }
+  }
+  if(offset == len){
+    str_array.push_back("");
+  }
+  else {
+    str_array.push_back(str.substring(offset, len - offset));
+  }
+}
+
+
+//template<typename StringContainer>
+//void StringVariableReplace::split(const String& str, StringContainer& str_array, char c)
+//{
+//  Span<const Byte> str_str = str.bytes();
+//
+//  Int64 offset = 0;
+//  Int64 len = str.length();
+//
+//
+//  for( Int64 i = 0; i < len; ++i ) {
+//    if (str_str[i] == c) {
+//      str_array.push_back(str.substring(offset, i - offset));
+//      offset = i+1;
+//
+//    }
+//  }
+//  str_array.push_back(str.substring(offset, len - offset));
+//}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/StringVariableReplace.cc
+++ b/arcane/src/arcane/core/internal/StringVariableReplace.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StringVariableReplace.h                                     (C) 2000-2023 */
+/* StringVariableReplace.cc                                    (C) 2000-2023 */
 /*                                                                           */
 /* Classe permettant de remplacer les symboles d'une chaine de caractères    */
 /* par une autre chaine de caractères définie dans les arguments de          */

--- a/arcane/src/arcane/core/internal/StringVariableReplace.h
+++ b/arcane/src/arcane/core/internal/StringVariableReplace.h
@@ -20,7 +20,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/ApplicationInfo.h"
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/VariableTypes.h"
 #include "arcane/utils/ParameterList.h"
 #include "arcane/utils/UniqueArray.h"
 #include "arcane/utils/StringBuilder.h"
@@ -37,7 +38,10 @@ namespace Arcane
 class ARCANE_CORE_EXPORT StringVariableReplace
 {
  public:
-  static String replaceWithCmdLineArgs(const ParameterList& parameter_list, const String& name);
+  static String replaceWithCmdLineArgs(const ParameterList& parameter_list, const String& string_with_symbols);
+
+ private:
+  static void _splitString(const String& str, UniqueArray<String>& str_array, UniqueArray<Integer>& int_array, Integer& nb_c, char c);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/StringVariableReplace.h
+++ b/arcane/src/arcane/core/internal/StringVariableReplace.h
@@ -13,8 +13,10 @@
 /* Un symbole est défini par une chaine de caractères entourée de @.         */
 /* Exemple : @mon_symbole@                                                   */
 /*---------------------------------------------------------------------------*/
+
 #ifndef ARCANE_CORE_INTERNAL_STRINGVARIABLEREPLACE_H
 #define ARCANE_CORE_INTERNAL_STRINGVARIABLEREPLACE_H
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -46,5 +48,4 @@ class ARCANE_CORE_EXPORT StringVariableReplace
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
-
+#endif

--- a/arcane/src/arcane/core/internal/StringVariableReplace.h
+++ b/arcane/src/arcane/core/internal/StringVariableReplace.h
@@ -7,15 +7,19 @@
 /*---------------------------------------------------------------------------*/
 /* StringVariableReplace.h                                     (C) 2000-2023 */
 /*                                                                           */
-/* TODO.                                                       */
+/* Classe permettant de remplacer les symboles d'une chaine de caractères    */
+/* par une autre chaine de caractères définie dans les arguments de          */
+/* lancement.                                                                */
+/* Un symbole est défini par une chaine de caractères entourée de @.         */
+/* Exemple : @mon_symbole@                                                   */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_STRINGVARIABLEREPLACE_H
-#define ARCANE_STRINGVARIABLEREPLACE_H
+#ifndef ARCANE_CORE_INTERNAL_STRINGVARIABLEREPLACE_H
+#define ARCANE_CORE_INTERNAL_STRINGVARIABLEREPLACE_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/ApplicationInfo.h"
-#include "arcane/utils/CommandLineArguments.h"
+#include "arcane/utils/ParameterList.h"
 #include "arcane/utils/UniqueArray.h"
 #include "arcane/utils/StringBuilder.h"
 
@@ -28,45 +32,10 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-class StringVariableReplace
+class ARCANE_CORE_EXPORT StringVariableReplace
 {
  public:
-
-  static String replaceWithCmdLineArgs(const ApplicationInfo& appinfo, const String& name){
-    if(name.empty()) return name;
-
-    String name_cpy = name;
-
-    // Permet de contourner le bug avec String::split() si le nom commence par '@'.
-    if (name_cpy.startsWith("@")) {
-      name_cpy = "@" + name_cpy;
-    }
-
-    StringUniqueArray string_splited;
-    // On découpe la string là où se trouve les @.
-    name_cpy.split(string_splited, '@');
-
-    if(string_splited.size() == 1) return name;
-
-    for(auto & elem : string_splited){
-      String reference_input = appinfo.commandLineArguments().getParameter(elem);
-      if(reference_input.null()) continue;
-      elem = reference_input;
-    }
-
-    // On recombine la chaine.
-    StringBuilder combined = "";
-    for (const String& str : string_splited) {
-      // Permet de contourner le bug avec String::split() s'il y a '@@@' dans le nom ou si le
-      // nom commence par '@' (en complément des premières lignes de la méthode).
-      if (str == "@")
-        continue;
-      combined.append(str);
-    }
-
-    return combined.toString();
-  }
-
+  static String replaceWithCmdLineArgs(const ParameterList& parameter_list, const String& name);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/srcs.cmake
+++ b/arcane/src/arcane/core/srcs.cmake
@@ -67,6 +67,7 @@ set(ARCANE_INTERNAL_SOURCES
   internal/ItemGroupInternal.h
   internal/ICaseOptionListInternal.h
   internal/IVariableMngInternal.h
+  internal/IVariableSynchronizerMngInternal.h
   internal/StringVariableReplace.h
   internal/StringVariableReplace.cc
   )

--- a/arcane/src/arcane/core/srcs.cmake
+++ b/arcane/src/arcane/core/srcs.cmake
@@ -67,7 +67,8 @@ set(ARCANE_INTERNAL_SOURCES
   internal/ItemGroupInternal.h
   internal/ICaseOptionListInternal.h
   internal/IVariableMngInternal.h
-  internal/IVariableSynchronizerMngInternal.h
+  internal/StringVariableReplace.h
+  internal/StringVariableReplace.cc
   )
 
 set(ARCANE_ORIGINAL_SOURCES

--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
@@ -1,35 +1,36 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneCaseMeshService.h                                     (C) 2000-2020 */
+/* ArcaneCaseMeshService.h                                     (C) 2000-2023 */
 /*                                                                           */
 /* Service Arcane gérant un maillage du jeu de données.                      */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ServiceFactory.h"
-#include "arcane/ServiceBuilder.h"
-#include "arcane/ICaseMeshService.h"
-#include "arcane/ICaseMeshReader.h"
-#include "arcane/IMeshBuilder.h"
-#include "arcane/IPrimaryMesh.h"
-#include "arcane/IItemFamily.h"
-#include "arcane/IMeshPartitionerBase.h"
-#include "arcane/IVariableMng.h"
-#include "arcane/IMeshModifier.h"
-#include "arcane/IMeshUtilities.h"
-#include "arcane/IParallelMng.h"
-#include "arcane/MeshBuildInfo.h"
-#include "arcane/IMeshMng.h"
-#include "arcane/IMeshFactoryMng.h"
-#include "arcane/IGhostLayerMng.h"
-#include "arcane/MeshPartInfo.h"
+#include "arcane/core/ServiceFactory.h"
+#include "arcane/core/ServiceBuilder.h"
+#include "arcane/core/ICaseMeshService.h"
+#include "arcane/core/ICaseMeshReader.h"
+#include "arcane/core/IMeshBuilder.h"
+#include "arcane/core/IPrimaryMesh.h"
+#include "arcane/core/IItemFamily.h"
+#include "arcane/core/IMeshPartitionerBase.h"
+#include "arcane/core/IVariableMng.h"
+#include "arcane/core/IMeshModifier.h"
+#include "arcane/core/IMeshUtilities.h"
+#include "arcane/core/IParallelMng.h"
+#include "arcane/core/MeshBuildInfo.h"
+#include "arcane/core/IMeshMng.h"
+#include "arcane/core/IMeshFactoryMng.h"
+#include "arcane/core/IGhostLayerMng.h"
+#include "arcane/core/MeshPartInfo.h"
 #include "arcane/impl/ArcaneCaseMeshService_axl.h"
-#include "arcane/core/StringVariableReplace.h"
+#include "arcane/core/internal/StringVariableReplace.h"
+#include "arcane/utils/CommandLineArguments.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -107,7 +108,7 @@ createMesh(const String& default_name)
                  options()->generator.rootTagName(),
                  options()->filename.name());
   if (has_filename){
-    m_mesh_file_name = StringVariableReplace::replaceWithCmdLineArgs(m_sub_domain->applicationInfo(), options()->filename);
+    m_mesh_file_name = StringVariableReplace::replaceWithCmdLineArgs(m_sub_domain->applicationInfo().commandLineArguments().parameters(), options()->filename);
     if (m_mesh_file_name.empty())
       ARCANE_FATAL("Invalid filename '{0}' in option '{1}'",
                    m_mesh_file_name,options()->filename.xpathFullName());

--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneCaseMeshService.h                                     (C) 2000-2023 */
+/* ArcaneCaseMeshService.cc                                    (C) 2000-2023 */
 /*                                                                           */
 /* Service Arcane gérant un maillage du jeu de données.                      */
 /*---------------------------------------------------------------------------*/
@@ -28,9 +28,9 @@
 #include "arcane/core/IMeshFactoryMng.h"
 #include "arcane/core/IGhostLayerMng.h"
 #include "arcane/core/MeshPartInfo.h"
-#include "arcane/impl/ArcaneCaseMeshService_axl.h"
 #include "arcane/core/internal/StringVariableReplace.h"
 #include "arcane/utils/CommandLineArguments.h"
+#include "arcane/impl/ArcaneCaseMeshService_axl.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
@@ -29,6 +29,7 @@
 #include "arcane/IGhostLayerMng.h"
 #include "arcane/MeshPartInfo.h"
 #include "arcane/impl/ArcaneCaseMeshService_axl.h"
+#include "arcane/core/StringVariableReplace.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -106,7 +107,7 @@ createMesh(const String& default_name)
                  options()->generator.rootTagName(),
                  options()->filename.name());
   if (has_filename){
-    m_mesh_file_name = options()->filename;
+    m_mesh_file_name = StringVariableReplace::replaceWithCmdLineArgs(m_sub_domain->applicationInfo(), options()->filename);
     if (m_mesh_file_name.empty())
       ARCANE_FATAL("Invalid filename '{0}' in option '{1}'",
                    m_mesh_file_name,options()->filename.xpathFullName());

--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
@@ -29,6 +29,7 @@
 #include "arcane/core/IGhostLayerMng.h"
 #include "arcane/core/MeshPartInfo.h"
 #include "arcane/core/internal/StringVariableReplace.h"
+#include "arcane/utils/ApplicationInfo.h"
 #include "arcane/utils/CommandLineArguments.h"
 #include "arcane/impl/ArcaneCaseMeshService_axl.h"
 

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -953,6 +953,13 @@ if (TARGET arcane_mpi)
   arcane_add_test_script(checkpoint_change_n7_n4 checkpoint_change_n7_n4.xml)
 endif()
 
+#################################################################
+#################################################################
+
+# Test pour la partie StringVariableReplace.
+arcane_add_test_sequential(string_variable_replace testStringVariableReplace.arc)
+
+
 # ----------------------------------------------------------------------------
 # Local Variables:
 # tab-width: 2

--- a/arcane/src/arcane/tests/StringVariableReplaceTest.axl
+++ b/arcane/src/arcane/tests/StringVariableReplaceTest.axl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<service name="StringVariableReplaceTest" version="1.0" type="caseoption" parent-name="Arcane::BasicUnitTest" namespace-name="ArcaneTest">
+ <interface name="Arcane::IUnitTest" inherited="false" />
+
+	<variables>
+  </variables>
+
+ <options/>
+</service>

--- a/arcane/src/arcane/tests/StringVariableReplaceTest.cc
+++ b/arcane/src/arcane/tests/StringVariableReplaceTest.cc
@@ -36,7 +36,7 @@ class StringVariableReplaceTest
 {
  public:
 
-  StringVariableReplaceTest(const ServiceBuildInfo& sbi);
+  explicit StringVariableReplaceTest(const ServiceBuildInfo& sbi);
   ~StringVariableReplaceTest();
 
  public:

--- a/arcane/src/arcane/tests/StringVariableReplaceTest.cc
+++ b/arcane/src/arcane/tests/StringVariableReplaceTest.cc
@@ -1,0 +1,187 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* StringVariableReplaceTest.cc                                (C) 2000-2023 */
+/*                                                                           */
+/* Service de test de StringVariableReplace.                                 */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/core/BasicUnitTest.h"
+#include "arcane/utils/ParameterList.h"
+#include "arcane/core/internal/StringVariableReplace.h"
+
+#include "arcane/tests/StringVariableReplaceTest_axl.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace ArcaneTest
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+using namespace Arcane;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class StringVariableReplaceTest
+: public ArcaneStringVariableReplaceTestObject
+{
+ public:
+
+  StringVariableReplaceTest(const ServiceBuildInfo& sbi);
+  ~StringVariableReplaceTest();
+
+ public:
+
+  void initializeTest() override;
+  void executeTest() override;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ARCANE_REGISTER_SERVICE_STRINGVARIABLEREPLACETEST(StringVariableReplaceTest, StringVariableReplaceTest);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+StringVariableReplaceTest::
+StringVariableReplaceTest(const ServiceBuildInfo& sbi)
+: ArcaneStringVariableReplaceTestObject(sbi)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+StringVariableReplaceTest::
+~StringVariableReplaceTest()
+= default;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void StringVariableReplaceTest::
+initializeTest()
+{
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void StringVariableReplaceTest::
+executeTest()
+{
+  ParameterList params;
+  String test("TEST1");
+
+  String result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+
+  if(result != test) {
+    ARCANE_FATAL("Test1 -- Expected: {0} -- Actual: {1}", test, result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  params.addParameterLine("ARCANE_REPLACE_SYMBOLS_IN_DATASET=1");
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, "");
+
+  if(result != "") {
+    ARCANE_FATAL("Test2 -- Expected: {0} -- Actual: {1}", "", result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+
+  if(result != test) {
+    ARCANE_FATAL("Test3 -- Expected: {0} -- Actual: {1}", test, result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  test = "@TEST1@TEST2@@TEST3@TEST4";
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+
+  if(result != test) {
+    ARCANE_FATAL("Test4 -- Expected: {0} -- Actual: {1}", test, result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  params.addParameterLine("TEST1=TEST5");
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+  String expected = "TEST5TEST2@@TEST3@TEST4";
+
+  if(result != expected) {
+    ARCANE_FATAL("Test5 -- Expected: {0} -- Actual: {1}", expected, result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  params.addParameterLine("TEST2=TEST6");
+
+  test = "@TEST1@TEST2@@TEST3@TEST4";
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+  expected = "TEST5TEST2@@TEST3@TEST4";
+
+  if(result != expected) {
+    ARCANE_FATAL("Test6 -- Expected: {0} -- Actual: {1}", expected, result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  test = "@TEST1@@TEST2@@TEST3@TEST4";
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+  expected = "TEST5TEST6@TEST3@TEST4";
+
+  if(result != expected) {
+    ARCANE_FATAL("Test7 -- Expected: {0} -- Actual: {1}", expected, result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  test = "@TEST1@@@@TEST2@@TEST3@TEST4@";
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+  expected = "TEST5@@TEST6@TEST3@TEST4@";
+
+  if(result != expected) {
+    ARCANE_FATAL("Test8 -- Expected: {0} -- Actual: {1}", expected, result);
+  }
+
+  /*---------------------------------------------------------------------------*/
+
+  params.addParameterLine("TEST4=TEST7");
+
+  test = "@TEST1@@@@TEST2@@TEST3@TEST4@";
+
+  result = StringVariableReplace::replaceWithCmdLineArgs(params, test);
+  expected = "TEST5@@TEST6@TEST3@TEST4@";
+
+  if(result != expected) {
+    ARCANE_FATAL("Test9 -- Expected: {0} -- Actual: {1}", expected, result);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/srcs.cmake
+++ b/arcane/src/arcane/tests/srcs.cmake
@@ -75,6 +75,7 @@ set(ARCANE_SOURCES
   RandomNumberGeneratorUnitTest.cc
   SimpleTableOutputUnitTest.cc
   SimpleTableComparatorUnitTest.cc
+  StringVariableReplaceTest.cc
 )
 
 set(AXL_FILES
@@ -123,5 +124,6 @@ set(AXL_FILES
   SimpleTableOutputUnitTest
   SimpleTableComparatorUnitTest
   SimpleTableOutputUnitTest
+  StringVariableReplaceTest
 )
 

--- a/arcane/tests/testStringVariableReplace.arc
+++ b/arcane/tests/testStringVariableReplace.arc
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<case codename="ArcaneTest" xml:lang="en" codeversion="1.0">
+  <arcane>
+    <title>Test StringVariableReplace</title>
+    <timeloop>UnitTest</timeloop>
+  </arcane>
+
+  <meshes>
+    <mesh>
+      <generator name="Cartesian2D" >
+        <face-numbering-version>1</face-numbering-version>
+
+        <nb-part-x>1</nb-part-x> 
+        <nb-part-y>1</nb-part-y>
+
+        <origin>0.0 0.0</origin>
+
+        <x>
+          <length>1.0</length>
+          <n>1</n>
+        </x>
+
+        <y>
+          <length>1.0</length>
+          <n>1</n>
+        </y>
+
+      </generator>
+    </mesh>
+  </meshes>
+
+
+  <unit-test-module>
+    <test name="StringVariableReplaceTest" />
+  </unit-test-module>
+
+</case>


### PR DESCRIPTION
With the `ARCANE_REPLACE_SYMBOLS_IN_DATASET` environment variable, the symbols in the mesh filename in datasets (<meshes><mesh><filename>) will be replaced by the string defined in the cmd line args.

Example:
```arc
<!-- example.arc -->
  <meshes>
    <mesh>
      <filename>@meshdir@/cube.msh</filename>
    </mesh>
  </meshes>
```
```sh
export ARCANE_REPLACE_SYMBOLS_IN_DATASET=1
/home/user/example/example -A,meshdir="/home/user/example/mesh" /home/user/example/example.arc
```