### PR TITLE
Fix compilation with ROCM 6.0

### DIFF
--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* HipAcceleratorRuntime.cc                                    (C) 2000-2023 */
+/* HipAcceleratorRuntime.cc                                    (C) 2000-2024 */
 /*                                                                           */
 /* Runtime pour 'HIP'.                                                       */
 /*---------------------------------------------------------------------------*/
@@ -300,11 +300,16 @@ class HipRunnerRuntime
     // hipPointerGetAttribute() retourne une erreur. Dans ce cas on considère
     // la mémoire comme non enregistrée.
     if (ret_value==hipSuccess){
+#if HIP_VERSION_MAJOR >= 6
+      auto rocm_memory_type = pa.type;
+#else
+      auto rocm_memory_type = pa.memoryType;
+#endif
       if (pa.isManaged)
         mem_type = ePointerMemoryType::Managed;
-      else if (pa.memoryType == hipMemoryTypeHost)
+      else if (rocm_memory_type == hipMemoryTypeHost)
         mem_type = ePointerMemoryType::Host;
-      else if (pa.memoryType == hipMemoryTypeDevice)
+      else if (rocm_memory_type == hipMemoryTypeDevice)
         mem_type = ePointerMemoryType::Device;
     }
 


### PR DESCRIPTION
Field  `memoryType` of  `hipPointerAttribute_t` has been renamed to `type` with version 6.