### PR TITLE
Add CSS to customize the <details><summary> sections

### DIFF
--- a/arcane/doc/doc_dev/how_write_doc.md
+++ b/arcane/doc/doc_dev/how_write_doc.md
@@ -340,3 +340,20 @@ Coucou ! Voici l'onglet n°1 !
 
 </div>
 ```
+
+---
+
+Il est possible d'utiliser les balises `<details><summary>` dans la documentation
+pour réduire un bout de texte.
+
+Exemple :
+```xml
+<details>
+  <summary>Titre</summary>
+  Contenu réduit.
+</details>
+```
+<details>
+  <summary>Titre</summary>
+  Contenu réduit.
+</details>

--- a/arcane/doc/theme/css/custom.css
+++ b/arcane/doc/theme/css/custom.css
@@ -324,3 +324,55 @@ dl.deprecated dd {
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
+
+/*
+ * Début : Personnalisation de la partie spoiler.
+ */
+details {
+  border: 1px solid;
+  border-color: var(--separator-color);
+  border-radius: 4px;
+  padding: 0.5em 0.5em 0;
+  margin: 10px 0 10px 0;
+}
+
+summary {
+  background-color: var(--side-nav-background);
+  margin: -0.5em -0.5em 0;
+  padding: 0.5em;
+  transition: color .08s ease-in-out, background-color .1s ease-in-out;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+summary:hover {
+  color: var(--primary-color) !important;
+  background-color: var(--odd-color);
+}
+
+summary::before {
+  content: '⯈' !important;
+}
+
+details[open] {
+  padding: 0.5em;
+}
+
+details[open] summary {
+  border-bottom: 2px solid;
+  border-bottom-color: var(--primary-color);
+  margin-bottom: 0.5em;
+  color: var(--primary-color) !important;
+}
+
+details[open] summary::before {
+  content: '⯆' !important;
+}
+/*
+ * Fin : Personnalisation de la partie spoiler.
+ */
+
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
To use it in the documentation : 
```html
<details>
  <summary>Titre</summary>
  Some text
</details>
```
<details>
  <summary>Titre</summary>
  Some text
</details>