### PR TITLE
Various minor improvements in Arccore

### DIFF
--- a/arccore/src/base/arccore/base/PlatformUtils.cc
+++ b/arccore/src/base/arccore/base/PlatformUtils.cc
@@ -717,14 +717,16 @@ bool _getHasColorTerminal()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-extern "C++" ARCCORE_BASE_EXPORT void Platform::
-platformInitialize()
+void Platform::
+platformInitialize(bool enable_fpe)
 {
   // Pour l'instant, la seule initialisation spécifique dépend
   // des processeurs i386. Elle consiste à changer la valeur par
   // défaut des flags de la FPU pour générer une exception
   // lors d'une erreur arithmétique (comme les divisions par zéro).
-  enableFloatingException(true);
+  if (enable_fpe)
+    enableFloatingException(true);
+
   getCPUTime();
 
   global_has_color_console = _getHasColorTerminal();
@@ -733,6 +735,15 @@ platformInitialize()
     arccoreSetPauseOnException(true);
   if (getEnvironmentVariable("ARCCORE_PRINT_ON_EXCEPTION")=="1")
     arccoreCallExplainInExceptionConstructor(true);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void Platform::
+platformInitialize()
+{
+  platformInitialize(true);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/PlatformUtils.h
+++ b/arccore/src/base/arccore/base/PlatformUtils.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* PlatformUtils.h                                             (C) 2000-2018 */
+/* PlatformUtils.h                                             (C) 2000-2023 */
 /*                                                                           */
 /* Fonctions utilitaires dépendant de la plateforme.                         */
 /*---------------------------------------------------------------------------*/
@@ -40,21 +40,42 @@ class IStackTraceService;
 namespace Platform
 {
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \brief Initialisations spécifiques à une platforme.
  *
- Cette routine est appelé lors de l'initialisation de l'architecture.
- Elle permet d'effectuer certains traitements qui dépendent de la
- plateforme
+ * Cette routine est appelé lors de l'initialisation de l'architecture.
+ * Elle permet d'effectuer certains traitements qui dépendent de la
+ * plateforme.
+ *
+ * Active les exceptions flottantes i elles sont disponibles.
  */
-extern "C++" ARCCORE_BASE_EXPORT void platformInitialize();
+extern "C++" ARCCORE_BASE_EXPORT void
+platformInitialize();
 
+/*!
+ * \brief Initialisations spécifiques à une platforme.
+ *
+ * Cette routine est appelé lors de l'initialisation de l'architecture.
+ * Elle permet d'effectuer certains traitements qui dépendent de la
+ * plateforme.
+ *
+ * Si \a enable_fpe est vrai, les exceptions flottantes sont activées si elles
+ * sont disponibles (via l'appel à enableFloatingException().
+ */
+extern "C++" ARCCORE_BASE_EXPORT void
+platformInitialize(bool enable_fpe);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \brief Routines de fin de programme spécifiques à une platforme.
  *
  Cette routine est appelé juste avant de quitter le programme.
  */
-extern "C++" ARCCORE_BASE_EXPORT void platformTerminate();
+extern "C++" ARCCORE_BASE_EXPORT void
+platformTerminate();
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -1066,7 +1066,6 @@ class Array
   Array(const Array<T>& rhs) = delete;
   void operator=(const Array<T>& rhs) = delete;
 
-
  public:
 
   ~Array()
@@ -1607,6 +1606,13 @@ class SharedArray
     this->copy(rhs);
     this->_checkValidSharedArray();
   }
+  void operator=(std::initializer_list<T> alist)
+  {
+    this->clear();
+    for( const auto& x : alist )
+      this->add(x);
+    this->_checkValidSharedArray();
+  }
   //! Détruit le tableau
   ~SharedArray() override
   {
@@ -1926,6 +1932,13 @@ class UniqueArray
   void operator=(const Span<const T>& rhs)
   {
     this->copy(rhs);
+  }
+  //! Copie les valeurs de la vue \a alist dans cette instance.
+  void operator=(std::initializer_list<T> alist)
+  {
+    this->clear();
+    for( const auto& x : alist )
+      this->add(x);
   }
   //! Détruit l'instance.
   ~UniqueArray() override

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -189,6 +189,8 @@ ARCCORE_DEFINE_ARRAY_PODTYPE(float);
 ARCCORE_DEFINE_ARRAY_PODTYPE(double);
 ARCCORE_DEFINE_ARRAY_PODTYPE(long double);
 ARCCORE_DEFINE_ARRAY_PODTYPE(std::byte);
+ARCCORE_DEFINE_ARRAY_PODTYPE(Float16);
+ARCCORE_DEFINE_ARRAY_PODTYPE(BFloat16);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -293,6 +293,26 @@ void _testArrayNewInternal()
     ASSERT_EQ(c2.size(),1293);
     ASSERT_EQ(c22.size(),2);
 
+    {
+      SharedArray<IntSubClass> values1 = { -7, 3, 4 };
+      ASSERT_EQ(values1.size(),3);
+      ASSERT_EQ(values1[0],-7);
+      ASSERT_EQ(values1[1],3);
+      ASSERT_EQ(values1[2],4);
+      values1 = { 2, -1, 9, 13 };
+      ASSERT_EQ(values1.size(),4);
+      ASSERT_EQ(values1[0],2);
+      ASSERT_EQ(values1[1],-1);
+      ASSERT_EQ(values1[2],9);
+      ASSERT_EQ(values1[3],13);
+      SharedArray<IntSubClass> values2 = values1;
+      ASSERT_EQ(values2,values1);
+
+      values1 = {};
+      ASSERT_EQ(values1.size(),0);
+      ASSERT_EQ(values2.size(),0);
+    }
+
   }
   {
     UniqueArray<Int32> values1 = { 2, 5 };
@@ -312,6 +332,14 @@ void _testArrayNewInternal()
     UniqueArray<IntPtrSubClass>::iterator i = std::begin(vx);
     UniqueArray<IntPtrSubClass>::const_iterator ci = i;
     std::cout << "V=" << i->m_v << " " << ci->m_v << '\n';
+
+    values1 = { -7, 3 };
+    ASSERT_EQ(values1.size(),2);
+    ASSERT_EQ(values1[0],-7);
+    ASSERT_EQ(values1[1],3);
+
+    values1 = {};
+    ASSERT_EQ(values1.size(),0);
   }
   {
     UniqueArray<Int32> values1;


### PR DESCRIPTION
- Make optional the enabling of floating point exception in `platformInitialize()`.
- Add `operator=(std::initializer_list)` for `UniqueArray` and `SharedArray`.
- Make `BFloat16` and `Float16` POD types for `Array`.