### PR TITLE
Cleanup Aleph/Hypre and handle version of Hypre compiled with accelerator support (CUDA,ROCM)

### DIFF
--- a/arcane/src/arcane/aleph/hypre/AlephHypre.cc
+++ b/arcane/src/arcane/aleph/hypre/AlephHypre.cc
@@ -967,7 +967,27 @@ class HypreAlephFactoryImpl
   }
 
  public:
-  void initialize() override {}
+
+  void initialize() override
+  {
+    // NOTE: A partir de la 2.29, on peut utiliser
+    // HYPRE_Initialize() et tester si l'initialisation
+    // a déjà été faite via HYPRE_Initialized().
+#if HYPRE_RELEASE_NUMBER >= 22900
+    if (!HYPRE_Initialized()){
+      info() << "Initializing HYPRE";
+      HYPRE_Initialize();
+    }
+#elif HYPRE_RELEASE_NUMBER >= 22700
+    info() << "Initializing HYPRE";
+    HYPRE_Init();
+#endif
+
+#if HYPRE_RELEASE_NUMBER >= 22700
+    HYPRE_SetMemoryLocation(HYPRE_MEMORY_HOST);
+    HYPRE_SetExecutionPolicy(HYPRE_EXEC_HOST);
+#endif
+  }
 
   IAlephTopology* createTopology(ITraceMng* tm,
                                  AlephKernel* kernel,

--- a/arcane/src/arcane/aleph/hypre/AlephHypre.cc
+++ b/arcane/src/arcane/aleph/hypre/AlephHypre.cc
@@ -1,12 +1,13 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephHypre.cc                                               (C) 2000-2023 */
+/* AlephHypre.cc                                               (C) 2000-2024 */
 /*                                                                           */
+/* Implémentation Hypre de Aleph.                                            */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -73,13 +74,7 @@ inline T*
 _allocHypre(Integer size)
 {
   size_t s = sizeof(T) * size;
-  // NOTE: Si erreur de compilation ici, cela signifie que la version de Hypre est
-  // trop vieille (2.14+ nécessaire)
-#ifdef ALEPH_HYPRE_USE_OLD_MALLOC
-  return (T*)hypre_TAlloc(char, s);
-#else
-  return (T*)hypre_TAlloc(char, s, HYPRE_MEMORY_HOST);
-#endif
+  return reinterpret_cast<T*>(hypre_TAlloc(char, s, HYPRE_MEMORY_HOST));
 }
 
 template <typename T>
@@ -87,13 +82,7 @@ inline T*
 _callocHypre(Integer size)
 {
   size_t s = sizeof(T) * size;
-  // NOTE: Si erreur de compilation ici, cela signifie que la version de Hypre est
-  // trop vieille (2.14+ nécessaire)
-#ifdef ALEPH_HYPRE_USE_OLD_MALLOC
-  return (T*)hypre_CTAlloc(char, s);
-#else
-  return (T*)hypre_CTAlloc(char, s, HYPRE_MEMORY_HOST);
-#endif
+  return reinterpret_cast<T*>(hypre_CTAlloc(char, s, HYPRE_MEMORY_HOST));
 }
 
 inline void

--- a/arcane/src/arcane/aleph/hypre/AlephHypre.cc
+++ b/arcane/src/arcane/aleph/hypre/AlephHypre.cc
@@ -153,17 +153,7 @@ class AlephVectorHypre
     hypreCheck("IJVectorSetObjectType", HYPRE_IJVectorSetObjectType(m_hypre_ijvector, HYPRE_PARCSR));
 
     debug() << "[AlephVectorHypre::AlephVectorCreate] HYPRE IJVectorInitialize";
-
-    // Avec Hypre 2.29 compilé avec vcpkg 2023-12-12, l'appel à HYPRE_IJVectorInitialize
-    // provoque une erreur générique. A priori si on ignore l'erreur, cela semble
-    // fonctionner ensuite. Pour éviter de lever une exception, on ne fait donc pas
-    // d'appel à hypreCheck().
-#ifdef BUG_HYPRE_2_29
     hypreCheck("HYPRE_IJVectorInitialize", HYPRE_IJVectorInitialize(m_hypre_ijvector));
-#else
-    HYPRE_IJVectorInitialize(m_hypre_ijvector);
-    HYPRE_ClearAllErrors();
-#endif
 
     HYPRE_IJVectorGetObject(m_hypre_ijvector, &object);
     m_hypre_parvector = (HYPRE_ParVector)object;

--- a/arcane/src/arcane/aleph/hypre/CMakeLists.txt
+++ b/arcane/src/arcane/aleph/hypre/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 # Recherche le numéro de version de Hypre.
 # Il est dans le fichier 'Hypre_config.h', sous la forme:
 # #define HYPRE_RELEASE_VERSION "2.20.0"
+# NOTE: on pourrait aussi utilier HYPRE_RELEASE_NUMBER. Il faudrait
+# vérifier depuis quelle version de Hypre cette macro est disponible
 find_file(_HYPRE_CONFIG_PATH NAMES HYPRE_config.h PATHS ${Hypre_INCLUDE_DIRS} REQUIRED)
 file(STRINGS ${_HYPRE_CONFIG_PATH} _HYPRE_VERSION_STR REGEX HYPRE_RELEASE_VERSION)
 string(REGEX MATCH "#define HYPRE_RELEASE_VERSION \"([0-9]+)\.([0-9]+)\.([0-9]+)\"" HYPRE_VERSION_REGEX_MATCH ${_HYPRE_VERSION_STR})
@@ -24,9 +26,6 @@ arcane_add_library(arcane_aleph_hypre
 
 arcane_add_arccon_packages(arcane_aleph_hypre PRIVATE ${PKGS})
 target_compile_definitions(arcane_aleph_hypre PRIVATE ARCANE_COMPONENT_arcane_aleph_hypre)
-if (ARCANE_HYPRE_VERSION VERSION_LESS 2.14)
-  target_compile_definitions(arcane_aleph_hypre PUBLIC ALEPH_HYPRE_USE_OLD_MALLOC)
-endif()
 
 target_link_libraries(arcane_aleph_hypre PUBLIC ${ARCANE_BASE_LIBRARIES})
 target_link_libraries(arcane_aleph_hypre PRIVATE arcane_aleph)


### PR DESCRIPTION
If `HYPRE` is compiled with accelerator support, it considers the execution is on device by default which is not the case for Aleph. We need to explicitly set execution policy to Host.
