### PR TITLE
Improve usage of class 'Ref'

### DIFF
--- a/arccore/src/base/arccore/base/Ref.h
+++ b/arccore/src/base/arccore/base/Ref.h
@@ -285,6 +285,8 @@ class Ref
     return a.isNull();
   }
 
+  operator bool() const { return (!isNull()); }
+
  public:
 
   //! Instance associée ou `nullptr` si aucune
@@ -350,7 +352,7 @@ class Ref
  * sera détruit par l'opérateur 'operator delete' lorsqu'il n'y aura plus
  * de référence dessus.
  */
-template <typename InstanceType> auto
+template <typename InstanceType> inline auto
 makeRef(InstanceType* t) -> Ref<InstanceType>
 {
   return Ref<InstanceType>::create(t);
@@ -379,6 +381,18 @@ inline Ref<InstanceType>
 makeRefFromInstance(InstanceType2* t)
 {
   return Ref<InstanceType>::create(t);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Créé une instance de type \a TrueType avec les arguments \a Args
+ * et retourne une référence dessus.
+ */
+template <typename TrueType, class... Args> inline Ref<TrueType>
+createRef(Args&&... args)
+{
+  return makeRef<TrueType>(new TrueType(std::forward<Args>(args)...));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/tests/TestRef.cc
+++ b/arccore/src/base/tests/TestRef.cc
@@ -216,6 +216,30 @@ _doTest2()
   }
 }
 
+void _doTest3()
+{
+  Ref<TestBaseType> t0;
+  {
+    auto myx3 = createRef<TestRefOwn>(23, "abc");
+    t0 = myx3;
+    bool is_ok = false;
+    if (myx3)
+      is_ok = true;
+    ASSERT_TRUE(is_ok);
+    ASSERT_FALSE(!myx3);
+    ASSERT_EQ(t0->pa(), 23);
+    ASSERT_EQ(t0->pb(), "abc");
+  }
+  {
+    Ref<TestBaseType> myx4;
+    bool is_null = true;
+    if (myx4)
+      is_null = false;
+    ASSERT_TRUE(is_null);
+    ASSERT_TRUE(!myx4);
+  }
+}
+
 namespace Arccore
 {
 ARCCORE_DEFINE_REFERENCE_COUNTED_CLASS(MyTest::TestBaseType);
@@ -230,4 +254,5 @@ TEST(Ref, Misc)
   _doTest1<TestRefOwn,1>();
   _doTest1<TestRefSharedPtr,0>();
   _doTest2();
+  _doTest3();
 }

--- a/arccore/src/base/tests/TestReferenceCounter.cc
+++ b/arccore/src/base/tests/TestReferenceCounter.cc
@@ -121,7 +121,7 @@ TEST(ReferenceCounter, Ref)
   }
   {
     StatInfo stat_info;
-    _doTest1(makeRef(new Simple2(&stat_info)));
+    _doTest1(createRef<Simple2>(&stat_info));
     ASSERT_TRUE(stat_info.checkValid(0)) << "Bad destroy3";
   }
 }
@@ -174,7 +174,7 @@ TEST(ReferenceCounter, RefWithDeleter)
     using namespace Test1;
     Ref<ITestClassWithDeleter> myx2;
     {
-      Ref<ITestClassWithDeleter> myx1 = makeRef<ITestClassWithDeleter>(new TestClassWithDeleter());
+      Ref<ITestClassWithDeleter> myx1 = makeRef<TestClassWithDeleter>(new TestClassWithDeleter());
       myx2 = myx1;
     }
     myx2.reset();
@@ -182,6 +182,23 @@ TEST(ReferenceCounter, RefWithDeleter)
     {
       auto* ptr1 = new TestClassWithDeleter();
       Ref<ITestClassWithDeleter> x4 = Ref<ITestClassWithDeleter>::createWithHandle(ptr1,external_ref);
+    }
+    {
+      Ref<ITestClassWithDeleter> myx3 = createRef<TestClassWithDeleter>();
+      myx2 = myx3;
+      bool is_ok = false;
+      if (myx3)
+        is_ok = true;
+      ASSERT_TRUE(is_ok);
+      ASSERT_FALSE(!myx3);
+    }
+    {
+      Ref<ITestClassWithDeleter> myx4;
+      bool is_null = true;
+      if (myx4)
+        is_null = false;
+      ASSERT_TRUE(is_null);
+      ASSERT_TRUE(!myx4);
     }
   }
   catch(const std::exception& ex){


### PR DESCRIPTION
- Add helper method `createRef()` to create an instance of type `T` and return a `Ref<T>`.
- Add conversion from `Ref` to `bool`.