### PR TITLE
Remove catching of FloatingPoint exception at end of execution

### DIFF
--- a/arcane/src/arcane/impl/ArcaneMain.cc
+++ b/arcane/src/arcane/impl/ArcaneMain.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneMain.cc                                               (C) 2000-2023 */
+/* ArcaneMain.cc                                               (C) 2000-2024 */
 /*                                                                           */
 /* Classe gérant l'exécution.                                                */
 /*---------------------------------------------------------------------------*/
@@ -468,6 +468,9 @@ execute()
 void ArcaneMainExecInfo::
 finalize()
 {
+  // Désactive les exceptions flottantes
+  platform::enableFloatingException(false);
+
   // Si l'exécution s'est bien déroulée mais que l'utilisateur a spécifié un
   // code d'erreur, on le récupère.
   int exe_error_code = m_exec_main->errorCode();

--- a/arcane/src/arcane/impl/ExecutionStatsDumper.cc
+++ b/arcane/src/arcane/impl/ExecutionStatsDumper.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExecutionStatsDumper.cc                                     (C) 2000-2023 */
+/* ExecutionStatsDumper.cc                                     (C) 2000-2024 */
 /*                                                                           */
 /* Ecriture des statistiques d'exécution.                                    */
 /*---------------------------------------------------------------------------*/
@@ -19,6 +19,7 @@
 #include "arcane/utils/Profiling.h"
 #include "arcane/utils/ITraceMng.h"
 #include "arcane/utils/JSONWriter.h"
+#include "arcane/utils/FloatingPointExceptionSentry.h"
 
 #include "arcane/utils/internal/ProfilingInternal.h"
 
@@ -239,6 +240,7 @@ _dumpOneAcceleratorListStat(std::ostream& o, const impl::AcceleratorStatInfoList
 void ExecutionStatsDumper::
 dumpStats(ISubDomain* sd, ITimeStats* time_stat)
 {
+  FloatingPointExceptionSentry fp_sentry(false);
   {
     // Statistiques sur la mémoire
     double mem = platform::getMemoryUsed();


### PR DESCRIPTION
This will remove random crash in the CI at end of execution.
This may be because of speculative execution.
