### PR TITLE
Refactor 'Runner' implementation

### DIFF
--- a/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
@@ -70,6 +70,8 @@ namespace impl
   class RunQueueImpl;
   class IRunQueueEventImpl;
   class RunCommandLaunchInfo;
+  class RunnerImpl;
+  class RunQueueImplStack;
 } // namespace impl
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/ReduceMemoryImpl.cc
+++ b/arcane/src/arcane/accelerator/core/ReduceMemoryImpl.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ReduceMemoryImpl.cc                                         (C) 2000-2023 */
+/* ReduceMemoryImpl.cc                                         (C) 2000-2024 */
 /*                                                                           */
 /* Gestion de la mémoire pour les réductions.                                */
 /*---------------------------------------------------------------------------*/
@@ -21,6 +21,7 @@
 #include "arcane/accelerator/core/Memory.h"
 #include "arcane/accelerator/core/IRunQueueStream.h"
 #include "arcane/accelerator/core/internal/RunCommandImpl.h"
+#include "arcane/accelerator/core/internal/RunnerImpl.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -65,7 +66,7 @@ release()
 void ReduceMemoryImpl::
 _setReducePolicy()
 {
-  m_grid_memory_info.m_reduce_policy = m_command->runner()->deviceReducePolicy();
+  m_grid_memory_info.m_reduce_policy = m_command->runner()->reducePolicy();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunCommandImpl.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommandImpl.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommandImpl.cc                                           (C) 2000-2023 */
+/* RunCommandImpl.cc                                           (C) 2000-2024 */
 /*                                                                           */
 /* Implémentation de la gestion d'une commande sur accélérateur.             */
 /*---------------------------------------------------------------------------*/
@@ -24,6 +24,7 @@
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
 #include "arcane/accelerator/core/internal/ReduceMemoryImpl.h"
+#include "arcane/accelerator/core/internal/RunnerImpl.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -163,7 +164,7 @@ notifyEndExecuteKernel()
 
   Int64 diff_time_ns = m_stop_event->elapsedTime(m_start_event);
 
-  runner()->_addCommandTime((double)diff_time_ns / 1.0e9);
+  runner()->addTime((double)diff_time_ns / 1.0e9);
 
   ForLoopOneExecStat* exec_info = m_loop_one_exec_stat_ptr;
   if (exec_info) {
@@ -230,7 +231,7 @@ internalStream() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-Runner* RunCommandImpl::
+RunnerImpl* RunCommandImpl::
 runner() const
 {
   return m_queue->runner();

--- a/arcane/src/arcane/accelerator/core/RunQueue.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueue.cc
@@ -20,6 +20,7 @@
 #include "arcane/accelerator/core/IRunQueueEventImpl.h"
 #include "arcane/accelerator/core/Memory.h"
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
+#include "arcane/accelerator/core/internal/RunnerImpl.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -32,7 +33,7 @@ namespace Arcane::Accelerator
 
 RunQueue::
 RunQueue(Runner& runner)
-: m_p(impl::RunQueueImpl::create(&runner))
+: m_p(impl::RunQueueImpl::create(runner._impl()))
 {
 }
 
@@ -41,7 +42,7 @@ RunQueue(Runner& runner)
 
 RunQueue::
 RunQueue(Runner& runner, const RunQueueBuildInfo& bi)
-: m_p(impl::RunQueueImpl::create(&runner, bi))
+: m_p(impl::RunQueueImpl::create(runner._impl(), bi))
 {
 }
 
@@ -229,7 +230,7 @@ isAsync() const
 bool RunQueue::
 _isAutoPrefetchCommand() const
 {
-  return m_p->m_runner->_isAutoPrefetchCommand();
+  return m_p->m_runner_impl->isAutoPrefetchCommand();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunQueueEvent.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueEvent.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunQueueEvent.cc                                            (C) 2000-2022 */
+/* RunQueueEvent.cc                                            (C) 2000-2024 */
 /*                                                                           */
 /* Evènement sur une file d'exécution.                                       */
 /*---------------------------------------------------------------------------*/
@@ -15,6 +15,7 @@
 
 #include "arcane/accelerator/core/IRunQueueEventImpl.h"
 #include "arcane/accelerator/core/Runner.h"
+#include "arcane/accelerator/core/internal/RunnerImpl.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -28,7 +29,7 @@ namespace Arcane::Accelerator
 RunQueueEvent::
 RunQueueEvent(Runner& runner)
 {
-  m_p = runner._createEvent();
+  m_p = runner._impl()->_createEvent();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
@@ -21,6 +21,7 @@
 #include "arcane/accelerator/core/IRunQueueStream.h"
 #include "arcane/accelerator/core/DeviceId.h"
 #include "arcane/accelerator/core/internal/RunCommandImpl.h"
+#include "arcane/accelerator/core/internal/RunnerImpl.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -32,10 +33,10 @@ namespace Arcane::Accelerator::impl
 /*---------------------------------------------------------------------------*/
 
 RunQueueImpl::
-RunQueueImpl(Runner* runner, Int32 id, const RunQueueBuildInfo& bi)
-: m_runner(runner)
-, m_execution_policy(runner->executionPolicy())
-, m_runtime(runner->_internalRuntime())
+RunQueueImpl(RunnerImpl* runner_impl, Int32 id, const RunQueueBuildInfo& bi)
+: m_runner_impl(runner_impl)
+, m_execution_policy(runner_impl->executionPolicy())
+, m_runtime(runner_impl->runtime())
 , m_queue_stream(m_runtime->createStream(bi))
 , m_id(id)
 {
@@ -76,7 +77,7 @@ _release()
       std::cerr << "WARNING: Error in internal accelerator barrier\n";
   }
   if (_isInPool())
-    m_runner->_internalPutRunQueueImplInPool(this);
+    m_runner_impl->_internalPutRunQueueImplInPool(this);
   else{
     delete this;
   }
@@ -86,7 +87,7 @@ _release()
 /*---------------------------------------------------------------------------*/
 
 RunQueueImpl* RunQueueImpl::
-create(Runner* r)
+create(RunnerImpl* r)
 {
   return _reset(r->_internalCreateOrGetRunQueueImpl());
 }
@@ -95,7 +96,7 @@ create(Runner* r)
 /*---------------------------------------------------------------------------*/
 
 RunQueueImpl* RunQueueImpl::
-create(Runner* r, const RunQueueBuildInfo& bi)
+create(RunnerImpl* r, const RunQueueBuildInfo& bi)
 {
   return _reset(r->_internalCreateOrGetRunQueueImpl(bi));
 }

--- a/arcane/src/arcane/accelerator/core/Runner.cc
+++ b/arcane/src/arcane/accelerator/core/Runner.cc
@@ -27,6 +27,7 @@
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
 #include "arcane/accelerator/core/internal/AcceleratorCoreGlobalInternal.h"
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
+#include "arcane/accelerator/core/internal/RunnerImpl.h"
 
 #include <stack>
 #include <map>
@@ -78,170 +79,61 @@ namespace
   }
 } // namespace
 
+} // namespace Arcane::Accelerator
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-class Runner::Impl
+namespace Arcane::Accelerator::impl
 {
-  class RunQueueImplStack
-  {
-   public:
 
-    explicit RunQueueImplStack(Runner* runner)
-    : m_runner(runner)
-    {}
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
-   public:
+void RunnerImpl::
+initialize(Runner* runner, eExecutionPolicy v, DeviceId device)
+{
+  if (m_is_init)
+    ARCANE_FATAL("Runner is already initialized");
+  if (v == eExecutionPolicy::None)
+    ARCANE_THROW(ArgumentException, "executionPolicy should not be eExecutionPolicy::None");
+  if (device.isHost() || device.isNull())
+    ARCANE_THROW(ArgumentException, "device should not be Device::hostDevice() or Device::nullDevice()");
 
-    bool empty() const { return m_stack.empty(); }
-    void pop() { m_stack.pop(); }
-    impl::RunQueueImpl* top() { return m_stack.top(); }
-    void push(impl::RunQueueImpl* v) { m_stack.push(v); }
+  m_execution_policy = v;
+  m_device_id = device;
+  m_runtime = _getRuntime(v);
+  m_is_init = true;
+  m_is_auto_prefetch_command = false;
 
-   public:
+  // Pour test
+  if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_ACCELERATOR_PREFETCH_COMMAND", true))
+    m_is_auto_prefetch_command = (v.value() != 0);
 
-    impl::RunQueueImpl* createRunQueue(const RunQueueBuildInfo& bi)
-    {
-      Int32 x = ++m_nb_created;
-      auto* q = new impl::RunQueueImpl(m_runner, x, bi);
-      q->m_is_in_pool = true;
-      return q;
-    }
+  // Il faut initialiser le pool à la fin car il a besoin d'accéder à \a m_runtime
+  m_run_queue_pool = new RunQueueImplStack(runner);
+}
 
-   private:
-
-    std::stack<impl::RunQueueImpl*> m_stack;
-    std::atomic<Int32> m_nb_created = -1;
-    Runner* m_runner;
-  };
-
- public:
-
-  //! Verrou pour le pool de RunQueue en multi-thread.
-  class Lock
-  {
-   public:
-
-    explicit Lock(Impl* p)
-    {
-      if (p->m_use_pool_mutex) {
-        m_mutex = p->m_pool_mutex.get();
-        if (m_mutex)
-          m_mutex->lock();
-      }
-    }
-    ~Lock()
-    {
-      if (m_mutex)
-        m_mutex->unlock();
-    }
-    Lock(const Lock&) = delete;
-    Lock& operator=(const Lock&) = delete;
-
-   private:
-
-    std::mutex* m_mutex = nullptr;
-  };
-
- public:
-
-  ~Impl()
-  {
-    _freePool(m_run_queue_pool);
-    delete m_run_queue_pool;
+void RunnerImpl::
+_freePool(RunQueueImplStack* s)
+{
+  if (!s)
+    return;
+  while (!s->empty()) {
+    delete s->top();
+    s->pop();
   }
+}
 
- public:
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+}
 
-  void initialize(Runner* runner, eExecutionPolicy v, DeviceId device)
-  {
-    if (m_is_init)
-      ARCANE_FATAL("Runner is already initialized");
-    if (v == eExecutionPolicy::None)
-      ARCANE_THROW(ArgumentException, "executionPolicy should not be eExecutionPolicy::None");
-    if (device.isHost() || device.isNull())
-      ARCANE_THROW(ArgumentException, "device should not be Device::hostDevice() or Device::nullDevice()");
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
-    m_execution_policy = v;
-    m_device_id = device;
-    m_runtime = _getRuntime(v);
-    m_is_init = true;
-    m_is_auto_prefetch_command = false;
-
-    // Pour test
-    if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_ACCELERATOR_PREFETCH_COMMAND", true))
-      m_is_auto_prefetch_command = (v.value() != 0);
-
-    // Il faut initialiser le pool à la fin car il a besoin d'accéder à \a m_runtime
-    m_run_queue_pool = new RunQueueImplStack(runner);
-  }
-
-  void setConcurrentQueueCreation(bool v)
-  {
-    m_use_pool_mutex = v;
-    if (!m_pool_mutex.get())
-      m_pool_mutex = std::make_unique<std::mutex>();
-  }
-  bool isConcurrentQueueCreation() const { return m_use_pool_mutex; }
-
- public:
-
-  RunQueueImplStack* getPool()
-  {
-    if (!m_run_queue_pool)
-      ARCANE_FATAL("Runner is not initialized");
-    return m_run_queue_pool;
-  }
-  void addTime(double v)
-  {
-    // 'v' est en seconde. On le convertit en nanosecond.
-    Int64 x = static_cast<Int64>(v * 1.0e9);
-    m_cumulative_command_time += x;
-  }
-  double cumulativeCommandTime() const
-  {
-    Int64 x = m_cumulative_command_time;
-    return static_cast<double>(x) / 1.0e9;
-  }
-
-  impl::IRunnerRuntime* runtime() const { return m_runtime; }
-  bool isAutoPrefetchCommand() const { return m_is_auto_prefetch_command; }
-
- public:
-
-  //TODO: mettre à None lorsqu'on aura supprimé Runner::setExecutionPolicy()
-  eExecutionPolicy m_execution_policy = eExecutionPolicy::None;
-  bool m_is_init = false;
-  eDeviceReducePolicy m_reduce_policy = eDeviceReducePolicy::Grid;
-  DeviceId m_device_id;
-
- private:
-
-  impl::IRunnerRuntime* m_runtime = nullptr;
-  RunQueueImplStack* m_run_queue_pool = nullptr;
-  std::unique_ptr<std::mutex> m_pool_mutex;
-  bool m_use_pool_mutex = false;
-  /*!
-   * \brief Temps passé dans le noyau en nano-seconde. On utilise un 'Int64'
-   * car les atomiques sur les flottants ne sont pas supportés partout.
-   */
-  std::atomic<Int64> m_cumulative_command_time = 0;
-
-  //! Indique si on pré-copie les données avant une commande de cette RunQueue
-  bool m_is_auto_prefetch_command = false;
-
- private:
-
-  void _freePool(RunQueueImplStack* s)
-  {
-    if (!s)
-      return;
-    while (!s->empty()) {
-      delete s->top();
-      s->pop();
-    }
-  }
-};
+namespace Arcane::Accelerator
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -251,7 +143,7 @@ class Runner::Impl
 
 Runner::
 Runner()
-: m_p(std::make_shared<Impl>())
+: m_p(std::make_shared<impl::RunnerImpl>())
 {
 }
 
@@ -284,6 +176,7 @@ Runner(eExecutionPolicy p, DeviceId device_id)
 impl::IRunnerRuntime* Runner::
 _internalRuntime() const
 {
+  _checkIsInit();
   return m_p->runtime();
 }
 
@@ -298,7 +191,7 @@ _internalCreateOrGetRunQueueImpl()
   auto pool = m_p->getPool();
 
   {
-    Impl::Lock my_lock(m_p.get());
+    impl::RunnerImpl::Lock my_lock(m_p.get());
     if (!pool->empty()) {
       impl::RunQueueImpl* p = pool->top();
       pool->pop();
@@ -332,7 +225,7 @@ _internalCreateOrGetRunQueueImpl(const RunQueueBuildInfo& bi)
 void Runner::
 _internalPutRunQueueImplInPool(impl::RunQueueImpl* p)
 {
-  Impl::Lock my_lock(m_p.get());
+  impl::RunnerImpl::Lock my_lock(m_p.get());
   m_p->getPool()->push(p);
 }
 
@@ -342,7 +235,7 @@ _internalPutRunQueueImplInPool(impl::RunQueueImpl* p)
 eExecutionPolicy Runner::
 executionPolicy() const
 {
-  return m_p->m_execution_policy;
+  return m_p->executionPolicy();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -351,7 +244,7 @@ executionPolicy() const
 bool Runner::
 isInitialized() const
 {
-  return m_p->m_is_init;
+  return m_p->isInit();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/Runner.h
+++ b/arcane/src/arcane/accelerator/core/Runner.h
@@ -55,7 +55,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT Runner
   friend impl::RunCommandImpl;
   friend RunQueue;
   friend RunQueueEvent;
-  class Impl;
+  friend impl::RunnerImpl;
 
  public:
 
@@ -157,7 +157,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT Runner
 
  private:
 
-  std::shared_ptr<Impl> m_p;
+  std::shared_ptr<impl::RunnerImpl> m_p;
 
  private:
 

--- a/arcane/src/arcane/accelerator/core/Runner.h
+++ b/arcane/src/arcane/accelerator/core/Runner.h
@@ -143,17 +143,12 @@ class ARCANE_ACCELERATOR_CORE_EXPORT Runner
    * \internal
    * \brief Stoppe toutes les activités de profiling.
    */
-   static void stopAllProfiling();
+  static void stopAllProfiling();
 
  private:
 
-  impl::RunQueueImpl* _internalCreateOrGetRunQueueImpl();
-  impl::RunQueueImpl* _internalCreateOrGetRunQueueImpl(const RunQueueBuildInfo& bi);
-  void _internalPutRunQueueImplInPool(impl::RunQueueImpl*);
-  impl::IRunQueueEventImpl* _createEvent();
-  impl::IRunQueueEventImpl* _createEventWithTimer();
-  void _addCommandTime(double v);
   impl::IRunnerRuntime* _internalRuntime() const;
+  impl::RunnerImpl* _impl() const { return m_p.get(); }
 
  private:
 

--- a/arcane/src/arcane/accelerator/core/internal/RunCommandImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunCommandImpl.h
@@ -64,7 +64,7 @@ class RunCommandImpl
 
   void releaseReduceMemoryImpl(ReduceMemoryImpl* p);
   IRunQueueStream* internalStream() const;
-  Runner* runner() const;
+  RunnerImpl* runner() const;
 
  private:
 

--- a/arcane/src/arcane/accelerator/core/internal/RunQueueImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunQueueImpl.h
@@ -38,6 +38,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueueImpl
   friend class Arcane::Accelerator::Runner;
   friend class Arcane::Accelerator::RunQueue;
   friend class RunCommandImpl;
+  friend class RunQueueImplStack;
 
  private:
 

--- a/arcane/src/arcane/accelerator/core/internal/RunQueueImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunQueueImpl.h
@@ -39,10 +39,11 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueueImpl
   friend class Arcane::Accelerator::RunQueue;
   friend class RunCommandImpl;
   friend class RunQueueImplStack;
+  friend class RunnerImpl;
 
  private:
 
-  RunQueueImpl(Runner* runner, Int32 id, const RunQueueBuildInfo& bi);
+  RunQueueImpl(RunnerImpl* runner_impl, Int32 id, const RunQueueBuildInfo& bi);
 
  public:
 
@@ -57,13 +58,13 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueueImpl
 
  public:
 
-  static RunQueueImpl* create(Runner* r, const RunQueueBuildInfo& bi);
-  static RunQueueImpl* create(Runner* r);
+  static RunQueueImpl* create(RunnerImpl* r, const RunQueueBuildInfo& bi);
+  static RunQueueImpl* create(RunnerImpl* r);
 
  public:
 
   eExecutionPolicy executionPolicy() const { return m_execution_policy; }
-  Runner* runner() const { return m_runner; }
+  RunnerImpl* runner() const { return m_runner_impl; }
 
  public:
 
@@ -91,10 +92,10 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueueImpl
 
  private:
 
-  Runner* m_runner;
+  RunnerImpl* m_runner_impl = nullptr;
   eExecutionPolicy m_execution_policy;
-  IRunnerRuntime* m_runtime;
-  IRunQueueStream* m_queue_stream;
+  IRunnerRuntime* m_runtime = nullptr;
+  IRunQueueStream* m_queue_stream = nullptr;
   //! Pool de commandes
   std::stack<RunCommandImpl*> m_run_command_pool;
   //! Liste des commandes en cours d'exécution

--- a/arcane/src/arcane/accelerator/core/internal/RunnerImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunnerImpl.h
@@ -1,0 +1,175 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* RunnerImpl.h                                                (C) 2000-2024 */
+/*                                                                           */
+/* Implémentation d'une 'RunQueue'.                                          */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_ACCELERATOR_CORE_INTERNAL_RUNNERIMPL_H
+#define ARCANE_ACCELERATOR_CORE_INTERNAL_RUNNERIMPL_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/accelerator/core/AcceleratorCoreGlobal.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator::impl
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class RunQueueImplStack
+{
+ public:
+
+  explicit RunQueueImplStack(Runner* runner)
+  : m_runner(runner)
+  {}
+
+ public:
+
+  bool empty() const { return m_stack.empty(); }
+  void pop() { m_stack.pop(); }
+  impl::RunQueueImpl* top() { return m_stack.top(); }
+  void push(impl::RunQueueImpl* v) { m_stack.push(v); }
+
+ public:
+
+  impl::RunQueueImpl* createRunQueue(const RunQueueBuildInfo& bi)
+  {
+    Int32 x = ++m_nb_created;
+    auto* q = new impl::RunQueueImpl(m_runner, x, bi);
+    q->m_is_in_pool = true;
+    return q;
+  }
+
+ private:
+
+  std::stack<impl::RunQueueImpl*> m_stack;
+  std::atomic<Int32> m_nb_created = -1;
+  Runner* m_runner;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class RunnerImpl
+{
+  friend ::Arcane::Accelerator::Runner;
+
+ public:
+
+  //! Verrou pour le pool de RunQueue en multi-thread.
+  class Lock
+  {
+   public:
+
+    explicit Lock(RunnerImpl* p)
+    {
+      if (p->m_use_pool_mutex) {
+        m_mutex = p->m_pool_mutex.get();
+        if (m_mutex)
+          m_mutex->lock();
+      }
+    }
+    ~Lock()
+    {
+      if (m_mutex)
+        m_mutex->unlock();
+    }
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+
+   private:
+
+    std::mutex* m_mutex = nullptr;
+  };
+
+ public:
+
+  ~RunnerImpl()
+  {
+    _freePool(m_run_queue_pool);
+    delete m_run_queue_pool;
+  }
+
+ public:
+
+  void initialize(Runner* runner, eExecutionPolicy v, DeviceId device);
+
+  void setConcurrentQueueCreation(bool v)
+  {
+    m_use_pool_mutex = v;
+    if (!m_pool_mutex.get())
+      m_pool_mutex = std::make_unique<std::mutex>();
+  }
+  bool isConcurrentQueueCreation() const { return m_use_pool_mutex; }
+
+ public:
+
+  RunQueueImplStack* getPool()
+  {
+    if (!m_run_queue_pool)
+      ARCANE_FATAL("Runner is not initialized");
+    return m_run_queue_pool;
+  }
+  void addTime(double v)
+  {
+    // 'v' est en seconde. On le convertit en nanosecond.
+    Int64 x = static_cast<Int64>(v * 1.0e9);
+    m_cumulative_command_time += x;
+  }
+  double cumulativeCommandTime() const
+  {
+    Int64 x = m_cumulative_command_time;
+    return static_cast<double>(x) / 1.0e9;
+  }
+
+  impl::IRunnerRuntime* runtime() const { return m_runtime; }
+  bool isAutoPrefetchCommand() const { return m_is_auto_prefetch_command; }
+
+  eExecutionPolicy executionPolicy() const { return m_execution_policy; }
+  bool isInit() const { return m_is_init; }
+  eDeviceReducePolicy reducePolicy() const { return m_reduce_policy; }
+  DeviceId deviceId() const { return m_device_id; }
+
+ private:
+
+  eExecutionPolicy m_execution_policy = eExecutionPolicy::None;
+  bool m_is_init = false;
+  eDeviceReducePolicy m_reduce_policy = eDeviceReducePolicy::Grid;
+  DeviceId m_device_id;
+  impl::IRunnerRuntime* m_runtime = nullptr;
+  RunQueueImplStack* m_run_queue_pool = nullptr;
+  std::unique_ptr<std::mutex> m_pool_mutex;
+  bool m_use_pool_mutex = false;
+  /*!
+   * \brief Temps passé dans le noyau en nano-seconde. On utilise un 'Int64'
+   * car les atomiques sur les flottants ne sont pas supportés partout.
+   */
+  std::atomic<Int64> m_cumulative_command_time = 0;
+
+  //! Indique si on pré-copie les données avant une commande de cette RunQueue
+  bool m_is_auto_prefetch_command = false;
+
+ private:
+
+  void _freePool(RunQueueImplStack* s);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::impl
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/accelerator/core/srcs.cmake
+++ b/arcane/src/arcane/accelerator/core/srcs.cmake
@@ -37,4 +37,5 @@ set( ARCANE_SOURCES
   internal/RunCommandImpl.h
   internal/RunQueueImpl.h
   internal/ReduceMemoryImpl.h
+  internal/RunnerImpl.h
 )


### PR DESCRIPTION
Rename `Runner::Impl` to `RunnerImpl` and keep instances of `RunnerImpl*` instead of `Runner*`.
Now that we can copy values of `Runner`, this is not safe to keep instances of `Runner*` because they may come from temporary objects.