### PR TITLE
Fix AllCellToAllEnvCellConverter bug of 0 env in Cell localID 0

### DIFF
--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.cc
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AllCellToAllEnvCellConverter.cc                             (C) 2000-2023 */
+/* AllCellToAllEnvCellConverter.cc                             (C) 2000-2024 */
 /*                                                                           */
 /* Conversion de 'Cell' en 'AllEnvCell'.                                     */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AllCellToAllEnvCellConverter.h                              (C) 2000-2023 */
+/* AllCellToAllEnvCellConverter.h                              (C) 2000-2024 */
 /*                                                                           */
 /* Conversion de 'Cell' en 'AllEnvCell'.                                     */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -109,6 +109,7 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
   IMemoryAllocator* m_alloc = nullptr;
   Integer m_size = 0;
   Span<ComponentItemLocalId>* m_allcell_allenvcell = nullptr;
+  ComponentItemLocalId* m_mem_pool = nullptr;
   Int32 m_current_max_nb_env = 0;
 };
 

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -214,19 +214,21 @@ initializeTest()
     Int32UniqueArray env1_indexes;
     Int32UniqueArray mat2_indexes;
     Int32UniqueArray sub_group_indexes;
-    Integer nb_cell = ownCells().size();
+    Integer nb_cell = allCells().size();
     Int64 total_nb_cell = nb_cell;
     ENUMERATE_CELL(icell,allCells()){
-      Cell cell = *icell;
-      Int64 cell_index = cell.uniqueId();
-      if (cell_index<((2*total_nb_cell)/3)){
-        env1_indexes.add(icell.itemLocalId());
+      if (icell.itemLocalId() != 0) {  // on ne veut pas de la première maille pour tester un cas tordu en //
+        Cell cell = *icell;
+        Int64 cell_index = cell.uniqueId();
+        if (cell_index<((2*total_nb_cell)/3)){
+          env1_indexes.add(icell.itemLocalId());
+        }
+        if (cell_index<(total_nb_cell/2) && cell_index>(total_nb_cell/3)){
+          mat2_indexes.add(icell.itemLocalId());
+        }
+        if ((cell_index%2)==0)
+          sub_group_indexes.add(icell.itemLocalId());
       }
-      if (cell_index<(total_nb_cell/2) && cell_index>(total_nb_cell/3)){
-        mat2_indexes.add(icell.itemLocalId());
-      }
-      if ((cell_index%2)==0)
-        sub_group_indexes.add(icell.itemLocalId());
     }
 
     // Ajoute les mailles du milieu 1

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshMaterialAcceleratorUnitTest.cc                          (C) 2000-2023 */
+/* MeshMaterialAcceleratorUnitTest.cc                          (C) 2000-2024 */
 /*                                                                           */
 /* Service de test unitaire du support accelerateurs des matériaux/milieux.  */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
bug encountered in parallel mode when the cell of local id 0 in a subdomain did not have any environment (and was a ghost cell)

Modify Unit test to detect this case