### PR TITLE
Make field 'ReferenceCounterImpl::m_nb_ref' private

### DIFF
--- a/arccore/src/base/arccore/base/ReferenceCounterImpl.h
+++ b/arccore/src/base/arccore/base/ReferenceCounterImpl.h
@@ -103,7 +103,7 @@ class ReferenceCounterImpl
     return m_external_deleter;
   }
 
- public:
+ private:
 
   std::atomic<Int32> m_nb_ref = 0;
 


### PR DESCRIPTION
This field is internal to the class and should not be public.
It is not normally not used outside of the class.