### PR TITLE
Change alien/ArcaneInterface CMake project name.

### DIFF
--- a/alien/ArcaneInterface/CMakeLists.txt
+++ b/alien/ArcaneInterface/CMakeLists.txt
@@ -13,8 +13,8 @@ string(REPLACE "_dev" "" ALIEN_VERSION ${ALIEN_VERSION_STR_FULL})
 string(STRIP "${ALIEN_VERSION}" ALIEN_VERSION)  # In case of \n
 message(STATUS "AlienLegacyVersion = ${ALIEN_VERSION}")
 
-project(ALIEN 
-        VERSION ${ALIEN_VERSION}) # Le nom est important car les axl sont générés dans <PROJECT_NAME>/axl
+project(AlienPlugins
+        VERSION ${ALIEN_VERSION})
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/hypre/CMakeLists.txt
@@ -17,6 +17,7 @@ generateAxl(alien_external_packages
         ${IS_WITH_ARCANE}
         ${IS_WITH_MESH}
         INSTALL_GENERATED_FILES
+        USER_INSTALL_PREFIX ALIEN
         )
 endif()
 

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/mtl/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/mtl/CMakeLists.txt
@@ -17,6 +17,7 @@
         ${IS_WITH_ARCANE}
         ${IS_WITH_MESH}
         INSTALL_GENERATED_FILES
+        USER_INSTALL_PREFIX ALIEN
         )
   endif()
   

--- a/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/external_packages/src/alien/kernels/petsc/CMakeLists.txt
@@ -44,6 +44,7 @@
           ${IS_WITH_ARCANE}
           ${IS_WITH_MESH}
           INSTALL_GENERATED_FILES
+          USER_INSTALL_PREFIX ALIEN
           )
   endif()
   addSources(alien_external_packages
@@ -75,6 +76,7 @@
               ${IS_WITH_ARCANE}
               ${IS_WITH_MESH}
               INSTALL_GENERATED_FILES
+              USER_INSTALL_PREFIX ALIEN
               )
       endif()
       addSources(alien_external_packages
@@ -94,6 +96,7 @@
               ${IS_WITH_ARCANE}
               ${IS_WITH_MESH}
               INSTALL_GENERATED_FILES
+              USER_INSTALL_PREFIX ALIEN
               )
       endif()
       addSources(alien_external_packages
@@ -112,6 +115,7 @@
               ${IS_WITH_ARCANE}
               ${IS_WITH_MESH}
               INSTALL_GENERATED_FILES
+              USER_INSTALL_PREFIX ALIEN
               )
       endif()
       addSources(alien_external_packages
@@ -130,6 +134,7 @@
                   ${IS_WITH_ARCANE}
                   ${IS_WITH_MESH}
                   INSTALL_GENERATED_FILES
+                  USER_INSTALL_PREFIX ALIEN
           )
       endif()
       addSources(alien_external_packages

--- a/alien/ArcaneInterface/modules/hpddm/src/alien/kernels/hpddm/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/hpddm/src/alien/kernels/hpddm/CMakeLists.txt
@@ -11,6 +11,7 @@ generateAxl(alien_hpddm
     ${IS_WITH_ARCANE}
     ${IS_WITH_MESH}
     INSTALL_GENERATED_FILES
+    USER_INSTALL_PREFIX ALIEN
     )
 addSources(alien_hpddm
     linear_solver/arcane/HPDDMSolverService.cc

--- a/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/hts/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/hts/CMakeLists.txt
@@ -17,6 +17,7 @@ generateAxl(alien_ifpen_solvers
     ${IS_WITH_ARCANE}
     ${IS_WITH_MESH}
     INSTALL_GENERATED_FILES
+    USER_INSTALL_PREFIX ALIEN
     )
 generateAxl(alien_ifpen_solvers
     eigen_solver/arcane/HTSEigenSolver.axl
@@ -25,6 +26,7 @@ generateAxl(alien_ifpen_solvers
     ${IS_WITH_ARCANE}
     ${IS_WITH_MESH}
     INSTALL_GENERATED_FILES
+    USER_INSTALL_PREFIX ALIEN
     )
 addSources(alien_ifpen_solvers
     linear_solver/arcane/HTSLinearSolver.cc

--- a/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/ifp/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/ifp/CMakeLists.txt
@@ -17,6 +17,7 @@ generateAxl(alien_ifpen_solvers
     ${IS_WITH_ARCANE}
     ${IS_WITH_MESH}
     INSTALL_GENERATED_FILES
+    USER_INSTALL_PREFIX ALIEN
     )
 
 addSources(alien_ifpen_solvers

--- a/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/mcg/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/mcg/CMakeLists.txt
@@ -15,6 +15,7 @@ generateAxl(alien_ifpen_solvers
     ${IS_WITH_ARCANE}
     ${IS_WITH_MESH}
     INSTALL_GENERATED_FILES
+    USER_INSTALL_PREFIX ALIEN
     )
 
 addSources(alien_ifpen_solvers

--- a/alien/ArcaneInterface/modules/plugins/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/plugins/CMakeLists.txt
@@ -18,6 +18,7 @@ generateAxl(alien_plugins_solvers
         ${IS_WITH_ARCANE}
         ${IS_WITH_MESH}
         INSTALL_GENERATED_FILES
+        USER_INSTALL_PREFIX ALIEN
         )
 
 addSources(alien_plugins_solvers

--- a/alien/ArcaneInterface/modules/trilinos/src/alien/kernels/trilinos/CMakeLists.txt
+++ b/alien/ArcaneInterface/modules/trilinos/src/alien/kernels/trilinos/CMakeLists.txt
@@ -19,6 +19,7 @@ generateAxl(alien_trilinos
     ${IS_WITH_ARCANE}
     ${IS_WITH_MESH}
     INSTALL_GENERATED_FILES
+    USER_INSTALL_PREFIX ALIEN
     )
 generateAxl(alien_trilinos
     eigen_solver/arcane/TrilinosEigenSolver.axl
@@ -27,6 +28,7 @@ generateAxl(alien_trilinos
     ${IS_WITH_ARCANE}
     ${IS_WITH_MESH}
     INSTALL_GENERATED_FILES
+    USER_INSTALL_PREFIX ALIEN
     )
 addSources(alien_trilinos
     linear_solver/arcane/TrilinosLinearSolver.cc

--- a/alien/ArcaneInterface/test/AlienBench/CMakeLists.txt
+++ b/alien/ArcaneInterface/test/AlienBench/CMakeLists.txt
@@ -11,6 +11,7 @@ generateAxl(alien_bench.exe
         AlienBench.axl
         AlienStokes.axl
         NO_COPY
+        USER_INSTALL_PREFIX ALIEN
         )
 
 if (TARGET intel)

--- a/alien/ArcaneInterface/test/AlienTest/CMakeLists.txt
+++ b/alien/ArcaneInterface/test/AlienTest/CMakeLists.txt
@@ -11,6 +11,7 @@ addSources(alien_arcane_test.exe
 generateAxl(alien_arcane_test.exe
             AlienTest.axl
             NO_COPY
+            USER_INSTALL_PREFIX ALIEN
            )
 
 # Les hooks pour les mallocs sont obsolètes et n'existent


### PR DESCRIPTION
The name ALIEN was conflicting (on non case sensitive OS) with alien-standalone name (Alien). The axl files are still generated in an ALIEN directory for compatibility.