### PR TITLE
Use by default version2 of item type computation for 'ItemGroup::applyOperation()'

### DIFF
--- a/arcane/src/arcane/core/ItemGroupImpl.cc
+++ b/arcane/src/arcane/core/ItemGroupImpl.cc
@@ -1606,8 +1606,9 @@ _computeChildrenByTypeV2()
       trace->info() << "ItemGroupImpl::_computeChildrenByTypeV2 for " << name()
                     << " type=" << type_mng->typeName(i) << " nb=" << n;
   }
-  trace->info() << "ItemGroupImpl::_computeChildrenByTypeV2 for " << name()
-                << " nb_item=" << nb_item << " nb_different_type=" << nb_different_type;
+  if (is_verbose)
+    trace->info() << "ItemGroupImpl::_computeChildrenByTypeV2 for " << name()
+                  << " nb_item=" << nb_item << " nb_different_type=" << nb_different_type;
 
   // Si nb_different_type == 1, cela signifie qu'il n'y a qu'un seul
   // type d'entité et on conserve juste ce type car dans ce cas on passera

--- a/arcane/src/arcane/core/internal/ItemGroupInternal.h
+++ b/arcane/src/arcane/core/internal/ItemGroupInternal.h
@@ -184,7 +184,7 @@ class ItemGroupInternal
 
   //! Gestion pour applyOperation() Version 2
   //@{
-  bool m_use_v2_for_apply_operation = false;
+  bool m_use_v2_for_apply_operation = true;
 
  public:
 

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -727,7 +727,8 @@ arcane_add_test_sequential(simple_csv_output_service testSimpleCsvOutputService.
 arcane_add_test_sequential(simple_csv_comparator_service testSimpleCsvComparatorService.arc)
 
 arcane_add_test(geometry testGeom.arc)
-arcane_add_test(geometry_applyoperation_v2 testGeom.arc -We,ARCANE_APPLYOPERATION_VERSION,2 -We,ARCANE_DEBUG_APPLYOPERATION,1)
+arcane_add_test(geometry_applyoperation_v2 testGeom.arc -We,ARCANE_DEBUG_APPLYOPERATION,1)
+arcane_add_test(geometry_applyoperation_v1 testGeom.arc -We,ARCANE_APPLYOPERATION_VERSION,1 -We,ARCANE_DEBUG_APPLYOPERATION,1)
 
 if(ARCANE_HAS_SOLVERS)
   ARCANE_ADD_TEST_PARALLEL(solver testSolver.arc 1)


### PR DESCRIPTION
The current version (version 1) uses one `ItemGroup` for each different type of item (for exemple one group for `IT_Quad4`, one group for `IT_Triangle3`, ...).
The version 2 uses `UniqueArray` for each type and if all the items are of same type uses the current container for the group to prevent memory duplication.