### PR TITLE
Fix errors in documentation generation

### DIFF
--- a/arcane/ceapart/src/arcane/tests/CMakeLists.txt
+++ b/arcane/ceapart/src/arcane/tests/CMakeLists.txt
@@ -16,15 +16,10 @@ arcane_add_library(arcane_cea_tests
   INPUT_PATH ${ARCANECEA_SRC_PATH}
   RELATIVE_PATH arcane/tests
   FILES ${ARCANE_SOURCES}
+  AXL_FILES ${AXL_FILES}
 )
 
 target_compile_definitions(arcane_cea_tests PRIVATE ARCANE_COMPONENT_arcane_cea_tests)
-
-arcane_add_axl_files(arcane_cea_tests
-  INPUT_PATH ${ARCANECEA_SRC_PATH}
-  RELATIVE_PATH arcane/tests
-  FILES ${AXL_FILES}
-)
 
 target_link_libraries(arcane_cea_tests PUBLIC arcane_materials arcane_cea_geometric arcane_cea ${ARCANE_BASE_LIBRARIES})
 if(TARGET arcane_aleph)

--- a/arcane/cmake/Functions.cmake
+++ b/arcane/cmake/Functions.cmake
@@ -92,8 +92,7 @@ macro(arcane_add_axl_files target)
 
   cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  set(rel_path ${ARGS_RELATIVE_PATH})
-  set(_OUT_AXL_DIR ${CMAKE_BINARY_DIR}/${rel_path})
+  set(_OUT_AXL_DIR ${CMAKE_BINARY_DIR}/${ARGS_RELATIVE_PATH})
   file(MAKE_DIRECTORY ${_OUT_AXL_DIR})
   if (NOT ARGS_INPUT_PATH)
     set(ARGS_INPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
@@ -110,13 +109,33 @@ macro(arcane_add_axl_files target)
   set(_INCLUDES_TO_ADD)
   foreach(iaxl ${ARGS_FILES})
     #message(STATUS "FOREACH i='${iaxl}'")
-    set(_AXL_FILE ${ARGS_INPUT_PATH}/${rel_path}/${iaxl}.axl)
+
+    # Partie permettant de prendre en compte le cas suivant :
+    # ARGS_INPUT_PATH      ${Arcane_SOURCE_DIR}/src
+    # ARGS_RELATIVE_PATH   arcane/geometry
+    # iaxl                 euclidian/Euclidian3Geometry
+
+    get_filename_component(TRUE_RELATIVE_PATH ${ARGS_RELATIVE_PATH}/${iaxl} DIRECTORY)
+    get_filename_component(TRUE_IAXL ${ARGS_RELATIVE_PATH}/${iaxl} NAME)
+
+#    message(STATUS "TRUE_RELATIVE_PATH : ${TRUE_RELATIVE_PATH}")
+#    message(STATUS "TRUE_IAXL : ${TRUE_IAXL}")
+
+    # ARGS_INPUT_PATH      ${Arcane_SOURCE_DIR}/src
+    # TRUE_RELATIVE_PATH   arcane/geometry/euclidian
+    # TRUE_IAXL            Euclidian3Geometry
+
+    # Des erreurs surviennent lors de la génération de la documentation si le
+    # relative path n'est pas correct.
+
+    set(_AXL_FILE ${ARGS_INPUT_PATH}/${TRUE_RELATIVE_PATH}/${TRUE_IAXL}.axl)
+
     set(_CUSTOM_ARGS)
-    # _TOCOPY_AXL_FILE est le nom du fichier 'axl' suffixé par 'rel_path' et où
+    # _TOCOPY_AXL_FILE est le nom du fichier 'axl' suffixé par 'TRUE_RELATIVE_PATH' et où
     # les '/' sont remplacés par des '_'.
-    # Par exemple, si \a rel_path vaut 'arcane/std' et le fichier est 'ArcaneVerifier',
+    # Par exemple, si \a TRUE_RELATIVE_PATH vaut 'arcane/std' et le fichier est 'ArcaneVerifier',
     # alors la valeur sera 'ArcaneVerifier_arcane_std.axl'
-    set(_AXL_RELATIVE_FILE ${rel_path}/${iaxl})
+    set(_AXL_RELATIVE_FILE ${TRUE_RELATIVE_PATH}/${TRUE_IAXL})
     get_filename_component(_AXL_RELATIVE_PATH ${_AXL_RELATIVE_FILE} DIRECTORY)
     get_filename_component(_AXL_ONLY_FILE ${_AXL_RELATIVE_FILE} NAME)
     string(REPLACE "/" "_" _TOCOPY_AXL_FILE ${_AXL_ONLY_FILE}/${_AXL_RELATIVE_PATH}.axl)
@@ -130,7 +149,7 @@ macro(arcane_add_axl_files target)
     file(MAKE_DIRECTORY ${_OUT_AXL_PATH})
     add_custom_command(OUTPUT ${_OUT_AXL_FILE}
       DEPENDS ${_AXL_FILE} ${AXLSTAR_AXL2CC_TARGETDEPEND}
-      COMMAND ${ARCANE_AXL2CC} ARGS -i ${rel_path} -o ${_OUT_AXL_PATH} ${_CUSTOM_ARGS} ${_AXL_FILE}
+      COMMAND ${ARCANE_AXL2CC} ARGS -i ${TRUE_RELATIVE_PATH} -o ${_OUT_AXL_PATH} ${_CUSTOM_ARGS} ${_AXL_FILE}
       )
     set_source_files_properties(${_OUT_AXL_FILE} PROPERTIES GENERATED TRUE)
     # Ajoute le fichier généré à la liste des sources. Cela n'est utile
@@ -234,7 +253,6 @@ function(arcane_add_library target)
 
   cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  set(rel_path ${ARGS_RELATIVE_PATH})
   set(_FILES)
   #set(_INSTALL_FILES)
   foreach(isource ${ARGS_FILES})
@@ -249,7 +267,7 @@ function(arcane_add_library target)
       get_filename_component(_HEADER_RELATIVE_PATH ${isource} DIRECTORY)
       string(REGEX MATCH "internal/" _INTERNAL_HEADER ${isource})
       if (NOT _INTERNAL_HEADER)
-        install(FILES ${_FILE} DESTINATION include/${rel_path}/${_HEADER_RELATIVE_PATH})
+        install(FILES ${_FILE} DESTINATION include/${ARGS_RELATIVE_PATH}/${_HEADER_RELATIVE_PATH})
       endif()
     endif()
     list(APPEND _FILES ${_FILE})

--- a/arcane/doc/generate_axl_infos.sh.in
+++ b/arcane/doc/generate_axl_infos.sh.in
@@ -10,5 +10,6 @@ export STDENV_CODE_NAME=Arcane
 ${BUILD_PATH}/bin/arcane_test_driver launch -arcane_opt arcane_internal
 /bin/rm ${AXL_OUTPATH}/final_axl/*.axl
 /bin/rm ${AXL_OUTPATH}/dox/*.dox
+/bin/rm ${AXL_OUTPATH}/dox/*.md
 ${BUILD_PATH}/bin/axldoc --generate-final -a ${BUILD_PATH}/lib/arcane_internal.xml -o ${AXL_OUTPATH}/final_axl ${AXL_OUTPATH}
 ${BUILD_PATH}/bin/axldoc -u User -a ${AXL_OUTPATH}/final_axl/final_internal.xml @ARCANEDOC_AXLDOC_LEGACY@ -o ${AXL_OUTPATH}/dox ${AXL_OUTPATH}/final_axl/*.axl

--- a/arcane/src/arcane/aleph/tests/CMakeLists.txt
+++ b/arcane/src/arcane/aleph/tests/CMakeLists.txt
@@ -4,15 +4,10 @@ arcane_add_library(arcane_aleph_tests
   INPUT_PATH ${Arcane_SOURCE_DIR}/src
   RELATIVE_PATH arcane/aleph/tests
   FILES ${ARCANE_SOURCES}
+  AXL_FILES ${AXL_FILES}
 )
 
 target_compile_definitions(arcane_aleph_tests PRIVATE ARCANE_COMPONENT_arcane_aleph_tests)
-
-arcane_add_axl_files(arcane_aleph_tests
-  INPUT_PATH ${Arcane_SOURCE_DIR}/src
-  RELATIVE_PATH arcane/aleph/tests
-  FILES ${AXL_FILES}
-)
 
 if(TARGET arcane_aleph_hypre)
   target_link_libraries(arcane_aleph_tests PUBLIC arcane_aleph_hypre)

--- a/arcane/src/arcane/geometry/CMakeLists.txt
+++ b/arcane/src/arcane/geometry/CMakeLists.txt
@@ -1,5 +1,5 @@
-make_directory(${CMAKE_BINARY_DIR}/arcane/geometry)
-make_directory(${CMAKE_BINARY_DIR}/arcane/geometry/euclidian)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/arcane/geometry)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/arcane/geometry/euclidian)
 
 include(srcs.cmake)
 


### PR DESCRIPTION
Fix RELATIVE_PATH given to AXL2CC and add forgotten copies of axl files in `build_dir/share/axl` folder.