### PR TITLE
Remove fields of 'ComponentItemInternal' and store values as arrays in 'ComponentItemSharedInfo'.

### DIFF
--- a/arcane/src/arcane/core/ItemInternal.h
+++ b/arcane/src/arcane/core/ItemInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemInternal.h                                              (C) 2000-2023 */
+/* ItemInternal.h                                              (C) 2000-2024 */
 /*                                                                           */
 /* Partie interne d'une entité.                                              */
 /*---------------------------------------------------------------------------*/
@@ -58,6 +58,7 @@ class PolyhedralMeshImpl;
 namespace Arcane::Materials
 {
 class ComponentItemInternal;
+class ComponentItemSharedInfo;
 }
 namespace Arcane
 {
@@ -481,6 +482,7 @@ class ARCANE_CORE_EXPORT ItemBase
   friend class ::Arcane::Item;
   friend class ::Arcane::ItemInternalCompatibility;
   friend class ::Arcane::Materials::ComponentItemInternal;
+  friend class ::Arcane::Materials::ComponentItemSharedInfo;
   friend MutableItemBase;
 
  private:

--- a/arcane/src/arcane/core/materials/ComponentItemInternal.cc
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.cc
@@ -33,18 +33,6 @@ ComponentItemSharedInfo* ComponentItemSharedInfo::null_shared_info_pointer = &Co
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ComponentItemInternal::
-_throwBadCast(Int32 v)
-{
-  throw BadCastException(A_FUNCINFO,String::format("Can not cast v={0} to type 'Int16'",v));
-}
-
-void matimpl::ConstituentItemBase::
-_throwBadCast(Int32 v)
-{
-  throw BadCastException(A_FUNCINFO,String::format("Can not cast v={0} to type 'Int16'",v));
-}
-
 std::ostream&
 operator<<(std::ostream& o,const ComponentItemInternalLocalId& id)
 {

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -260,7 +260,7 @@ _computeInfosForEnvCells()
         Int32 lid = local_ids[z];
         Int32 pos = current_pos[lid];
         ++current_pos[lid];
-        Int32 nb_mat = m_component_connectivity_list->cellNbMaterial(CellLocalId(lid), env_id);
+        Int16 nb_mat = m_component_connectivity_list->cellNbMaterial(CellLocalId(lid), env_id);
         matimpl::ConstituentItemBase ref_ii = m_item_internal_data.envItemBase(pos);
         ComponentItemInternalLocalId cii_lid = all_env_items_internal_range[lid];
         env->setConstituentItem(z, ref_ii._internalLocalId());
@@ -280,7 +280,7 @@ _computeInfosForEnvCells()
     ENUMERATE_CELL (icell, all_cells) {
       Cell c = *icell;
       Int32 lid = icell.itemLocalId();
-      Int32 n = cells_nb_env[lid];
+      Int16 n = cells_nb_env[lid];
       matimpl::ConstituentItemBase ref_ii = m_item_internal_data.allEnvItemBase(c);
       ref_ii._setSuperAndGlobalItem({}, c);
       ref_ii._setVariableIndex(MatVarIndex(0, lid));

--- a/arcane/src/arcane/materials/ComponentItemInternalData.cc
+++ b/arcane/src/arcane/materials/ComponentItemInternalData.cc
@@ -36,6 +36,7 @@ Storage(const MemoryAllocationOptions& alloc_info)
 , m_component_id_list(alloc_info)
 , m_nb_sub_constituent_item_list(alloc_info)
 , m_global_item_local_id_list(alloc_info)
+, m_var_index_list(alloc_info)
 {
 }
 
@@ -64,12 +65,16 @@ resize(Int32 new_size, ComponentItemSharedInfo* shared_info)
   m_global_item_local_id_list.resize(true_size);
   m_global_item_local_id_list[0] = NULL_ITEM_LOCAL_ID;
 
+  m_var_index_list.resize(true_size);
+  m_var_index_list[0].reset();
+
   shared_info->m_storage_size = new_size;
   shared_info->m_first_sub_constituent_item_id_data = m_first_sub_constituent_item_id_list.data() + 1;
   shared_info->m_super_component_item_local_id_data = m_super_component_item_local_id_list.data() + 1;
   shared_info->m_component_id_data = m_component_id_list.data() + 1;
   shared_info->m_nb_sub_constituent_item_data = m_nb_sub_constituent_item_list.data() + 1;
   shared_info->m_global_item_local_id_data = m_global_item_local_id_list.data() + 1;
+  shared_info->m_var_index_data = m_var_index_list.data() + 1;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ComponentItemInternalData.cc
+++ b/arcane/src/arcane/materials/ComponentItemInternalData.cc
@@ -29,6 +29,34 @@ namespace Arcane::Materials
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+ComponentItemInternalData::Storage::
+Storage(const MemoryAllocationOptions& alloc_info)
+: m_first_sub_constituent_list(alloc_info)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ComponentItemInternalData::Storage::
+resize(Int32 new_size, ComponentItemSharedInfo* shared_info)
+{
+  // On dimensionne au nombre d'éléments + 1.
+  // On décale de 1 la vue pour qu'elle puisse être indexée avec l'entité
+  // nulle (d'indice (-1)).
+  m_first_sub_constituent_list.resize(new_size + 1);
+  m_first_sub_constituent_list[0] = {};
+
+  shared_info->m_storage_size = new_size;
+  shared_info->m_first_sub_constituent_list_ptr = m_first_sub_constituent_list.data() + 1;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 ComponentItemInternalData::
 ComponentItemInternalData(MeshMaterialMng* mmg)
 : TraceAccessor(mmg->traceMng())
@@ -38,6 +66,9 @@ ComponentItemInternalData(MeshMaterialMng* mmg)
 , m_mat_item_internal_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
 , m_shared_infos(MemoryUtils::getAllocatorForMostlyReadOnlyData())
 , m_mat_items_internal_range(MemoryUtils::getAllocatorForMostlyReadOnlyData())
+, m_all_env_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
+, m_env_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
+, m_mat_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
 {
   // Il y a une instance pour les MatCell, les EnvCell et les AllEnvCell
   // Il ne faut ensuite plus modifier ce tableau car on conserve des pointeurs
@@ -116,6 +147,10 @@ resizeComponentItemInternals(Int32 max_local_id, Int32 total_nb_env_cell)
       index_in_container += nb_cell_mat;
     }
   }
+
+  m_all_env_storage.resize(max_local_id, allEnvSharedInfo());
+  m_env_storage.resize(total_nb_env_cell, envSharedInfo());
+  m_mat_storage.resize(total_nb_mat_cell, matSharedInfo());
 
   _resetItemsInternal();
 

--- a/arcane/src/arcane/materials/ComponentItemInternalData.cc
+++ b/arcane/src/arcane/materials/ComponentItemInternalData.cc
@@ -31,7 +31,9 @@ namespace Arcane::Materials
 
 ComponentItemInternalData::Storage::
 Storage(const MemoryAllocationOptions& alloc_info)
-: m_first_sub_constituent_list(alloc_info)
+: m_first_sub_constituent_item_id_list(alloc_info)
+, m_component_id_list(alloc_info)
+, m_nb_sub_constituent_item_list(alloc_info)
 {
 }
 
@@ -44,11 +46,20 @@ resize(Int32 new_size, ComponentItemSharedInfo* shared_info)
   // On dimensionne au nombre d'éléments + 1.
   // On décale de 1 la vue pour qu'elle puisse être indexée avec l'entité
   // nulle (d'indice (-1)).
-  m_first_sub_constituent_list.resize(new_size + 1);
-  m_first_sub_constituent_list[0] = {};
+  Int32 true_size = new_size + 1;
+  m_first_sub_constituent_item_id_list.resize(true_size);
+  m_first_sub_constituent_item_id_list[0] = {};
+
+  m_component_id_list.resize(true_size);
+  m_component_id_list[0] = -1;
+
+  m_nb_sub_constituent_item_list.resize(true_size);
+  m_nb_sub_constituent_item_list[0] = 0;
 
   shared_info->m_storage_size = new_size;
-  shared_info->m_first_sub_constituent_list_ptr = m_first_sub_constituent_list.data() + 1;
+  shared_info->m_first_sub_constituent_item_id_data = m_first_sub_constituent_item_id_list.data() + 1;
+  shared_info->m_component_id_data = m_component_id_list.data() + 1;
+  shared_info->m_nb_sub_constituent_item_data = m_nb_sub_constituent_item_list.data() + 1;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ComponentItemInternalData.cc
+++ b/arcane/src/arcane/materials/ComponentItemInternalData.cc
@@ -32,8 +32,10 @@ namespace Arcane::Materials
 ComponentItemInternalData::Storage::
 Storage(const MemoryAllocationOptions& alloc_info)
 : m_first_sub_constituent_item_id_list(alloc_info)
+, m_super_component_item_local_id_list(alloc_info)
 , m_component_id_list(alloc_info)
 , m_nb_sub_constituent_item_list(alloc_info)
+, m_global_item_local_id_list(alloc_info)
 {
 }
 
@@ -50,16 +52,24 @@ resize(Int32 new_size, ComponentItemSharedInfo* shared_info)
   m_first_sub_constituent_item_id_list.resize(true_size);
   m_first_sub_constituent_item_id_list[0] = {};
 
+  m_super_component_item_local_id_list.resize(true_size);
+  m_super_component_item_local_id_list[0] = {};
+
   m_component_id_list.resize(true_size);
   m_component_id_list[0] = -1;
 
   m_nb_sub_constituent_item_list.resize(true_size);
   m_nb_sub_constituent_item_list[0] = 0;
 
+  m_global_item_local_id_list.resize(true_size);
+  m_global_item_local_id_list[0] = NULL_ITEM_LOCAL_ID;
+
   shared_info->m_storage_size = new_size;
   shared_info->m_first_sub_constituent_item_id_data = m_first_sub_constituent_item_id_list.data() + 1;
+  shared_info->m_super_component_item_local_id_data = m_super_component_item_local_id_list.data() + 1;
   shared_info->m_component_id_data = m_component_id_list.data() + 1;
   shared_info->m_nb_sub_constituent_item_data = m_nb_sub_constituent_item_list.data() + 1;
+  shared_info->m_global_item_local_id_data = m_global_item_local_id_list.data() + 1;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshEnvironment.cc
+++ b/arcane/src/arcane/materials/MeshEnvironment.cc
@@ -233,7 +233,7 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data)
     Integer nb_mat = m_true_materials.size();
     for (Integer i = 0; i < nb_mat; ++i) {
       MeshMaterial* mat = m_true_materials[i];
-      Int32 mat_id = mat->id();
+      Int16 mat_id = mat->componentId();
       const MeshMaterialVariableIndexer* var_indexer = mat->variableIndexer();
       CellGroup mat_cells = mat->cells();
       info(4) << "COMPUTE (V2) mat_cells mat=" << mat->name() << " nb_cell=" << mat_cells.size()

--- a/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
@@ -128,8 +128,10 @@ class ComponentItemInternalData
    private:
 
     UniqueArray<ComponentItemInternalLocalId> m_first_sub_constituent_item_id_list;
+    UniqueArray<ComponentItemInternalLocalId> m_super_component_item_local_id_list;
     UniqueArray<Int16> m_component_id_list;
     UniqueArray<Int16> m_nb_sub_constituent_item_list;
+    UniqueArray<Int32> m_global_item_local_id_list;
   };
 
  public:

--- a/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
@@ -114,6 +114,7 @@ class ComponentItemInternalRange
 class ComponentItemInternalData
 : public TraceAccessor
 {
+  //! Conteneur pour les informations de ComponentItemSharedInfo
   class Storage
   {
    public:
@@ -126,7 +127,9 @@ class ComponentItemInternalData
 
    private:
 
-    UniqueArray<ComponentItemInternalLocalId> m_first_sub_constituent_list;
+    UniqueArray<ComponentItemInternalLocalId> m_first_sub_constituent_item_id_list;
+    UniqueArray<Int16> m_component_id_list;
+    UniqueArray<Int16> m_nb_sub_constituent_item_list;
   };
 
  public:

--- a/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
@@ -132,6 +132,7 @@ class ComponentItemInternalData
     UniqueArray<Int16> m_component_id_list;
     UniqueArray<Int16> m_nb_sub_constituent_item_list;
     UniqueArray<Int32> m_global_item_local_id_list;
+    UniqueArray<MatVarIndex> m_var_index_list;
   };
 
  public:

--- a/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
@@ -114,6 +114,21 @@ class ComponentItemInternalRange
 class ComponentItemInternalData
 : public TraceAccessor
 {
+  class Storage
+  {
+   public:
+
+    explicit Storage(const MemoryAllocationOptions& alloc_info);
+
+   public:
+
+    void resize(Int32 new_size, ComponentItemSharedInfo* shared_info);
+
+   private:
+
+    UniqueArray<ComponentItemInternalLocalId> m_first_sub_constituent_list;
+  };
+
  public:
 
   explicit ComponentItemInternalData(MeshMaterialMng* mm);
@@ -202,6 +217,10 @@ class ComponentItemInternalData
   ComponentItemInternalRange m_all_env_items_internal_range;
   ComponentItemInternalRange m_env_items_internal_range;
   UniqueArray<ComponentItemInternalRange> m_mat_items_internal_range;
+
+  Storage m_all_env_storage;
+  Storage m_env_storage;
+  Storage m_mat_storage;
 
  private:
 

--- a/arcane/tools/wrapper/materials/csharp/ComponentItem.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItem.cs
@@ -23,9 +23,9 @@ namespace Arcane.Materials
     }
 
     public Cell GlobalCell { get { return m_internal->m_shared_info->GlobalCell(m_internal->m_component_item_internal_local_id); } }
-    public MatVarIndex MatVarIndex { get { return m_internal->m_var_index; } }
-    internal int _matvarArrayIndex { get { return m_internal->m_var_index.ArrayIndex; } }
-    internal int _matvarValueIndex { get { return m_internal->m_var_index.ValueIndex; } }
+    public MatVarIndex MatVarIndex { get { return m_internal->m_shared_info->VarIndex(m_internal->m_component_item_internal_local_id); } }
+    internal int _matvarArrayIndex { get { return MatVarIndex.ArrayIndex; } }
+    internal int _matvarValueIndex { get { return MatVarIndex.ValueIndex; } }
 
     [Obsolete("This method is internal to Arcane")]
     public ComponentItem(ComponentItemInternal* ci)
@@ -46,9 +46,9 @@ namespace Arcane.Materials
       set { m_internal = value; }
     }
     public Cell GlobalCell { get { return m_internal->m_shared_info->GlobalCell(m_internal->m_component_item_internal_local_id); } }
-    public MatVarIndex MatVarIndex { get { return m_internal->m_var_index; } }
-    internal int _matvarArrayIndex { get { return m_internal->m_var_index.ArrayIndex; } }
-    internal int _matvarValueIndex { get { return m_internal->m_var_index.ValueIndex; } }
+    public MatVarIndex MatVarIndex { get { return m_internal->m_shared_info->VarIndex(m_internal->m_component_item_internal_local_id); } }
+    internal int _matvarArrayIndex { get { return MatVarIndex.ArrayIndex; } }
+    internal int _matvarValueIndex { get { return MatVarIndex.ValueIndex; } }
     [Obsolete("This method is internal to Arcane")]
     public MatItem(ComponentItemInternal* ci)
     {
@@ -67,9 +67,9 @@ namespace Arcane.Materials
     }
 
     public Cell GlobalCell { get { return m_internal->m_shared_info->GlobalCell(m_internal->m_component_item_internal_local_id); } }
-    public MatVarIndex MatVarIndex { get { return m_internal->m_var_index; } }
-    internal int _matvarArrayIndex { get { return m_internal->m_var_index.ArrayIndex; } }
-    internal int _matvarValueIndex { get { return m_internal->m_var_index.ValueIndex; } }
+    public MatVarIndex MatVarIndex { get { return m_internal->m_shared_info->VarIndex(m_internal->m_component_item_internal_local_id); } }
+    internal int _matvarArrayIndex { get { return MatVarIndex.ArrayIndex; } }
+    internal int _matvarValueIndex { get { return MatVarIndex.ValueIndex; } }
 
     [Obsolete("This method is internal to Arcane")]
     public EnvItem(ComponentItemInternal* ci)

--- a/arcane/tools/wrapper/materials/csharp/ComponentItem.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItem.cs
@@ -22,7 +22,7 @@ namespace Arcane.Materials
       set { m_internal = value; }
     }
 
-    public Cell GlobalCell { get { return new Cell(m_internal->m_shared_info->m_item_shared_info->m_items_internal[m_internal->m_global_item_local_id]); } }
+    public Cell GlobalCell { get { return m_internal->m_shared_info->GlobalCell(m_internal->m_component_item_internal_local_id); } }
     public MatVarIndex MatVarIndex { get { return m_internal->m_var_index; } }
     internal int _matvarArrayIndex { get { return m_internal->m_var_index.ArrayIndex; } }
     internal int _matvarValueIndex { get { return m_internal->m_var_index.ValueIndex; } }
@@ -45,7 +45,7 @@ namespace Arcane.Materials
       get { return m_internal; }
       set { m_internal = value; }
     }
-    public Cell GlobalCell { get { return new Cell(m_internal->m_shared_info->m_item_shared_info->m_items_internal[m_internal->m_global_item_local_id]); } }
+    public Cell GlobalCell { get { return m_internal->m_shared_info->GlobalCell(m_internal->m_component_item_internal_local_id); } }
     public MatVarIndex MatVarIndex { get { return m_internal->m_var_index; } }
     internal int _matvarArrayIndex { get { return m_internal->m_var_index.ArrayIndex; } }
     internal int _matvarValueIndex { get { return m_internal->m_var_index.ValueIndex; } }
@@ -66,7 +66,7 @@ namespace Arcane.Materials
       set { m_internal = value; }
     }
 
-    public Cell GlobalCell { get { return new Cell(m_internal->m_shared_info->m_item_shared_info->m_items_internal[m_internal->m_global_item_local_id]); } }
+    public Cell GlobalCell { get { return m_internal->m_shared_info->GlobalCell(m_internal->m_component_item_internal_local_id); } }
     public MatVarIndex MatVarIndex { get { return m_internal->m_var_index; } }
     internal int _matvarArrayIndex { get { return m_internal->m_var_index.ArrayIndex; } }
     internal int _matvarValueIndex { get { return m_internal->m_var_index.ValueIndex; } }

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
@@ -6,6 +6,13 @@ namespace Arcane.Materials
   [StructLayout(LayoutKind.Sequential)]
   public unsafe struct ComponentItemSharedInfo
   {
+    // Structure de la classe C++ ComponentItemSharedInfoStorageView
+    Int32 m_storage_size;
+    Int32* m_first_sub_constituent_item_id_data;
+    Int16* m_component_id_data;
+    Int16* m_nb_sub_constituent_item_data;
+
+    // Structure de la classe C++ ComponentItemSharedInfo
     internal ItemSharedInfo* m_item_shared_info;
     internal Int16 m_level;
     internal MeshEnvironmentListView m_components;
@@ -18,12 +25,12 @@ namespace Arcane.Materials
   public unsafe struct ComponentItemInternal
   {
     internal MatVarIndex m_var_index;
-    internal Int16 m_component_id;
-    internal Int16 m_nb_sub_component_item;
+    //internal Int16 m_component_id;
+    //internal Int16 m_nb_sub_component_item;
     internal Int32 m_global_item_local_id;
     internal Int32 m_component_item_internal_local_id;
     internal Int32 m_super_component_item_local_id;
-    internal Int32 m_first_sub_component_item_local_id;
+    //internal Int32 m_first_sub_component_item_local_id;
     internal ComponentItemSharedInfo* m_shared_info;
   }
 

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
@@ -11,6 +11,8 @@ namespace Arcane.Materials
     Int32* m_first_sub_constituent_item_id_data;
     Int16* m_component_id_data;
     Int16* m_nb_sub_constituent_item_data;
+    Int32* m_global_item_local_id_data;
+    Int32* m_super_component_item_local_id_data;
 
     // Structure de la classe C++ ComponentItemSharedInfo
     internal ItemSharedInfo* m_item_shared_info;
@@ -19,6 +21,12 @@ namespace Arcane.Materials
     internal ComponentItemSharedInfo* m_super_component_item_shared_info;
     internal ComponentItemSharedInfo* m_sub_component_item_shared_info;
     internal ComponentItemInternalConstArrayView m_component_item_internal_view;
+
+    internal Cell GlobalCell(Int32 constituent_local_id)
+    {
+      Int32 global_local_id = m_global_item_local_id_data[constituent_local_id];
+      return new Cell(m_item_shared_info->m_items_internal[global_local_id]);
+    }
   }
 
   [StructLayout(LayoutKind.Sequential)]
@@ -27,9 +35,9 @@ namespace Arcane.Materials
     internal MatVarIndex m_var_index;
     //internal Int16 m_component_id;
     //internal Int16 m_nb_sub_component_item;
-    internal Int32 m_global_item_local_id;
+    //internal Int32 m_global_item_local_id;
     internal Int32 m_component_item_internal_local_id;
-    internal Int32 m_super_component_item_local_id;
+    //internal Int32 m_super_component_item_local_id;
     //internal Int32 m_first_sub_component_item_local_id;
     internal ComponentItemSharedInfo* m_shared_info;
   }

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
@@ -13,6 +13,7 @@ namespace Arcane.Materials
     Int16* m_nb_sub_constituent_item_data;
     Int32* m_global_item_local_id_data;
     Int32* m_super_component_item_local_id_data;
+    MatVarIndex* m_var_index_data;
 
     // Structure de la classe C++ ComponentItemSharedInfo
     internal ItemSharedInfo* m_item_shared_info;
@@ -27,18 +28,16 @@ namespace Arcane.Materials
       Int32 global_local_id = m_global_item_local_id_data[constituent_local_id];
       return new Cell(m_item_shared_info->m_items_internal[global_local_id]);
     }
+    internal MatVarIndex VarIndex(Int32 constituent_local_id)
+    {
+      return m_var_index_data[constituent_local_id];
+    }
   }
 
   [StructLayout(LayoutKind.Sequential)]
   public unsafe struct ComponentItemInternal
   {
-    internal MatVarIndex m_var_index;
-    //internal Int16 m_component_id;
-    //internal Int16 m_nb_sub_component_item;
-    //internal Int32 m_global_item_local_id;
     internal Int32 m_component_item_internal_local_id;
-    //internal Int32 m_super_component_item_local_id;
-    //internal Int32 m_first_sub_component_item_local_id;
     internal ComponentItemSharedInfo* m_shared_info;
   }
 


### PR DESCRIPTION
With this PR the class `ComponentItemInternal` does no longer contains useful fields which we enable us to remove it.