### PR TITLE
Remove class 'ComponentItemInternal'

### DIFF
--- a/arcane/src/arcane/core/materials/ComponentItem.cc
+++ b/arcane/src/arcane/core/materials/ComponentItem.cc
@@ -29,7 +29,7 @@ void ComponentCell::
 _badConversion(matimpl::ConstituentItemBase item_base, Int32 level,Int32 expected_level)
 {
   ARCANE_FATAL("bad level for internal component cell level={0} expected={1} cid={2} component_id={3}",
-               level,expected_level, item_base._constituentItemIndex(),item_base.componentId());
+               level,expected_level, item_base.m_constituent_item_index,item_base.componentId());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/ComponentItemInternal.cc
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.cc
@@ -25,8 +25,6 @@ namespace Arcane::Materials
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ComponentItemInternal ComponentItemInternal::nullComponentItemInternal;
-
 ComponentItemSharedInfo ComponentItemSharedInfo::null_shared_info;
 ComponentItemSharedInfo* ComponentItemSharedInfo::null_shared_info_pointer = &ComponentItemSharedInfo::null_shared_info;
 

--- a/arcane/src/arcane/core/materials/ComponentItemInternal.h
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.h
@@ -254,7 +254,13 @@ namespace Arcane::Materials::matimpl
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
+ * \internal
  * \brief Informations générique sur une entité d'un constituant.
+ *
+ * Cette classe est le pendant de ItemInternal pour la gestion des matériaux
+ * et des milieux. Elle ne doit en principe pas être utilisée directement, sauf
+ * par les classes de Arcane. Il vaut mieux utiliser les
+ * classes ComponentCell,  MatCell, EnvCell ou AllEnvCell.
  */
 class ARCANE_CORE_EXPORT ConstituentItemBase
 {
@@ -344,8 +350,6 @@ class ARCANE_CORE_EXPORT ConstituentItemBase
 
   inline ARCCORE_HOST_DEVICE ConstituentItemIndex _internalLocalId() const;
 
-  inline void _reset(ConstituentItemIndex id, ComponentItemSharedInfo* shared_info);
-
  private:
 
   ConstituentItemIndex m_constituent_item_index;
@@ -367,56 +371,6 @@ class ARCANE_CORE_EXPORT ConstituentItemBase
 
 namespace Arcane::Materials
 {
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \internal
- * \brief Partie interne d'une maille matériau ou milieu.
- *
- * Cette classe est le pendant de ItemInternal pour la gestion des matériaux
- * et des milieux. Elle ne doit en principe pas être utilisée directement, sauf
- * par les classes de Arcane. Il vaut mieux utiliser les
- * classes ComponentCell,  MatCell, EnvCell ou AllEnvCell.
- *
- * \todo pour économiser la mémoire, utiliser un ComponentItemSharedInfo
- * pour stocker une fois les infos multiples.
- */
-class ARCANE_CORE_EXPORT ComponentItemInternal
-{
-  friend class ComponentItemInternalData;
-
-  friend matimpl::ConstituentItemBase;
-
- private:
-
-  //! Entité nulle
-  static ComponentItemInternal nullComponentItemInternal;
-
- public:
-
-  ComponentItemInternal() = default;
-
- protected:
-
-  // NOTE : Cette classe est partagée avec le wrapper C#
-  // Toute modification de la structure interne doit être reportée
-  // dans la structure C# correspondante
-  ConstituentItemIndex m_component_item_index;
-  ComponentItemSharedInfo* m_shared_info = nullptr;
-
- private:
-
-  void _reset(ConstituentItemIndex id, ComponentItemSharedInfo* shared_info)
-  {
-    m_component_item_index = id;
-    m_shared_info = shared_info;
-    m_shared_info->_reset(id);
-  }
-};
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -578,14 +532,6 @@ inline ARCCORE_HOST_DEVICE ConstituentItemIndex matimpl::ConstituentItemBase::
 _internalLocalId() const
 {
   return m_constituent_item_index;
-}
-
-inline void matimpl::ConstituentItemBase::
-_reset(ConstituentItemIndex id, ComponentItemSharedInfo* shared_info)
-{
-  m_constituent_item_index = id;
-  m_shared_info = shared_info;
-  m_shared_info->_reset(id);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -263,7 +263,7 @@ _computeInfosForEnvCells()
         Int16 nb_mat = m_component_connectivity_list->cellNbMaterial(CellLocalId(lid), env_id);
         matimpl::ConstituentItemBase ref_ii = m_item_internal_data.envItemBase(pos);
         ConstituentItemIndex cii_lid = all_env_items_internal_range[lid];
-        env->setConstituentItem(z, ref_ii._internalLocalId());
+        env->setConstituentItem(z, ref_ii.constituentItemIndex());
         ref_ii._setSuperAndGlobalItem(cii_lid, ItemLocalId(lid));
         ref_ii._setNbSubItem(nb_mat);
         ref_ii._setVariableIndex(mvi);

--- a/arcane/src/arcane/materials/ComponentItemInternalData.cc
+++ b/arcane/src/arcane/materials/ComponentItemInternalData.cc
@@ -87,9 +87,6 @@ ComponentItemInternalData::
 ComponentItemInternalData(MeshMaterialMng* mmg)
 : TraceAccessor(mmg->traceMng())
 , m_material_mng(mmg)
-, m_all_env_item_internal_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
-, m_env_item_internal_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
-, m_mat_item_internal_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
 , m_shared_infos(MemoryUtils::getAllocatorForMostlyReadOnlyData())
 , m_mat_items_internal_range(MemoryUtils::getAllocatorForMostlyReadOnlyData())
 , m_all_env_storage(MemoryUtils::getAllocatorForMostlyReadOnlyData())
@@ -109,7 +106,7 @@ void ComponentItemInternalData::
 endCreate()
 {
   const Int32 nb_env = m_material_mng->environments().size();
-  m_mat_items_internal.resize(nb_env);
+  //m_mat_items_internal.resize(nb_env);
   m_mat_items_internal_range.resize(nb_env);
   _initSharedInfos();
 }
@@ -122,23 +119,18 @@ endCreate()
 void ComponentItemInternalData::
 _resetItemsInternal()
 {
-  ConstituentItemIndex internal_local_id;
-  ArrayView<ComponentItemInternal> all_env_storage = m_all_env_item_internal_storage;
-  ArrayView<ComponentItemInternal> env_storage = m_env_item_internal_storage;
-  ArrayView<ComponentItemInternal> mat_storage = m_mat_item_internal_storage;
-
   ComponentItemSharedInfo* all_env_shared_info = allEnvSharedInfo();
   for (ConstituentItemIndex id : m_all_env_items_internal_range)
-    all_env_storage[id.localId()]._reset(id, all_env_shared_info);
+    all_env_shared_info->_reset(id);
 
   ComponentItemSharedInfo* env_shared_info = envSharedInfo();
   for (ConstituentItemIndex id : m_env_items_internal_range)
-    env_storage[id.localId()]._reset(id, env_shared_info);
+    env_shared_info->_reset(id);
 
   ComponentItemSharedInfo* mat_shared_info = matSharedInfo();
   for (ComponentItemInternalRange mat_range : m_mat_items_internal_range) {
     for (ConstituentItemIndex id : mat_range)
-      mat_storage[id.localId()]._reset(id, mat_shared_info);
+      mat_shared_info->_reset(id);
   }
 }
 
@@ -153,22 +145,19 @@ resizeComponentItemInternals(Int32 max_local_id, Int32 total_nb_env_cell)
   for (const MeshEnvironment* env : m_material_mng->trueEnvironments())
     total_nb_mat_cell += env->totalNbCellMat();
 
-  // Redimensionne les conteneurs. Il ne fautdra plus les modifier par la suite
-  m_all_env_item_internal_storage.resize(max_local_id);
-  m_env_item_internal_storage.resize(total_nb_env_cell);
-  m_mat_item_internal_storage.resize(total_nb_mat_cell);
+  // Redimensionne les conteneurs. Il ne faudra plus les modifier par la suite
+  //m_all_env_item_internal_storage.resize(max_local_id);
+  //m_env_item_internal_storage.resize(total_nb_env_cell);
+  //m_mat_item_internal_storage.resize(total_nb_mat_cell);
 
   // Maintenant récupère les vues sur chaque partie du conteneur
   {
-    m_all_env_items_internal = m_all_env_item_internal_storage;
     m_all_env_items_internal_range.setRange(0, max_local_id);
-    m_env_items_internal = m_env_item_internal_storage;
     m_env_items_internal_range.setRange(0, total_nb_env_cell);
     Int32 index_in_container = 0;
     for (const MeshEnvironment* env : m_material_mng->trueEnvironments()) {
       Int32 nb_cell_mat = env->totalNbCellMat();
       Int32 env_id = env->id();
-      m_mat_items_internal[env_id] = m_mat_item_internal_storage.subView(index_in_container, nb_cell_mat);
       m_mat_items_internal_range[env_id].setRange(index_in_container, nb_cell_mat);
       index_in_container += nb_cell_mat;
     }

--- a/arcane/src/arcane/materials/MeshEnvironment.cc
+++ b/arcane/src/arcane/materials/MeshEnvironment.cc
@@ -225,7 +225,7 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data)
       if (nb_mat != 0) {
         env_item._setFirstSubItem(mat_items_internal_range[cell_index]);
       }
-      cells_env[lid] = env_item._internalLocalId();
+      cells_env[lid] = env_item.constituentItemIndex();
       cell_index += nb_mat;
     }
   }
@@ -251,7 +251,7 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data)
         Int32 pos = cells_pos[lid];
         ++cells_pos[lid];
         matimpl::ConstituentItemBase ref_ii = item_internal_data->matItemBase(env_id,pos);
-        mat->setConstituentItem(z, ref_ii._internalLocalId());
+        mat->setConstituentItem(z, ref_ii.constituentItemIndex());
         ref_ii._setSuperAndGlobalItem(cells_env[lid], ItemLocalId(lid));
         ref_ii._setComponent(mat_id);
         ref_ii._setVariableIndex(mvi);

--- a/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemInternalData.h
@@ -194,23 +194,6 @@ class ComponentItemInternalData
 
   MeshMaterialMng* m_material_mng = nullptr;
 
-  UniqueArray<ComponentItemInternal> m_all_env_item_internal_storage;
-  UniqueArray<ComponentItemInternal> m_env_item_internal_storage;
-  UniqueArray<ComponentItemInternal> m_mat_item_internal_storage;
-  /*!
-   * \brief Liste des ComponentItemInternal pour les AllEnvcell.
-   *
-   * Les éléments de ce tableau peuvent être indexés directement avec
-   * le localId() de la maille.
-   */
-  ArrayView<ComponentItemInternal> m_all_env_items_internal;
-
-  //! Liste des ComponentItemInternal pour chaque milieu
-  ArrayView<ComponentItemInternal> m_env_items_internal;
-
-  //! Liste des ComponentItemInternal pour les matériaux de chaque milieu
-  UniqueArray<ArrayView<ComponentItemInternal>> m_mat_items_internal;
-
   //! Liste des informations partagées
   UniqueArray<ComponentItemSharedInfo> m_shared_infos;
 
@@ -225,7 +208,6 @@ class ComponentItemInternalData
  private:
 
   void _initSharedInfos();
-  void _resetMatItemsInternal(Int32 env_index);
   //! Réinitialise les ComponentItemInternal associés aux EnvCell et AllEnvCell
   void _resetItemsInternal();
 };

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
@@ -21,7 +21,6 @@ namespace Arcane.Materials
     internal MeshEnvironmentListView m_components;
     internal ComponentItemSharedInfo* m_super_component_item_shared_info;
     internal ComponentItemSharedInfo* m_sub_component_item_shared_info;
-    internal ComponentItemInternalConstArrayView m_component_item_internal_view;
 
     internal Cell GlobalCell(Int32 constituent_local_id)
     {
@@ -50,29 +49,5 @@ namespace Arcane.Materials
     }
     internal Cell GlobalCell { get { return m_shared_info->GlobalCell(m_component_item_index); } }
     internal MatVarIndex MatVarIndex { get { return m_shared_info->VarIndex(m_component_item_index); } }
-}
-
-  [StructLayout(LayoutKind.Sequential)]
-  public unsafe struct ComponentItemInternal
-  {
-    internal Int32 m_component_item_index;
-    internal ComponentItemSharedInfo* m_shared_info;
-  }
-
-  [StructLayout(LayoutKind.Sequential)]
-  public unsafe struct ComponentItemInternalConstArrayView
-  {
-    internal Int32 m_size;
-    internal Arcane.Materials.ComponentItemInternal* m_ptr;
-  }
-}
-
-namespace Arcane
-{
-  [StructLayout(LayoutKind.Sequential)]
-  public unsafe struct ComponentItemInternalPtrConstArrayView
-  {
-    internal Int32 m_size;
-    internal Arcane.Materials.ComponentItemInternal** m_ptr;
   }
 }


### PR DESCRIPTION
This class is not longer used. It is replaced with `ConstituentItemBase`.