### PR TITLE
Fix wrong deletion of instance when calling 'Ref::_release()'

### DIFF
--- a/arccore/src/base/arccore/base/ExternalRef.h
+++ b/arccore/src/base/arccore/base/ExternalRef.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExternalRef.h                                               (C) 2000-2019 */
+/* ExternalRef.h                                               (C) 2000-2024 */
 /*                                                                           */
 /* Gestion d'une référence sur un objet externe au C++.                      */
 /*---------------------------------------------------------------------------*/
@@ -15,6 +15,7 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arccore/base/ReferenceCounter.h"
+
 #include <atomic>
 
 /*---------------------------------------------------------------------------*/
@@ -43,16 +44,21 @@ namespace Arccore::Internal
 class ARCCORE_BASE_EXPORT ExternalRef
 {
  private:
+
   struct Handle
   {
-    Handle() : handle(nullptr){}
-    Handle(void* h) : handle(h){}
+    Handle()
+    : handle(nullptr)
+    {}
+    Handle(void* h)
+    : handle(h)
+    {}
     ~Handle();
     void addReference() { ++m_nb_ref; }
     void removeReference()
     {
-      Int32 v = std::atomic_fetch_add(&m_nb_ref,-1);
-      if (v==1)
+      Int32 v = std::atomic_fetch_add(&m_nb_ref, -1);
+      if (v == 1)
         delete this;
     }
     void* handle;
@@ -66,19 +72,30 @@ class ARCCORE_BASE_EXPORT ExternalRef
  public:
 
   ExternalRef() = default;
-  ExternalRef(void* handle) : m_handle(new Handle(handle)){}
+  ExternalRef(void* handle)
+  : m_handle(new Handle(handle))
+  {}
 
  public:
-  bool isValid() const { return _internalHandle()!=nullptr; }
+
+  bool isValid() const
+  {
+    Handle* p = m_handle.get();
+    if (!p)
+      return false;
+    return _internalHandle() != nullptr;
+  }
   void* _internalHandle() const { return m_handle->handle; }
+
  private:
+
   Arccore::ReferenceCounter<Handle> m_handle;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace Arccore::Internal
+} // namespace Arccore::Internal
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/RefBase.h
+++ b/arccore/src/base/arccore/base/RefBase.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RefBase.h                                                   (C) 2000-2023 */
+/* RefBase.h                                                   (C) 2000-2024 */
 /*                                                                           */
 /* Classe de base de la gestion des références sur une instance.             */
 /*---------------------------------------------------------------------------*/
@@ -60,9 +60,9 @@ class ARCCORE_BASE_EXPORT RefBase
 
    protected:
 
+    DeleterBase() = default;
     DeleterBase(ExternalRef h)
     : m_handle(std::move(h))
-    , m_no_destroy(false)
     {}
     DeleterBase(ExternalRef h, bool no_destroy)
     : m_handle(std::move(h))
@@ -77,7 +77,7 @@ class ARCCORE_BASE_EXPORT RefBase
      * \brief Indique si on doit appeler le destructeur de l'instance
      * lorsqu'il n'y a plus de références dessus.
      */
-    bool m_no_destroy;
+    bool m_no_destroy = false;
   };
 };
 

--- a/arccore/src/base/tests/TestRef.cc
+++ b/arccore/src/base/tests/TestRef.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -172,6 +172,20 @@ _doTest1Helper()
       ASSERT_EQ(ct2,nullptr);
     }
   }
+  std::cout << "DoTestRelease\n";
+  {
+    RefType ref_ct(makeRef(new ClassType(a,b)));
+    ASSERT_NE(ref_ct.get(),nullptr);
+    ASSERT_EQ(ref_ct->pa(),a);
+    ASSERT_EQ(ref_ct->pb(),b);
+    if constexpr (id==0){
+      ClassType* ct2 = ref_ct._release();
+      ASSERT_NE(ct2,nullptr);
+      ASSERT_EQ(ct2->pa(),a);
+      ASSERT_EQ(ct2->pb(),b);
+      delete ct2;
+    }
+  }
   std::cout << "** ** END_TEST\n";
 }
 
@@ -180,7 +194,7 @@ _doTest1()
 {
   global_nb_create = global_nb_destroy = 0;
   _doTest1Helper<ClassType,id>();
-  ASSERT_EQ(global_nb_create,2);
+  ASSERT_EQ(global_nb_create,3);
   ASSERT_EQ(global_nb_create,global_nb_destroy);
 }
 

--- a/arccore/src/base/tests/TestReferenceCounter.cc
+++ b/arccore/src/base/tests/TestReferenceCounter.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -182,9 +182,6 @@ TEST(ReferenceCounter, RefWithDeleter)
     {
       auto* ptr1 = new TestClassWithDeleter();
       Ref<ITestClassWithDeleter> x4 = Ref<ITestClassWithDeleter>::createWithHandle(ptr1,external_ref);
-      ITestClassWithDeleter* t = x4._release();
-      std::cerr << "T=" << t << " ptr1=" << ptr1 << "\n";
-      delete t;    
     }
   }
   catch(const std::exception& ex){


### PR DESCRIPTION
`Ref::_release()` should release the pointer but not destroy it.
After the last refactoring (december 2023), the pointer was destroyed because the type used in `std::get_deleter()` was wrong.
This method `Ref::_release()` is only called when using deprecated methods. 