### PR TITLE
Revert to using 'UniqueArray' instead of 'std::set' to manage list of 'ExtraGhostBuilder'

### DIFF
--- a/arcane/src/arcane/mesh/ExtraGhostCellsBuilder.cc
+++ b/arcane/src/arcane/mesh/ExtraGhostCellsBuilder.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExtraGhostCellsBuilder.cc                                   (C) 2000-2022 */
+/* ExtraGhostCellsBuilder.cc                                   (C) 2000-2024 */
 /*                                                                           */
 /* Construction des mailles fantômes supplémentaires.                        */
 /*---------------------------------------------------------------------------*/
@@ -45,9 +45,9 @@ ExtraGhostCellsBuilder(DynamicMesh* mesh)
 void ExtraGhostCellsBuilder::
 addExtraGhostCellsBuilder(IExtraGhostCellsBuilder* builder)
 {
-  if (m_builders.find(builder)!=m_builders.end())
+  if (m_builders.contains(builder))
     ARCANE_FATAL("Instance {0} is already registered",builder);
-  m_builders.insert(builder);
+  m_builders.add(builder);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -56,10 +56,12 @@ addExtraGhostCellsBuilder(IExtraGhostCellsBuilder* builder)
 void ExtraGhostCellsBuilder::
 removeExtraGhostCellsBuilder(IExtraGhostCellsBuilder* builder)
 {
-  auto x = m_builders.find(builder);
-  if (x==m_builders.end())
+  auto iter_begin = m_builders.begin();
+  auto iter_end = m_builders.end();
+  auto x = std::find(iter_begin,iter_end,builder);
+  if (x==iter_end)
     ARCANE_FATAL("Instance {0} is not registered",builder);
-  m_builders.erase(x);
+  m_builders.remove(x - iter_begin);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ExtraGhostCellsBuilder.h
+++ b/arcane/src/arcane/mesh/ExtraGhostCellsBuilder.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExtraGhostCellsBuilder.h                                    (C) 2000-2022 */
+/* ExtraGhostCellsBuilder.h                                    (C) 2000-2024 */
 /*                                                                           */
 /* Construction des mailles fantômes supplémentaires.                        */
 /*---------------------------------------------------------------------------*/
@@ -18,8 +18,6 @@
 #include "arcane/utils/Array.h"
 
 #include "arcane/mesh/MeshGlobal.h"
-
-#include <set>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -57,8 +55,8 @@ class ExtraGhostCellsBuilder
 
  private:
 
-  DynamicMesh* m_mesh;
-  std::set<IExtraGhostCellsBuilder*> m_builders;
+  DynamicMesh* m_mesh = nullptr;
+  UniqueArray<IExtraGhostCellsBuilder*> m_builders;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ExtraGhostParticlesBuilder.cc
+++ b/arcane/src/arcane/mesh/ExtraGhostParticlesBuilder.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExtraGhostParticlesBuilder.cc                               (C) 2000-2023 */
+/* ExtraGhostParticlesBuilder.cc                               (C) 2000-2024 */
 /*                                                                           */
 /* Construction des mailles fantômes supplémentaires.                        */
 /*---------------------------------------------------------------------------*/
@@ -47,9 +47,9 @@ ExtraGhostParticlesBuilder(DynamicMesh* mesh)
 void ExtraGhostParticlesBuilder::
 addExtraGhostParticlesBuilder(IExtraGhostParticlesBuilder* builder)
 {
-  if (m_builders.find(builder)!=m_builders.end())
+  if (m_builders.contains(builder))
     ARCANE_FATAL("Instance {0} is already registered",builder);
-  m_builders.insert(builder);
+  m_builders.add(builder);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -58,10 +58,12 @@ addExtraGhostParticlesBuilder(IExtraGhostParticlesBuilder* builder)
 void ExtraGhostParticlesBuilder::
 removeExtraGhostParticlesBuilder(IExtraGhostParticlesBuilder* builder)
 {
-  auto x = m_builders.find(builder);
-  if (x==m_builders.end())
+  auto iter_begin = m_builders.begin();
+  auto iter_end = m_builders.end();
+  auto x = std::find(iter_begin,iter_end,builder);
+  if (x==iter_end)
     ARCANE_FATAL("Instance {0} is not registered",builder);
-  m_builders.erase(x);
+  m_builders.remove(x - iter_begin);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ExtraGhostParticlesBuilder.h
+++ b/arcane/src/arcane/mesh/ExtraGhostParticlesBuilder.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExtraGhostParticlesBuilder.h                                (C) 2000-2022 */
+/* ExtraGhostParticlesBuilder.h                                (C) 2000-2024 */
 /*                                                                           */
 /* Construction des mailles fantômes supplémentaires.                        */
 /*---------------------------------------------------------------------------*/
@@ -18,8 +18,6 @@
 #include "arcane/utils/Array.h"
 
 #include "arcane/mesh/MeshGlobal.h"
-
-#include <set>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -51,7 +49,7 @@ class ExtraGhostParticlesBuilder
 {
  public:
 
-  ExtraGhostParticlesBuilder(DynamicMesh* mesh);
+  explicit ExtraGhostParticlesBuilder(DynamicMesh* mesh);
   
  public:
 
@@ -62,8 +60,8 @@ class ExtraGhostParticlesBuilder
 
  private:
   
-  DynamicMesh* m_mesh;
-  std::set<IExtraGhostParticlesBuilder*> m_builders;
+  DynamicMesh* m_mesh = nullptr;
+  UniqueArray<IExtraGhostParticlesBuilder*> m_builders;
 
  private:
 


### PR DESCRIPTION
This is needed to make sure iteration on items of this list are in the order between sub-domains.
