### PR TITLE
Minor improvement in accelerator API

### DIFF
--- a/arcane/src/arcane/accelerator/CommonUtils.h
+++ b/arcane/src/arcane/accelerator/CommonUtils.h
@@ -92,10 +92,10 @@ class GenericDeviceStorage
     if (!m_ptr)
       return;
 #if defined(ARCANE_COMPILING_CUDA)
-    ARCANE_CHECK_CUDA(::cudaFree(m_ptr));
+    ARCANE_CHECK_CUDA_NOTHROW(::cudaFree(m_ptr));
 #endif
 #if defined(ARCANE_COMPILING_HIP)
-    ARCANE_CHECK_HIP(::hipFree(m_ptr));
+    ARCANE_CHECK_HIP_NOTHROW(::hipFree(m_ptr));
 #endif
     m_ptr = nullptr;
     m_size = 0;

--- a/arcane/src/arcane/accelerator/Filterer.cc
+++ b/arcane/src/arcane/accelerator/Filterer.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Filtering.cc                                                (C) 2000-2023 */
+/* Filtering.cc                                                (C) 2000-2024 */
 /*                                                                           */
 /* Algorithme de filtrage.                                                   */
 /*---------------------------------------------------------------------------*/
@@ -35,9 +35,6 @@ _nbOutputElement() const
 {
   if (m_queue)
     m_queue->barrier();
-  // Peut arriver si on n'a pas encore appelé _allocate()
-  //if (m_host_nb_out_storage.totalNbElement()==0)
-  //ARCANE_FATAL("Can not get output return 0;
   return m_host_nb_out_storage[0];
 }
 

--- a/arcane/src/arcane/accelerator/core/RunQueue.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueue.cc
@@ -235,6 +235,15 @@ _isAutoPrefetchCommand() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+bool RunQueue::
+isAcceleratorPolicy() const
+{
+  return Arcane::Accelerator::isAcceleratorPolicy(executionPolicy());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 extern "C++" ePointerAccessibility
 getPointerAccessibility(RunQueue* queue, const void* ptr, PointerAttribute* ptr_attr)
 {

--- a/arcane/src/arcane/accelerator/core/RunQueue.h
+++ b/arcane/src/arcane/accelerator/core/RunQueue.h
@@ -85,6 +85,8 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
 
   //! Politique d'exécution de la file.
   eExecutionPolicy executionPolicy() const;
+  //! Indique si l'instance est associée à un accélérateur
+  bool isAcceleratorPolicy() const;
   /*!
    * \brief Positionne l'asynchronisme de l'instance.
    *

--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -83,7 +83,7 @@ class CudaMemoryAllocatorBase
   }
   void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo mem_info) final
   {
-    ARCANE_CHECK_CUDA(_deallocate(mem_info, args));
+    ARCANE_CHECK_CUDA_NOTHROW(_deallocate(mem_info, args));
   }
 
  protected:

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -150,7 +150,7 @@ class CudaRunQueueStream
   }
   bool _barrierNoException() override
   {
-    return (cudaStreamSynchronize(m_cuda_stream)!=CUDA_SUCCESS);
+    return (cudaStreamSynchronize(m_cuda_stream) != cudaSuccess);
   }
   void copyMemory(const MemoryCopyArgs& args) override
   {

--- a/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
+++ b/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* HipAccelerator.cc                                           (C) 2000-2022 */
+/* HipAccelerator.cc                                           (C) 2000-2024 */
 /*                                                                           */
 /* Backend 'HIP' pour les accélérateurs.                                     */
 /*---------------------------------------------------------------------------*/
@@ -81,7 +81,7 @@ class HipMemoryAllocatorBase
   }
   void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr) override
   {
-    ARCANE_CHECK_HIP(_deallocate(ptr.baseAddress(), args));
+    ARCANE_CHECK_HIP_NOTHROW(_deallocate(ptr.baseAddress(), args));
   }
 
  protected:

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -262,7 +262,7 @@ _switchCellsForEnvironments(const IMeshEnvironment* modified_env,
                             ConstArrayView<Int32> ids)
 {
   const bool is_add = m_work_info.isAdd();
-  const bool is_device = isAcceleratorPolicy(m_copy_queue.executionPolicy());
+  const bool is_device = m_copy_queue.isAcceleratorPolicy();
 
   // Ne copie pas les valeurs partielles des milieux vers les valeurs globales
   // en cas de suppression de mailles car cela sera fait avec la valeur matériau

--- a/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
@@ -273,7 +273,7 @@ endUpdateRemoveV2(ConstituentModifierWorkInfo& work_info, Integer nb_remove, Run
         last_local_ids[output_index] = local_ids[true_index];
       }
     };
-    filterer.applyWithIndex(orig_nb_item, select_lambda, setter_lambda);
+    filterer.applyWithIndex(orig_nb_item, select_lambda, setter_lambda, A_FUNCINFO);
     filterer.nbOutputElement();
   }
 
@@ -287,7 +287,7 @@ endUpdateRemoveV2(ConstituentModifierWorkInfo& work_info, Integer nb_remove, Run
       matvar_indexes[input_index] = last_matvar_indexes[output_index];
       local_ids[input_index] = last_local_ids[output_index];
     };
-    filterer.applyWithIndex(orig_nb_item - nb_remove, select_lambda, setter_lambda);
+    filterer.applyWithIndex(orig_nb_item - nb_remove, select_lambda, setter_lambda, A_FUNCINFO);
     filterer.nbOutputElement();
   }
   nb_item -= nb_remove;
@@ -515,7 +515,7 @@ _switchBetweenPureAndPartial(ConstituentModifierWorkInfo& work_info,
       partial_indexes[output_index] = current_index;
       matvar_indexes[input_index] = MatVarIndex(var_index, current_index);
     };
-    filterer.applyWithIndex(nb, select_lambda, setter_lambda);
+    filterer.applyWithIndex(nb, select_lambda, setter_lambda, A_FUNCINFO);
   }
   else {
     // Transformation Partial -> Pure
@@ -535,7 +535,7 @@ _switchBetweenPureAndPartial(ConstituentModifierWorkInfo& work_info,
       partial_indexes[output_index] = var_index;
       matvar_indexes[input_index] = MatVarIndex(0, local_id);
     };
-    filterer.applyWithIndex(nb, select_lambda, setter_lambda);
+    filterer.applyWithIndex(nb, select_lambda, setter_lambda, A_FUNCINFO);
   }
 
   Int32 nb_out = filterer.nbOutputElement();


### PR DESCRIPTION
- Add profiling for `GenericFiltering`
- Do not throw exceptions for memory de-allocation functions
- Add method `RunQueue::isAcceleratorPolicy()` which returns `true` if the `RunQueue` is associated to an accelerator.