### PR TITLE
Fix version 2 of MPI sub-request handling for serialization when using MPI_ANY_SOURCE

### DIFF
--- a/arccore/src/message_passing/arccore/message_passing/CMakeLists.txt
+++ b/arccore/src/message_passing/arccore/message_passing/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES
   Stat.cc
   SerializeMessageList.h
   SerializeMessageList.cc
+  internal/SubRequestCompletionInfo.h
 )
 
 arccore_add_component_library(message_passing

--- a/arccore/src/message_passing/arccore/message_passing/MessagePassingGlobal.h
+++ b/arccore/src/message_passing/arccore/message_passing/MessagePassingGlobal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MessagePassingGlobal.h                                      (C) 2000-2022 */
+/* MessagePassingGlobal.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Définitions globales de la composante 'MessagePassing' de 'Arccore'.      */
 /*---------------------------------------------------------------------------*/
@@ -57,6 +57,7 @@ static const Int32 A_ANY_SOURCE_RANK = static_cast<Int32>(-2);
 static const Int32 A_PROC_NULL_RANK = static_cast<Int32>(-3);
 
 class Communicator;
+class SubRequestCompletionInfo;
 class IRequestCreator;
 class IRequestList;
 class ISerializeMessage;
@@ -74,6 +75,7 @@ class MessagePassingMng;
 class IDispatchers;
 class Dispatchers;
 class IProfiler;
+class ISubRequest;
 class IControlDispatcher;
 template<typename DataType> class ITypeDispatcher;
 class GatherMessageInfoBase;

--- a/arccore/src/message_passing/arccore/message_passing/Request.h
+++ b/arccore/src/message_passing/arccore/message_passing/Request.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Request.h                                                   (C) 2000-2020 */
+/* Request.h                                                   (C) 2000-2024 */
 /*                                                                           */
 /* Requête d'un message.                                                     */
 /*---------------------------------------------------------------------------*/
@@ -15,6 +15,8 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arccore/message_passing/MessagePassingGlobal.h"
+#include "arccore/message_passing/MessageRank.h"
+#include "arccore/message_passing/MessageTag.h"
 #include "arccore/base/Ref.h"
 
 #include <cstddef>
@@ -25,14 +27,20 @@
 
 namespace Arccore::MessagePassing
 {
-class Request;
-
+/*!
+ * \internal
+ * \brief Sous-requête d'une requête
+ */
 class ARCCORE_MESSAGEPASSING_EXPORT ISubRequest
 {
  public:
+
   virtual ~ISubRequest() = default;
+
  public:
-  virtual Request executeOnCompletion() =0;
+
+  //! Callback appelé lorsque la requête associée est terminée
+  virtual Request executeOnCompletion(const SubRequestCompletionInfo&) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/message_passing/arccore/message_passing/internal/SubRequestCompletionInfo.h
+++ b/arccore/src/message_passing/arccore/message_passing/internal/SubRequestCompletionInfo.h
@@ -1,0 +1,62 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* SubRequestCompletionInfo.h                                  (C) 2000-2024 */
+/*                                                                           */
+/* Informations de complétion pour une sous-requête.                         */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCCORE_MESSAGEPASSING_INTERNAL_SUBREQUESTCOMPLETIONINFO_H
+#define ARCCORE_MESSAGEPASSING_INTERNAL_SUBREQUESTCOMPLETIONINFO_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/message_passing/MessageRank.h"
+#include "arccore/message_passing/MessageTag.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arccore::MessagePassing
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations de complètion d'une sous-requête.
+ */
+class ARCCORE_MESSAGEPASSING_EXPORT SubRequestCompletionInfo
+{
+ public:
+
+  SubRequestCompletionInfo(MessageRank rank, MessageTag tag)
+  : m_source_rank(rank)
+  , m_source_tag(tag)
+  {}
+
+ public:
+
+  //! Rang d'origine de la requête
+  MessageRank sourceRank() const { return m_source_rank; }
+  //! Tag d'origine de la requête
+  MessageTag sourceTag() const { return m_source_tag; }
+
+ private:
+
+  MessageRank m_source_rank;
+  MessageTag m_source_tag;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif  
+


### PR DESCRIPTION
We were also using `MPI_ANY_SOURCE` for the second request and so it may be possible that the first and second request was not from the same source rank.