### PR TITLE
Minor optimisation in incremental material update

### DIFF
--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -406,7 +406,8 @@ void AllEnvData::
 recomputeIncremental()
 {
   forceRecompute(false);
-  _checkConnectivityCoherency();
+  if (arcaneIsCheck())
+    _checkConnectivityCoherency();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -70,7 +70,7 @@ apply(MaterialModifierOperation* operation)
 {
   bool is_add = operation->isAdd();
   IMeshMaterial* mat = operation->material();
-  Int32ConstArrayView ids = operation->ids();
+  ConstArrayView<Int32> ids = operation->ids();
 
   auto* true_mat = ARCANE_CHECK_POINTER(dynamic_cast<MeshMaterial*>(mat));
 
@@ -82,8 +82,6 @@ apply(MaterialModifierOperation* operation)
 
   ConstituentConnectivityList* connectivity = m_all_env_data->componentConnectivityList();
 
-  Int32UniqueArray cells_changed_in_env;
-
   if (nb_mat != 1) {
 
     // S'il est possible d'avoir plusieurs matériaux par milieu, il faut gérer
@@ -94,12 +92,18 @@ apply(MaterialModifierOperation* operation)
     // - en cas de suppression, le milieu évolue dans la maille s'il y avait
     //   1 seul matériau avant. Dans ce cas le milieu est supprimé de la maille.
 
-    Int32UniqueArray cells_unchanged_in_env;
+    UniqueArray<Int32>& cells_changed_in_env = m_work_info.cells_changed_in_env;
+    UniqueArray<Int32>& cells_unchanged_in_env = m_work_info.cells_unchanged_in_env;
+    const Int32 nb_id = ids.size();
+    cells_unchanged_in_env.clear();
+    cells_unchanged_in_env.reserve(nb_id);
+    cells_changed_in_env.clear();
+    cells_changed_in_env.reserve(nb_id);
     const Int32 ref_nb_mat = is_add ? 0 : 1;
     const Int16 env_id = true_env->componentId();
     info(4) << "Using optimisation updateMaterialDirect is_add?=" << is_add;
 
-    for (Integer i = 0, n = ids.size(); i < n; ++i) {
+    for (Integer i = 0; i < nb_id; ++i) {
       Int32 lid = ids[i];
       Int32 current_cell_nb_mat = connectivity->cellNbMaterial(CellLocalId(lid), env_id);
       if (current_cell_nb_mat != ref_nb_mat) {

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -70,7 +70,8 @@ apply(MaterialModifierOperation* operation)
 {
   bool is_add = operation->isAdd();
   IMeshMaterial* mat = operation->material();
-  ConstArrayView<Int32> ids = operation->ids();
+  ConstArrayView<Int32> orig_ids = operation->ids();
+  ConstArrayView<Int32> ids = orig_ids;
 
   auto* true_mat = ARCANE_CHECK_POINTER(dynamic_cast<MeshMaterial*>(mat));
 
@@ -157,9 +158,9 @@ apply(MaterialModifierOperation* operation)
   // d'ajout) ou les mailles partielles en mailles pures (en cas de
   // suppression).
   info(4) << "Transform PartialPure for material name=" << true_mat->name();
-  _switchComponentItemsForMaterials(true_mat);
+  _switchCellsForMaterials(true_mat, orig_ids);
   info(4) << "Transform PartialPure for environment name=" << env->name();
-  _switchComponentItemsForEnvironments(env);
+  _switchCellsForEnvironments(env, orig_ids);
 
   // Si je suis mono-mat, alors mat->cells()<=>env->cells() et il ne faut
   // mettre à jour que l'un des deux groupes.
@@ -194,7 +195,8 @@ apply(MaterialModifierOperation* operation)
  * (suppression d'un matériau)
  */
 void IncrementalComponentModifier::
-_switchComponentItemsForMaterials(const MeshMaterial* modified_mat)
+_switchCellsForMaterials(const MeshMaterial* modified_mat,
+                         ConstArrayView<Int32> ids)
 {
   const bool is_add = m_work_info.isAdd();
 
@@ -207,16 +209,13 @@ _switchComponentItemsForMaterials(const MeshMaterial* modified_mat)
       m_work_info.pure_local_ids.clear();
       m_work_info.partial_indexes.clear();
 
-      const MeshEnvironment* env = mat->trueEnvironment();
-      if (env != true_env)
-        ARCANE_FATAL("BAD ENV");
       MeshMaterialVariableIndexer* indexer = mat->variableIndexer();
 
       info(4) << "TransformCells (V3) is_add?=" << is_add << " indexer=" << indexer->name();
 
-      _computeCellsToTransform(mat);
-
+      _computeCellsToTransformForMaterial(mat, ids);
       indexer->transformCellsV2(m_work_info);
+      m_work_info.resetTransformedCells(ids);
 
       info(4) << "NB_MAT_TRANSFORM=" << m_work_info.pure_local_ids.size() << " name=" << mat->name();
 
@@ -242,7 +241,8 @@ _switchComponentItemsForMaterials(const MeshMaterial* modified_mat)
  * en pure (dans le cas de suppression d'un matériau)
  */
 void IncrementalComponentModifier::
-_switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env)
+_switchCellsForEnvironments(const IMeshEnvironment* modified_env,
+                            ConstArrayView<Int32> ids)
 {
   const bool is_add = m_work_info.isAdd();
 
@@ -264,8 +264,9 @@ _switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env)
 
     info(4) << "TransformCells (V2) is_add?=" << is_add << " indexer=" << indexer->name();
 
-    _computeCellsToTransform();
+    _computeCellsToTransformForEnvironments(ids);
     indexer->transformCellsV2(m_work_info);
+    m_work_info.resetTransformedCells(ids);
 
     info(4) << "NB_ENV_TRANSFORM=" << m_work_info.pure_local_ids.size()
             << " name=" << env->name();
@@ -283,7 +284,7 @@ _switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env)
  * \brief Calcule les mailles à transformer pour le matériau \at mat.
  */
 void IncrementalComponentModifier::
-_computeCellsToTransform(const MeshMaterial* mat)
+_computeCellsToTransformForMaterial(const MeshMaterial* mat, ConstArrayView<Int32> ids)
 {
   const MeshEnvironment* env = mat->trueEnvironment();
   const Int16 env_id = env->componentId();
@@ -293,23 +294,25 @@ _computeCellsToTransform(const MeshMaterial* mat)
   ConstituentConnectivityList* connectivity = m_all_env_data->componentConnectivityList();
   ConstArrayView<Int16> cells_nb_env = connectivity->cellsNbEnvironment();
 
-  ENUMERATE_ (Cell, icell, all_cells) {
+  for (Int32 local_id : ids) {
     bool do_transform = false;
+    CellLocalId cell_id(local_id);
     // En cas d'ajout on passe de pure à partiel s'il y a plusieurs milieux ou
     // plusieurs matériaux dans le milieu.
     // En cas de supression, on passe de partiel à pure si on est le seul matériau
     // et le seul milieu.
+    const Int16 nb_env = cells_nb_env[local_id];
     if (is_add) {
-      do_transform = cells_nb_env[icell.itemLocalId()] > 1;
+      do_transform = (nb_env > 1);
       if (!do_transform)
-        do_transform = connectivity->cellNbMaterial(icell, env_id) > 1;
+        do_transform = connectivity->cellNbMaterial(cell_id, env_id) > 1;
     }
     else {
-      do_transform = cells_nb_env[icell.itemLocalId()] == 1;
+      do_transform = (nb_env == 1);
       if (do_transform)
-        do_transform = connectivity->cellNbMaterial(icell, env_id) == 1;
+        do_transform = connectivity->cellNbMaterial(cell_id, env_id) == 1;
     }
-    m_work_info.setTransformedCell(icell, do_transform);
+    m_work_info.setTransformedCell(cell_id, do_transform);
   }
 }
 
@@ -320,22 +323,22 @@ _computeCellsToTransform(const MeshMaterial* mat)
  * d'un milieu.
  */
 void IncrementalComponentModifier::
-_computeCellsToTransform()
+_computeCellsToTransformForEnvironments(ConstArrayView<Int32> ids)
 {
   ConstituentConnectivityList* connectivity = m_all_env_data->componentConnectivityList();
   ConstArrayView<Int16> cells_nb_env = connectivity->cellsNbEnvironment();
   CellGroup all_cells = m_material_mng->mesh()->allCells();
   const bool is_add = m_work_info.isAdd();
 
-  ENUMERATE_ (Cell, icell, all_cells) {
+  for (Int32 lid : ids) {
     bool do_transform = false;
     // En cas d'ajout on passe de pure à partiel s'il y a plusieurs milieux.
     // En cas de supression, on passe de partiel à pure si on est le seul milieu.
     if (is_add)
-      do_transform = cells_nb_env[icell.itemLocalId()] > 1;
+      do_transform = cells_nb_env[lid] > 1;
     else
-      do_transform = cells_nb_env[icell.itemLocalId()] == 1;
-    m_work_info.setTransformedCell(icell, do_transform);
+      do_transform = cells_nb_env[lid] == 1;
+    m_work_info.setTransformedCell(CellLocalId(lid), do_transform);
   }
 }
 

--- a/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
@@ -153,45 +153,6 @@ endUpdateAdd(const ComponentItemListBuilder& builder)
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialVariableIndexer::
-endUpdateRemove(ConstArrayView<bool> removed_local_ids_filter,Integer nb_remove)
-{
-  // TODO: à supprimer et à remplacer par la version qui prend un
-  // ConstituentModifierWorkInfo à la place
-
-  Integer nb_item = nbItem();
-  Integer orig_nb_item = nb_item;
-
-  //ATTENTION: on modifie nb_item pendant l'itération.
-  for (Integer i=0; i<nb_item; ++i) {
-    Int32 lid = m_local_ids[i];
-    if (removed_local_ids_filter[lid]) {
-      // Déplace le dernier MatVarIndex vers l'élément courant.
-      Int32 last = nb_item - 1;
-      m_matvar_indexes[i] = m_matvar_indexes[last];
-      m_local_ids[i] = m_local_ids[last];
-      //info() << "REMOVE ITEM lid=" << lid << " i=" << i;
-      --nb_item;
-      --i; // Il faut refaire l'itération courante.
-    }
-  }
-  m_matvar_indexes.resize(nb_item);
-  m_local_ids.resize(nb_item);
-
-  // Vérifie qu'on a bien supprimé autant d'entité que prévu.
-  Integer nb_remove_computed = (orig_nb_item - nb_item);
-  if (nb_remove_computed!=nb_remove)
-    ARCANE_FATAL("Bad number of removed material items expected={0} v={1} name={2}",
-                 nb_remove,nb_remove_computed,name());
-  info(4) << "END_UPDATE_REMOVE nb_removed=" << nb_remove_computed;
-
-  // TODO: il faut recalculer m_max_index_in_multiple_array
-  // et compacter éventuellement les variables. (pas indispensable)
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void MeshMaterialVariableIndexer::
 endUpdateRemove(const ConstituentModifierWorkInfo& work_info,Integer nb_remove)
 {
   Integer nb_item = nbItem();

--- a/arcane/src/arcane/materials/internal/ConstituentModifierWorkInfo.h
+++ b/arcane/src/arcane/materials/internal/ConstituentModifierWorkInfo.h
@@ -70,6 +70,12 @@ class ARCANE_MATERIALS_EXPORT ConstituentModifierWorkInfo
     m_cells_to_transform[local_id.localId()] = v;
   }
 
+  //! Positionne l'état de transformation de la maille \a local_id pour l'opération courante
+  void resetTransformedCells(ConstArrayView<Int32> local_ids)
+  {
+    for( Int32 x : local_ids )
+      m_cells_to_transform[x] = false;
+  }
   //! Indique si la maille \a local_id est supprimée du matériaux pour l'opération courante.
   bool isRemovedCell(Int32 local_id) const { return m_removed_local_ids_filter[local_id]; }
 

--- a/arcane/src/arcane/materials/internal/ConstituentModifierWorkInfo.h
+++ b/arcane/src/arcane/materials/internal/ConstituentModifierWorkInfo.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ConstituentModifierWorkInfo.h                               (C) 2000-2023 */
+/* ConstituentModifierWorkInfo.h                               (C) 2000-2024 */
 /*                                                                           */
 /* Structure de travail utilisée lors de la modification des constituants.   */
 /*---------------------------------------------------------------------------*/
@@ -45,6 +45,11 @@ class ARCANE_MATERIALS_EXPORT ConstituentModifierWorkInfo
   UniqueArray<Int32> pure_local_ids;
   UniqueArray<Int32> partial_indexes;
   bool is_verbose = false;
+
+  //! Liste des mailles d'un milieu qui vont être ajoutées ou supprimées lors d'une opération
+  UniqueArray<Int32> cells_changed_in_env;
+  //! Liste des mailles d'un milieu qui sont déjà présentes dans un milieu lors d'une opération
+  UniqueArray<Int32> cells_unchanged_in_env;
 
  public:
 

--- a/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
+++ b/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IncrementalComponentModifier.h                              (C) 2000-2023 */
+/* IncrementalComponentModifier.h                              (C) 2000-2024 */
 /*                                                                           */
 /* Modification incrémentale des constituants.                               */
 /*---------------------------------------------------------------------------*/
@@ -57,10 +57,12 @@ class ARCANE_MATERIALS_EXPORT IncrementalComponentModifier
 
  private:
 
-  void _switchComponentItemsForEnvironments(const IMeshEnvironment* modified_env);
-  void _switchComponentItemsForMaterials(const MeshMaterial* modified_mat);
-  void _computeCellsToTransform(const MeshMaterial* mat);
-  void _computeCellsToTransform();
+  void _switchCellsForEnvironments(const IMeshEnvironment* modified_env,
+                                   ConstArrayView<Int32> ids);
+  void _switchCellsForMaterials(const MeshMaterial* modified_mat,
+                                ConstArrayView<Int32> ids);
+  void _computeCellsToTransformForMaterial(const MeshMaterial* mat, ConstArrayView<Int32> ids);
+  void _computeCellsToTransformForEnvironments(ConstArrayView<Int32> ids);
   void _removeItemsFromEnvironment(MeshEnvironment* env, MeshMaterial* mat,
                                    Int32ConstArrayView local_ids, bool update_env_indexer);
   void _addItemsToEnvironment(MeshEnvironment* env, MeshMaterial* mat,

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
@@ -96,7 +96,6 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
 
   void changeLocalIds(Int32ConstArrayView old_to_new_ids);
   void endUpdateAdd(const ComponentItemListBuilder& builder);
-  void endUpdateRemove(ConstArrayView<bool> removed_local_ids_filter,Integer nb_remove);
   void endUpdateRemove(const ConstituentModifierWorkInfo& args,Integer nb_remove);
   //@}
 


### PR DESCRIPTION
- Keep some working array between modification operation
- Loop only on added/removed cells instead of all cells when detecting cells needing transformation between pure and partial.