### PR TITLE
Remove instance of 'IMeshComponent' in 'ComponentItemInternal'

### DIFF
--- a/arcane/src/arcane/core/materials/ComponentItem.h
+++ b/arcane/src/arcane/core/materials/ComponentItem.h
@@ -7,7 +7,7 @@
 /*---------------------------------------------------------------------------*/
 /* ComponentItem.h                                             (C) 2000-2023 */
 /*                                                                           */
-/* Entité composant d'une maillage multi-matériau.                           */
+/* Entité représentant un constituant d'une maille multi-matériaux.          */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCANE_CORE_MATERIALS_COMPONENTITEM_H
 #define ARCANE_CORE_MATERIALS_COMPONENTITEM_H
@@ -84,7 +84,7 @@ class ARCANE_CORE_EXPORT ComponentCell
   //! \internal
   ARCCORE_HOST_DEVICE MatVarIndex _varIndex() const { return m_internal->variableIndex(); }
 
-  ARCCORE_HOST_DEVICE matimpl::ConstituentItemBase itemBase() const { return m_internal; }
+  ARCCORE_HOST_DEVICE matimpl::ConstituentItemBase constituentItemBase() const { return m_internal; }
 
   //! Composant associé
   IMeshComponent* component() const { return m_internal->component(); }
@@ -123,12 +123,13 @@ class ARCANE_CORE_EXPORT ComponentCell
  public:
 
   //! \internal
-  ARCANE_DEPRECATED_REASON("Y2023: This method is internal to Arcane. Use itemBase() instead")
+  ARCANE_DEPRECATED_REASON("Y2023: This method is internal to Arcane. Use constituentItemBase() instead")
   ARCCORE_HOST_DEVICE ComponentItemInternal* internal() const { return m_internal; }
 
  protected:
 
-  static ARCCORE_HOST_DEVICE void _checkLevel([[maybe_unused]] ComponentItemInternal* internal, [[maybe_unused]] Int32 expected_level)
+  static ARCCORE_HOST_DEVICE void _checkLevel([[maybe_unused]] ComponentItemInternal* internal,
+                                              [[maybe_unused]] Int32 expected_level)
   {
 #if !defined(ARCCORE_DEVICE_CODE)
     if (internal->null())

--- a/arcane/src/arcane/core/materials/MatItem.h
+++ b/arcane/src/arcane/core/materials/MatItem.h
@@ -58,7 +58,7 @@ class MatCell
   }
 
   explicit ARCCORE_HOST_DEVICE MatCell(const ComponentCell& item)
-  : MatCell(item.itemBase())
+  : MatCell(item.constituentItemBase())
   {
   }
 
@@ -126,7 +126,7 @@ class EnvCell
 #endif
   }
   explicit ARCCORE_HOST_DEVICE EnvCell(const ComponentCell& item)
-  : EnvCell(item.itemBase())
+  : EnvCell(item.constituentItemBase())
   {
   }
   ARCANE_DEPRECATED_REASON("Y2023: This method is internal to Arcane. Use overload with ConstituentItemBase instead")
@@ -192,7 +192,7 @@ class AllEnvCell
   }
 
   explicit ARCCORE_HOST_DEVICE AllEnvCell(const ComponentCell& item)
-  : AllEnvCell(item.itemBase())
+  : AllEnvCell(item.constituentItemBase())
   {
   }
 

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -265,7 +265,7 @@ _computeInfosForEnvCells()
         Int32 nb_mat = nb_mat_per_cell[lid];
         ComponentItemInternal& ref_ii = env_items_internal[pos];
         env_items_internal_pointer[z] = &env_items_internal[pos];
-        ref_ii._setSuperAndGlobalItem(&all_env_items_internal[lid],items_internal[lid]);
+        ref_ii._setSuperAndGlobalItem(&all_env_items_internal[lid], ItemLocalId(lid));
         ref_ii._setNbSubItem(nb_mat);
         ref_ii._setVariableIndex(mvi);
       }

--- a/arcane/src/arcane/materials/ComponentItemInternalData.cc
+++ b/arcane/src/arcane/materials/ComponentItemInternalData.cc
@@ -99,17 +99,26 @@ _initSharedInfos()
   IItemFamily* family = m_material_mng->mesh()->cellFamily();
   ItemSharedInfo* item_shared_info = family->_internalApi()->commonItemSharedInfo();
 
+  // NOTE : les champs 'm_components' sont des vues et donc il
+  // ne faut pas que conteneurs associés de \a m_materials_mng soient modifiées.
+  // Normalement ce n'est pas le cas, car la liste des constituants est fixe.
   ComponentItemSharedInfo* info_mat = sharedInfo(LEVEL_MATERIAL);
   info_mat->m_level = LEVEL_MATERIAL;
   info_mat->m_item_shared_info = item_shared_info;
+  info_mat->m_components = m_material_mng->materialsAsComponents();
 
   ComponentItemSharedInfo* info_env = sharedInfo(LEVEL_ENVIRONMENT);
   info_env->m_level = LEVEL_ENVIRONMENT;
   info_env->m_item_shared_info = item_shared_info;
+  info_env->m_components = m_material_mng->environmentsAsComponents();
 
   ComponentItemSharedInfo* info_all_env = sharedInfo(LEVEL_ALLENVIRONMENT);
   info_all_env->m_level = LEVEL_ALLENVIRONMENT;
   info_all_env->m_item_shared_info = item_shared_info;
+  info_all_env->m_components = ConstArrayView<IMeshComponent*>();
+
+  info() << "EndCreate ComponentItemInternalData nb_mat=" << info_mat->m_components.size()
+         << " nb_env=" << info_env->m_components.size();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshComponentData.cc
+++ b/arcane/src/arcane/materials/MeshComponentData.cc
@@ -130,7 +130,7 @@ _changeLocalIdsForInternalList(Int32ConstArrayView old_to_new_ids)
     Int32 new_lid = old_to_new_ids[lid];
     if (new_lid!=NULL_ITEM_LOCAL_ID){
       new_internals.add(current_internals[i]);
-      current_internals[i]->_setGlobalItem(global_item_list[new_lid]);
+      current_internals[i]->_setGlobalItem(ItemLocalId(new_lid));
     }
   }
 

--- a/arcane/src/arcane/materials/MeshEnvironment.cc
+++ b/arcane/src/arcane/materials/MeshEnvironment.cc
@@ -238,7 +238,7 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data)
       cells_pos[lid] = cell_index;
       //info(4) << "XZ=" << z << " LID=" << lid << " POS=" << cell_index;
       env_item->_setNbSubItem(nb_mat);
-      env_item->_setComponent(this,env_id);
+      env_item->_setComponent(env_id);
       if (nb_mat!=0){
         env_item->_setFirstSubItem(&mat_items_internal[cell_index]);
         cells_env[lid] = env_item;
@@ -272,8 +272,8 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data)
         ++cells_pos[lid];
         ComponentItemInternal& ref_ii = mat_items_internal[pos];
         mat_items_internal_pointer[z] = &mat_items_internal[pos];
-        ref_ii._setSuperAndGlobalItem(cells_env[lid],items_internal[lid]);
-        ref_ii._setComponent(mat,mat_id);
+        ref_ii._setSuperAndGlobalItem(cells_env[lid], ItemLocalId(lid));
+        ref_ii._setComponent(mat_id);
         ref_ii._setVariableIndex(mvi);
       }
     }

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
@@ -17,7 +17,6 @@ namespace Arcane.Materials
     internal Int16 m_component_id;
     internal Int16 m_nb_sub_component_item;
     internal Int32 m_global_item_local_id;
-    internal IntPtr m_component; // IMeshComponent* m_component;
     internal ComponentItemInternal* m_super_component_item;
     internal ComponentItemInternal* m_first_sub_component_item;
     internal ComponentItemSharedInfo* m_shared_info;


### PR DESCRIPTION
This is no longer needed because we can get the information from `ComponentItemSharedInfo` and `ComponentItemInternal::m_component_id`.