### PR TITLE
Make sure we do not use copy constructor in 'Array::resizeNoInit'

### DIFF
--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Array.h                                                     (C) 2000-2023 */
+/* Array.h                                                     (C) 2000-2024 */
 /*                                                                           */
 /* Tableau 1D.                                                               */
 /*---------------------------------------------------------------------------*/
@@ -566,7 +566,8 @@ class AbstractArray
    *
    * Si la nouvelle capacité est inférieure à l'ancienne, rien ne se passe.
    */
-  void _internalRealloc(Int64 new_capacity,bool compute_capacity)
+  template<typename PodType>
+  void _internalRealloc(Int64 new_capacity,bool compute_capacity,PodType pod_type)
   {
     if (_isSharedNull()){
       if (new_capacity!=0)
@@ -585,7 +586,12 @@ class AbstractArray
     // Si la nouvelle capacité est inférieure à la courante,ne fait rien.
     if (acapacity <= m_md->capacity)
       return;
-    _internalReallocate(acapacity,IsPODType());
+    _internalReallocate(acapacity,pod_type);
+  }
+
+  void _internalRealloc(Int64 new_capacity,bool compute_capacity)
+  {
+    _internalRealloc(new_capacity,compute_capacity,IsPODType());
   }
 
   //! Réallocation pour un type POD
@@ -797,7 +803,7 @@ class AbstractArray
     if (s<0)
       s = 0;
     if (s>m_md->size) {
-      this->_internalRealloc(s,false);
+      this->_internalRealloc(s,false,pod_type);
       this->_createRangeDefault(m_md->size,s,pod_type);
     }
     else{

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -584,6 +584,12 @@ TEST(Array, SubViews)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+class NoCopyData
+{
+ public:
+  NoCopyData(const NoCopyData& x) = delete;
+};
+
 template <typename DataType>
 class MyArrayTest
 : public Arccore::Array<DataType>
@@ -613,21 +619,25 @@ TEST(Array, Misc3)
     const Int32 ref_value1 = 12;
     const Int32 ref_value2 = 7;
 
-    c.resize(9,IntSubClassNoPod(ref_value1));
+    c.resize(9, IntSubClassNoPod(ref_value1));
     std::cout << "C1=" << c << "\n";
-    for(IntSubClassNoPod x : c )
-      ASSERT_EQ(x,ref_value1);
+    for (IntSubClassNoPod x : c)
+      ASSERT_EQ(x, ref_value1);
 
-    c.resize(21,IntSubClassNoPod(ref_value2));
-    ASSERT_EQ(c.size(),21);
+    c.resize(21, IntSubClassNoPod(ref_value2));
+    ASSERT_EQ(c.size(), 21);
     std::cout << "C2=" << c << "\n";
 
     // Redimensionne sans initialiser. Les valeurs pour les éléments
     // de 9 à 18 doivent valoir \a ref_value2
     c.resizeNoInit(18);
     std::cout << "C4=" << c << "\n";
-    for( Int32 i=9, s=c.size(); i<s; ++i )
-      ASSERT_EQ(c[i],ref_value2);
+    for (Int32 i = 9, s = c.size(); i < s; ++i)
+      ASSERT_EQ(c[i], ref_value2);
+  }
+  {
+    MyArrayTest<NoCopyData> c2;
+    c2.resizeNoInit(25);
   }
 }
 


### PR DESCRIPTION
This will segfault if we use this method for non POD-type allocated in device memory.