### PR TITLE
Use one container of 'ComponentItemInternal' for each type of constituent item

### DIFF
--- a/arcane/src/arcane/core/materials/CellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/core/materials/CellToAllEnvCellConverter.h
@@ -71,7 +71,7 @@ class CellToAllEnvCellConverter
 {
  public:
 
-  explicit CellToAllEnvCellConverter(ArrayView<ComponentItemInternal> v)
+  explicit CellToAllEnvCellConverter(ConstArrayView<ComponentItemInternal> v)
   : m_all_env_items_internal(v){}
 
   explicit CellToAllEnvCellConverter(IMeshMaterialMng* mm)
@@ -84,7 +84,7 @@ class CellToAllEnvCellConverter
   //! Converti une maille \a Cell en maille \a AllEnvCell
   AllEnvCell operator[](Cell c)
   {
-    return AllEnvCell(matimpl::ConstituentItemBase(&m_all_env_items_internal[c.localId()]));
+    return operator[](CellLocalId(c));
   }
   //! Converti une maille \a CellLocalId en maille \a AllEnvCell
   ARCCORE_HOST_DEVICE AllEnvCell operator[](CellLocalId c) const
@@ -95,7 +95,7 @@ class CellToAllEnvCellConverter
 
  private:
 
-  ArrayView<ComponentItemInternal> m_all_env_items_internal;
+  ConstArrayView<ComponentItemInternal> m_all_env_items_internal;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/ComponentItem.cc
+++ b/arcane/src/arcane/core/materials/ComponentItem.cc
@@ -26,10 +26,10 @@ namespace Arcane::Materials
 /*---------------------------------------------------------------------------*/
 
 void ComponentCell::
-_badConversion(Int32 level,Int32 expected_level)
+_badConversion(ComponentItemInternal* item_internal, Int32 level,Int32 expected_level)
 {
-  ARCANE_FATAL("bad level for internal component cell level={0} expected={1}",
-               level,expected_level);
+  ARCANE_FATAL("bad level for internal component cell level={0} expected={1} cid={2} component_id={3}",
+               level,expected_level,item_internal->_internalLocalId(),item_internal->componentId());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/ComponentItem.h
+++ b/arcane/src/arcane/core/materials/ComponentItem.h
@@ -117,18 +117,18 @@ class ARCANE_CORE_EXPORT ComponentCell
 
  protected:
 
-  static ARCCORE_HOST_DEVICE void _checkLevel([[maybe_unused]] ComponentItemInternal* internal,
+  static ARCCORE_HOST_DEVICE void _checkLevel([[maybe_unused]] ComponentItemInternal* item_internal,
                                               [[maybe_unused]] Int32 expected_level)
   {
 #if !defined(ARCCORE_DEVICE_CODE)
-    if (internal->null())
+    if (item_internal->null())
       return;
-    Int32 lvl = internal->level();
-    if (!internal->null() && lvl != expected_level)
-      _badConversion(lvl, expected_level);
+    Int32 lvl = item_internal->level();
+    if (lvl != expected_level)
+      _badConversion(item_internal, lvl, expected_level);
 #endif
   }
-  static void _badConversion(Int32 level, Int32 expected_level);
+  static void _badConversion(ComponentItemInternal* item_internal, Int32 level, Int32 expected_level);
 
  protected:
 

--- a/arcane/src/arcane/core/materials/ComponentItemInternal.cc
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.cc
@@ -39,6 +39,12 @@ _throwBadCast(Int32 v)
   throw BadCastException(A_FUNCINFO,String::format("Can not cast v={0} to type 'Int16'",v));
 }
 
+void matimpl::ConstituentItemBase::
+_throwBadCast(Int32 v)
+{
+  throw BadCastException(A_FUNCINFO,String::format("Can not cast v={0} to type 'Int16'",v));
+}
+
 std::ostream&
 operator<<(std::ostream& o,const ComponentItemInternalLocalId& id)
 {

--- a/arcane/src/arcane/core/materials/ComponentItemInternal.h
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.h
@@ -26,6 +26,7 @@ namespace Arcane::Materials
 class MeshEnvironment;
 class MeshComponentData;
 class AllEnvData;
+class MeshMaterialMng;
 namespace matimpl
 {
   class ConstituentItemBase;
@@ -104,7 +105,8 @@ class ARCANE_CORE_EXPORT ComponentItemSharedInfo
   ItemSharedInfo* m_item_shared_info = ItemSharedInfo::nullInstance();
   Int16 m_level = (-1);
   ConstArrayView<IMeshComponent*> m_components;
-  ComponentItemSharedInfo* m_parent_component_item_shared_info = null_shared_info_pointer;
+  ComponentItemSharedInfo* m_super_component_item_shared_info = null_shared_info_pointer;
+  ComponentItemSharedInfo* m_sub_component_item_shared_info = null_shared_info_pointer;
   ArrayView<ComponentItemInternal> m_component_item_internal_view;
 };
 
@@ -128,6 +130,7 @@ class ARCANE_CORE_EXPORT ConstituentItemBase
   friend Arcane::Materials::EnvCell;
   friend Arcane::Materials::MatCell;
   friend Arcane::Materials::AllEnvData;
+  friend Arcane::Materials::MeshMaterialMng;
 
   friend Arcane::Materials::MeshEnvironment;
   friend Arcane::Materials::MeshComponentData;
@@ -365,10 +368,10 @@ class ARCANE_CORE_EXPORT ComponentItemInternal
     return &nullComponentItemInternal;
   }
 
-  //! Composant supérieur (0 si aucun)
+  //! Composant supérieur (null si aucun)
   inline matimpl::ConstituentItemBase _superItemBase() const;
 
-  //! Première entité sous-composant.
+  //! Première entité du sous-constituant
   ARCCORE_HOST_DEVICE ComponentItemInternalLocalId _firstSubItemLocalId() const
   {
     return m_first_sub_component_item_local_id;
@@ -425,14 +428,14 @@ inline ARCCORE_HOST_DEVICE matimpl::ConstituentItemBase ComponentItemInternal::
 _subItemBase(Int32 i) const
 {
   ComponentItemInternalLocalId lid(m_first_sub_component_item_local_id.localId() + i);
-  return m_shared_info->_item(lid);
+  return m_shared_info->m_sub_component_item_shared_info->_item(lid);
 }
 
 matimpl::ConstituentItemBase ComponentItemInternal::
 _superItemBase() const
 {
   ComponentItemInternalLocalId lid(m_super_component_item_local_id.localId());
-  return m_shared_info->m_parent_component_item_shared_info->_item(lid);
+  return m_shared_info->m_super_component_item_shared_info->_item(lid);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/ComponentItemInternal.h
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.h
@@ -25,6 +25,7 @@ namespace Arcane::Materials
 {
 class MeshEnvironment;
 class MeshComponentData;
+class AllEnvData;
 namespace matimpl
 {
   class ConstituentItemBase;
@@ -126,6 +127,7 @@ class ARCANE_CORE_EXPORT ConstituentItemBase
   friend Arcane::Materials::AllEnvCell;
   friend Arcane::Materials::EnvCell;
   friend Arcane::Materials::MatCell;
+  friend Arcane::Materials::AllEnvData;
 
   friend Arcane::Materials::MeshEnvironment;
   friend Arcane::Materials::MeshComponentData;
@@ -220,6 +222,15 @@ class ARCANE_CORE_EXPORT ConstituentItemBase
  private:
 
   ComponentItemInternal* m_component_item = nullptr;
+
+ private:
+
+  void _checkIsInt16(Int32 v)
+  {
+    if (v < (-32768) || v > 32767)
+      _throwBadCast(v);
+  }
+  void _throwBadCast(Int32 v);
 };
 
 /*---------------------------------------------------------------------------*/
@@ -354,28 +365,8 @@ class ARCANE_CORE_EXPORT ComponentItemInternal
     return &nullComponentItemInternal;
   }
 
-  //! Positionne l'indexeur dans les variables matériaux.
-  void _setVariableIndex(MatVarIndex index)
-  {
-    m_var_index = index;
-  }
-
   //! Composant supérieur (0 si aucun)
-  matimpl::ConstituentItemBase _superItemBase() const
-  {
-    return &m_shared_info->m_component_item_internal_view[m_super_component_item_local_id.localId()];
-  }
-
-  void _setSuperAndGlobalItem(ComponentItemInternalLocalId cii, ItemLocalId ii)
-  {
-    m_super_component_item_local_id = cii;
-    m_global_item_local_id = ii.localId();
-  }
-
-  void _setGlobalItem(ItemLocalId ii)
-  {
-    m_global_item_local_id = ii.localId();
-  }
+  inline matimpl::ConstituentItemBase _superItemBase() const;
 
   //! Première entité sous-composant.
   ARCCORE_HOST_DEVICE ComponentItemInternalLocalId _firstSubItemLocalId() const
@@ -384,29 +375,6 @@ class ARCANE_CORE_EXPORT ComponentItemInternal
   }
 
   ARCCORE_HOST_DEVICE matimpl::ConstituentItemBase _subItemBase(Int32 i) const;
-
-  //! Positionne le nombre de sous-composants.
-  void _setNbSubItem(Int32 nb_sub_item)
-  {
-#ifdef ARCANE_CHECK
-    _checkIsInt16(nb_sub_item);
-#endif
-    m_nb_sub_component_item = static_cast<Int16>(nb_sub_item);
-  }
-
-  //! Positionne le premier sous-composant.
-  void _setFirstSubItem(ComponentItemInternalLocalId first_sub_item)
-  {
-    m_first_sub_component_item_local_id = first_sub_item;
-  }
-
-  void _setComponent(Int32 component_id)
-  {
-#ifdef ARCANE_CHECK
-    _checkIsInt16(component_id);
-#endif
-    m_component_id = static_cast<Int16>(component_id);
-  }
 
   ARCCORE_HOST_DEVICE ComponentItemInternalLocalId _internalLocalId() const
   {
@@ -458,6 +426,13 @@ _subItemBase(Int32 i) const
 {
   ComponentItemInternalLocalId lid(m_first_sub_component_item_local_id.localId() + i);
   return m_shared_info->_item(lid);
+}
+
+matimpl::ConstituentItemBase ComponentItemInternal::
+_superItemBase() const
+{
+  ComponentItemInternalLocalId lid(m_super_component_item_local_id.localId());
+  return m_shared_info->m_parent_component_item_shared_info->_item(lid);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -514,7 +489,7 @@ componentUniqueId() const
 inline void matimpl::ConstituentItemBase::
 _setVariableIndex(MatVarIndex index)
 {
-  m_component_item->_setVariableIndex(index);
+  m_component_item->m_var_index = index;
 }
 
 inline matimpl::ConstituentItemBase matimpl::ConstituentItemBase::
@@ -526,13 +501,14 @@ _superItemBase() const
 inline void matimpl::ConstituentItemBase::
 _setSuperAndGlobalItem(ComponentItemInternalLocalId cii, ItemLocalId ii)
 {
-  m_component_item->_setSuperAndGlobalItem(cii, ii);
+  m_component_item->m_super_component_item_local_id = cii;
+  m_component_item->m_global_item_local_id = ii.localId();
 }
 
 inline void matimpl::ConstituentItemBase::
 _setGlobalItem(ItemLocalId ii)
 {
-  m_component_item->_setGlobalItem(ii);
+  m_component_item->m_global_item_local_id = ii.localId();
 }
 
 //! Première entité sous-composant.
@@ -552,26 +528,32 @@ _subItemBase(Int32 i) const
 inline void matimpl::ConstituentItemBase::
 _setNbSubItem(Int32 nb_sub_item)
 {
-  m_component_item->_setNbSubItem(nb_sub_item);
+#ifdef ARCANE_CHECK
+  _checkIsInt16(nb_sub_item);
+#endif
+  m_component_item->m_nb_sub_component_item = static_cast<Int16>(nb_sub_item);
 }
 
 //! Positionne le premier sous-composant.
 inline void matimpl::ConstituentItemBase::
 _setFirstSubItem(ComponentItemInternalLocalId first_sub_item)
 {
-  m_component_item->_setFirstSubItem(first_sub_item);
+  m_component_item->m_first_sub_component_item_local_id = first_sub_item;
 }
 
 inline void matimpl::ConstituentItemBase::
 _setComponent(Int32 component_id)
 {
-  m_component_item->_setComponent(component_id);
+#ifdef ARCANE_CHECK
+  _checkIsInt16(component_id);
+#endif
+  m_component_item->m_component_id = static_cast<Int16>(component_id);
 }
 
 inline ARCCORE_HOST_DEVICE ComponentItemInternalLocalId matimpl::ConstituentItemBase::
 _internalLocalId() const
 {
-  return m_component_item->_internalLocalId();
+  return m_component_item->m_component_item_internal_local_id;
 }
 
 inline void matimpl::ConstituentItemBase::

--- a/arcane/src/arcane/core/materials/MatItemEnumerator.h
+++ b/arcane/src/arcane/core/materials/MatItemEnumerator.h
@@ -76,7 +76,7 @@ class ARCANE_CORE_EXPORT AllEnvCellVectorView
 
  protected:
 
-  AllEnvCellVectorView(Int32ConstArrayView local_ids,ArrayView<ComponentItemInternal> items_internal)
+  AllEnvCellVectorView(Int32ConstArrayView local_ids, ConstArrayView<ComponentItemInternal> items_internal)
   : m_local_ids(local_ids), m_items_internal(items_internal)
   {
   }
@@ -89,8 +89,8 @@ class ARCANE_CORE_EXPORT AllEnvCellVectorView
   // \i ème maille du vecteur
   AllEnvCell operator[](Integer index)
   {
-    Int32 lid = m_local_ids[index];
-    return AllEnvCell(matimpl::ConstituentItemBase(&m_items_internal[lid]));
+    const ComponentItemInternal* c = &m_items_internal[m_local_ids[index]];
+    return AllEnvCell(matimpl::ConstituentItemBase(const_cast<ComponentItemInternal*>(c)));
   }
 
   // localId() de la \i ème maille du vecteur
@@ -102,7 +102,7 @@ class ARCANE_CORE_EXPORT AllEnvCellVectorView
  private:
 
   Int32ConstArrayView m_local_ids;
-  ArrayView<ComponentItemInternal> m_items_internal;
+  ConstArrayView<ComponentItemInternal> m_items_internal;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/MatItemEnumerator.h
+++ b/arcane/src/arcane/core/materials/MatItemEnumerator.h
@@ -365,7 +365,7 @@ class ARCANE_CORE_EXPORT CellComponentCellEnumerator
   ARCCORE_HOST_DEVICE explicit CellComponentCellEnumerator(ComponentCell super_item)
   : m_size(super_item._internal()->nbSubItem())
   , m_items_begin(super_item._internal()->_firstSubItemLocalId().localId())
-  , m_item_internal_list(super_item._internal()->m_shared_info->m_component_item_internal_view)
+  , m_item_internal_list(super_item._internal()->m_shared_info->m_sub_component_item_shared_info->m_component_item_internal_view)
   {
   }
 

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -219,8 +219,6 @@ _computeInfosForEnvCells()
   ConstArrayView<MeshEnvironment*> true_environments(m_material_mng->trueEnvironments());
 
   ComponentItemInternalRange all_env_items_internal_range = m_item_internal_data.allEnvItemsInternalRange();
-  ArrayView<ComponentItemInternal> all_env_items_internal = m_item_internal_data.allEnvItemsInternal();
-  ArrayView<ComponentItemInternal> env_items_internal = m_item_internal_data.envItemsInternal();
   ComponentItemInternalRange env_items_internal_range = m_item_internal_data.envItemsInternalRange();
   ConstArrayView<Int16> cells_nb_env = m_component_connectivity_list->cellsNbEnvironment();
 
@@ -263,7 +261,7 @@ _computeInfosForEnvCells()
         Int32 pos = current_pos[lid];
         ++current_pos[lid];
         Int32 nb_mat = m_component_connectivity_list->cellNbMaterial(CellLocalId(lid), env_id);
-        ComponentItemInternal& ref_ii = env_items_internal[pos];
+        matimpl::ConstituentItemBase ref_ii = m_item_internal_data.envItemBase(pos);
         ComponentItemInternalLocalId cii_lid = all_env_items_internal_range[lid];
         env->setConstituentItem(z, ref_ii._internalLocalId());
         ref_ii._setSuperAndGlobalItem(cii_lid, ItemLocalId(lid));
@@ -283,7 +281,7 @@ _computeInfosForEnvCells()
       Cell c = *icell;
       Int32 lid = icell.itemLocalId();
       Int32 n = cells_nb_env[lid];
-      ComponentItemInternal& ref_ii = all_env_items_internal[lid];
+      matimpl::ConstituentItemBase ref_ii = m_item_internal_data.allEnvItemBase(c);
       ref_ii._setSuperAndGlobalItem({}, c);
       ref_ii._setVariableIndex(MatVarIndex(0, lid));
       ref_ii._setNbSubItem(n);

--- a/arcane/src/arcane/materials/MeshEnvironment.cc
+++ b/arcane/src/arcane/materials/MeshEnvironment.cc
@@ -201,7 +201,8 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data)
 
   IItemFamily* cell_family = cells().itemFamily();
   Integer max_local_id = cell_family->maxLocalId();
-  ArrayView<ComponentItemInternal> mat_items_internal = item_internal_data->matItemsInternal(id());
+  const Int16 env_id = componentId();
+  //ArrayView<ComponentItemInternal> mat_items_internal = item_internal_data->matItemsInternal(id());
   ComponentItemInternalRange mat_items_internal_range = item_internal_data->matItemsInternalRange(id());
 
   Int32UniqueArray cells_index(max_local_id);
@@ -248,9 +249,8 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data)
         MatVarIndex mvi = matvar_indexes[z];
         Int32 lid = local_ids[z];
         Int32 pos = cells_pos[lid];
-        //info(4) << "Z=" << z << " LID=" << lid << " POS=" << pos;
         ++cells_pos[lid];
-        ComponentItemInternal& ref_ii = mat_items_internal[pos];
+        matimpl::ConstituentItemBase ref_ii = item_internal_data->matItemBase(env_id,pos);
         mat->setConstituentItem(z, ref_ii._internalLocalId());
         ref_ii._setSuperAndGlobalItem(cells_env[lid], ItemLocalId(lid));
         ref_ii._setComponent(mat_id);

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -643,17 +643,16 @@ checkValid()
     if (cell_nb_env != nb_env_per_cell[cell.localId()])
       ARCANE_FATAL("Bad value for nb_env direct='{0}' var='{1}'",
                    cell_nb_env, nb_env_per_cell[cell.localId()]);
-
     for( Integer z=0; z<cell_nb_env; ++z ){
       EnvCell ec = all_env_cell.cell(z);
       Integer cell_nb_mat = ec.nbMaterial();
-      ComponentItemInternal* eii = ec._internal();
-      if (all_env_cell._internal()!=eii->_superItemBase())
+      matimpl::ConstituentItemBase eii = ec.constituentItemBase();
+      if (all_env_cell.constituentItemBase()!=eii._superItemBase())
         ARCANE_FATAL("Bad corresponding allEnvItem() in env_item uid={0}",cell_uid);
-      if (eii->globalItemBase()!=cell)
+      if (eii.globalItemBase()!=cell)
         ARCANE_FATAL("Bad corresponding globalItem() in env_item");
-      if (eii->level()!=LEVEL_ENVIRONMENT)
-        ARCANE_FATAL("Bad level '{0}' for in env_item",eii->level());
+      if (eii.level()!=LEVEL_ENVIRONMENT)
+        ARCANE_FATAL("Bad level '{0}' for in env_item",eii.level());
       // Si la maille n'est pas pure, la variable milieu ne peut être équivalente à
       // la variable globale.
       if (cell_nb_env>1 && ec._varIndex().arrayIndex()==0)
@@ -661,13 +660,13 @@ checkValid()
 
       for( Integer k=0; k<cell_nb_mat; ++k ){
         MatCell mc = ec.cell(k);
-        ComponentItemInternal* mci = mc._internal();
-        if (eii!=mci->_superItemBase())
+        matimpl::ConstituentItemBase mci = mc.constituentItemBase();
+        if (eii!=mci._superItemBase())
           ARCANE_FATAL("Bad corresponding env_item in mat_item");
-        if (mci->globalItemBase()!=cell)
+        if (mci.globalItemBase()!=cell)
           ARCANE_FATAL("Bad corresponding globalItem() in mat_item");
-        if (mci->level()!=LEVEL_MATERIAL)
-          ARCANE_FATAL("Bad level '{0}' for in mat_item",mci->level());
+        if (mci.level()!=LEVEL_MATERIAL)
+          ARCANE_FATAL("Bad level '{0}' for in mat_item",mci.level());
         // Si la maille n'est pas pure, la variable matériau ne peut être équivalente à
         // la variable globale.
         if ((cell_nb_env>1 || cell_nb_mat>1) && mc._varIndex().arrayIndex()==0){

--- a/arcane/src/arcane/materials/internal/AllEnvData.h
+++ b/arcane/src/arcane/materials/internal/AllEnvData.h
@@ -55,7 +55,7 @@ class AllEnvData
 
  public:
 
-  ArrayView<ComponentItemInternal> allEnvItemsInternal()
+  ConstArrayView<ComponentItemInternal> allEnvItemsInternal()
   {
     return m_item_internal_data.allEnvItemsInternal();
   }

--- a/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
@@ -125,28 +125,28 @@ class ComponentItemInternalData
 
  public:
 
-  //! Liste des AllEnvCell
+  //! Liste des AllEnvCell. Uniquement pour les itérateurs.
   ConstArrayView<ComponentItemInternal> allEnvItemsInternal() const
   {
     return m_all_env_items_internal;
   }
 
-  //! Liste des AllEnvCell
-  ArrayView<ComponentItemInternal> allEnvItemsInternal()
+  //! Retourne la AllEnvCell correspondant à la maille \a id
+  matimpl::ConstituentItemBase allEnvItemBase(CellLocalId id)
   {
-    return m_all_env_items_internal;
+    return matimpl::ConstituentItemBase(&m_all_env_items_internal[id.localId()]);
   }
 
-  //! Liste des mailles milieux.
-  ArrayView<ComponentItemInternal> envItemsInternal()
+  //! Retourne la EnvCell correspondant à l'indice \a index
+  matimpl::ConstituentItemBase envItemBase(Int32 index)
   {
-    return m_env_items_internal;
+    return matimpl::ConstituentItemBase(&m_env_items_internal[index]);
   }
 
-  //! Liste des mailles matériaux pour le \a env_index ème milieu
-  ArrayView<ComponentItemInternal> matItemsInternal(Int32 env_index)
+  //! Retourne la MatCell correspondant au milieu d'indice \a index du milieu \a env_index
+  matimpl::ConstituentItemBase matItemBase(Int16 env_index,Int32 index)
   {
-    return m_mat_items_internal[env_index];
+    return matimpl::ConstituentItemBase(&m_mat_items_internal[env_index][index]);
   }
 
   ComponentItemInternalRange allEnvItemsInternalRange() const

--- a/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
@@ -179,7 +179,9 @@ class ComponentItemInternalData
 
   MeshMaterialMng* m_material_mng = nullptr;
 
-  UniqueArray<ComponentItemInternal> m_component_item_internal_storage;
+  UniqueArray<ComponentItemInternal> m_all_env_item_internal_storage;
+  UniqueArray<ComponentItemInternal> m_env_item_internal_storage;
+  UniqueArray<ComponentItemInternal> m_mat_item_internal_storage;
   /*!
    * \brief Liste des ComponentItemInternal pour les AllEnvcell.
    *
@@ -203,8 +205,7 @@ class ComponentItemInternalData
 
  private:
 
-  void
-  _initSharedInfos();
+  void _initSharedInfos();
   void _resetMatItemsInternal(Int32 env_index);
   //! Réinitialise les ComponentItemInternal associés aux EnvCell et AllEnvCell
   void _resetItemsInternal();

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
@@ -9,7 +9,8 @@ namespace Arcane.Materials
     internal ItemSharedInfo* m_item_shared_info;
     internal Int16 m_level;
     internal MeshEnvironmentListView m_components;
-    internal ComponentItemSharedInfo* m_parent_component_item_shared_info;
+    internal ComponentItemSharedInfo* m_super_component_item_shared_info;
+    internal ComponentItemSharedInfo* m_sub_component_item_shared_info;
     internal ComponentItemInternalConstArrayView m_component_item_internal_view;
   }
 


### PR DESCRIPTION
There will be 3 containers: one for `MatCell`, one for `EnvCell` and one for `AllEnvCell`.
