### PR TITLE
Revert renumbering for CartesianMesh without patch to version 3.11 and before

### DIFF
--- a/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-1.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-1.arc
@@ -63,9 +63,9 @@
      <length>2.0 2.0</length>
    </refinement-2d>
    <expected-number-of-cells-in-patchs>153 8 4 80 128</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>928b887dd8459a75ab8eeaf8622a9893</nodes-uid-hash>
-   <faces-uid-hash>9e4b11603725691496fa833e56bd87dc</faces-uid-hash>
-   <cells-uid-hash>a337136a4b240f5d062f7ac6eb63af09</cells-uid-hash>
+   <nodes-uid-hash>eef03075d1b1d32b63c9014bc567704e</nodes-uid-hash>
+   <faces-uid-hash>6d1b4ec0963f467f704c08f3f50dbd73</faces-uid-hash>
+   <cells-uid-hash>a577cb5e34dcbac51cec397ff7cb684e</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-2.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh2D-Cell-RenumberingV1-2.arc
@@ -49,9 +49,9 @@
      <length>2.0 2.0</length>
    </refinement-2d>
    <expected-number-of-cells-in-patchs>4 4 4</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>4fc2a63b0178bd7d3f389570dee86059</nodes-uid-hash>
-   <faces-uid-hash>b873493ea50b8d85e7771c2f8560ef08</faces-uid-hash>
-   <cells-uid-hash>a3a41734beca00414d049926921cefb2</cells-uid-hash>
+   <nodes-uid-hash>5fe67ed5bc2ee2112947e7db8fad5ed4</nodes-uid-hash>
+   <faces-uid-hash>e27ee8eef5bb304b1f09ca3286a5980e</faces-uid-hash>
+   <cells-uid-hash>cee8747ee64863eca941b41345f23f9d</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-1.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-1.arc
@@ -61,9 +61,9 @@
      <length>3.0 4.0 0.8</length>
    </refinement-3d> -->
    <expected-number-of-cells-in-patchs>1224 144 40</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>a78eb2e91aa9378816e8f28e62e7b8ec</nodes-uid-hash>
-   <faces-uid-hash>085cc27581e1990074a8028c9bc78c5d</faces-uid-hash>
-   <cells-uid-hash>f75cfcb40b124345dd1c056ad28a8f4e</cells-uid-hash>
+   <nodes-uid-hash>3ef51546e83d8303b770300b808f617e</nodes-uid-hash>
+   <faces-uid-hash>460c3b5083dce8f2c88d1e2b68d28c7f</faces-uid-hash>
+   <cells-uid-hash>91b7c816009cca00c223d088d86f9a1e</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-2.arc
+++ b/arcane/ceapart/tests/testAMRCartesianMesh3D-Cell-RenumberingV1-2.arc
@@ -70,9 +70,9 @@
      <length>2.0 2.0 2.0</length>
    </refinement-3d>
    <expected-number-of-cells-in-patchs>8 8 8 8 8 8 8 8</expected-number-of-cells-in-patchs>
-   <nodes-uid-hash>108ab65a162f420b2b49beee10b1f85b</nodes-uid-hash>
-   <faces-uid-hash>819e4e765d55fcb976d8b00e4c8d7718</faces-uid-hash>
-   <cells-uid-hash>04538c5721f934d717ee13d181b81d76</cells-uid-hash>
+   <nodes-uid-hash>3cbd376d768e895a0b8e33d091bb3ff5</nodes-uid-hash>
+   <faces-uid-hash>2582173a840acc76dabb2abf8528410b</faces-uid-hash>
+   <cells-uid-hash>a39d1e99166f13d23ffb74d4965b06a2</cells-uid-hash>
  </a-m-r-cartesian-mesh-tester>
 
  <arcane-protections-reprises>

--- a/arcane/src/arcane/cartesianmesh/internal/CartesianMeshUniqueIdRenumbering.cc
+++ b/arcane/src/arcane/cartesianmesh/internal/CartesianMeshUniqueIdRenumbering.cc
@@ -139,9 +139,13 @@ renumber()
 
   NewUniqueIdList new_uids(mesh);
 
+  // Indique si on utilise le patch par défaut.
+  bool use_default_patch = false;
   CartesianPatch patch0 = m_parent_patch;
-  if (patch0.isNull())
+  if (patch0.isNull()){
     patch0 = m_cartesian_mesh->patch(0);
+    use_default_patch = true;
+  }
 
   // TODO: Afficher le numéro du patch.
 
@@ -176,7 +180,7 @@ renumber()
 
   // Calcule le nombre de mailles du patch servant de référence.
   // Suppose qu'on raffine d'un facteur 2 à chaque fois
-  info() << "PatchLevel=" << patch_level;
+  info() << "PatchLevel=" << patch_level << " use_default_path=" << use_default_patch;
   Int32 multiplier = 1;
   for (Int32 z = 0; z < patch_level; ++z)
     multiplier *= 2;
@@ -189,6 +193,8 @@ renumber()
   Int64 max_item_uid = pm->reduce(Parallel::ReduceMax, new_uids.maxUniqueId());
   info() << "MaxItem uniqueId=" << max_item_uid;
   Int64 base_adder = 1 + max_item_uid;
+  if (use_default_patch)
+    base_adder = 0;
 
   // On suppose que la patch servant de référence a une numérotation cartésienne d'origine
   // ce qui veut dire qu'on peut déterminer les coordonnées topologiques de la maille
@@ -203,6 +209,9 @@ renumber()
       if (m_is_verbose)
         info() << "Renumbering: PARENT: cell_uid=" << uid << " I=" << coord_i
                << " J=" << coord_j << " nb_cell_x=" << nb_cell_x;
+      if (use_default_patch)
+        // Indique qu'on est de niveau 1 pour avoir la même numérotation qu'avec la version 3.9
+        level = 1;
       _applyChildrenCell2D(cell, new_uids, coord_i, coord_j, nb_cell_x, nb_cell_y, level, base_adder);
     }
   }


### PR DESCRIPTION
To make easier to compare results with old version of Arcane, we revert the renumbering of cartesian mesh to the version used in Arcane 3.11 and before.
