### PR TITLE
Add 3D Renumbering for AMR after coarsening

### DIFF
--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -172,6 +172,15 @@ arcane_add_test(amr-cartesian2D-V1-coarse-1 testAMRCartesianMesh2D-V1-coarse-1.a
 arcane_add_test(amr-cartesian2D-V1-coarse-2 testAMRCartesianMesh2D-V1-coarse-2.arc "-m 20")
 arcane_add_test(amr-cartesian2D-V1-coarse-3 testAMRCartesianMesh2D-V1-coarse-3.arc "-m 10")
 arcane_add_test(amr-cartesian2D-V1-coarse-4 testAMRCartesianMesh2D-V1-coarse-4.arc "-m 10")
+arcane_add_test(amr-cartesian3D-V1-coarse-1 testAMRCartesianMesh3D-V1-coarse-1.arc "-m 10" "-We,ARCANE_CARTESIANMESH_COARSENING_VERBOSITY_LEVEL,2")
+arcane_add_test_sequential(amr-cartesian3D-V1-coarse-2 testAMRCartesianMesh3D-V1-coarse-2.arc "-m 10")
+arcane_add_test_parallel_thread(amr-cartesian3D-V1-coarse-2 testAMRCartesianMesh3D-V1-coarse-2.arc 8 "-m 10")
+
+# Ce test prend du temps (environ 30 secondes) donc on ne l'active pas par défaut
+if (BIG_TEST)
+  arcane_add_test_sequential(amr-cartesian3D-V1-coarse-3 testAMRCartesianMesh3D-V1-coarse-3.arc "-m 10")
+  arcane_add_test_parallel_thread(amr-cartesian3D-V1-coarse-3 testAMRCartesianMesh3D-V1-coarse-3.arc 8 "-m 10")
+endif()
 
 # Tests sur le renumérotation des faces en cartésien
 # L'idéal est d'avoir pas mal de sous-domaines pour être sur que le

--- a/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-1.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-1.arc
@@ -3,7 +3,7 @@
  <arcane>
   <titre>Test CartesianMesh 2D Cell Renumbering V1 (Variant 1)</titre>
 
-  <description>Test du raffinement d'un maillage cartesian 2D avec le type d'AMR Cell et la renumérotation V1</description>
+  <description>Test du raffinement d'un maillage cartesian 2D avec le type d'AMR Cell et la renumerotation V1</description>
 
   <boucle-en-temps>AMRCartesianMeshTestLoop</boucle-en-temps>
 
@@ -63,9 +63,9 @@
      <length>2.0 2.0</length>
    </refinement-2d>
    <expected-number-of-cells-in-patchs>153 8 4 80 128</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>d0ef46e1ab3391a062232e491ab5833f</nodes-uid-hash>
-   <faces-uid-hash>ed6f4c975e26cfb86eafc83c9c9e6caa</faces-uid-hash>
-   <cells-uid-hash>f5304b74f95da0e344fc34a1b053025e</cells-uid-hash>
+   <nodes-uid-hash>928b887dd8459a75ab8eeaf8622a9893</nodes-uid-hash>
+   <faces-uid-hash>9e4b11603725691496fa833e56bd87dc</faces-uid-hash>
+   <cells-uid-hash>a337136a4b240f5d062f7ac6eb63af09</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-2.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-2.arc
@@ -49,9 +49,9 @@
      <length>2.0 2.0</length>
    </refinement-2d>
    <expected-number-of-cells-in-patchs>4 4 4</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>bc65bf43bfd497ef30d0c8bf27902c3e</nodes-uid-hash>
-   <faces-uid-hash>28f3c42e101ca63375a3d3c35cb69e46</faces-uid-hash>
-   <cells-uid-hash>caafd69302d60b35b327cfe0bc7d90af</cells-uid-hash>
+   <nodes-uid-hash>4fc2a63b0178bd7d3f389570dee86059</nodes-uid-hash>
+   <faces-uid-hash>b873493ea50b8d85e7771c2f8560ef08</faces-uid-hash>
+   <cells-uid-hash>a3a41734beca00414d049926921cefb2</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh2D-V1-coarse-2.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh2D-V1-coarse-2.arc
@@ -65,9 +65,9 @@
    </refinement-2d>
    <expected-number-of-cells-in-patchs>48 192 12 8 64 72</expected-number-of-cells-in-patchs>
    <expected-number-of-ghost-cells-in-patchs>120 480 12 8 192 216</expected-number-of-ghost-cells-in-patchs>
-   <nodes-uid-hash>87b35ebb3e0f099582ec2c268d31c120</nodes-uid-hash>
-   <faces-uid-hash>36a596cfbd8ab6fc774feb97877ce810</faces-uid-hash>
-   <cells-uid-hash>f18aa5bcab39a0cc12e188576d5dbb0d</cells-uid-hash>
+   <nodes-uid-hash>abe468e571c521f6e1d0537d07c82d9f</nodes-uid-hash>
+   <faces-uid-hash>671e325a4fcd2785a83f38c5c227fbff</faces-uid-hash>
+   <cells-uid-hash>d21fc971bb27a0e0ed872cb755912f64</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh2D-V1-coarse-3.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh2D-V1-coarse-3.arc
@@ -50,9 +50,9 @@
 
    <expected-number-of-cells-in-patchs>1600 6400 484</expected-number-of-cells-in-patchs>
    <expected-number-of-ghost-cells-in-patchs>516 2064 0</expected-number-of-ghost-cells-in-patchs>
-   <nodes-uid-hash>0943c4d2337f81576f43c8665ab3df59</nodes-uid-hash>
-   <faces-uid-hash>97b4040448ca0f51341c2dbb0ac8f710</faces-uid-hash>
-   <cells-uid-hash>de15423978457e4a607921e6d45aa790</cells-uid-hash>
+   <nodes-uid-hash>123ea5235d1fbd0f946407da35010199</nodes-uid-hash>
+   <faces-uid-hash>406c3302e3f2fedf56129dfbdfd27617</faces-uid-hash>
+   <cells-uid-hash>bd641ece2308db5e65f6c967c0e08478</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh2D-V1-coarse-4.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh2D-V1-coarse-4.arc
@@ -67,9 +67,9 @@
    </refinement-2d>
    <expected-number-of-cells-in-patchs>1600 6400 484 1144 1936 3600 1600</expected-number-of-cells-in-patchs>
    <expected-number-of-ghost-cells-in-patchs>516 2064 0 0 528 720 960</expected-number-of-ghost-cells-in-patchs>
-   <nodes-uid-hash>19f96ae658a9aa61b31d8d6e3d2571dc</nodes-uid-hash>
-   <faces-uid-hash>082ed72694144a6382d5e2e1f0078913</faces-uid-hash>
-   <cells-uid-hash>d019a200fcce273ba173ce9c9200e750</cells-uid-hash>
+   <nodes-uid-hash>390f7e52dece2f3c6e83c63c1bba7adf</nodes-uid-hash>
+   <faces-uid-hash>873c8d5a520f07b7c63eabd973a0d657</faces-uid-hash>
+   <cells-uid-hash>922ed4e573d0b7905e2a276199b88dab</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-1.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-1.arc
@@ -3,7 +3,7 @@
  <arcane>
   <titre>Test CartesianMesh 3D Cell Renumbering V1 (Variant 1)</titre>
 
-  <description>Test du raffinement d'un maillage cartesian 3D avec le type d'AMR Cell et la renumérotation V1</description>
+  <description>Test du raffinement d'un maillage cartesian 3D avec le type d'AMR Cell et la renumerotation V1</description>
 
   <boucle-en-temps>AMRCartesianMeshTestLoop</boucle-en-temps>
 
@@ -61,9 +61,9 @@
      <length>3.0 4.0 0.8</length>
    </refinement-3d> -->
    <expected-number-of-cells-in-patchs>1224 144 40</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>3ef51546e83d8303b770300b808f617e</nodes-uid-hash>
-   <faces-uid-hash>460c3b5083dce8f2c88d1e2b68d28c7f</faces-uid-hash>
-   <cells-uid-hash>91b7c816009cca00c223d088d86f9a1e</cells-uid-hash>
+   <nodes-uid-hash>a78eb2e91aa9378816e8f28e62e7b8ec</nodes-uid-hash>
+   <faces-uid-hash>085cc27581e1990074a8028c9bc78c5d</faces-uid-hash>
+   <cells-uid-hash>f75cfcb40b124345dd1c056ad28a8f4e</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-2.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-2.arc
@@ -3,7 +3,7 @@
  <arcane>
   <titre>Test CartesianMesh 3D Cell Renumbering V1 (Variant 2)</titre>
 
-  <description>Test du raffinement d'un maillage cartesian 3D avec le type d'AMR Cell et la renumérotation V1</description>
+  <description>Test du raffinement d'un maillage cartesian 3D avec le type d'AMR Cell et la renumerotation V1</description>
 
   <boucle-en-temps>AMRCartesianMeshTestLoop</boucle-en-temps>
 
@@ -70,9 +70,9 @@
      <length>2.0 2.0 2.0</length>
    </refinement-3d>
    <expected-number-of-cells-in-patchs>8 8 8 8 8 8 8 8</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>3cbd376d768e895a0b8e33d091bb3ff5</nodes-uid-hash>
-   <faces-uid-hash>2582173a840acc76dabb2abf8528410b</faces-uid-hash>
-   <cells-uid-hash>a39d1e99166f13d23ffb74d4965b06a2</cells-uid-hash>
+   <nodes-uid-hash>108ab65a162f420b2b49beee10b1f85b</nodes-uid-hash>
+   <faces-uid-hash>819e4e765d55fcb976d8b00e4c8d7718</faces-uid-hash>
+   <cells-uid-hash>04538c5721f934d717ee13d181b81d76</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-V1-coarse-1.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-V1-coarse-1.arc
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<cas codename="ArcaneTest" xml:lang="fr" codeversion="1.0">
+ <arcane>
+  <titre>Test CartesianMesh</titre>
+
+  <description>Test des maillages cartesiens AMR 2D</description>
+
+  <boucle-en-temps>AMRCartesianMeshTestLoop</boucle-en-temps>
+
+  <modules>
+    <module name="ArcanePostProcessing" active="true" />
+    <module name="ArcaneCheckpoint" active="true" />
+  </modules>
+
+ </arcane>
+
+ <arcane-post-traitement>
+   <periode-sortie>1</periode-sortie>
+   <depouillement>
+    <variable>Density</variable>
+    <variable>NodeDensity</variable>
+    <groupe>AllCells</groupe>
+    <groupe>AllNodes</groupe>
+    <groupe>AllFacesDirection0</groupe>
+    <groupe>AllFacesDirection1</groupe>
+   </depouillement>
+ </arcane-post-traitement>
+ 
+ 
+ <maillage amr="true">
+   <meshgenerator>
+     <cartesian>
+       <nsd>2 2 1</nsd>
+       <origine>0.0 0.0 0.0</origine>
+       <lx nx='3' prx='1.1'>3.0</lx>
+       <lx nx='5' prx='1.0'>5.0</lx>
+
+       <ly ny='3' pry='1.0'>3.0</ly>
+       <ly ny='5' pry='1.1'>10.0</ly>
+
+       <lz nz='4' prz='1.0'>2.0</lz>
+     </cartesian>
+   </meshgenerator>
+ </maillage>
+
+ <a-m-r-cartesian-mesh-tester>
+   <renumber-patch-method>1</renumber-patch-method>
+   <coarse-at-init>true</coarse-at-init>
+   <refinement-3d>
+     <position>1.0 2.0 0.5</position>
+     <length>1.0 2.0 1.0</length>
+   </refinement-3d>
+   <refinement-3d>
+     <position>1.4 3.0 1.0</position>
+     <length>0.5 1.0 0.5</length>
+   </refinement-3d>
+   <expected-number-of-cells-in-patchs>32 256 32 16</expected-number-of-cells-in-patchs>
+   <expected-number-of-ghost-cells-in-patchs>40 320 32 16</expected-number-of-ghost-cells-in-patchs>
+   <nodes-uid-hash>f708721c983630feaa936c31f1d839dc</nodes-uid-hash>
+   <faces-uid-hash>ec4598f6ca14d980bd3bee7e4959787f</faces-uid-hash>
+   <cells-uid-hash>6a466175634dd458394e1d44a488f908</cells-uid-hash>
+ </a-m-r-cartesian-mesh-tester>
+
+ <arcane-protections-reprises>
+   <service-protection name="ArcaneBasic2CheckpointWriter" />
+ </arcane-protections-reprises>
+</cas>

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-V1-coarse-2.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-V1-coarse-2.arc
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<cas codename="ArcaneTest" xml:lang="fr" codeversion="1.0">
+ <arcane>
+  <titre>Test CartesianMesh</titre>
+
+  <description>Test des maillages cartesiens AMR 2D</description>
+
+  <boucle-en-temps>AMRCartesianMeshTestLoop</boucle-en-temps>
+
+  <modules>
+    <module name="ArcanePostProcessing" active="true" />
+    <module name="ArcaneCheckpoint" active="true" />
+  </modules>
+
+ </arcane>
+
+ <arcane-post-traitement>
+   <periode-sortie>1</periode-sortie>
+   <depouillement>
+    <variable>Density</variable>
+    <variable>NodeDensity</variable>
+    <groupe>AllCells</groupe>
+    <groupe>AllNodes</groupe>
+    <groupe>AllFacesDirection0</groupe>
+    <groupe>AllFacesDirection1</groupe>
+   </depouillement>
+ </arcane-post-traitement>
+ 
+ 
+ <maillage amr="true">
+   <meshgenerator>
+     <cartesian>
+       <nsd>2 2 2</nsd>
+       <origine>0.0 0.0 0.0</origine>
+       <lx nx='20' prx='1.0'>4.0</lx>
+       <ly ny='40' pry='1.0'>12.0</ly>
+       <lz nz='12' prz='1.0'>2.0</lz>
+     </cartesian>
+   </meshgenerator>
+ </maillage>
+
+ <a-m-r-cartesian-mesh-tester>
+   <verbosity-level>0</verbosity-level>
+   <renumber-patch-method>3</renumber-patch-method>
+   <coarse-at-init>true</coarse-at-init>
+   <refinement-3d>
+     <position>1.0 2.0 0.5</position>
+     <length>1.0 2.0 1.0</length>
+   </refinement-3d>
+   <refinement-3d>
+     <position>1.4 3.0 1.0</position>
+     <length>0.5 1.0 0.5</length>
+   </refinement-3d> 
+   <expected-number-of-cells-in-patchs>1200 9600 1440 1440</expected-number-of-cells-in-patchs>
+   <expected-number-of-ghost-cells-in-patchs>912 7296 1920 2400</expected-number-of-ghost-cells-in-patchs>
+   <nodes-uid-hash>36751d8d85e85f03f433c031b869dc83</nodes-uid-hash>
+   <faces-uid-hash>ccbe21ae69af4c7d3e2008bcd3807c08</faces-uid-hash>
+   <cells-uid-hash>f727f7b0a26401984bf9da0fb766862d</cells-uid-hash>
+ </a-m-r-cartesian-mesh-tester>
+
+ <arcane-protections-reprises>
+   <service-protection name="ArcaneBasic2CheckpointWriter" />
+ </arcane-protections-reprises>
+</cas>

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-V1-coarse-3.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-V1-coarse-3.arc
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<cas codename="ArcaneTest" xml:lang="fr" codeversion="1.0">
+ <arcane>
+  <titre>Test CartesianMesh</titre>
+
+  <description>Test des maillages cartesiens AMR 2D</description>
+
+  <boucle-en-temps>AMRCartesianMeshTestLoop</boucle-en-temps>
+
+  <modules>
+    <module name="ArcanePostProcessing" active="true" />
+    <module name="ArcaneCheckpoint" active="true" />
+  </modules>
+
+ </arcane>
+
+ <arcane-post-traitement>
+   <periode-sortie>1</periode-sortie>
+   <depouillement>
+    <variable>Density</variable>
+    <variable>NodeDensity</variable>
+    <groupe>AllCells</groupe>
+    <groupe>AllNodes</groupe>
+    <groupe>AllFacesDirection0</groupe>
+    <groupe>AllFacesDirection1</groupe>
+   </depouillement>
+ </arcane-post-traitement>
+ 
+ 
+ <maillage amr="true">
+   <meshgenerator>
+     <cartesian>
+       <nsd>2 2 2</nsd>
+       <origine>0.0 0.0 0.0</origine>
+       <lx nx='40' prx='1.0'>4.0</lx>
+       <ly ny='60' pry='1.0'>12.0</ly>
+       <lz nz='20' prz='1.0'>2.0</lz>
+     </cartesian>
+   </meshgenerator>
+ </maillage>
+
+ <a-m-r-cartesian-mesh-tester>
+   <verbosity-level>0</verbosity-level>
+   <renumber-patch-method>1</renumber-patch-method>
+   <coarse-at-init>true</coarse-at-init>
+   <refinement-3d>
+     <position>1.0 2.0 0.5</position>
+     <length>1.0 2.0 1.0</length>
+   </refinement-3d>
+   <refinement-3d>
+     <position>1.4 3.0 1.0</position>
+     <length>0.5 1.0 0.5</length>
+   </refinement-3d> 
+   <refinement-3d>
+     <position>1.4 3.0 1.0</position>
+     <length>0.5 1.0 0.5</length>
+   </refinement-3d> 
+   <refinement-3d>
+     <position>2.4 4.0 0.5</position>
+     <length>0.2 0.4 0.4</length>
+   </refinement-3d> 
+   <expected-number-of-cells-in-patchs>6000 48000 8000 8000 64000 128</expected-number-of-cells-in-patchs>
+   <expected-number-of-ghost-cells-in-patchs>2448 19584 5440 5440 43520 32</expected-number-of-ghost-cells-in-patchs>
+   <nodes-uid-hash>a25987a396eb57aade3170d3d0cab944</nodes-uid-hash>
+   <faces-uid-hash>9afdc3fecd353854428efc354bf1c8a3</faces-uid-hash>
+   <cells-uid-hash>fbc3d61943e2f2fafc40c2855553fbb6</cells-uid-hash>
+ </a-m-r-cartesian-mesh-tester>
+
+ <arcane-protections-reprises>
+   <service-protection name="ArcaneBasic2CheckpointWriter" />
+ </arcane-protections-reprises>
+</cas>

--- a/arcane/src/arcane/cartesianmesh/CartesianMesh.cc
+++ b/arcane/src/arcane/cartesianmesh/CartesianMesh.cc
@@ -780,11 +780,11 @@ renumberItemsUniqueId(const CartesianMeshRenumberingInfo& v)
 
   // Regarde ensuite les patchs si demandé.
   Int32 patch_method = v.renumberPatchMethod();
-  if (patch_method > 2 || patch_method < 0)
-    ARCANE_FATAL("Invalid value '{0}' for renumberPatchMethod(). Valid values are 0 or 1 or 2");
+  if (patch_method > 3 || patch_method < 0)
+    ARCANE_FATAL("Invalid value '{0}' for renumberPatchMethod(). Valid values are 0, 1, 2 or 3");
     
-  else if (patch_method == 1){
-    CartesianMeshUniqueIdRenumbering renumberer(this,cmgi,v.parentPatch());
+  else if (patch_method == 1 || patch_method == 3){
+    CartesianMeshUniqueIdRenumbering renumberer(this,cmgi,v.parentPatch(),patch_method);
     renumberer.renumber();
   }
   else if (patch_method == 2){

--- a/arcane/src/arcane/cartesianmesh/CartesianMeshRenumberingInfo.h
+++ b/arcane/src/arcane/cartesianmesh/CartesianMeshRenumberingInfo.h
@@ -35,12 +35,18 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianMeshRenumberingInfo
   /*!
    * \brief Méthode pour renuméroter les patchs.
    *
-   * Si 0, il n'y a pas de renumérotation. La seule autre valeur valide est 1. Dans ce
-   * cas, les uniqueId() des entités (Node,Face,Cell) des patches sont renumérotées
-   * pour avoir la même numérotation
-   * quel que soit le découpage. La numérotation n'est pas contigue. Seules
-   * les entités des patchs sont renumérotées. Les entités issues du maillage initial
-   * ne sont pas renumérotées.
+   * Les valeurs possibles sont les suivantes:
+   * - 0 pas de renumérotation.
+   * - 1 renumérotation par défaut.
+   * - 2 version expérimentale de la renumérotation
+   * - 3 comme la version 1 mais avec une implémentation différente
+   * pour les maillages 2D.
+   *
+   * En cas de renumérotation, les uniqueId() des entités (Node,Face,Cell)
+   * des patches sont renumérotées pour avoir la même numérotation quel
+   * que soit le découpage.
+   * La numérotation n'est pas contigue. Seules les entités filles
+   * des entités du patch parentPatch() sont renumérotées.
    */
   void setRenumberPatchMethod(Int32 v) { m_renumber_patch_method = v; }
   Int32 renumberPatchMethod() const { return m_renumber_patch_method; }

--- a/arcane/src/arcane/cartesianmesh/internal/CartesianMeshUniqueIdRenumbering.h
+++ b/arcane/src/arcane/cartesianmesh/internal/CartesianMeshUniqueIdRenumbering.h
@@ -45,7 +45,7 @@ class CartesianMeshUniqueIdRenumbering
  public:
 
   CartesianMeshUniqueIdRenumbering(ICartesianMesh* cmesh, ICartesianMeshGenerationInfo* gen_info,
-                                   CartesianPatch parent_patch);
+                                   CartesianPatch parent_patch, Int32 patch_method);
   ~CartesianMeshUniqueIdRenumbering() = default;
 
  public:
@@ -58,6 +58,7 @@ class CartesianMeshUniqueIdRenumbering
   ICartesianMeshGenerationInfo* m_generation_info = nullptr;
   CartesianPatch m_parent_patch;
   bool m_is_verbose = false;
+  Int32 m_patch_method = 1;
 
  private:
 
@@ -68,6 +69,10 @@ class CartesianMeshUniqueIdRenumbering
                             Int64 coord_i, Int64 coord_j, Int64 coord_k,
                             Int64 current_level_nb_cell_x, Int64 current_level_nb_cell_y, Int64 current_level_nb_cell_z,
                             Int32 current_level, Int64 cell_adder, Int64 node_adder, Int64 face_adder);
+  void _applyChildrenCell3DV2(Cell cell, NewUniqueIdList& new_uids,
+                              Int64 coord_i, Int64 coord_j, Int64 coord_k,
+                              Int64 current_level_nb_cell_x, Int64 current_level_nb_cell_y, Int64 current_level_nb_cell_z,
+                              Int32 current_level, Int64 cell_adder, Int64 node_adder, Int64 face_adder);
   void _applyFamilyRenumbering(IItemFamily* family, VariableItemInt64& items_new_uid);
   void _markItemsToKeepCurrentNumbering(ICartesianMeshPatch* patch);
 };


### PR DESCRIPTION
Also fix the computation of the 2D part: the topological coordinates were not correct if the initial patch is not the coarse grid.