### PR TITLE
Use the real page size instead of hardcoded 4096 bytes that can be false

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CudaAccelerator.cc                                          (C) 2000-2023 */
+/* CudaAccelerator.cc                                          (C) 2000-2024 */
 /*                                                                           */
 /* Backend 'CUDA' pour les accélérateurs.                                    */
 /*---------------------------------------------------------------------------*/
@@ -100,7 +100,7 @@ class UnifiedMemoryCudaMemoryAllocator
 {
  public:
 
-  static constexpr Int64 page_size = 4096;
+  Int64 page_size = platform::getPageSize();
 
   void initialize()
   {

--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -121,7 +121,7 @@ class UnifiedMemoryCudaMemoryAllocator
       _applyHint(ptr.baseAddress(), ptr.size(), new_args);
   }
 
-  Int64 adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const
+  Int64 adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const override
   {
     wanted_capacity = AlignedMemoryAllocator3::adjustedCapacity(args, wanted_capacity, element_size);
     const bool do_page = m_page_allocate_level > 0;
@@ -173,7 +173,7 @@ class UnifiedMemoryCudaMemoryAllocator
     return ::cudaFree(ptr);
   }
 
-  cudaError_t _allocate(void** ptr, size_t new_size, MemoryAllocationArgs args)
+  cudaError_t _allocate(void** ptr, size_t new_size, MemoryAllocationArgs args) override
   {
     auto r = ::cudaMallocManaged(ptr, new_size, cudaMemAttachGlobal);
     void* p = *ptr;

--- a/arcane/src/arcane/utils/PlatformUtils.cc
+++ b/arcane/src/arcane/utils/PlatformUtils.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* PlatformUtils.cc                                            (C) 2000-2023 */
+/* PlatformUtils.cc                                            (C) 2000-2024 */
 /*                                                                           */
 /* Fonctions utilitaires dépendant de la plateforme.                         */
 /*---------------------------------------------------------------------------*/
@@ -520,6 +520,25 @@ getRealTimeNS()
   auto y = std::chrono::time_point_cast<std::chrono::nanoseconds>(x);
   // Retourne le temps en nano-secondes.
   return static_cast<Int64>(y.time_since_epoch().count());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+extern "C++" ARCANE_UTILS_EXPORT Int64 platform::
+getPageSize()
+{
+#if defined(ARCCORE_OS_WIN32)
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  return si.dwPageSize;
+#elif defined(ARCANE_OS_LINUX)
+  return ::sysconf(_SC_PAGESIZE);
+#else
+#warning "getPageSize() not implemented for your platform. Default is 4096"
+  Int64 page_size = 4096;
+  return page_size;
+#endif
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/PlatformUtils.h
+++ b/arcane/src/arcane/utils/PlatformUtils.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* PlatformUtils.h                                             (C) 2000-2019 */
+/* PlatformUtils.h                                             (C) 2000-2024 */
 /*                                                                           */
 /* Fonctions utilitaires dépendant de la plateforme.                         */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/PlatformUtils.h
+++ b/arcane/src/arcane/utils/PlatformUtils.h
@@ -386,6 +386,14 @@ fillCommandLineArguments(StringList& arg_list);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Taille des pages du système hôte en octets
+ */
+extern "C++" ARCANE_UTILS_EXPORT Int64
+getPageSize();
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 // Définition du pragma pour indiquer l'indépendance des itérations
 

--- a/arcane/src/arcane/utils/tests/CMakeLists.txt
+++ b/arcane/src/arcane/utils/tests/CMakeLists.txt
@@ -7,6 +7,7 @@
   TestHash.cc
   TestHashTable.cc
   TestMemory.cc
+  TestPlatform.cc
   TestVector2.cc
   TestVector3.cc
 )

--- a/arcane/src/arcane/utils/tests/TestPlatform.cc
+++ b/arcane/src/arcane/utils/tests/TestPlatform.cc
@@ -1,0 +1,28 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "arcane/utils/HashTableMap.h"
+#include "arcane/utils/PlatformUtils.h"
+
+#include <iostream>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+using namespace Arcane;
+
+TEST(TestPlatform, Misc)
+{
+  Int64 page_size = platform::getPageSize();
+  std::cout << "PageSize=" << page_size << "\n";
+  ASSERT_TRUE(page_size>0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR includes the POSIX way to get the page size of the system.
This PR also includes little fixes like std::size_t instead of size_t and missing override keyword.