### PR TITLE
Rewrite AxlDoc 'BriefDescription' part

### DIFF
--- a/arcane/doc/doc_user/chap_core_types/subchap_axl/0_axl.md
+++ b/arcane/doc/doc_user/chap_core_types/subchap_axl/0_axl.md
@@ -63,6 +63,10 @@ Sommaire de ce sous-chapitre :
   Explique comment paramétrer les modules avec des options utilisateurs fournies 
   dans le jeu de données.
 
+4. \subpage arcanedoc_core_types_axl_others <br>
+  Présente les détails qui n'apparaissent pas dans les
+  autres sous-chapitres.
+
 ____
 
 <div class="section_buttons">

--- a/arcane/doc/doc_user/chap_core_types/subchap_axl/4_others.md
+++ b/arcane/doc/doc_user/chap_core_types/subchap_axl/4_others.md
@@ -1,0 +1,51 @@
+# Autres élements {#arcanedoc_core_types_axl_others}
+
+[TOC]
+
+## La documentation
+
+Comme vous avez pu le constater précédemment, il y a des champs `<description>`
+qui sont disponibles.
+
+Prenons cet exemple :
+```xml
+<module name="Test" version="1.0">
+  <name lang="fr">Test</name>
+  <userclass>User</userclass>
+  <description>Descripteur du module Test</description>
+
+  <variables>
+    <variable field-name="pressure" name="Pressure" data-type="real" item-kind="cell" dim="0" dump="true" need-sync="true">
+      <userclass>User</userclass>
+      <description>Descripteur de la variable pressure</description>
+    </variable>
+  </variables>
+
+  <entry-points>
+		<entry-point method-name="testPressureSync" name="TestPressureSync" where="compute-loop" property="none">
+      <userclass>User</userclass>
+      <description>Descripteur du point d''entrée TestPressureSync</description>
+    </entry-point>
+  </entry-points>
+
+  <options>
+    <simple name = "simple-real" type = "real">
+      <name lang='fr'>reel-simple</name>
+      <userclass>User</userclass>
+      <description>Réel simple</description>
+    </simple>
+  </options>
+</module>
+```
+TODO `<description doc-brief-force-close-cmds="true" doc-brief-max-nb-of-char="-1" doc-brief-stop-at-dot="false">`
+
+____
+
+<div class="section_buttons">
+<span class="back_section_button">
+\ref arcanedoc_core_types_axl_caseoptions
+</span>
+<span class="next_section_button">
+\ref arcanedoc_core_types_casefile
+</span>
+</div>

--- a/arcane/doc/doc_user/chap_core_types/subchap_axl/4_others.md
+++ b/arcane/doc/doc_user/chap_core_types/subchap_axl/4_others.md
@@ -2,17 +2,16 @@
 
 [TOC]
 
-## La documentation
-
-Comme vous avez pu le constater précédemment, il y a des champs `<description>`
-qui sont disponibles.
+## La documentation {#arcanedoc_core_types_axl_others_doc}
 
 Prenons cet exemple :
 ```xml
 <module name="Test" version="1.0">
   <name lang="fr">Test</name>
   <userclass>User</userclass>
-  <description>Descripteur du module Test</description>
+  <description>
+    Descripteur du module Test
+  </description>
 
   <variables>
     <variable field-name="pressure" name="Pressure" data-type="real" item-kind="cell" dim="0" dump="true" need-sync="true">
@@ -22,7 +21,7 @@ Prenons cet exemple :
   </variables>
 
   <entry-points>
-		<entry-point method-name="testPressureSync" name="TestPressureSync" where="compute-loop" property="none">
+    <entry-point method-name="testPressureSync" name="TestPressureSync" where="compute-loop" property="none">
       <userclass>User</userclass>
       <description>Descripteur du point d''entrée TestPressureSync</description>
     </entry-point>
@@ -37,7 +36,143 @@ Prenons cet exemple :
   </options>
 </module>
 ```
-TODO `<description doc-brief-force-close-cmds="true" doc-brief-max-nb-of-char="-1" doc-brief-stop-at-dot="false">`
+Ceci est valable pour les modules et les services.
+
+### Balises <userclass>
+
+Les balises `<userclass>` sont disponibles et permettent de choisir dans quelle version
+de la documentation faire apparaitre chaque élément, avec la description correspondante.
+
+Les valeurs possibles sont `User` et `Dev`.
+
+### Balises <description>
+
+Les balises `<description>` sont disponibles pour chaque élément de l'`axl`.
+En plus de décrire l'élément pour ceux qui lisent le fichier `axl`, ce champ permet
+de générer une documentation pour ce module/service. La génération sera effectuée
+par le programme `axldoc`.
+
+Ce programme va générer (entre autres) une page listant tous les services et modules
+disponibles (`axldoc_casemainpage.md`, disponible ici : \ref axldoc_casemainpage)
+et une page pour le service/module.
+
+\todo Peut-être faire une page pour expliquer comment générer cette documentation
+pour un projet utilisant %Arcane.
+
+### Spécificités des balises <userclass> et <description> entre les balises <module> (ou <service>) 
+<em>(lignes 3-6 de l'exemple)</em>
+
+Admettons que nous générons la documentation `User`.
+Pour que notre module apparaisse dans la liste des modules, il est nécessaire d'ajouter
+`<userclass>User</userclass>` entre les balises `<module>` (ou `<service>`).
+
+Sur la page \ref axldoc_casemainpage "axldoc_casemainpage.md", il est possible de voir qu'il y a
+des descriptions pour chaque module et service. Il est désormais possible de contrôler la génération
+de cette description. Trois attributs sont disponibles pour la balise `<description>` :
+
+
+<details>
+  <summary>Attribut doc-brief-max-nb-of-char</summary>
+  ```xml
+  <description doc-brief-max-nb-of-char="120"></description>
+  ```
+  Attribut permettant de limiter le nombre de caractères max de la courte description.
+  Par défaut, la limite est définie à `120`. Mettre la valeur `-1` permet
+  de désactiver cette limite.
+</details>
+
+<details>
+  <summary>Attribut doc-brief-force-close-cmds</summary>
+  ```xml
+  <description doc-brief-force-close-cmds="true"></description>
+  ```
+  Attribut permettant de forcer `axldoc` à ne pas couper la description lorsque la limite de caractères
+  est atteinte dans une commande Doxygen avant la fin de cette commande. C'est un attribut assez utile
+  pour, par exemple, ne pas découper une formule LaTeX en plein milieu.
+
+  En revanche, `axldoc` garantie que les balises compatibles sont bien refermées et les referment si 
+  ce n'est pas fait.
+
+  Les balises compatibles sont :
+  - `\verbatim \endverbatim`
+  - `\code \endcode`
+  - `\f$ \f$`
+  - `\f( \f)`
+  - `\f[ \f]`
+  - `\f{ \f}`
+
+  Par défaut, cet attribut est défini à `false`.
+
+  Exemple :
+  ```xml
+  <description doc-brief-force-close-cmds="false" doc-brief-max-nb-of-char="120">
+   Ma description
+     \f[
+     |I_2|=\left| \int_{0}^T \psi(t)
+     \left\{
+     u(a,t)-
+     \int_{\gamma(t)}^a
+     \frac{d\theta}{k(\theta,t)}
+     \int_{a}^\theta c(\xi)u_t(\xi,t)\,d\xi
+     \right\} dt
+     \right|
+     \f]
+  </description>
+  ```
+  donne :
+
+  Ma description
+  \f[
+  |I_2|=\left| \int_{0}^T \psi(t)
+  \left\{
+  u(a,t)-
+  \int_{\gamma(t)}^a
+  \frac{d\theta}{k(\theta,t)}
+  \int_{a}^\theta c(\xi)u_t(\xi,t)\,d\xi 
+  \f]
+
+  alors que :
+  ```xml
+  <description doc-brief-force-close-cmds="true" doc-brief-max-nb-of-char="120">
+    Ma description
+    \f[
+    |I_2|=\left| \int_{0}^T \psi(t)
+    \left\{
+    u(a,t)-
+    \int_{\gamma(t)}^a
+    \frac{d\theta}{k(\theta,t)}
+    \int_{a}^\theta c(\xi)u_t(\xi,t)\,d\xi
+    \right\} dt
+    \right|
+    \f]
+  </description>
+  ```
+  donne :
+
+  Ma description
+  \f[
+  |I_2|=\left| \int_{0}^T \psi(t)
+  \left\{
+  u(a,t)-
+  \int_{\gamma(t)}^a
+  \frac{d\theta}{k(\theta,t)}
+  \int_{a}^\theta c(\xi)u_t(\xi,t)\,d\xi
+  \right\} dt
+  \right|
+  \f]
+  
+</details>
+
+
+<details>
+  <summary>Attribut doc-brief-stop-at-dot</summary>
+  ```xml
+  <description doc-brief-stop-at-dot="true"></description>
+  ```
+  Attribut permettant de limiter le nombre de caractères en coupant la courte description
+  au premier point trouvé.
+  Par défaut, cet attribut est défini à `true`.
+</details>
 
 ____
 

--- a/arcane/doc/doc_user/chap_core_types/subchap_axl/subchap_caseoptions/0_caseoptions.md
+++ b/arcane/doc/doc_user/chap_core_types/subchap_axl/subchap_caseoptions/0_caseoptions.md
@@ -67,7 +67,7 @@ ____
 
 <div class="section_buttons">
 <span class="back_section_button">
-\ref arcanedoc_core_types_axl
+\ref arcanedoc_core_types_axl_entrypoint
 </span>
 <span class="next_section_button">
 \ref arcanedoc_core_types_axl_caseoptions_struct

--- a/arcane/doc/doc_user/chap_core_types/subchap_axl/subchap_caseoptions/5_default_values.md
+++ b/arcane/doc/doc_user/chap_core_types/subchap_axl/subchap_caseoptions/5_default_values.md
@@ -107,6 +107,6 @@ ____
 \ref arcanedoc_core_types_axl_caseoptions_usage
 </span>
 <span class="next_section_button">
-\ref arcanedoc_core_types_casefile
+\ref arcanedoc_core_types_axl_others
 </span>
 </div>

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationGenerator.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationGenerator.cs
@@ -13,6 +13,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Xml;
+using System.Text;
 using Arcane.Axl;
 
 namespace Arcane.AxlDoc
@@ -264,7 +265,7 @@ namespace Arcane.AxlDoc
       // à la fin de la chaine de caractères.
       Stack<string> stack_balises = new Stack<string>();
 
-      string output_text = "";
+      StringBuilder output_string = new StringBuilder();
 
       string[] lines = input_text.Split(new[] { "\n", "\r\n" }, StringSplitOptions.None);
       foreach (string line in lines)
@@ -281,7 +282,7 @@ namespace Arcane.AxlDoc
             if(!string.IsNullOrEmpty(balises[word])){
               stack_balises.Push(balises[word]);
             }
-            output_text += word + " ";
+            output_string.Append(word).Append(" ");
           }
 
           // Vérifie si le mot est une balise fermante.
@@ -289,25 +290,25 @@ namespace Arcane.AxlDoc
 
             // Dépile et écrit les balises jusqu'à trouver la bonne balise fermante.
             while (stack_balises.Count > 0 && stack_balises.Peek() != word){
-              output_text += stack_balises.Pop() + " ";
+              output_string.Append(stack_balises.Pop()).Append(" ");
             }
 
             // Retire la balise fermante de la pile si elle a été trouvée.
             if (stack_balises.Count > 0 && stack_balises.Peek() == word){
-              output_text += stack_balises.Pop() + " ";
+              output_string.Append(stack_balises.Pop()).Append(" ");
             }
           }
 
           // Si le mot commence par un backslash, n'est pas une balise connue et si la stack
           // n'est pas vide, on retire le backslash.
           else if (word.StartsWith("\\") && stack_balises.Count == 0){
-            output_text += word.Substring(1) + " ";
+            output_string.Append(word.Substring(1)).Append(" ");
             nb_char += word.Length - 1;
           }
 
           // Si ce n'est pas une balise et ne commence pas par un backslash, on ajoute tel quel le mot.
           else{
-            output_text += word + " ";
+            output_string.Append(word).Append(" ");
             nb_char += word.Length;
           }
 
@@ -323,18 +324,16 @@ namespace Arcane.AxlDoc
         if(nb_char >= max_nb_char && (!force_close_cmds || stack_balises.Count == 0)){
           break;
         }
-        output_text += Environment.NewLine;
+        output_string.Append(Environment.NewLine);
       }
 
       // Ajoute les balises restantes de la stack à la fin du texte.
       while (stack_balises.Count > 0){
-        output_text += stack_balises.Pop() + " ";
+        output_string.Append(stack_balises.Pop()).Append(" ");
       }
 
-      // Supprime le retour à la ligne final.
-      output_text = output_text.TrimEnd(Environment.NewLine.ToCharArray());
-
-      return output_text;
+      // Récupère le string et supprime le retour à la ligne final.
+      return output_string.ToString().TrimEnd(Environment.NewLine.ToCharArray());
     }
 
     /*!

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationGenerator.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationGenerator.cs
@@ -300,7 +300,7 @@ namespace Arcane.AxlDoc
           }
 
           // Si le mot commence par un backslash, n'est pas une balise connue et si la stack
-          // n'est pas vide, on retire le backslash.
+          // est vide, on retire le backslash.
           else if (word.StartsWith("\\") && stack_balises.Count == 0){
             output_string.Append(word.Substring(1)).Append(" ");
             nb_char += word.Length - 1;
@@ -322,6 +322,7 @@ namespace Arcane.AxlDoc
         // Si on a atteint la limite de caractère, on break.
         // Si force_close_attributes == True, alors il faut que la stack soit vide pour finir.
         if(nb_char >= max_nb_char && (!force_close_cmds || stack_balises.Count == 0)){
+          output_string.Append("...");
           break;
         }
         output_string.Append(Environment.NewLine);


### PR DESCRIPTION
Add support of Doxygen commands in brief description parts (in the `casemainpage`).

Supported commands :
`\verbatim` `\endverbatim`
`\code` `\endcode`
`\f$` `\f$`
`\f(` `\f)`
`\f[` `\f]`
`\f{` `\f}`

And add optional attributes for `<description>` :
- `doc-brief-force-close-cmds=Boolean` (default: false) : don't break the brief description until the Doxygen command has been closed,
- `doc-brief-max-nb-of-char=Int32` (default: 120) : number of chars before breaking the brief description,
- `doc-brief-stop-at-dot=Boolean` (default: true) : break the brief description at the first dot.