### PR TITLE
Add method 'IMesh::computeSynchronizeInfos()' to recompute synchronisation information

### DIFF
--- a/arcane/src/arcane/core/IMesh.h
+++ b/arcane/src/arcane/core/IMesh.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IMesh.h                                                     (C) 2000-2023 */
+/* IMesh.h                                                     (C) 2000-2024 */
 /*                                                                           */
 /* Interface d'un maillage.                                                  */
 /*---------------------------------------------------------------------------*/
@@ -355,6 +355,20 @@ class IMesh
 
   //! Gestionnaire de types d'entités associé
   virtual ItemTypeMng* itemTypeMng() const =0;
+
+ public:
+
+  /*!
+   * \brief Recalcule les informations de synchronisation.
+   *
+   * Cette opération est collective.
+   *
+   * Normalement cela est fait automatiquement par %Arcane lorsque c'est
+   * nécessaire. Néanmoins il peut arriver suite à certaines modifications
+   * internes qu'il faille manuellement mettre à jour les informations pour
+   * les synchronisations.
+   */
+  virtual void computeSynchronizeInfos() =0;
 
  public:
 

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -471,7 +471,7 @@ reloadMesh()
   Timer timer(subDomain(),"DynamicMesh::reloadMesh",Timer::TimerReal);
   {
     Timer::Sentry sentry(&timer);
-    _computeSynchronizeInfos();
+    computeSynchronizeInfos();
     m_mesh_checker->checkMeshFromReferenceFile();
   }
   info() << "Time to reallocate the mesh structures (direct method) (unit: second): "
@@ -806,7 +806,7 @@ endAllocate()
   }
 #endif
 
-  _computeSynchronizeInfos();
+  computeSynchronizeInfos();
   m_mesh_checker->checkMeshFromReferenceFile();
 
   // Positionne les proprietaires pour que cela soit comme apres
@@ -2207,7 +2207,6 @@ updateGhostLayerFromParent(Array<Int64>& ghost_cell_to_refine_uid,
   CHECKPERF( m_perf_counter.start(PerfCounter::UPGHOSTLAYER1) ) ;
   
   m_need_compact = true;
-  
   //Integer current_iteration = subDomain()->commonVariables().globalIteration();
   if (!m_is_dynamic)
     ARCANE_FATAL("Property isDynamic() has to be 'true'");
@@ -2253,7 +2252,7 @@ updateGhostLayerFromParent(Array<Int64>& ghost_cell_to_refine_uid,
   // des entités
   //pm->computeSynchronizeInfos();
   CHECKPERF( m_perf_counter.start(PerfCounter::UPGHOSTLAYER4) )
-  _computeSynchronizeInfos();
+  computeSynchronizeInfos();
   _synchronizeGroupsAndVariables();
   CHECKPERF( m_perf_counter.stop(PerfCounter::UPGHOSTLAYER4) )
 
@@ -3402,6 +3401,15 @@ IMeshModifierInternal* DynamicMesh::
 _modifierInternalApi()
 {
   return m_internal_api.get();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void DynamicMesh::
+computeSynchronizeInfos()
+{
+  _computeSynchronizeInfos();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DynamicMesh.h
+++ b/arcane/src/arcane/mesh/DynamicMesh.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DynamicMesh.h                                               (C) 2000-2023 */
+/* DynamicMesh.h                                               (C) 2000-2024 */
 /*                                                                           */
 /* Classe de gestion d'un maillage évolutif.                                 */
 /*---------------------------------------------------------------------------*/
@@ -523,6 +523,8 @@ public:
   IMeshMng* meshMng() const override { return m_mesh_mng; }
   IVariableMng* variableMng() const override { return m_variable_mng; }
   ItemTypeMng* itemTypeMng() const override { return m_item_type_mng; }
+
+  void computeSynchronizeInfos() override;
 
  public:
 

--- a/arcane/src/arcane/mesh/EmptyMesh.h
+++ b/arcane/src/arcane/mesh/EmptyMesh.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* EmptyMesh                                                   (C) 2000-2023 */
+/* EmptyMesh                                                   (C) 2000-2024 */
 /*                                                                           */
 /* Brief code description                                                    */
 /*---------------------------------------------------------------------------*/
@@ -541,6 +541,11 @@ class EmptyMesh
   {
     _error();
     return nullptr;
+  }
+
+  void computeSynchronizeInfos() override
+  {
+    ARCANE_THROW(NotImplementedException,"");
   }
 
   IMeshInternal* _internalApi() override


### PR DESCRIPTION
This may be needed if the user update various internal structures.