### PR TITLE
Update MeshTimeHistoryAdder and add GlobalTimeHistoryAdder

### DIFF
--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
@@ -26,7 +26,9 @@ namespace Arcane
 GlobalTimeHistoryAdder::
 GlobalTimeHistoryAdder(ITimeHistoryMng* time_history_mng)
 : m_thm(time_history_mng)
-{}
+{
+  m_thm->_internalApi()->setIOMasterWriteOnly(true);
+}
 
 void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)

--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
@@ -24,8 +24,8 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 GlobalTimeHistoryAdder::
-GlobalTimeHistoryAdder(ITimeHistoryMng* thm)
-: m_thm(thm)
+GlobalTimeHistoryAdder(ITimeHistoryMng* time_history_mng)
+: m_thm(time_history_mng)
 {}
 
 void GlobalTimeHistoryAdder::

--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshTimeHistoryAdder.cc                                     (C) 2000-2024 */
+/* GlobalTimeHistoryAdder.cc                                   (C) 2000-2024 */
 /*                                                                           */
-/* Classe permettant d'ajouter un historique de valeur lié à un maillage.    */
+/* Classe permettant d'ajouter un historique de valeur global.               */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/core/MeshTimeHistoryAdder.h"
+#include "arcane/core/GlobalTimeHistoryAdder.h"
 #include "arcane/core/internal/ITimeHistoryMngInternal.h"
 
 /*---------------------------------------------------------------------------*/
@@ -23,58 +23,57 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-MeshTimeHistoryAdder::
-MeshTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm, const MeshHandle& mesh_handle)
+GlobalTimeHistoryAdder::
+GlobalTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm)
 : m_thm(thm)
 , m_pm(pm)
-, m_mesh_handle(mesh_handle)
 {}
 
-void MeshTimeHistoryAdder::
+void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)
 {
   if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
+    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
   }
 }
 
-void MeshTimeHistoryAdder::
+void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int64 value)
 {
   if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
+    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
   }
 }
 
-void MeshTimeHistoryAdder::
+void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int32 value)
 {
   if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
+    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
   }
 }
 
-void MeshTimeHistoryAdder::
+void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, RealConstArrayView values)
 {
   if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
+    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
   }
 }
 
-void MeshTimeHistoryAdder::
+void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int32ConstArrayView values)
 {
   if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
+    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
   }
 }
 
-void MeshTimeHistoryAdder::
+void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values)
 {
   if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
+    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
   }
 }
 

--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.cc
@@ -24,57 +24,44 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 GlobalTimeHistoryAdder::
-GlobalTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm)
+GlobalTimeHistoryAdder(ITimeHistoryMng* thm)
 : m_thm(thm)
-, m_pm(pm)
 {}
 
 void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
 }
 
 void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int64 value)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
 }
 
 void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int32 value)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), value);
 }
 
 void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, RealConstArrayView values)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
 }
 
 void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int32ConstArrayView values)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
 }
 
 void GlobalTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp), values);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
@@ -15,7 +15,6 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/core/ITimeHistoryAdder.h"
-#include "arcane/core/IParallelMng.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -30,7 +29,7 @@ class ARCANE_CORE_EXPORT GlobalTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
-  GlobalTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm);
+  explicit GlobalTimeHistoryAdder(ITimeHistoryMng* thm);
   ~GlobalTimeHistoryAdder() override = default;
 
  public:
@@ -43,7 +42,6 @@ class ARCANE_CORE_EXPORT GlobalTimeHistoryAdder
 
  private:
   ITimeHistoryMng* m_thm;
-  IParallelMng* m_pm;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
@@ -5,18 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshTimeHistoryAdder.h                                      (C) 2000-2024 */
+/* GlobalTimeHistoryAdder.h                                    (C) 2000-2024 */
 /*                                                                           */
-/* Classe permettant d'ajouter un historique de valeur lié à un maillage.    */
+/* Classe permettant d'ajouter un historique de valeur global.               */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_CORE_MESHTIMEHISTORYADDER_H
-#define ARCANE_CORE_MESHTIMEHISTORYADDER_H
+#ifndef ARCANE_CORE_GLOBALTIMEHISTORYADDER_H
+#define ARCANE_CORE_GLOBALTIMEHISTORYADDER_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/core/ITimeHistoryAdder.h"
 #include "arcane/core/IParallelMng.h"
-#include "arcane/core/MeshHandle.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -27,12 +26,12 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
+class ARCANE_CORE_EXPORT GlobalTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
-  MeshTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm, const MeshHandle& mesh_handle);
-  ~MeshTimeHistoryAdder() override = default;
+  GlobalTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm);
+  ~GlobalTimeHistoryAdder() override = default;
 
  public:
   void addValue(const TimeHistoryAddValueArg& thp, Real value) override;
@@ -45,7 +44,6 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
  private:
   ITimeHistoryMng* m_thm;
   IParallelMng* m_pm;
-  MeshHandle m_mesh_handle;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
@@ -55,6 +55,7 @@ class ARCANE_CORE_EXPORT GlobalTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
+
   /*!
    * \brief Constructeur.
    *
@@ -64,6 +65,7 @@ class ARCANE_CORE_EXPORT GlobalTimeHistoryAdder
   ~GlobalTimeHistoryAdder() override = default;
 
  public:
+
   void addValue(const TimeHistoryAddValueArg& thp, Real value) override;
   void addValue(const TimeHistoryAddValueArg& thp, Int32 value) override;
   void addValue(const TimeHistoryAddValueArg& thp, Int64 value) override;
@@ -72,6 +74,7 @@ class ARCANE_CORE_EXPORT GlobalTimeHistoryAdder
   void addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values) override;
 
  private:
+
   ITimeHistoryMng* m_thm;
 };
 

--- a/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/GlobalTimeHistoryAdder.h
@@ -25,11 +25,42 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*!
+ * \brief Classe permettant d'ajouter une ou plusieurs valeurs à un
+ * historique de valeurs.
+ *
+ * Cette classe enregistrera les courbes de manière globale, sans support.
+ * C'est-à-dire que les courbes ne seront liée qu'au domaine complet ou au
+ * sous-domaine demandé, par opposition au MeshTimeHistoryAdder qui lie les
+ * courbes au maillage désiré.
+ *
+ * Pour un nom d'historique donné, il ne peut y avoir qu'une courbe de une
+ * ou plusieurs valeurs par sous-domaine (et une globale à tous les
+ * sous-domaines).
+ *
+ * Exemple : plusieurs courbes de moyennes des pressions (appelons-les
+ * "avg_pressure") et deux sous-domaines (0 et 1). Une valeur par itération.
+ * - Une courbe "avg_pressure" liée au sous-domaine 0. Chaque valeur est la
+ *   moyenne des pressions de chaque maille du sous-domaine 0.
+ * - Une courbe "avg_pressure" liée au sous-domaine 1. Chaque valeur est la
+ *   moyenne des pressions de chaque maille du sous-domaine 1.
+ * - Une courbe "avg_pressure" liée au domaine complet. Chaque valeur est la
+ *   moyenne des pressions de chaque sous-domaine.
+ *
+ * On peut remarquer qu'il est possible d'avoir plusieurs courbes
+ * indépendantes avec le même nom mais liée à des sous-domaines différents
+ * (+1 courbe globale).
+ */
 class ARCANE_CORE_EXPORT GlobalTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
-  explicit GlobalTimeHistoryAdder(ITimeHistoryMng* thm);
+  /*!
+   * \brief Constructeur.
+   *
+   * \param time_history_mng Un pointeur vers une instance de ITimeHistoryMng.
+   */
+  explicit GlobalTimeHistoryAdder(ITimeHistoryMng* time_history_mng);
   ~GlobalTimeHistoryAdder() override = default;
 
  public:

--- a/arcane/src/arcane/core/ITimeHistoryAdder.h
+++ b/arcane/src/arcane/core/ITimeHistoryAdder.h
@@ -38,6 +38,11 @@ class ITimeHistoryAdder
 
  public:
   virtual void addValue(const TimeHistoryAddValueArg& thp, Real value) = 0;
+  virtual void addValue(const TimeHistoryAddValueArg& thp, Int32 value) = 0;
+  virtual void addValue(const TimeHistoryAddValueArg& thp, Int64 value) = 0;
+  virtual void addValue(const TimeHistoryAddValueArg& thp, RealConstArrayView values) = 0;
+  virtual void addValue(const TimeHistoryAddValueArg& thp, Int32ConstArrayView values) = 0;
+  virtual void addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ITimeHistoryAdder.h
+++ b/arcane/src/arcane/core/ITimeHistoryAdder.h
@@ -31,17 +31,62 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*!
+ * \brief Interface de classe permettant d'ajouter une ou plusieurs valeurs
+ * à un historique de valeurs.
+ */
 class ITimeHistoryAdder
 {
  public:
   virtual ~ITimeHistoryAdder() = default; //!< Libère les ressources
 
  public:
+  /*!
+   * \brief Méthode permettant d'ajouter une valeur à un historique.
+   *
+   * \param thpi Les paramètres de la valeur.
+   * \param value La valeur à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArg& thp, Real value) = 0;
+
+  /*!
+   * \brief Méthode permettant d'ajouter une valeur à un historique.
+   *
+   * \param thpi Les paramètres de la valeur.
+   * \param value La valeur à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArg& thp, Int32 value) = 0;
+
+  /*!
+   * \brief Méthode permettant d'ajouter une valeur à un historique.
+   *
+   * \param thpi Les paramètres de la valeur.
+   * \param value La valeur à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArg& thp, Int64 value) = 0;
+
+  /*!
+   * \brief Méthode permettant d'ajouter des valeurs à un historique.
+   *
+   * \param thpi Les paramètres des valeurs.
+   * \param value Les valeurs à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArg& thp, RealConstArrayView values) = 0;
+
+  /*!
+   * \brief Méthode permettant d'ajouter des valeurs à un historique.
+   *
+   * \param thpi Les paramètres des valeurs.
+   * \param value Les valeurs à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArg& thp, Int32ConstArrayView values) = 0;
+
+  /*!
+   * \brief Méthode permettant d'ajouter des valeurs à un historique.
+   *
+   * \param thpi Les paramètres des valeurs.
+   * \param value Les valeurs à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values) = 0;
 };
 

--- a/arcane/src/arcane/core/ITimeHistoryAdder.h
+++ b/arcane/src/arcane/core/ITimeHistoryAdder.h
@@ -38,9 +38,11 @@ namespace Arcane
 class ITimeHistoryAdder
 {
  public:
+
   virtual ~ITimeHistoryAdder() = default; //!< Libère les ressources
 
  public:
+
   /*!
    * \brief Méthode permettant d'ajouter une valeur à un historique.
    *
@@ -93,10 +95,9 @@ class ITimeHistoryAdder
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-}
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
-
+#endif

--- a/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
+++ b/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
@@ -42,15 +42,32 @@ class TimeHistoryCurveInfo
 {
  public:
 
-  TimeHistoryCurveInfo(const String& aname,Int32ConstArrayView aiterations,
-                       RealConstArrayView avalues,Integer sub_size)
-  : m_name(aname), m_iterations(aiterations), m_values(avalues),
-    m_sub_size(sub_size){}
+  TimeHistoryCurveInfo(const String& aname, Int32ConstArrayView aiterations,
+                       RealConstArrayView avalues, Integer sub_size)
+  : m_name(aname)
+  , m_support()
+  , m_has_support(false)
+  , m_iterations(aiterations)
+  , m_values(avalues)
+  , m_sub_size(sub_size)
+  {}
+
+  TimeHistoryCurveInfo(const String& aname, const String& asupport, Int32ConstArrayView aiterations,
+                       RealConstArrayView avalues, Integer sub_size)
+  : m_name(aname)
+  , m_support(asupport)
+  , m_has_support(true)
+  , m_iterations(aiterations)
+  , m_values(avalues)
+  , m_sub_size(sub_size)
+  {}
 
  public:
 
   //! Nom de la courbe
   const String& name() const { return m_name; }
+  const String& support() const { return m_support; }
+  bool hasSupport() const { return m_has_support; }
   //! Liste des itérations
   Int32ConstArrayView iterations() const { return m_iterations; }
   //! Liste des valeurs de la courbe
@@ -64,6 +81,8 @@ class TimeHistoryCurveInfo
  private:
 #endif
   String m_name;
+  String m_support;
+  bool m_has_support;
   Int32ConstArrayView m_iterations;
   RealConstArrayView m_values;
   Integer m_sub_size;

--- a/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
+++ b/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ITimeHistoryCurveWriter2.h                                  (C) 2000-2018 */
+/* ITimeHistoryCurveWriter2.h                                  (C) 2000-2024 */
 /*                                                                           */
 /* Interface d'un écrivain d'une courbe d'un historique (Version 2).         */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
+++ b/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
@@ -50,6 +50,18 @@ class TimeHistoryCurveInfo
   , m_iterations(aiterations)
   , m_values(avalues)
   , m_sub_size(sub_size)
+  , m_sub_domain(-1)
+  {}
+
+  TimeHistoryCurveInfo(const String& aname, Int32ConstArrayView aiterations,
+                       RealConstArrayView avalues, Integer sub_size, Integer sub_domain)
+  : m_name(aname)
+  , m_support()
+  , m_has_support(false)
+  , m_iterations(aiterations)
+  , m_values(avalues)
+  , m_sub_size(sub_size)
+  , m_sub_domain(sub_domain)
   {}
 
   TimeHistoryCurveInfo(const String& aname, const String& asupport, Int32ConstArrayView aiterations,
@@ -60,6 +72,18 @@ class TimeHistoryCurveInfo
   , m_iterations(aiterations)
   , m_values(avalues)
   , m_sub_size(sub_size)
+  , m_sub_domain(-1)
+  {}
+
+  TimeHistoryCurveInfo(const String& aname, const String& asupport, Int32ConstArrayView aiterations,
+                       RealConstArrayView avalues, Integer sub_size, Integer sub_domain)
+  : m_name(aname)
+  , m_support(asupport)
+  , m_has_support(true)
+  , m_iterations(aiterations)
+  , m_values(avalues)
+  , m_sub_size(sub_size)
+  , m_sub_domain(sub_domain)
   {}
 
  public:
@@ -74,6 +98,8 @@ class TimeHistoryCurveInfo
   RealConstArrayView values() const { return m_values; }
   //! Nombre de valeur par temps
   Integer subSize() const { return m_sub_size; }
+  // TODO nom pas terrible
+  Integer subDomain() const { return m_sub_domain; }
 
 #if ARCANE_ALLOW_CURVE_WRITER_PRIVATE_ACCESS
  public:
@@ -86,6 +112,7 @@ class TimeHistoryCurveInfo
   Int32ConstArrayView m_iterations;
   RealConstArrayView m_values;
   Integer m_sub_size;
+  Integer m_sub_domain;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
+++ b/arcane/src/arcane/core/ITimeHistoryCurveWriter2.h
@@ -103,6 +103,7 @@ class TimeHistoryCurveInfo
 
 #if ARCANE_ALLOW_CURVE_WRITER_PRIVATE_ACCESS
  public:
+
 #else
  private:
 #endif
@@ -124,8 +125,10 @@ class TimeHistoryCurveWriterInfo
 {
  public:
 
-  TimeHistoryCurveWriterInfo(const String& apath,RealConstArrayView atimes)
-  : m_path(apath), m_times(atimes){}
+  TimeHistoryCurveWriterInfo(const String& apath, RealConstArrayView atimes)
+  : m_path(apath)
+  , m_times(atimes)
+  {}
 
  public:
 
@@ -139,6 +142,7 @@ class TimeHistoryCurveWriterInfo
 
 #if ARCANE_ALLOW_CURVE_WRITER_PRIVATE_ACCESS
  public:
+
 #else
  private:
 #endif
@@ -166,22 +170,22 @@ class ITimeHistoryCurveWriter2
  public:
 
   //! Libère les ressources
-  virtual ~ITimeHistoryCurveWriter2(){}
+  virtual ~ITimeHistoryCurveWriter2() {}
 
  public:
-	
-  virtual void build() =0;
-  
+
+  virtual void build() = 0;
+
   /*!
    * \brief Notifie un début d'écriture.
    */
-  virtual void beginWrite(const TimeHistoryCurveWriterInfo& infos) =0;
+  virtual void beginWrite(const TimeHistoryCurveWriterInfo& infos) = 0;
 
   /*!
    * \brief Notifie la fin de l'écriture.
    */
-  virtual void endWrite() =0;
-  
+  virtual void endWrite() = 0;
+
   /*!
    * \brief Ecrit une courbe.
    *
@@ -191,10 +195,10 @@ class ITimeHistoryCurveWriter2
    * chaque valeur.
    * \a path contient le répertoire où seront écrites les courbes
    */
-  virtual void writeCurve(const TimeHistoryCurveInfo& infos) =0;
+  virtual void writeCurve(const TimeHistoryCurveInfo& infos) = 0;
 
   //! Nom de l'écrivain
-  virtual String name() const =0;
+  virtual String name() const = 0;
 
   /*!
    * \brief Répertoire de base où seront écrites les courbes.
@@ -202,10 +206,10 @@ class ITimeHistoryCurveWriter2
    * Si nul, c'est le répertoire spécifié lors de beginWrite()
    * qui est utilisé.
    */
-  virtual void setOutputPath(const String& path) =0;
+  virtual void setOutputPath(const String& path) = 0;
 
   //! Répertoire de base où seront écrites les courbes.
-  virtual String outputPath() const =0;
+  virtual String outputPath() const = 0;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -216,5 +220,4 @@ ARCANE_END_NAMESPACE
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
-
+#endif

--- a/arcane/src/arcane/core/ITimeHistoryMng.h
+++ b/arcane/src/arcane/core/ITimeHistoryMng.h
@@ -107,7 +107,7 @@ class ITimeHistoryMng
 {
  public:
 
-  virtual ~ITimeHistoryMng() {} //!< Libère les ressources
+  virtual ~ITimeHistoryMng() = default; //!< Libère les ressources
 
  public:
 

--- a/arcane/src/arcane/core/ITimeHistoryMng.h
+++ b/arcane/src/arcane/core/ITimeHistoryMng.h
@@ -32,27 +32,30 @@ namespace Arcane
 class TimeHistoryAddValueArg
 {
  public:
-  TimeHistoryAddValueArg(const String& name, bool end_time, bool is_local)
+  TimeHistoryAddValueArg(const String& name, Integer local_proc_id, bool end_time)
   : m_name(name)
   , m_end_time(end_time)
-  , m_is_local(is_local)
+  , m_local_proc_id(local_proc_id)
+  {}
+
+  TimeHistoryAddValueArg(const String& name, Integer local_proc_id)
+  : TimeHistoryAddValueArg(name, local_proc_id, true)
   {}
 
   explicit TimeHistoryAddValueArg(const String& name)
-  : m_name(name)
-  , m_end_time(true)
-  , m_is_local(false)
+  : TimeHistoryAddValueArg(name, -1)
   {}
 
  public:
   const String& name() const { return m_name; }
   bool endTime() const { return m_end_time; }
-  bool isLocal() const { return m_is_local; }
+  bool isLocal() const { return m_local_proc_id!=-1; }
+  Integer localProcId() const { return m_local_proc_id; }
 
  private:
   String m_name;
   bool m_end_time;
-  bool m_is_local;
+  Integer m_local_proc_id;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ITimeHistoryMng.h
+++ b/arcane/src/arcane/core/ITimeHistoryMng.h
@@ -33,16 +33,39 @@ class TimeHistoryAddValueArg
 {
  public:
 
+  /*!
+   * \brief Constructeur avec trois paramètres.
+   *
+   * \param name Le nom de la courbe.
+   * \param end_time Doit-on écrire la valeur à notre itération ou à notre itération-1 ?
+   * \param local_proc_id Le processus qui doit sauver la valeur (-1 pour global).
+   */
   TimeHistoryAddValueArg(const String& name, bool end_time, Integer local_proc_id)
   : m_name(name)
   , m_end_time(end_time)
   , m_local_proc_id(local_proc_id)
   {}
 
+  /*!
+   * \brief Constructeur avec deux paramètres.
+   *
+   * La valeur sera sauvegardé globalement, et non sur un sous-domaine en particulier.
+   *
+   * \param name Le nom de la courbe.
+   * \param end_time Doit-on écrire la valeur à notre itération ou à notre itération-1 ?
+   */
   TimeHistoryAddValueArg(const String& name, bool end_time)
   : TimeHistoryAddValueArg(name, end_time, -1)
   {}
 
+  /*!
+   * \brief Constructeur avec un paramètre.
+   *
+   * La valeur sera sauvegardé globalement, et non sur un sous-domaine en particulier.
+   * La valeur sera sauvegardé à notre itération.
+   *
+   * \param name Le nom de la courbe.
+   */
   explicit TimeHistoryAddValueArg(const String& name)
   : TimeHistoryAddValueArg(name, true)
   {}
@@ -114,6 +137,8 @@ class ITimeHistoryMng
   // TODO Deprecated
   /*! \brief Ajoute la valeur \a value à l'historique \a name.
    *
+   * \deprecated Cette méthode est dépréciée et est remplacée par l'utilisation de l'objet GlobalTimeHistoryAdder.
+   *
    * La valeur est celle au temps de fin de l'itération si \a end_time est vrai,
    * au début sinon.
    * le booleen is_local indique si la courbe est propre au process ou pas pour pouvoir écrire des courbes meme
@@ -121,6 +146,8 @@ class ITimeHistoryMng
    */
   virtual void addValue(const String& name, Real value, bool end_time = true, bool is_local = false) = 0;
   /*! \brief Ajoute la valeur \a value à l'historique \a name.
+   *
+   * \deprecated Cette méthode est dépréciée et est remplacée par l'utilisation de l'objet GlobalTimeHistoryAdder.
    *
    * La valeur est celle au temps de fin de l'itération si \a end_time est vrai,
    * au début sinon.
@@ -130,6 +157,8 @@ class ITimeHistoryMng
   virtual void addValue(const String& name, Int32 value, bool end_time = true, bool is_local = false) = 0;
   /*! Ajoute la valeur \a value à l'historique \a name.
    *
+   * \deprecated Cette méthode est dépréciée et est remplacée par l'utilisation de l'objet GlobalTimeHistoryAdder.
+   *
    * La valeur est celle au temps de fin de l'itération si \a end_time est vrai,
    * au début sinon.
    * le booleen is_local indique si la courbe est propre au process ou pas pour pouvoir écrire des courbes meme
@@ -137,6 +166,8 @@ class ITimeHistoryMng
    */
   virtual void addValue(const String& name, Int64 value, bool end_time = true, bool is_local = false) = 0;
   /*! \brief Ajoute la valeur \a value à l'historique \a name.
+   *
+   * \deprecated Cette méthode est dépréciée et est remplacée par l'utilisation de l'objet GlobalTimeHistoryAdder.
    *
    * Le nombre d'éléments de \a value doit être constant au cours du temps.
    * La valeur est celle au temps de fin de l'itération si \a end_time est vrai,
@@ -147,6 +178,8 @@ class ITimeHistoryMng
   virtual void addValue(const String& name, RealConstArrayView value, bool end_time = true, bool is_local = false) = 0;
   /*! \brief Ajoute la valeur \a value à l'historique \a name.
    *
+   * \deprecated Cette méthode est dépréciée et est remplacée par l'utilisation de l'objet GlobalTimeHistoryAdder.
+   *
    * Le nombre d'éléments de \a value doit être constant au cours du temps.
    * La valeur est celle au temps de fin de l'itération si \a end_time est vrai,
    * au début sinon.
@@ -155,6 +188,8 @@ class ITimeHistoryMng
    */
   virtual void addValue(const String& name, Int32ConstArrayView value, bool end_time = true, bool is_local = false) = 0;
   /*! Ajoute la valeur \a value à l'historique \a name.
+   *
+   * \deprecated Cette méthode est dépréciée et est remplacée par l'utilisation de l'objet GlobalTimeHistoryAdder.
    *
    * Le nombre d'éléments de \a value doit être constant au cours du temps.
    * La valeur est celle au temps de fin de l'itération si \a end_time est vrai,
@@ -166,6 +201,11 @@ class ITimeHistoryMng
 
  public:
 
+  /*!
+   * \brief Méthode permettant de récupérer un pointeur vers un objet de type GlobalTimeHistoryAdder.
+   *
+   * \return Le pointeur.
+   */
   virtual ITimeHistoryAdder* adder() = 0;
 
  public:

--- a/arcane/src/arcane/core/ITimeHistoryMng.h
+++ b/arcane/src/arcane/core/ITimeHistoryMng.h
@@ -32,18 +32,19 @@ namespace Arcane
 class TimeHistoryAddValueArg
 {
  public:
-  TimeHistoryAddValueArg(const String& name, Integer local_proc_id, bool end_time)
+
+  TimeHistoryAddValueArg(const String& name, bool end_time, Integer local_proc_id)
   : m_name(name)
   , m_end_time(end_time)
   , m_local_proc_id(local_proc_id)
   {}
 
-  TimeHistoryAddValueArg(const String& name, Integer local_proc_id)
-  : TimeHistoryAddValueArg(name, local_proc_id, true)
+  TimeHistoryAddValueArg(const String& name, bool end_time)
+  : TimeHistoryAddValueArg(name, end_time, -1)
   {}
 
   explicit TimeHistoryAddValueArg(const String& name)
-  : TimeHistoryAddValueArg(name, -1)
+  : TimeHistoryAddValueArg(name, true)
   {}
 
  public:

--- a/arcane/src/arcane/core/ITimeHistoryMng.h
+++ b/arcane/src/arcane/core/ITimeHistoryMng.h
@@ -14,6 +14,7 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arcane/core/ArcaneTypes.h"
 #include "arcane/utils/UtilsTypes.h"
 #include "arcane/utils/FatalErrorException.h"
 
@@ -55,7 +56,7 @@ class TimeHistoryAddValueArg
    * \param end_time Doit-on écrire la valeur à notre itération ou à notre itération-1 ?
    */
   TimeHistoryAddValueArg(const String& name, bool end_time)
-  : TimeHistoryAddValueArg(name, end_time, -1)
+  : TimeHistoryAddValueArg(name, end_time, NULL_SUB_DOMAIN_ID)
   {}
 
   /*!
@@ -73,7 +74,7 @@ class TimeHistoryAddValueArg
  public:
   const String& name() const { return m_name; }
   bool endTime() const { return m_end_time; }
-  bool isLocal() const { return m_local_proc_id!=-1; }
+  bool isLocal() const { return m_local_proc_id!=NULL_SUB_DOMAIN_ID; }
   Integer localProcId() const { return m_local_proc_id; }
 
  private:
@@ -201,15 +202,6 @@ class ITimeHistoryMng
 
  public:
 
-  /*!
-   * \brief Méthode permettant de récupérer un pointeur vers un objet de type GlobalTimeHistoryAdder.
-   *
-   * \return Le pointeur.
-   */
-  virtual ITimeHistoryAdder* adder() = 0;
-
- public:
-
   virtual void timeHistoryBegin() = 0;
   virtual void timeHistoryEnd() = 0;
   virtual void timeHistoryInit() = 0;
@@ -305,7 +297,7 @@ class ITimeHistoryMng
  public:
 
   //! API interne à Arcane
-  virtual ITimeHistoryMngInternal* _internalApi() = 0;
+  virtual ITimeHistoryMngInternal* _internalApi() { ARCANE_FATAL("Invalid usage"); };
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ITimeHistoryMng.h
+++ b/arcane/src/arcane/core/ITimeHistoryMng.h
@@ -72,12 +72,14 @@ class TimeHistoryAddValueArg
   {}
 
  public:
+
   const String& name() const { return m_name; }
   bool endTime() const { return m_end_time; }
-  bool isLocal() const { return m_local_proc_id!=NULL_SUB_DOMAIN_ID; }
+  bool isLocal() const { return m_local_proc_id != NULL_SUB_DOMAIN_ID; }
   Integer localProcId() const { return m_local_proc_id; }
 
  private:
+
   String m_name;
   bool m_end_time;
   Integer m_local_proc_id;
@@ -303,10 +305,9 @@ class ITimeHistoryMng
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-}
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
-
+#endif

--- a/arcane/src/arcane/core/ITimeHistoryMng.h
+++ b/arcane/src/arcane/core/ITimeHistoryMng.h
@@ -66,6 +66,7 @@ class ITimeHistoryCurveWriter;
 class ITimeHistoryCurveWriter2;
 class ITimeHistoryTransformer;
 class ITimeHistoryMngInternal;
+class ITimeHistoryAdder;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -165,12 +166,7 @@ class ITimeHistoryMng
 
  public:
 
-  virtual void addValue(const TimeHistoryAddValueArg& thp, Real value) = 0;
-  virtual void addValue(const TimeHistoryAddValueArg& thp, Int32 value) = 0;
-  virtual void addValue(const TimeHistoryAddValueArg& thp, Int64 value) = 0;
-  virtual void addValue(const TimeHistoryAddValueArg& thp, RealConstArrayView values) = 0;
-  virtual void addValue(const TimeHistoryAddValueArg& thp, Int32ConstArrayView values) = 0;
-  virtual void addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values) = 0;
+  virtual ITimeHistoryAdder* adder() = 0;
 
  public:
 

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
@@ -24,15 +24,18 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 MeshTimeHistoryAdder::
-MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle)
+MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle, IParallelMng* pm)
 : m_thm(thm)
 , m_mesh_handle(mesh_handle)
+, m_pm(pm)
 {}
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)
 {
-  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
+  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
+    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
@@ -24,15 +24,15 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 MeshTimeHistoryAdder::
-MeshTimeHistoryAdder(ITimeHistoryMng* thm, IMesh* mesh)
+MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle)
 : m_thm(thm)
-, m_mesh(mesh)
+, m_mesh_handle(mesh_handle)
 {}
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)
 {
-  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh), value);
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
@@ -24,8 +24,8 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 MeshTimeHistoryAdder::
-MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle)
-: m_thm(thm)
+MeshTimeHistoryAdder(ITimeHistoryMng* time_history_mng, const MeshHandle& mesh_handle)
+: m_thm(time_history_mng)
 , m_mesh_handle(mesh_handle)
 {}
 

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
@@ -27,7 +27,9 @@ MeshTimeHistoryAdder::
 MeshTimeHistoryAdder(ITimeHistoryMng* time_history_mng, const MeshHandle& mesh_handle)
 : m_thm(time_history_mng)
 , m_mesh_handle(mesh_handle)
-{}
+{
+  m_thm->_internalApi()->setIOMasterWriteOnly(true);
+}
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
@@ -24,58 +24,45 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 MeshTimeHistoryAdder::
-MeshTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm, const MeshHandle& mesh_handle)
+MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle)
 : m_thm(thm)
-, m_pm(pm)
 , m_mesh_handle(mesh_handle)
 {}
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
 }
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int64 value)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
 }
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int32 value)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), value);
 }
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, RealConstArrayView values)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
 }
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int32ConstArrayView values)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
 }
 
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values)
 {
-  if(!thp.isLocal() || thp.localProcId() == m_pm->commRank()) {
-    m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
-  }
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh_handle), values);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.cc
@@ -32,7 +32,7 @@ MeshTimeHistoryAdder(ITimeHistoryMng* thm, IMesh* mesh)
 void MeshTimeHistoryAdder::
 addValue(const TimeHistoryAddValueArg& thp, Real value)
 {
-  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh->name()), value);
+  m_thm->_internalApi()->addValue(TimeHistoryAddValueArgInternal(thp, m_mesh), value);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.h
@@ -27,11 +27,61 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*!
+ * \brief Classe permettant d'ajouter une ou plusieurs valeurs à un
+ * historique de valeurs.
+ *
+ * Cette classe enregistrera les courbes avec comme support un maillage.
+ * C'est-à-dire que les courbes seront liées à un maillage, en plus d'être
+ * liées au domaine complet ou au sous-domaine demandé.
+ * Si le lien au maillage n'est pas désiré, la classe GlobalTimeHistoryAdder
+ * peut être plus intéressante.
+ *
+ * Pour un nom d'historique donné, il peut y avoir qu'une courbe de une
+ * ou plusieurs valeurs par maillage et par sous-domaine (et une globale à
+ * tous les sous-domaines).
+ *
+ * Exemple : plusieurs courbes de moyennes des pressions (appelons-les
+ * "avg_pressure"), deux sous-domaines (0 et 1) et deux maillages (mesh0 et mesh1).
+ * Une valeur par itération.
+ * - Une courbe "avg_pressure" liée au sous-domaine 0 et au maillage 0. Chaque
+ *   valeur est la moyenne des pressions de chaque maille du maillage 0 et
+ *   du sous-domaine 0.
+ * - Une courbe "avg_pressure" liée au sous-domaine 0 et au maillage 1. Chaque
+ *   valeur est la moyenne des pressions de chaque maille du maillage 1 et
+ *   du sous-domaine 0.
+ * - Une courbe "avg_pressure" liée au sous-domaine 1 et au maillage 0. Chaque
+ *   valeur est la moyenne des pressions de chaque maille du maillage 0 et
+ *   du sous-domaine 1.
+ * - Une courbe "avg_pressure" liée au sous-domaine 1 et au maillage 1. Chaque
+ *   valeur est la moyenne des pressions de chaque maille du maillage 1 et
+ *   du sous-domaine 1.
+ * - Une courbe "avg_pressure" liée au domaine complet et au maillage 0.
+ *   Chaque valeur est la moyenne des pressions du maillage 0 de chaque
+ *   sous-domaine.
+ * - Une courbe "avg_pressure" liée au domaine complet et au maillage 1.
+ *   Chaque valeur est la moyenne des pressions du maillage 1 de chaque
+ *   sous-domaine.
+ *
+ * On peut remarquer qu'il est possible d'avoir plusieurs courbes
+ * indépendantes avec le même nom mais liée à des maillages différents et à
+ * des sous-domaines différents (+1 courbe globale). Et il est important de
+ * souligner que ce même nom peut être aussi utilisé avec les courbes de
+ * GlobalTimeHistoryAdder indépendement, donc l'exemple ci-dessus peut être
+ * complémentaire avec celui donné dans la description de GlobalTimeHistoryAdder !
+ * (donc possiblement 9 courbes indépendantes mais de même nom !)
+ */
 class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
-  MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle);
+  /*!
+   * \brief Constructeur.
+   *
+   * \param time_history_mng Un pointeur vers une instance de ITimeHistoryMng.
+   * \param mesh_handle Le maillage à lier aux courbes.
+   */
+  MeshTimeHistoryAdder(ITimeHistoryMng* time_history_mng, const MeshHandle& mesh_handle);
   ~MeshTimeHistoryAdder() override = default;
 
  public:

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.h
@@ -17,6 +17,7 @@
 #include "arcane/core/ITimeHistoryAdder.h"
 #include "arcane/core/IMesh.h"
 #include "arcane/core/MeshHandle.h"
+#include "arcane/core/IParallelMng.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -31,7 +32,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
-  MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle);
+  MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle, IParallelMng* pm);
   ~MeshTimeHistoryAdder() override = default;
 
  public:
@@ -40,6 +41,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
  private:
   ITimeHistoryMng* m_thm;
   MeshHandle m_mesh_handle;
+  IParallelMng* m_pm;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.h
@@ -31,7 +31,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
-  MeshTimeHistoryAdder(ITimeHistoryMng* thm, IParallelMng* pm, const MeshHandle& mesh_handle);
+  MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle);
   ~MeshTimeHistoryAdder() override = default;
 
  public:
@@ -44,7 +44,6 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
 
  private:
   ITimeHistoryMng* m_thm;
-  IParallelMng* m_pm;
   MeshHandle m_mesh_handle;
 };
 

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.h
@@ -75,6 +75,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
+
   /*!
    * \brief Constructeur.
    *
@@ -85,6 +86,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
   ~MeshTimeHistoryAdder() override = default;
 
  public:
+
   void addValue(const TimeHistoryAddValueArg& thp, Real value) override;
   void addValue(const TimeHistoryAddValueArg& thp, Int32 value) override;
   void addValue(const TimeHistoryAddValueArg& thp, Int64 value) override;
@@ -93,6 +95,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
   void addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values) override;
 
  private:
+
   ITimeHistoryMng* m_thm;
   MeshHandle m_mesh_handle;
 };

--- a/arcane/src/arcane/core/MeshTimeHistoryAdder.h
+++ b/arcane/src/arcane/core/MeshTimeHistoryAdder.h
@@ -16,6 +16,7 @@
 
 #include "arcane/core/ITimeHistoryAdder.h"
 #include "arcane/core/IMesh.h"
+#include "arcane/core/MeshHandle.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -30,7 +31,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
 : public ITimeHistoryAdder
 {
  public:
-  MeshTimeHistoryAdder(ITimeHistoryMng* thm, IMesh* mesh);
+  MeshTimeHistoryAdder(ITimeHistoryMng* thm, const MeshHandle& mesh_handle);
   ~MeshTimeHistoryAdder() override = default;
 
  public:
@@ -38,7 +39,7 @@ class ARCANE_CORE_EXPORT MeshTimeHistoryAdder
 
  private:
   ITimeHistoryMng* m_thm;
-  IMesh* m_mesh;
+  MeshHandle m_mesh_handle;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -19,8 +19,11 @@
 
 #include "arcane/utils/UtilsTypes.h"
 #include "arcane/utils/FatalErrorException.h"
+
 #include "arcane/core/ITimeHistoryMng.h"
 #include "arcane/core/IMesh.h"
+#include "arcane/core/IPropertyMng.h"
+#include "arcane/core/Directory.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -39,7 +42,7 @@ class ITimeHistoryTransformer;
 class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
 {
  public:
-  TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp)
+  explicit TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp)
   : m_thp(thp)
   , m_mesh_handle()
   {}
@@ -121,7 +124,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
   /*!
    * Méthode permettant de récupérer les courbes lors d'une reprise.
    */
-  virtual void readVariables() =0;
+  virtual void readVariables(IMeshMng* mesh_mng, IMesh* default_mesh) =0;
 
   /*!
    * Ajoute un écrivain
@@ -184,7 +187,9 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    */
   virtual bool isNonIOMasterCurvesEnabled() = 0;
 
-  virtual void addObservers() = 0;
+  virtual void addObservers(IPropertyMng* prop_mng) = 0;
+
+  virtual void editOutputPath(const Directory& directory) = 0;
 
 };
 

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -49,8 +49,8 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
   , m_mesh_handle(mesh_handle)
   {}
 
-  TimeHistoryAddValueArgInternal(const String& name, Integer local_proc_id, bool end_time)
-  : m_thp(name, local_proc_id, end_time)
+  TimeHistoryAddValueArgInternal(const String& name, bool end_time, Integer local_proc_id)
+  : m_thp(name, end_time, local_proc_id)
   , m_mesh_handle()
   {}
 

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -39,7 +39,7 @@ class ITimeHistoryTransformer;
 class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
 {
  public:
-  explicit TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp)
+  TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp)
   : m_thp(thp)
   , m_mesh_handle()
   {}
@@ -49,8 +49,8 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
   , m_mesh_handle(mesh_handle)
   {}
 
-  TimeHistoryAddValueArgInternal(const String& name, bool end_time, bool is_local)
-  : m_thp(name, end_time, is_local)
+  TimeHistoryAddValueArgInternal(const String& name, Integer local_proc_id, bool end_time)
+  : m_thp(name, local_proc_id, end_time)
   , m_mesh_handle()
   {}
 

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -38,6 +38,10 @@ class ITimeHistoryTransformer;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*!
+ * \brief Classe étendant les arguments lors d'un ajout de valeur
+ * dans un historique de valeur.
+ */
 class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
 {
  public:
@@ -57,7 +61,7 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
   {}
 
  public:
-  const TimeHistoryAddValueArg& thp() const { return m_thp; }
+  const TimeHistoryAddValueArg& timeHistoryAddValueArg() const { return m_thp; }
   const MeshHandle& meshHandle() const { return m_mesh_handle; }
 
  private:
@@ -68,6 +72,9 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*!
+ * \brief Interface de la partie interne d'un gestionnaire d'historique de valeur.
+ */
 class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
 {
  public:
@@ -75,17 +82,52 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
 
  public:
 
-  // TODO com
+  /*!
+   * \brief Méthode permettant d'ajouter une valeur à un historique.
+   *
+   * \param thpi Les paramètres de historique.
+   * \param value La valeur à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Real value) =0;
 
+  /*!
+   * \brief Méthode permettant d'ajouter une valeur à un historique.
+   *
+   * \param thpi Les paramètres de historique.
+   * \param value La valeur à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int32 value) =0;
 
+  /*!
+   * \brief Méthode permettant d'ajouter une valeur à un historique.
+   *
+   * \param thpi Les paramètres de historique.
+   * \param value La valeur à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int64 value) =0;
 
+  /*!
+   * \brief Méthode permettant d'ajouter des valeurs à un historique.
+   *
+   * \param thpi Les paramètres de historique.
+   * \param value Les valeurs à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, RealConstArrayView values) =0;
 
+  /*!
+   * \brief Méthode permettant d'ajouter des valeurs à un historique.
+   *
+   * \param thpi Les paramètres de historique.
+   * \param value Les valeurs à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int32ConstArrayView values) =0;
 
+  /*!
+   * \brief Méthode permettant d'ajouter des valeurs à un historique.
+   *
+   * \param thpi Les paramètres de historique.
+   * \param value Les valeurs à ajouter.
+   */
   virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int64ConstArrayView values) =0;
 
   /*!
@@ -94,49 +136,61 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
   virtual void addNowInGlobalTime() = 0;
 
   /*!
-   * Méthode permettant de copier le tableau de GlobalTime dans la variable globale GlobalTime.
+   * \brief Méthode permettant de copier le tableau de GlobalTime dans la variable globale GlobalTime.
    */
   virtual void updateGlobalTimeCurve() = 0;
 
   /*!
-   * Méthode permettant de redimensionner les tableaux de valeurs après une reprise.
+   * \brief Méthode permettant de redimensionner les tableaux de valeurs après une reprise.
    */
   virtual void resizeArrayAfterRestore() = 0;
 
   /*!
-   * Méthode permettant d"écrire les courbes à l'aide du writer fourni.
-   * @param writer Le writer avec lequel les courbes doivent être écrites.
+   * \brief Méthode permettant d"écrire les courbes à l'aide du writer fourni.
+   *
+   * \param writer Le writer avec lequel les courbes doivent être écrites.
+   * \param master_only Si tous les historiques doivent être transférés sur
+   *                    le masterIO avant la copie.
    */
   virtual void dumpCurves(ITimeHistoryCurveWriter2* writer, bool master_only) =0;
 
   /*!
-   * Méthode permettant d'écrire toutes les courbes à l'aide de tous les writers enregistrés
-   * @param is_verbose Active ou non les messages supplémentaires.
+   * \brief Méthode permettant d'écrire toutes les courbes à l'aide de tous les writers enregistrés.
    */
-  virtual void dumpHistory(bool is_verbose) =0;
+  virtual void dumpHistory() =0;
 
   /*!
-   * Méthode permettant de mettre à jour les méta-données des courbes.
+   * \brief Méthode permettant de mettre à jour les méta-données des courbes.
    */
   virtual void updateMetaData() =0;
 
   /*!
-   * Méthode permettant de récupérer les courbes lors d'une reprise.
+   * \brief Méthode permettant de récupérer les courbes précédemment écrites lors d'une reprise.
+   *
+   * \param mesh_mng Un pointeur vers un meshMng.
+   * \param default_mesh Un pointeur vers le maillage par défaut (nécessaire uniquement pour
+   *                     la récupération d'anciens checkpoints).
    */
   virtual void readVariables(IMeshMng* mesh_mng, IMesh* default_mesh) =0;
 
   /*!
-   * Ajoute un écrivain
+   * \brief Méthode permettant d'ajouter un écrivain pour la sortie des courbes.
+   *
+   * \param writer Une ref vers l'écrivain.
    */
   virtual void addCurveWriter(Ref<ITimeHistoryCurveWriter2> writer) =0;
 
   /*!
-   * Retire l'écrivain avec le nom name.
+   * \brief Méthode permettant de retirer un écrivain.
+   *
+   * \param writer Le nom de l'écrivain.
    */
   virtual void removeCurveWriter(const String& name) =0;
 
   /*!
    * \brief Applique la transformation \a v à l'ensemble des courbes.
+   *
+   * \param v La transformation à appliquer.
    */
   virtual void applyTransformation(ITimeHistoryTransformer* v) =0;
 
@@ -176,20 +230,40 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
   virtual void setDumpActive(bool is_active) =0;
 
   /*!
-   * Méthode permettant de savoir si notre processus est l'écrivain.
+   * \brief Méthode permettant de savoir si notre processus est l'écrivain.
    * @return True si nous sommes l'écrivain.
    */
   virtual bool isMasterIO() = 0;
-
   /*!
-   * Méthode permettant de savoir si tous les processus peuvent avoir un historique de valeurs.
+   * \brief Méthode permettant de savoir si tous les processus peuvent avoir un historique de valeurs.
    */
   virtual bool isNonIOMasterCurvesEnabled() = 0;
 
+  /*!
+   * \brief Méthode permettant de rajouter les observers sauvegardant l'historique avant une protection.
+   *
+   * \param prop_mng Un pointeur vers un IPropertyMng.
+   */
   virtual void addObservers(IPropertyMng* prop_mng) = 0;
 
+  /*!
+   * \brief Méthode permettant de changer le répertoire de sortie des courbes.
+   *
+   * À noter que le répertoire sera créé s'il n'existe pas.
+   *
+   * \param directory Le nouveau répertoire de sortie.
+   */
   virtual void editOutputPath(const Directory& directory) = 0;
 
+  /*!
+   * \brief Méthode permettant de sortir les itérations et les valeurs d'un historique.
+   *
+   * Méthode utile pour du débug/test.
+   *
+   * \param thpi Les informations nécessaire à la récupération de l'historique.
+   * \param iterations [OUT] Les itérations où ont été récupéré chaque valeur.
+   * \param values [OUT] Les valeurs récupérées.
+   */
   virtual void iterationsAndValues(const TimeHistoryAddValueArgInternal& thpi, UniqueArray<Int32>& iterations, UniqueArray<Real>& values) = 0;
 
 };
@@ -197,7 +271,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-}
+} // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -190,6 +190,8 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
 
   virtual void editOutputPath(const Directory& directory) = 0;
 
+  virtual void iterationsAndValues(const TimeHistoryAddValueArgInternal& thpi, UniqueArray<Int32>& iterations, UniqueArray<Real>& values) = 0;
+
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -18,7 +18,6 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/UtilsTypes.h"
-#include "arcane/utils/FatalErrorException.h"
 
 #include "arcane/core/ITimeHistoryMng.h"
 #include "arcane/core/IMesh.h"

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -45,6 +45,7 @@ class ITimeHistoryTransformer;
 class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
 {
  public:
+
   explicit TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp)
   : m_thp(thp)
   , m_mesh_handle()
@@ -61,10 +62,12 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
   {}
 
  public:
+
   const TimeHistoryAddValueArg& timeHistoryAddValueArg() const { return m_thp; }
   const MeshHandle& meshHandle() const { return m_mesh_handle; }
 
  private:
+
   TimeHistoryAddValueArg m_thp;
   MeshHandle m_mesh_handle;
 };
@@ -78,6 +81,7 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
 class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
 {
  public:
+
   virtual ~ITimeHistoryMngInternal() = default; //!< Libère les ressources
 
  public:
@@ -88,7 +92,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param thpi Les paramètres de historique.
    * \param value La valeur à ajouter.
    */
-  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Real value) =0;
+  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Real value) = 0;
 
   /*!
    * \brief Méthode permettant d'ajouter une valeur à un historique.
@@ -96,7 +100,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param thpi Les paramètres de historique.
    * \param value La valeur à ajouter.
    */
-  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int32 value) =0;
+  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int32 value) = 0;
 
   /*!
    * \brief Méthode permettant d'ajouter une valeur à un historique.
@@ -104,7 +108,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param thpi Les paramètres de historique.
    * \param value La valeur à ajouter.
    */
-  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int64 value) =0;
+  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int64 value) = 0;
 
   /*!
    * \brief Méthode permettant d'ajouter des valeurs à un historique.
@@ -112,7 +116,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param thpi Les paramètres de historique.
    * \param value Les valeurs à ajouter.
    */
-  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, RealConstArrayView values) =0;
+  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, RealConstArrayView values) = 0;
 
   /*!
    * \brief Méthode permettant d'ajouter des valeurs à un historique.
@@ -120,7 +124,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param thpi Les paramètres de historique.
    * \param value Les valeurs à ajouter.
    */
-  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int32ConstArrayView values) =0;
+  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int32ConstArrayView values) = 0;
 
   /*!
    * \brief Méthode permettant d'ajouter des valeurs à un historique.
@@ -128,7 +132,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param thpi Les paramètres de historique.
    * \param value Les valeurs à ajouter.
    */
-  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int64ConstArrayView values) =0;
+  virtual void addValue(const TimeHistoryAddValueArgInternal& thpi, Int64ConstArrayView values) = 0;
 
   /*!
    * \brief Méthode permettant d'ajouter le GlobalTime actuel au tableau des GlobalTimes.
@@ -152,17 +156,17 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param master_only Si tous les historiques doivent être transférés sur
    *                    le masterIO avant la copie.
    */
-  virtual void dumpCurves(ITimeHistoryCurveWriter2* writer) =0;
+  virtual void dumpCurves(ITimeHistoryCurveWriter2* writer) = 0;
 
   /*!
    * \brief Méthode permettant d'écrire toutes les courbes à l'aide de tous les writers enregistrés.
    */
-  virtual void dumpHistory() =0;
+  virtual void dumpHistory() = 0;
 
   /*!
    * \brief Méthode permettant de mettre à jour les méta-données des courbes.
    */
-  virtual void updateMetaData() =0;
+  virtual void updateMetaData() = 0;
 
   /*!
    * \brief Méthode permettant de récupérer les courbes précédemment écrites lors d'une reprise.
@@ -171,37 +175,37 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param default_mesh Un pointeur vers le maillage par défaut (nécessaire uniquement pour
    *                     la récupération d'anciens checkpoints).
    */
-  virtual void readVariables(IMeshMng* mesh_mng, IMesh* default_mesh) =0;
+  virtual void readVariables(IMeshMng* mesh_mng, IMesh* default_mesh) = 0;
 
   /*!
    * \brief Méthode permettant d'ajouter un écrivain pour la sortie des courbes.
    *
    * \param writer Une ref vers l'écrivain.
    */
-  virtual void addCurveWriter(Ref<ITimeHistoryCurveWriter2> writer) =0;
+  virtual void addCurveWriter(Ref<ITimeHistoryCurveWriter2> writer) = 0;
 
   /*!
    * \brief Méthode permettant de retirer un écrivain.
    *
    * \param writer Le nom de l'écrivain.
    */
-  virtual void removeCurveWriter(const String& name) =0;
+  virtual void removeCurveWriter(const String& name) = 0;
 
   /*!
    * \brief Applique la transformation \a v à l'ensemble des courbes.
    *
    * \param v La transformation à appliquer.
    */
-  virtual void applyTransformation(ITimeHistoryTransformer* v) =0;
+  virtual void applyTransformation(ITimeHistoryTransformer* v) = 0;
 
   /*!
    * \brief Retourne un booléen indiquant si l'historique est compressé
    */
-  virtual bool isShrinkActive() const =0;
+  virtual bool isShrinkActive() const = 0;
   /*!
    * \brief Positionne le booléen indiquant si l'historique est compressé
    */
-  virtual void setShrinkActive(bool is_active) =0;
+  virtual void setShrinkActive(bool is_active) = 0;
 
   /*!
    * \brief Indique l'état d'activation.
@@ -210,12 +214,12 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * est active. Dans le cas contraire, les appels à addValue() sont
    * ignorés.
    */
-  virtual bool active() const =0;
+  virtual bool active() const = 0;
   /*!
    * \brief Positionne l'état d'activation.
    * \sa active().
    */
-  virtual void setActive(bool is_active) =0;
+  virtual void setActive(bool is_active) = 0;
 
   /*!
    * \brief Indique l'état d'activation des sorties.
@@ -223,11 +227,11 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * La fonction dumpHistory() est inactives
    * si isDumpActive() est faux.
    */
-  virtual bool isDumpActive() const =0;
+  virtual bool isDumpActive() const = 0;
   /*!
    * \brief Positionne l'état d'activation des sorties.
    */
-  virtual void setDumpActive(bool is_active) =0;
+  virtual void setDumpActive(bool is_active) = 0;
 
   /*!
    * \brief Méthode permettant de savoir si notre processus est l'écrivain.
@@ -278,8 +282,6 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param values [OUT] Les valeurs récupérées.
    */
   virtual void iterationsAndValues(const TimeHistoryAddValueArgInternal& thpi, UniqueArray<Int32>& iterations, UniqueArray<Real>& values) = 0;
-
-
 };
 
 /*---------------------------------------------------------------------------*/
@@ -290,5 +292,4 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
-
+#endif

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -20,9 +20,9 @@
 #include "arcane/utils/UtilsTypes.h"
 
 #include "arcane/core/ITimeHistoryMng.h"
-#include "arcane/core/IMesh.h"
 #include "arcane/core/IPropertyMng.h"
 #include "arcane/core/Directory.h"
+#include "arcane/core/MeshHandle.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -184,6 +184,8 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    */
   virtual bool isNonIOMasterCurvesEnabled() = 0;
 
+  virtual void addObservers() = 0;
+
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -105,7 +105,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * Méthode permettant d"écrire les courbes à l'aide du writer fourni.
    * @param writer Le writer avec lequel les courbes doivent être écrites.
    */
-  virtual void dumpCurves(ITimeHistoryCurveWriter2* writer) =0;
+  virtual void dumpCurves(ITimeHistoryCurveWriter2* writer, bool master_only) =0;
 
   /*!
    * Méthode permettant d'écrire toutes les courbes à l'aide de tous les writers enregistrés

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -20,6 +20,7 @@
 #include "arcane/utils/UtilsTypes.h"
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/core/ITimeHistoryMng.h"
+#include "arcane/core/IMesh.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -40,31 +41,26 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
  public:
   explicit TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp)
   : m_thp(thp)
-  , m_metadata()
-  , m_has_metadata(false)
+  , m_mesh(nullptr)
   {}
 
-  TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp, const String& metadata)
+  TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp, IMesh* mesh)
   : m_thp(thp)
-  , m_metadata(metadata)
-  , m_has_metadata(true)
+  , m_mesh(mesh)
   {}
 
   TimeHistoryAddValueArgInternal(const String& name, bool end_time, bool is_local)
   : m_thp(name, end_time, is_local)
-  , m_metadata()
-  , m_has_metadata(false)
+  , m_mesh(nullptr)
   {}
 
  public:
   const TimeHistoryAddValueArg& thp() const { return m_thp; }
-  const String& metadata() const { return m_metadata; }
-  bool hasMetadata() const { return m_has_metadata; }
+  IMesh* mesh() const { return m_mesh; }
 
  private:
   TimeHistoryAddValueArg m_thp;
-  String m_metadata; //TODO tmp
-  bool m_has_metadata;
+  IMesh* m_mesh;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -152,7 +152,7 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
    * \param master_only Si tous les historiques doivent être transférés sur
    *                    le masterIO avant la copie.
    */
-  virtual void dumpCurves(ITimeHistoryCurveWriter2* writer, bool master_only) =0;
+  virtual void dumpCurves(ITimeHistoryCurveWriter2* writer) =0;
 
   /*!
    * \brief Méthode permettant d'écrire toutes les courbes à l'aide de tous les writers enregistrés.
@@ -240,6 +240,19 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
   virtual bool isNonIOMasterCurvesEnabled() = 0;
 
   /*!
+   * \brief Méthode permettant de savoir s'il n'y a que le processus maitre qui appelle les écrivains.
+   *
+   * \return true si oui
+   */
+  virtual bool isIOMasterWriteOnly() = 0;
+  /*!
+   * \brief Méthode permettant de définir si seul le processus maitre appelle les écrivains.
+   *
+   * \param is_active true si oui
+   */
+  virtual void setIOMasterWriteOnly(bool is_active) = 0;
+
+  /*!
    * \brief Méthode permettant de rajouter les observers sauvegardant l'historique avant une protection.
    *
    * \param prop_mng Un pointeur vers un IPropertyMng.
@@ -258,13 +271,14 @@ class ARCANE_CORE_EXPORT ITimeHistoryMngInternal
   /*!
    * \brief Méthode permettant de sortir les itérations et les valeurs d'un historique.
    *
-   * Méthode utile pour du débug/test.
+   * Méthode utile pour du debug/test.
    *
    * \param thpi Les informations nécessaire à la récupération de l'historique.
    * \param iterations [OUT] Les itérations où ont été récupéré chaque valeur.
    * \param values [OUT] Les valeurs récupérées.
    */
   virtual void iterationsAndValues(const TimeHistoryAddValueArgInternal& thpi, UniqueArray<Int32>& iterations, UniqueArray<Real>& values) = 0;
+
 
 };
 

--- a/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
+++ b/arcane/src/arcane/core/internal/ITimeHistoryMngInternal.h
@@ -41,26 +41,26 @@ class ARCANE_CORE_EXPORT TimeHistoryAddValueArgInternal
  public:
   explicit TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp)
   : m_thp(thp)
-  , m_mesh(nullptr)
+  , m_mesh_handle()
   {}
 
-  TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp, IMesh* mesh)
+  TimeHistoryAddValueArgInternal(const TimeHistoryAddValueArg& thp, const MeshHandle& mesh_handle)
   : m_thp(thp)
-  , m_mesh(mesh)
+  , m_mesh_handle(mesh_handle)
   {}
 
   TimeHistoryAddValueArgInternal(const String& name, bool end_time, bool is_local)
   : m_thp(name, end_time, is_local)
-  , m_mesh(nullptr)
+  , m_mesh_handle()
   {}
 
  public:
   const TimeHistoryAddValueArg& thp() const { return m_thp; }
-  IMesh* mesh() const { return m_mesh; }
+  const MeshHandle& meshHandle() const { return m_mesh_handle; }
 
  private:
   TimeHistoryAddValueArg m_thp;
-  IMesh* m_mesh;
+  MeshHandle m_mesh_handle;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/srcs.cmake
+++ b/arcane/src/arcane/core/srcs.cmake
@@ -471,6 +471,8 @@ set(ARCANE_ORIGINAL_SOURCES
   FactoryService.h
   GeometricUtilities.cc
   GeometricUtilities.h
+  GlobalTimeHistoryAdder.cc
+  GlobalTimeHistoryAdder.h
   GroupIndexTable.cc
   GroupIndexTable.h
   MathUtils.cc

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -160,27 +160,27 @@ class TimeHistoryMng2
 
   void addValue(const String& name,Real value,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), value);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), value);
   }
   void addValue(const String& name,Int64 value,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), value);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), value);
   }
   void addValue(const String& name,Int32 value,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), value);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), value);
   }
   void addValue(const String& name,RealConstArrayView values,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), values);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), values);
   }
   void addValue(const String& name,Int32ConstArrayView values,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), values);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), values);
   }
   void addValue(const String& name,Int64ConstArrayView values,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), values);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), values);
   }
 
   void addValue(const TimeHistoryAddValueArg& thp, Real value) override

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -83,7 +83,8 @@ class GnuplotTimeHistoryCurveWriter2
   }
   void writeCurve(const TimeHistoryCurveInfo& infos) override
   {
-    String sname(m_gnuplot_path.file(infos.name()));
+
+    String sname(m_gnuplot_path.file(infos.hasSupport() ? infos.name().clone() + "_" + infos.support() : infos.name()));
     FILE* ofile = fopen(sname.localstr(),"w");
     if (!ofile){
       warning() << "Can not open gnuplot curve file '" << sname << "'";

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -86,11 +86,12 @@ class GnuplotTimeHistoryCurveWriter2
   void writeCurve(const TimeHistoryCurveInfo& infos) override
   {
     String name(infos.name().clone());
-    if(infos.hasSupport()){
-      name = name + "_" + infos.support();
+
+    if(infos.subDomain() != NULL_SUB_DOMAIN_ID){
+      name = "SD" + String::fromNumber(infos.subDomain()) + "_" + name;
     }
-    if(infos.subDomain() != -1){
-      name = name + "_SubDomain" + infos.subDomain();
+    if(infos.hasSupport()){
+      name = infos.support() + "_" + name;
     }
 
     String sname(m_gnuplot_path.file(name));
@@ -184,8 +185,6 @@ class TimeHistoryMng2
   {
     m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), values);
   }
-
-  ITimeHistoryAdder* adder() override { return m_adder.get(); }
 
  public:
 
@@ -394,7 +393,7 @@ dumpHistory(bool is_verbose)
 void TimeHistoryMng2::
 dumpCurves(ITimeHistoryCurveWriter2* writer)
 {
-  m_internal->dumpCurves(writer, true);//todo
+  m_internal->dumpCurves(writer);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -241,12 +241,7 @@ class TimeHistoryMng2
 
  private:
 
-  ObserverPool m_observer_pool;
   Ref<ITimeHistoryMngInternal> m_internal;
-
- private:
-
-  void _writeVariablesNotify();
 };
 
 /*---------------------------------------------------------------------------*/
@@ -342,18 +337,13 @@ void TimeHistoryMng2::
 timeHistoryInit()
 {
   //warning() << "timeHistoryInit " << m_global_time() << " " << m_global_times.size();
-  
-  ISubDomain* sd = subDomain();
-  IVariableMng* vm = sd->variableMng();
 
   info(4) << "TimeHistory is MasterIO ? " << m_internal->isMasterIO();
   if (!m_internal->isMasterIO() && !m_internal->isNonIOMasterCurvesEnabled())
     return;
 
-  m_observer_pool.addObserver(this,
-                              &TimeHistoryMng2::_writeVariablesNotify,
-                              vm->writeObservable());
-  
+  m_internal->addObservers();
+
   if (platform::getEnvironmentVariable("ARCANE_DISABLE_GNUPLOT_CURVES").null()){
     ITimeHistoryCurveWriter2* gnuplot_curve_writer = new GnuplotTimeHistoryCurveWriter2(traceMng());
     m_internal->addCurveWriter(makeRef(gnuplot_curve_writer));
@@ -379,15 +369,6 @@ void TimeHistoryMng2::
 addCurveWriter(ITimeHistoryCurveWriter2* writer)
 {
   m_internal->addCurveWriter(makeRef(writer));
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void TimeHistoryMng2::
-_writeVariablesNotify()
-{
-  m_internal->updateMetaData();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -424,7 +424,7 @@ dumpHistory(bool is_verbose)
 void TimeHistoryMng2::
 dumpCurves(ITimeHistoryCurveWriter2* writer)
 {
-  m_internal->dumpCurves(writer);
+  m_internal->dumpCurves(writer, true);//todo
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -83,8 +83,15 @@ class GnuplotTimeHistoryCurveWriter2
   }
   void writeCurve(const TimeHistoryCurveInfo& infos) override
   {
+    String name(infos.name().clone());
+    if(infos.hasSupport()){
+      name = name + "_" + infos.support();
+    }
+    if(infos.subDomain() != -1){
+      name = name + "_SubDomain" + infos.subDomain();
+    }
 
-    String sname(m_gnuplot_path.file(infos.hasSupport() ? infos.name().clone() + "_" + infos.support() : infos.name()));
+    String sname(m_gnuplot_path.file(name));
     FILE* ofile = fopen(sname.localstr(),"w");
     if (!ofile){
       warning() << "Can not open gnuplot curve file '" << sname << "'";
@@ -153,52 +160,64 @@ class TimeHistoryMng2
 
   void addValue(const String& name,Real value,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, is_local), value);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), value);
   }
   void addValue(const String& name,Int64 value,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, is_local), value);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), value);
   }
   void addValue(const String& name,Int32 value,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, is_local), value);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), value);
   }
   void addValue(const String& name,RealConstArrayView values,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, is_local), values);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), values);
   }
   void addValue(const String& name,Int32ConstArrayView values,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, is_local), values);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), values);
   }
   void addValue(const String& name,Int64ConstArrayView values,bool end_time,bool is_local) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, is_local), values);
+    m_internal->addValue(TimeHistoryAddValueArgInternal(name, (is_local ? parallelMng()->commRank() : -1), end_time), values);
   }
 
   void addValue(const TimeHistoryAddValueArg& thp, Real value) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(thp), value);
+    if(!thp.isLocal() || thp.localProcId() == parallelMng()->commRank()) {
+      m_internal->addValue(TimeHistoryAddValueArgInternal(thp), value);
+    }
   }
   void addValue(const TimeHistoryAddValueArg& thp, Int64 value) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(thp), value);
+    if(!thp.isLocal() || thp.localProcId() == parallelMng()->commRank()) {
+      m_internal->addValue(TimeHistoryAddValueArgInternal(thp), value);
+    }
   }
   void addValue(const TimeHistoryAddValueArg& thp, Int32 value) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(thp), value);
+    if(!thp.isLocal() || thp.localProcId() == parallelMng()->commRank()) {
+      m_internal->addValue(TimeHistoryAddValueArgInternal(thp), value);
+    }
   }
   void addValue(const TimeHistoryAddValueArg& thp, RealConstArrayView values) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(thp), values);
+    if(!thp.isLocal() || thp.localProcId() == parallelMng()->commRank()) {
+      m_internal->addValue(TimeHistoryAddValueArgInternal(thp), values);
+    }
   }
   void addValue(const TimeHistoryAddValueArg& thp, Int32ConstArrayView values) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(thp), values);
+    if(!thp.isLocal() || thp.localProcId() == parallelMng()->commRank()) {
+      m_internal->addValue(TimeHistoryAddValueArgInternal(thp), values);
+    }
   }
   void addValue(const TimeHistoryAddValueArg& thp, Int64ConstArrayView values) override
   {
-    m_internal->addValue(TimeHistoryAddValueArgInternal(thp), values);
+    if(!thp.isLocal() || thp.localProcId() == parallelMng()->commRank()) {
+      m_internal->addValue(TimeHistoryAddValueArgInternal(thp), values);
+    }
   }
 
  public:

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -240,7 +240,7 @@ TimeHistoryMng2(const ModuleBuildInfo& mb, bool add_entry_points)
 , CommonVariables(this)
 , m_internal(makeRef(new TimeHistoryMngInternal(subDomain()->variableMng(),
                                                 makeRef(new Properties(subDomain()->propertyMng(), "ArcaneTimeHistoryProperties")))))
-, m_adder(makeRef(new GlobalTimeHistoryAdder(this, subDomain()->parallelMng())))
+, m_adder(makeRef(new GlobalTimeHistoryAdder(this)))
 {
   if (add_entry_points){
     addEntryPoint(this,"ArcaneTimeHistoryBegin",&TimeHistoryMng2::timeHistoryBegin,
@@ -266,7 +266,6 @@ TimeHistoryMng2(const ModuleBuildInfo& mb, bool add_entry_points)
 void TimeHistoryMng2::
 timeHistoryStartInit()
 {
-  //warning() << "timeHistoryStartInit " << m_global_time() << " " << m_global_times.size();
   m_internal->addNowInGlobalTime();
 }
 

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -61,12 +61,14 @@ class GnuplotTimeHistoryCurveWriter2
 , public ITimeHistoryCurveWriter2
 {
  public:
+
   GnuplotTimeHistoryCurveWriter2(ITraceMng* tm)
   : TraceAccessor(tm)
   {
   }
 
  public:
+
   void build() override {}
   void beginWrite(const TimeHistoryCurveWriterInfo& infos) override
   {
@@ -76,9 +78,9 @@ class GnuplotTimeHistoryCurveWriter2
     if (m_output_path.empty())
       m_output_path = path;
 
-    m_gnuplot_path = Directory(Directory(m_output_path),"gnuplot");
+    m_gnuplot_path = Directory(Directory(m_output_path), "gnuplot");
     // Créé le répertoire de sortie.
-    if (m_gnuplot_path.createDirectory()){
+    if (m_gnuplot_path.createDirectory()) {
       warning() << "Can not create gnuplot curve directory '"
                 << m_gnuplot_path.path() << "'";
     }
@@ -87,16 +89,16 @@ class GnuplotTimeHistoryCurveWriter2
   {
     String name(infos.name().clone());
 
-    if(infos.subDomain() != NULL_SUB_DOMAIN_ID){
+    if (infos.subDomain() != NULL_SUB_DOMAIN_ID) {
       name = "SD" + String::fromNumber(infos.subDomain()) + "_" + name;
     }
-    if(infos.hasSupport()){
+    if (infos.hasSupport()) {
       name = infos.support() + "_" + name;
     }
 
     String sname(m_gnuplot_path.file(name));
-    FILE* ofile = fopen(sname.localstr(),"w");
-    if (!ofile){
+    FILE* ofile = fopen(sname.localstr(), "w");
+    if (!ofile) {
       warning() << "Can not open gnuplot curve file '" << sname << "'";
       return;
     }
@@ -104,11 +106,11 @@ class GnuplotTimeHistoryCurveWriter2
     Int32ConstArrayView iterations = infos.iterations();
     Integer nb_val = iterations.size();
     Integer sub_size = infos.subSize();
-    for( Integer i=0; i<nb_val; ++i ){
-      fprintf(ofile,"%.16E",Convert::toDouble(m_times[iterations[i]]));
-      for( Integer z=0; z<sub_size; ++z )
-        fprintf(ofile," %.16E",Convert::toDouble(values[(i*sub_size)+z]));
-      fprintf(ofile,"\n");
+    for (Integer i = 0; i < nb_val; ++i) {
+      fprintf(ofile, "%.16E", Convert::toDouble(m_times[iterations[i]]));
+      for (Integer z = 0; z < sub_size; ++z)
+        fprintf(ofile, " %.16E", Convert::toDouble(values[(i * sub_size) + z]));
+      fprintf(ofile, "\n");
     }
     fclose(ofile);
   }
@@ -151,37 +153,37 @@ class TimeHistoryMng2
 {
 
  public:
-	
-  TimeHistoryMng2(const ModuleBuildInfo& cb, bool add_entry_points=true);
+
+  TimeHistoryMng2(const ModuleBuildInfo& cb, bool add_entry_points = true);
   ~TimeHistoryMng2() override = default;
 
  public:
-	
-  VersionInfo versionInfo() const override { return VersionInfo(1,0,0); }
+
+  VersionInfo versionInfo() const override { return VersionInfo(1, 0, 0); }
 
  public:
 
-  void addValue(const String& name,Real value,bool end_time,bool is_local) override
+  void addValue(const String& name, Real value, bool end_time, bool is_local) override
   {
     m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), value);
   }
-  void addValue(const String& name,Int64 value,bool end_time,bool is_local) override
+  void addValue(const String& name, Int64 value, bool end_time, bool is_local) override
   {
     m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), value);
   }
-  void addValue(const String& name,Int32 value,bool end_time,bool is_local) override
+  void addValue(const String& name, Int32 value, bool end_time, bool is_local) override
   {
     m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), value);
   }
-  void addValue(const String& name,RealConstArrayView values,bool end_time,bool is_local) override
+  void addValue(const String& name, RealConstArrayView values, bool end_time, bool is_local) override
   {
     m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), values);
   }
-  void addValue(const String& name,Int32ConstArrayView values,bool end_time,bool is_local) override
+  void addValue(const String& name, Int32ConstArrayView values, bool end_time, bool is_local) override
   {
     m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), values);
   }
-  void addValue(const String& name,Int64ConstArrayView values,bool end_time,bool is_local) override
+  void addValue(const String& name, Int64ConstArrayView values, bool end_time, bool is_local) override
   {
     m_internal->addValue(TimeHistoryAddValueArgInternal(name, end_time, (is_local ? parallelMng()->commRank() : -1)), values);
   }
@@ -241,21 +243,21 @@ TimeHistoryMng2(const ModuleBuildInfo& mb, bool add_entry_points)
                                                 makeRef(new Properties(subDomain()->propertyMng(), "ArcaneTimeHistoryProperties")))))
 , m_adder(makeRef(new GlobalTimeHistoryAdder(this)))
 {
-  if (add_entry_points){
-    addEntryPoint(this,"ArcaneTimeHistoryBegin",&TimeHistoryMng2::timeHistoryBegin,
-                  IEntryPoint::WComputeLoop,IEntryPoint::PAutoLoadBegin);
-    addEntryPoint(this,"ArcaneTimeHistoryEnd",&TimeHistoryMng2::timeHistoryEnd,
-                  IEntryPoint::WComputeLoop,IEntryPoint::PAutoLoadEnd);
-    addEntryPoint(this,"ArcaneTimeHistoryInit",&TimeHistoryMng2::timeHistoryInit,
-                  IEntryPoint::WInit,IEntryPoint::PAutoLoadBegin);
-    addEntryPoint(this,"ArcaneTimeHistoryStartInit",&TimeHistoryMng2::timeHistoryStartInit,
-                  IEntryPoint::WStartInit,IEntryPoint::PAutoLoadBegin);
-    addEntryPoint(this,"ArcaneTimeHistoryContinueInit",&TimeHistoryMng2::timeHistoryContinueInit,
-                  IEntryPoint::WContinueInit,IEntryPoint::PAutoLoadBegin);
-    addEntryPoint(this,"ArcaneTimeHistoryStartInitEnd",&TimeHistoryMng2::timeHistoryStartInitEnd,
-                  IEntryPoint::WStartInit,IEntryPoint::PAutoLoadEnd);
-    addEntryPoint(this,"ArcaneTimeHistoryRestore",&TimeHistoryMng2::timeHistoryRestore,
-                  IEntryPoint::WRestore,IEntryPoint::PAutoLoadBegin);
+  if (add_entry_points) {
+    addEntryPoint(this, "ArcaneTimeHistoryBegin", &TimeHistoryMng2::timeHistoryBegin,
+                  IEntryPoint::WComputeLoop, IEntryPoint::PAutoLoadBegin);
+    addEntryPoint(this, "ArcaneTimeHistoryEnd", &TimeHistoryMng2::timeHistoryEnd,
+                  IEntryPoint::WComputeLoop, IEntryPoint::PAutoLoadEnd);
+    addEntryPoint(this, "ArcaneTimeHistoryInit", &TimeHistoryMng2::timeHistoryInit,
+                  IEntryPoint::WInit, IEntryPoint::PAutoLoadBegin);
+    addEntryPoint(this, "ArcaneTimeHistoryStartInit", &TimeHistoryMng2::timeHistoryStartInit,
+                  IEntryPoint::WStartInit, IEntryPoint::PAutoLoadBegin);
+    addEntryPoint(this, "ArcaneTimeHistoryContinueInit", &TimeHistoryMng2::timeHistoryContinueInit,
+                  IEntryPoint::WContinueInit, IEntryPoint::PAutoLoadBegin);
+    addEntryPoint(this, "ArcaneTimeHistoryStartInitEnd", &TimeHistoryMng2::timeHistoryStartInitEnd,
+                  IEntryPoint::WStartInit, IEntryPoint::PAutoLoadEnd);
+    addEntryPoint(this, "ArcaneTimeHistoryRestore", &TimeHistoryMng2::timeHistoryRestore,
+                  IEntryPoint::WRestore, IEntryPoint::PAutoLoadBegin);
   }
 }
 
@@ -284,20 +286,20 @@ timeHistoryBegin()
 {
   // Si on n'est pas actif, on ne grossit pas inutilement le m_global_times
   // qui sera copié dans la variable backupée 'm_th_global_time'
-  if (isShrinkActive() && !active()){
+  if (isShrinkActive() && !active()) {
     // On ne fait rien
   }
-  else{
+  else {
     //warning() << "timeHistoryBegin " << m_global_time() << " " << m_global_times.size();
     m_internal->addNowInGlobalTime();
   }
-  
+
   // Regarde s'il faut imprimer les sorties temporelles
   {
     bool force_print_thm = false;
     int th_step = subDomain()->caseOptionsMain()->writeHistoryPeriod();
-    if (th_step!=0){
-      if ((globalIteration() % th_step)==0)
+    if (th_step != 0) {
+      if ((globalIteration() % th_step) == 0)
         if (parallelMng()->isMasterIO() || m_internal->isNonIOMasterCurvesEnabled())
           force_print_thm = true;
     }
@@ -331,17 +333,17 @@ timeHistoryInit()
   m_internal->editOutputPath(Directory(subDomain()->exportDirectory(), "courbes"));
   m_internal->addObservers(subDomain()->propertyMng());
 
-  if (platform::getEnvironmentVariable("ARCANE_DISABLE_GNUPLOT_CURVES").null()){
+  if (platform::getEnvironmentVariable("ARCANE_DISABLE_GNUPLOT_CURVES").null()) {
     ITimeHistoryCurveWriter2* gnuplot_curve_writer = new GnuplotTimeHistoryCurveWriter2(traceMng());
     m_internal->addCurveWriter(makeRef(gnuplot_curve_writer));
   }
 
-  if (m_internal->isMasterIO() || m_internal->isNonIOMasterCurvesEnabled()){
+  if (m_internal->isMasterIO() || m_internal->isNonIOMasterCurvesEnabled()) {
     ServiceBuilder<ITimeHistoryCurveWriter2> builder(subDomain());
     auto writers = builder.createAllInstances();
-    for( auto& wr_ref : writers ){
+    for (auto& wr_ref : writers) {
       ITimeHistoryCurveWriter2* cw = wr_ref.get();
-      if (cw){
+      if (cw) {
         info() << "FOUND CURVE SERVICE (V2)!";
         m_internal->addCurveWriter(wr_ref);
       }
@@ -423,12 +425,12 @@ removeCurveWriter(const String& name)
 extern "C++" ARCANE_IMPL_EXPORT ITimeHistoryMng*
 arcaneCreateTimeHistoryMng2(ISubDomain* mng)
 {
-  return new TimeHistoryMng2(ModuleBuildInfo(mng,"TimeHistoryMng"));
+  return new TimeHistoryMng2(ModuleBuildInfo(mng, "TimeHistoryMng"));
 }
 extern "C++" ARCANE_IMPL_EXPORT ITimeHistoryMng*
 arcaneCreateTimeHistoryMng2(ISubDomain* mng, bool add_entry_points)
 {
-  return new TimeHistoryMng2(ModuleBuildInfo(mng,"TimeHistoryMng"), add_entry_points);
+  return new TimeHistoryMng2(ModuleBuildInfo(mng, "TimeHistoryMng"), add_entry_points);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/TimeHistoryMng2.cc
+++ b/arcane/src/arcane/impl/TimeHistoryMng2.cc
@@ -305,7 +305,7 @@ timeHistoryBegin()
     if (subDomain()->applicationInfo().isDebug())
       force_print_thm = true;
     if (force_print_thm)
-      m_internal->dumpHistory(false);
+      m_internal->dumpHistory();
   }
 }
 
@@ -384,7 +384,8 @@ timeHistoryRestore()
 void TimeHistoryMng2::
 dumpHistory(bool is_verbose)
 {
-  m_internal->dumpHistory(is_verbose);
+  ARCANE_UNUSED(is_verbose);
+  m_internal->dumpHistory();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -335,9 +335,9 @@ _addHistoryValue(const TimeHistoryAddValueArgInternal& thpi, ConstArrayView<Data
   if (!m_is_active)
     return;
 
-  String name = thpi.thp().name().clone();
-  if(thpi.hasMetadata()){
-    name = name + "_" + thpi.metadata();
+  String name_to_find = thpi.thp().name().clone();
+  if(thpi.mesh() != nullptr){
+    name_to_find = name_to_find + "_" + thpi.mesh()->name();
   }
 
   Integer iteration = m_sd->commonVariables().globalIteration();
@@ -345,21 +345,25 @@ _addHistoryValue(const TimeHistoryAddValueArgInternal& thpi, ConstArrayView<Data
   if (!thpi.thp().endTime() && iteration!=0)
     --iteration;
 
-  auto hl = m_history_list.find(name);
+  auto hl = m_history_list.find(name_to_find);
   TimeHistoryValueT<DataType>* th = nullptr;
   // Trouvé, on le retourne.
   if (hl!=m_history_list.end())
     th = dynamic_cast<TimeHistoryValueT<DataType>* >(hl->second);
   else{
-    th = new TimeHistoryValueT<DataType>(m_sd,name,(Integer)m_history_list.size(),
-                                          values.size(),isShrinkActive());
-    m_history_list.insert(HistoryValueType(name,th));
+    if(thpi.mesh() != nullptr) {
+      th = new TimeHistoryValueT<DataType>(thpi.mesh(), thpi.thp().name(), (Integer)m_history_list.size(), values.size(), isShrinkActive());
+    }
+    else{
+      th = new TimeHistoryValueT<DataType>(m_sd, thpi.thp().name(), (Integer)m_history_list.size(), values.size(), isShrinkActive());
+    }
+    m_history_list.insert(HistoryValueType(name_to_find, th));
   }
   if (!th)
     return;
   if (values.size()!=th->subSize()){
     ARCANE_FATAL("Bad subsize for curve '{0}' current={1} old={2}",
-                 name,values.size(),th->subSize());
+                 name_to_find, values.size(), th->subSize());
   }
   th->addValue(values,iteration);
 }

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -635,11 +635,17 @@ template <class DataType>
 void TimeHistoryMngInternal::
 _addHistoryValue(const TimeHistoryAddValueArgInternal& thpi, ConstArrayView<DataType> values)
 {
-  if (!m_is_master_io && !(m_enable_non_io_master_curves && thpi.thp().isLocal()))
+  if(!m_is_master_io && (!thpi.thp().isLocal() || !m_enable_non_io_master_curves)) {
     return;
+  }
 
-  if (!m_is_active)
+  if(thpi.thp().isLocal() && thpi.thp().localProcId() != m_parallel_mng->commRank()) {
     return;
+  }
+
+  if (!m_is_active) {
+    return;
+  }
 
   String name_to_find = thpi.thp().name().clone();
   if(!thpi.meshHandle().isNull()){

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -301,7 +301,7 @@ readVariables()
       // ou le même nom qu'un historique "globale".
       name = name + "_" + mh.meshName();
     }
-    if(sub_domain){
+    if(sub_domain != -1){
       name = name + "_Local";
     }
     if (!val)

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -12,8 +12,10 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/impl/internal/TimeHistoryMngInternal.h"
+
 #include "arcane/core/IMeshMng.h"
 #include "arcane/core/IPropertyMng.h"
+
 #include "arcane/utils/JSONWriter.h"
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -387,7 +387,7 @@ _dumpSummaryOfCurvesLegacy()
   // Génère un fichier xml contenant la liste des courbes de l'historique
   Directory out_dir(m_output_path);
   IParallelMng* parallel_mng = m_sd->parallelMng();
-  Integer master_io_rank = parallel_mng->masterIORank() ;
+  Integer master_io_rank = parallel_mng->masterIORank();
   if (m_is_master_io) {
     std::ofstream ofile(out_dir.file("time_history.xml").localstr());
     ofile << "<?xml version='1.0' ?>\n";
@@ -398,7 +398,9 @@ _dumpSummaryOfCurvesLegacy()
       if(!th.meshHandle().isNull()){
         ofile << "_" << th.meshHandle().meshName();
       }
-      //TODO : subDomain
+      if(th.isLocal()){
+        ofile << "_SubDomain" << master_io_rank;
+      }
       ofile << "'/>\n";
     }
     if (m_enable_non_io_master_curves) {
@@ -419,7 +421,7 @@ _dumpSummaryOfCurvesLegacy()
               parallel_mng->recv(buf2,i);
               ofile << "_" << buf2.unguardedBasePointer();
             }
-            //TODO : subDomain
+            ofile << "_SubDomain" << i;
             ofile << "'/>\n";
           }
         }
@@ -502,7 +504,6 @@ _dumpSummaryOfCurves()
                     json_writer.write("support", buf2.unguardedBasePointer());
                   }
                   json_writer.write("sub-domain", i);
-
                 }
               }
             }
@@ -511,7 +512,6 @@ _dumpSummaryOfCurves()
         }
       }
     }
-
 
     Directory out_dir(m_output_path);
     std::ofstream ofile(out_dir.file("time_history.json").localstr());

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -336,8 +336,8 @@ _addHistoryValue(const TimeHistoryAddValueArgInternal& thpi, ConstArrayView<Data
     return;
 
   String name_to_find = thpi.thp().name().clone();
-  if(thpi.mesh() != nullptr){
-    name_to_find = name_to_find + "_" + thpi.mesh()->name();
+  if(!thpi.meshHandle().isNull()){
+    name_to_find = name_to_find + "_" + thpi.meshHandle().meshName();
   }
 
   Integer iteration = m_sd->commonVariables().globalIteration();
@@ -351,8 +351,8 @@ _addHistoryValue(const TimeHistoryAddValueArgInternal& thpi, ConstArrayView<Data
   if (hl!=m_history_list.end())
     th = dynamic_cast<TimeHistoryValueT<DataType>* >(hl->second);
   else{
-    if(thpi.mesh() != nullptr) {
-      th = new TimeHistoryValueT<DataType>(thpi.mesh(), thpi.thp().name(), (Integer)m_history_list.size(), values.size(), isShrinkActive());
+    if(!thpi.meshHandle().isNull()) {
+      th = new TimeHistoryValueT<DataType>(thpi.meshHandle(), thpi.thp().name(), (Integer)m_history_list.size(), values.size(), isShrinkActive());
     }
     else{
       th = new TimeHistoryValueT<DataType>(m_sd, thpi.thp().name(), (Integer)m_history_list.size(), values.size(), isShrinkActive());

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -13,6 +13,7 @@
 
 #include "arcane/impl/internal/TimeHistoryMngInternal.h"
 #include "arcane/core/IMeshMng.h"
+#include "arcane/core/IPropertyMng.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -83,8 +84,24 @@ updateMetaData()
   }
 
   updateGlobalTimeCurve();
-  _saveProperties();
+}
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void TimeHistoryMngInternal::
+addObservers()
+{
+  IVariableMng* vm = m_sd->variableMng();
+  IPropertyMng* prop_mng = m_sd->propertyMng();
+
+  m_observer_pool.addObserver(this,
+                              &TimeHistoryMngInternal::_saveProperties,
+                              prop_mng->writeObservable());
+
+  m_observer_pool.addObserver(this,
+                              &TimeHistoryMngInternal::updateMetaData,
+                              vm->writeObservable());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -193,7 +210,6 @@ readVariables()
   else{
     ARCANE_FATAL("Unknown TimeHistory Variables format -- Found version: {0}", version);
   }
-
 
   m_tmng->info(4) << "readVariables resizes m_global_time to " << m_th_global_time.size();
   m_global_times.resize(m_th_global_time.size());

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -139,7 +139,7 @@ dumpHistory(bool is_verbose)
 
   _checkOutputPath();
   _dumpCurvesAllWriters(is_verbose);
-  _dumpSummaryOfCurves();
+  _dumpSummaryOfCurvesLegacy();
 
   m_tmng->info() << "Fin sortie historique: " << platform::getCurrentDateTime();
 }
@@ -319,7 +319,7 @@ _dumpCurvesAllWriters(bool is_verbose)
 /*---------------------------------------------------------------------------*/
 
 void TimeHistoryMngInternal::
-_dumpSummaryOfCurves()
+_dumpSummaryOfCurvesLegacy()
 {
   // Génère un fichier xml contenant la liste des courbes de l'historique
   Directory out_dir(m_output_path);
@@ -332,10 +332,7 @@ _dumpSummaryOfCurves()
     for( ConstIterT<HistoryList> i(m_history_list); i(); ++i ){
       const TimeHistoryValue& th = *(i->second);
       if(!th.meshHandle().isNull()){
-        ofile << "<curve name='" << th.name()
-              << "' support='" << th.meshHandle().meshName()
-              << "'/>\n"
-        ;
+        ofile << "<curve name='" <<  th.name() << "_" << th.meshHandle().meshName() << "'/>\n";
       }
       else{
         ofile << "<curve name='" <<  th.name() << "'/>\n";
@@ -359,10 +356,7 @@ _dumpSummaryOfCurves()
               UniqueArray<char> buf2(length[1]);
               parallel_mng->recv(buf,i);
               parallel_mng->recv(buf2,i);
-              ofile << "<curve name='" <<  buf.unguardedBasePointer()
-                    << "' support='" << buf2.unguardedBasePointer()
-                    << "'/>\n"
-              ;
+              ofile << "<curve name='" <<  buf.unguardedBasePointer() << "_" << buf2.unguardedBasePointer() << "'/>\n";
             }
           }
         }

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -234,6 +234,9 @@ readVariables()
       default:
         break;
       }
+      // Important dans le cas où on a deux historiques de même nom pour deux maillages différents,
+      // ou le même nom qu'un historique "globale".
+      name = name + "_" + mh.meshName();
     }
     if(need_update){
       val->fromOldToNewVariables(m_sd);
@@ -374,6 +377,8 @@ _addHistoryValue(const TimeHistoryAddValueArgInternal& thpi, ConstArrayView<Data
 
   String name_to_find = thpi.thp().name().clone();
   if(!thpi.meshHandle().isNull()){
+    // Important dans le cas où on a deux historiques de même nom pour deux maillages différents,
+    // ou le même nom qu'un historique "globale".
     name_to_find = name_to_find + "_" + thpi.meshHandle().meshName();
   }
 

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.cc
@@ -120,7 +120,7 @@ void TimeHistoryMngInternal::
 addNowInGlobalTime()
 {
   m_global_times.add(m_sd->commonVariables().globalTime());
-  TimeHistoryAddValueArgInternal thpi(m_sd->commonVariables().m_global_time.name(), -1, true);
+  TimeHistoryAddValueArgInternal thpi(m_sd->commonVariables().m_global_time.name(), true, -1);
   addValue(thpi, m_sd->commonVariables().globalTime());
 }
 
@@ -263,7 +263,7 @@ readVariables()
 
     TimeHistoryValue* val = nullptr;
     if(support_str.null()){
-      TimeHistoryAddValueArgInternal thpi(name, sub_domain, true);
+      TimeHistoryAddValueArgInternal thpi(name, true, sub_domain);
       switch(dt){
       case DT_Real:
         val = new TimeHistoryValueT<Real>(m_sd, thpi, index, sub_size, isShrinkActive());
@@ -283,7 +283,7 @@ readVariables()
     }
     else{
       MeshHandle mh = m_sd->meshMng()->findMeshHandle(support_str);
-      TimeHistoryAddValueArgInternal thpi(TimeHistoryAddValueArg(name, sub_domain, true), mh);
+      TimeHistoryAddValueArgInternal thpi(TimeHistoryAddValueArg(name, true, sub_domain), mh);
       switch(dt){
       case DT_Real:
         val = new TimeHistoryValueT<Real>(thpi, index, sub_size, isShrinkActive());

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -418,6 +418,7 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   void _destroyAll();
   void _dumpCurvesAllWriters(bool is_verbose);
   void _dumpSummaryOfCurvesLegacy();
+  void _dumpSummaryOfCurves();
   void _removeCurveWriter(const Ref<ITimeHistoryCurveWriter2>& writer)
   {
     m_curve_writers2.erase(writer);

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -339,7 +339,7 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   , m_is_active(true)
   , m_is_shrink_active(false)
   , m_is_dump_active(true)
-  , m_properties(new Properties(sd->propertyMng(), "ArcaneTimeHistoryProperties_"))
+  , m_properties(new Properties(sd->propertyMng(), "ArcaneTimeHistoryProperties"))
   , m_version(2)
   {
     m_enable_non_io_master_curves = !platform::getEnvironmentVariable("ARCANE_ENABLE_NON_IO_MASTER_CURVES").null();
@@ -408,6 +408,7 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   void setDumpActive(bool is_active) override { m_is_dump_active = is_active; }
   bool isMasterIO() override { return m_is_master_io; }
   bool isNonIOMasterCurvesEnabled() override { return m_enable_non_io_master_curves; }
+  void addObservers() override;
 
 
  private:

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -401,11 +401,12 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   , m_trace_mng(m_variable_mng->traceMng())
   , m_parallel_mng(m_variable_mng->parallelMng())
   , m_common_variables(m_variable_mng)
-  , m_th_meta_data(VariableBuildInfo(m_variable_mng,"TimeHistoryMngMetaData"))
-  , m_th_global_time(VariableBuildInfo(m_variable_mng,"TimeHistoryMngGlobalTime"))
   , m_is_active(true)
   , m_is_shrink_active(false)
   , m_is_dump_active(true)
+  , m_io_master_write_only(false)
+  , m_th_meta_data(VariableBuildInfo(m_variable_mng,"TimeHistoryMngMetaData"))
+  , m_th_global_time(VariableBuildInfo(m_variable_mng,"TimeHistoryMngGlobalTime"))
   , m_properties(properties)
   , m_version(2)
   {
@@ -460,7 +461,7 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   void addNowInGlobalTime() override;
   void updateGlobalTimeCurve() override;
   void resizeArrayAfterRestore() override;
-  void dumpCurves(ITimeHistoryCurveWriter2* writer, bool master_only) override;
+  void dumpCurves(ITimeHistoryCurveWriter2* writer) override;
   void dumpHistory() override;
   void updateMetaData() override;
   void readVariables(IMeshMng* mesh_mng, IMesh* default_mesh) override;
@@ -482,6 +483,8 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   void setDumpActive(bool is_active) override { m_is_dump_active = is_active; }
   bool isMasterIO() override { return m_is_master_io; }
   bool isNonIOMasterCurvesEnabled() override { return m_enable_non_io_master_curves; }
+  bool isIOMasterWriteOnly() override { return m_io_master_write_only; }
+  void setIOMasterWriteOnly(bool is_active) override { m_io_master_write_only = is_active; }
 
  private:
 
@@ -545,6 +548,11 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
 
   bool m_is_master_io; //!< True si je suis le gestionnaire actif
   bool m_enable_non_io_master_curves; //!< Indique si l'ecriture  de courbes par des procs non io_master est possible
+  bool m_is_active; //!< Indique si le service est actif.
+  bool m_is_shrink_active; //!< Indique si la compression de l'historique est active
+  bool m_is_dump_active; //!< Indique si les dump sont actifs
+  bool m_io_master_write_only; //!< Indique si les writers doivent être appelé par tous les processus.
+
   String m_output_path;
   ObserverPool m_observer_pool;
   HistoryList m_history_list; //!< Liste des historiques
@@ -552,9 +560,6 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   VariableArrayReal m_th_global_time; //!< Tableau des instants de temps
   RealUniqueArray m_global_times; //!< Liste des temps globaux
   CurveWriter2List m_curve_writers2;
-  bool m_is_active; //!< Indique si le service est actif.
-  bool m_is_shrink_active; //!< Indique si la compression de l'historique est active
-  bool m_is_dump_active; //!< Indique si les dump sont actifs
   Ref<Properties> m_properties;
   Integer m_version;
 };

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -175,8 +175,8 @@ class TimeHistoryValueT
 
   TimeHistoryValueT(const MeshHandle& mesh_handle, const String& name, Integer index, Integer nb_element, bool shrink)
   : TimeHistoryValue(name, mesh_handle, DataTypeTraitsT<DataType>::type(), index, nb_element)
-  , m_values(VariableBuildInfo(mesh_handle, String("TimeHistory_Values_")+index,VAR_BUILD_FLAGS))
-  , m_iterations(VariableBuildInfo(mesh_handle, String("TimeHistory_Iterations_")+index,VAR_BUILD_FLAGS))
+  , m_values(VariableBuildInfo(mesh_handle, String("TimeHistoryMngValues")+index,VAR_BUILD_FLAGS))
+  , m_iterations(VariableBuildInfo(mesh_handle, String("TimeHistoryMngIterations")+index,VAR_BUILD_FLAGS))
   , m_use_compression(false)
   , m_shrink_history(shrink)
   {

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -85,6 +85,10 @@ class TimeHistoryValue
                           ITimeHistoryCurveWriter2* writer,
                           const TimeHistoryCurveWriterInfo& infos) const =0;
 
+  virtual void arrayToWrite(UniqueArray<Int32>& iterations,
+                            UniqueArray<Real>& values,
+                            const TimeHistoryCurveWriterInfo& infos) const =0;
+
   virtual void applyTransformation(ITraceMng* msg,
                                    ITimeHistoryTransformer* v) =0;
 
@@ -261,8 +265,9 @@ class TimeHistoryValueT
     for(Integer i=0, is=nb_iteration; i<is; ++i ){
       Integer iter = m_iterations[i];
       if (iter<max_iter){
-        for(Integer z=0; z<sub_size; ++z )
-          values_to_write.add(Convert::toReal(m_values[(i*sub_size)+ z]));
+        for(Integer z=0; z<sub_size; ++z ) {
+          values_to_write.add(Convert::toReal(m_values[(i * sub_size) + z]));
+        }
         iterations_to_write.add(iter);
       }
     }
@@ -304,6 +309,24 @@ class TimeHistoryValueT
     m_values.resize(nb_value);
     for( Integer i=0; i<nb_value; ++i )
       m_values[i] = values[i];
+  }
+
+  void arrayToWrite(UniqueArray<Int32>& iterations, UniqueArray<Real>& values, const TimeHistoryCurveWriterInfo& infos) const override {
+
+    Integer max_iter = infos.times().size();
+    Integer nb_iteration = m_iterations.size();
+    iterations.reserve(nb_iteration);
+    Integer sub_size = subSize();
+    values.reserve(nb_iteration*sub_size);
+    for(Integer i=0, is=nb_iteration; i<is; ++i ){
+      Integer iter = m_iterations[i];
+      if (iter<max_iter){
+        for(Integer z=0; z<sub_size; ++z ) {
+          values.add(Convert::toReal(m_values[(i * sub_size) + z]));
+        }
+        iterations.add(iter);
+      }
+    }
   }
 
   const ValueList& values() const { return m_values; }
@@ -384,7 +407,7 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   void addNowInGlobalTime() override;
   void updateGlobalTimeCurve() override;
   void resizeArrayAfterRestore() override;
-  void dumpCurves(ITimeHistoryCurveWriter2* writer) override;
+  void dumpCurves(ITimeHistoryCurveWriter2* writer, bool master_only) override;
   void dumpHistory(bool is_verbose) override;
   void updateMetaData() override;
   void readVariables() override;

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -278,8 +278,14 @@ class TimeHistoryValueT
         iterations_to_write.add(iter);
       }
     }
-    TimeHistoryCurveInfo curve_info(name(),iterations_to_write,values_to_write,sub_size);
-    writer->writeCurve(curve_info);
+    if(!meshHandle().isNull()){
+      TimeHistoryCurveInfo curve_info(name(), meshHandle().meshName(), iterations_to_write, values_to_write, sub_size);
+      writer->writeCurve(curve_info);
+    }
+    else{
+      TimeHistoryCurveInfo curve_info(name(), iterations_to_write, values_to_write, sub_size);
+      writer->writeCurve(curve_info);
+    }
   }
 
   void applyTransformation(ITraceMng* msg,ITimeHistoryTransformer* v) override

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -184,6 +184,17 @@ class TimeHistoryValueT
   , m_iterations(VariableBuildInfo(sd,String("TimeHistoryMngIterations")+index,VAR_BUILD_FLAGS))
   , m_use_compression(false)
   , m_shrink_history(shrink)
+  , m_mesh_support(nullptr)
+  {
+  }
+
+  TimeHistoryValueT(IMesh* mesh, const String& name, Integer index, Integer nb_element, bool shrink=false)
+  : TimeHistoryValue(name, DataTypeTraitsT<DataType>::type(), index, nb_element)
+  , m_values(VariableBuildInfo(mesh,String("TimeHistory_Values_")+index,VAR_BUILD_FLAGS))
+  , m_iterations(VariableBuildInfo(mesh,String("TimeHistory_Iterations_")+index,VAR_BUILD_FLAGS))
+  , m_use_compression(false)
+  , m_shrink_history(shrink)
+  , m_mesh_support(mesh)
   {
   }
 
@@ -299,6 +310,7 @@ class TimeHistoryValueT
   IterationList m_iterations;
   bool m_use_compression;
   bool m_shrink_history;
+  IMesh* m_mesh_support;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -306,8 +306,10 @@ class TimeHistoryValueT
 
     Integer max_iter = infos.times().size();
     Integer nb_iteration = m_iterations.size();
-    iterations.reserve(nb_iteration);
     Integer sub_size = subSize();
+    iterations.clear();
+    iterations.reserve(nb_iteration);
+    values.clear();
     values.reserve(nb_iteration*sub_size);
     for(Integer i=0, is=nb_iteration; i<is; ++i ){
       Integer iter = m_iterations[i];

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -73,6 +73,15 @@ class TimeHistoryValue
   , m_data_type(dt)
   , m_index(index)
   , m_sub_size(sub_size)
+  , m_mesh_handle()
+  {}
+
+  TimeHistoryValue(const String& name, const MeshHandle& mesh_handle, eDataType dt, Integer index, Integer sub_size)
+  : m_name(name)
+  , m_data_type(dt)
+  , m_index(index)
+  , m_sub_size(sub_size)
+  , m_mesh_handle(mesh_handle)
   {}
 
   virtual ~TimeHistoryValue() = default; //!< Libére les ressources
@@ -107,12 +116,15 @@ class TimeHistoryValue
 
   Integer subSize() const { return m_sub_size; }
 
+  const MeshHandle& meshHandle() const { return m_mesh_handle; }
+
  private:
 
   String m_name; //!< Nom de l'historique
   eDataType m_data_type; //!< Type de la donnée
   Integer m_index; //!< Index de l'historique dans la liste
   Integer m_sub_size;
+  MeshHandle m_mesh_handle;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -184,17 +196,15 @@ class TimeHistoryValueT
   , m_iterations(VariableBuildInfo(sd,String("TimeHistoryMngIterations")+index,VAR_BUILD_FLAGS))
   , m_use_compression(false)
   , m_shrink_history(shrink)
-  , m_mesh_support(nullptr)
   {
   }
 
-  TimeHistoryValueT(IMesh* mesh, const String& name, Integer index, Integer nb_element, bool shrink=false)
-  : TimeHistoryValue(name, DataTypeTraitsT<DataType>::type(), index, nb_element)
-  , m_values(VariableBuildInfo(mesh,String("TimeHistory_Values_")+index,VAR_BUILD_FLAGS))
-  , m_iterations(VariableBuildInfo(mesh,String("TimeHistory_Iterations_")+index,VAR_BUILD_FLAGS))
+  TimeHistoryValueT(const MeshHandle& mesh_handle, const String& name, Integer index, Integer nb_element, bool shrink=false)
+  : TimeHistoryValue(name, mesh_handle, DataTypeTraitsT<DataType>::type(), index, nb_element)
+  , m_values(VariableBuildInfo(mesh_handle, String("TimeHistory_Values_")+index,VAR_BUILD_FLAGS))
+  , m_iterations(VariableBuildInfo(mesh_handle, String("TimeHistory_Iterations_")+index,VAR_BUILD_FLAGS))
   , m_use_compression(false)
   , m_shrink_history(shrink)
-  , m_mesh_support(mesh)
   {
   }
 
@@ -310,7 +320,6 @@ class TimeHistoryValueT
   IterationList m_iterations;
   bool m_use_compression;
   bool m_shrink_history;
-  IMesh* m_mesh_support;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -421,7 +421,8 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   bool isMasterIO() override { return m_is_master_io; }
   bool isNonIOMasterCurvesEnabled() override { return m_enable_non_io_master_curves; }
   void addObservers(IPropertyMng* prop_mng) override;
-  void editOutputPath(const Directory& directory);
+  void editOutputPath(const Directory& directory) override;
+  void iterationsAndValues(const TimeHistoryAddValueArgInternal& thpi, UniqueArray<Int32>& iterations, UniqueArray<Real>& values) override;
 
 
  private:

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -16,29 +16,23 @@
 
 #include "arcane/utils/Iostream.h"
 #include "arcane/utils/Iterator.h"
-#include "arcane/utils/ApplicationInfo.h"
 #include "arcane/utils/ScopedPtr.h"
 #include "arcane/utils/ITraceMng.h"
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/OStringStream.h"
 
-#include "arcane/IIOMng.h"
-#include "arcane/CommonVariables.h"
-#include "arcane/Directory.h"
-#include "arcane/AbstractModule.h"
-#include "arcane/EntryPoint.h"
-#include "arcane/ObserverPool.h"
-#include "arcane/IVariableMng.h"
-#include "arcane/CaseOptionsMain.h"
-#include "arcane/IParallelMng.h"
-#include "arcane/ITimeHistoryCurveWriter2.h"
-#include "arcane/ITimeHistoryTransformer.h"
-#include "arcane/XmlNode.h"
-#include "arcane/XmlNodeList.h"
-#include "arcane/IXmlDocumentHolder.h"
-#include "arcane/ServiceFinder2.h"
-#include "arcane/ServiceBuilder.h"
+#include "arcane/core/IIOMng.h"
 #include "arcane/core/CommonVariables.h"
+#include "arcane/core/Directory.h"
+#include "arcane/core/ObserverPool.h"
+#include "arcane/core/IVariableMng.h"
+#include "arcane/core/IParallelMng.h"
+#include "arcane/core/ITimeHistoryCurveWriter2.h"
+#include "arcane/core/ITimeHistoryTransformer.h"
+#include "arcane/core/XmlNode.h"
+#include "arcane/core/XmlNodeList.h"
+#include "arcane/core/IXmlDocumentHolder.h"
+#include "arcane/core/ServiceBuilder.h"
 #include "arcane/core/Properties.h"
 
 #include "arcane/datatype/DataTypeTraits.h"
@@ -47,7 +41,6 @@
 
 #include <map>
 #include <set>
-#include <variant>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -40,6 +40,7 @@
 #include "arcane/ServiceFinder2.h"
 #include "arcane/ServiceBuilder.h"
 #include "arcane/core/CommonVariables.h"
+#include "arcane/core/Properties.h"
 
 #include "arcane/datatype/DataTypeTraits.h"
 
@@ -338,6 +339,8 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   , m_is_active(true)
   , m_is_shrink_active(false)
   , m_is_dump_active(true)
+  , m_properties(new Properties(sd->propertyMng(), "ArcaneTimeHistoryProperties_"))
+  , m_version(2)
   {
     m_enable_non_io_master_curves = !platform::getEnvironmentVariable("ARCANE_ENABLE_NON_IO_MASTER_CURVES").null();
     // Seul le sous-domaine maître des IO rend actif les time history.
@@ -419,7 +422,8 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
     m_curve_writers2.erase(writer);
   }
 
-  bool _fromOldFormat();
+  void _fromLegacyFormat();
+  void _saveProperties();
 
  private:
   ISubDomain* m_sd;
@@ -437,7 +441,8 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   bool m_is_active; //!< Indique si le service est actif.
   bool m_is_shrink_active; //!< Indique si la compression de l'historique est active
   bool m_is_dump_active; //!< Indique si les dump sont actifs
-
+  Properties* m_properties;
+  Integer m_version;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
+++ b/arcane/src/arcane/impl/internal/TimeHistoryMngInternal.h
@@ -413,7 +413,7 @@ class ARCANE_IMPL_EXPORT TimeHistoryMngInternal
   void _checkOutputPath();
   void _destroyAll();
   void _dumpCurvesAllWriters(bool is_verbose);
-  void _dumpSummaryOfCurves();
+  void _dumpSummaryOfCurvesLegacy();
   void _removeCurveWriter(const Ref<ITimeHistoryCurveWriter2>& writer)
   {
     m_curve_writers2.erase(writer);

--- a/arcane/src/arcane/std/ArcaneCurveWriter.cc
+++ b/arcane/src/arcane/std/ArcaneCurveWriter.cc
@@ -230,6 +230,12 @@ writeCurve(const TimeHistoryCurveInfo& infos)
   node.setAttrValue("values-offset",String::fromNumber(values_offset));
   node.setAttrValue("values-size",String::fromNumber(infos.values().size()));
   node.setAttrValue("sub-size",String::fromNumber(infos.subSize()));
+  if(infos.hasSupport()){
+    node.setAttrValue("support",infos.support());
+  }
+  if(infos.subDomain() != -1){
+    node.setAttrValue("sub-domain",String::fromNumber(infos.subDomain()));
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/std/ArcaneCurveWriter.cc
+++ b/arcane/src/arcane/std/ArcaneCurveWriter.cc
@@ -224,16 +224,27 @@ writeCurve(const TimeHistoryCurveInfo& infos)
   Int64 iteration_offset = _write(iterations);
 
   XmlNode node = m_p->m_root_element.createAndAppendElement("curve");
-  node.setAttrValue("name",infos.name());
+
+  String name(infos.name().clone());
+
+  if(infos.subDomain() != NULL_SUB_DOMAIN_ID){
+    name = "SD" + String::fromNumber(infos.subDomain()) + "_" + name;
+  }
+  if(infos.hasSupport()){
+    name = infos.support() + "_" + name;
+  }
+
+  node.setAttrValue("name",name);
   node.setAttrValue("iterations-offset",String::fromNumber(iteration_offset));
   node.setAttrValue("iterations-size",String::fromNumber(iterations.size()));
   node.setAttrValue("values-offset",String::fromNumber(values_offset));
   node.setAttrValue("values-size",String::fromNumber(infos.values().size()));
   node.setAttrValue("sub-size",String::fromNumber(infos.subSize()));
+  node.setAttrValue("base-name",infos.name());
   if(infos.hasSupport()){
     node.setAttrValue("support",infos.support());
   }
-  if(infos.subDomain() != -1){
+  if(infos.subDomain() != NULL_SUB_DOMAIN_ID){
     node.setAttrValue("sub-domain",String::fromNumber(infos.subDomain()));
   }
 }

--- a/arcane/src/arcane/std/ArcaneCurveWriter.cc
+++ b/arcane/src/arcane/std/ArcaneCurveWriter.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneCurveWriter.cc                                        (C) 2000-2021 */
+/* ArcaneCurveWriter.cc                                        (C) 2000-2024 */
 /*                                                                           */
 /* Ecriture des courbes au format Arcane.                                    */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/ArcaneTest.config
+++ b/arcane/src/arcane/tests/ArcaneTest.config
@@ -296,6 +296,28 @@
     </entry-points>
   </time-loop>
 
+   <time-loop name="TimeHistoryAdderTestModuleLoop">
+     <title>Boucle en temps pour tester ITimeHistoryAdder</title>
+     <description>Boucle en temps pour tester les implementations de ITimeHistoryAdder</description>
+     <modules>
+       <module name="TimeHistoryAdderTest" need="required" />
+       <module name="ArcaneCheckpoint" need="required" />
+     </modules>
+
+     <entry-points where="init">
+       <entry-point name="TimeHistoryAdderTest.Init"/>
+     </entry-points>
+
+     <entry-points where="compute-loop">
+       <entry-point name="TimeHistoryAdderTest.Loop"/>
+     </entry-points>
+
+     <entry-points where="exit">
+       <entry-point name="TimeHistoryAdderTest.Exit"/>
+     </entry-points>
+
+   </time-loop>
+
    <time-loop name="CustomMeshTestLoop">
      <title>Boucle en temps pour tester le branchement de maillage custom</title>
      <description>Boucle en temps pour tester le branchement de maillage custom</description>

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -978,7 +978,7 @@ arcane_add_test_sequential(string_variable_replace testStringVariableReplace.arc
 #################################################################
 
 # Test pour les implementations de TimeHistoryAdder.
-arcane_add_test_sequential(time_history_adder_1 testTimeHistoryAdder-1.arc -c 2 -m 5 -We,ARCANE_ENABLE_NON_IO_MASTER_CURVES,1)
+arcane_add_test(time_history_adder_1 testTimeHistoryAdder-1.arc -c 2 -m 5 -We,ARCANE_ENABLE_NON_IO_MASTER_CURVES,1)
 
 
 # ----------------------------------------------------------------------------

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -974,6 +974,12 @@ endif()
 # Test pour la partie StringVariableReplace.
 arcane_add_test_sequential(string_variable_replace testStringVariableReplace.arc)
 
+#################################################################
+#################################################################
+
+# Test pour les implementations de TimeHistoryAdder.
+arcane_add_test_sequential(time_history_adder_1 testTimeHistoryAdder-1.arc -c 2 -m 5 -We,ARCANE_ENABLE_NON_IO_MASTER_CURVES,1)
+
 
 # ----------------------------------------------------------------------------
 # Local Variables:

--- a/arcane/src/arcane/tests/TimeHistoryAdderTest.axl
+++ b/arcane/src/arcane/tests/TimeHistoryAdderTest.axl
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<module name="TimeHistoryAdderTest" version="1.0" namespace-name="ArcaneTest">
+  <description>
+  </description>
+
+  <entry-points>
+    <entry-point method-name="init" name="Init" where="init" property="none" />
+    <entry-point method-name="loop" name="Loop" where="compute-loop" property="none" />
+    <entry-point method-name="exit" name="Exit" where="exit" property="none" />
+  </entry-points>
+
+  <options>
+  </options>
+</module>

--- a/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
+++ b/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
@@ -88,11 +88,6 @@ _writer()
   ISubDomain* sd = subDomain();
   Integer iteration = globalIteration();
 
-  // TODO : Conserve-t-on la méthode adder ?
-  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA"), iteration++);
-  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA", true, 0), iteration++);
-  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA", true, 1), iteration++);
-
   // Création d'un adder global.
   GlobalTimeHistoryAdder global_adder(sd->timeHistoryMng());
 
@@ -135,58 +130,6 @@ _checker()
 
   Integer adder = 1;
 
-  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("AAA")), iterations, values);
-  for(Integer i = 0; i < iteration; ++i){
-    debug() << "iteration[" << i << "] = " << iterations[i]
-            << " == i+1 = " << i+1
-            << " -- values[" << i << "] = " << values[i]
-            << " == i+(adder++) = " << i+(adder)
-    ;
-    ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-    ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
-  }
-  adder++;
-
-  iterations.clear();
-  values.clear();
-  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("AAA", true, 0)), iterations, values);
-  if(pm->commRank() == 0) {
-    for (Integer i = 0; i < iteration; ++i) {
-      debug() << "iteration[" << i << "] = " << iterations[i]
-              << " == i+1 = " << i+1
-              << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+(adder)
-      ;
-      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
-    }
-  }
-  else{
-    ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
-    ARCANE_ASSERT((values.empty()), ("Values not empty"));
-  }
-  adder++;
-
-  iterations.clear();
-  values.clear();
-  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("AAA", true, 1)), iterations, values);
-  if(pm->commRank() == 1) {
-    for(Integer i = 0; i < iteration; ++i){
-      debug() << "iteration[" << i << "] = " << iterations[i]
-              << " == i+1 = " << i+1
-              << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+(adder)
-      ;
-      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
-    }
-  }
-  else{
-    ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
-    ARCANE_ASSERT((values.empty()), ("Values not empty"));
-  }
-  adder++;
-
   iterations.clear();
   values.clear();
   sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB")), iterations, values);
@@ -194,7 +137,7 @@ _checker()
     debug() << "iteration[" << i << "] = " << iterations[i]
             << " == i+1 = " << i+1
             << " -- values[" << i << "] = " << values[i]
-            << " == i+(adder++) = " << i+(adder)
+            << " == i+(adder++) = " << i+adder
     ;
     ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
     ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
@@ -209,7 +152,7 @@ _checker()
       debug() << "iteration[" << i << "] = " << iterations[i]
               << " == i+1 = " << i+1
               << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+(adder)
+              << " == i+(adder++) = " << i+adder
       ;
       ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
       ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
@@ -229,7 +172,7 @@ _checker()
       debug() << "iteration[" << i << "] = " << iterations[i]
               << " == i+1 = " << i+1
               << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+(adder)
+              << " == i+(adder++) = " << i+adder
       ;
       ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
       ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
@@ -249,7 +192,7 @@ _checker()
       debug() << "iteration[" << i << "] = " << iterations[i]
               << " == i+1 = " << i+1
               << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+(adder)
+              << " == i+(adder++) = " << i+adder
       ;
       ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
       ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
@@ -264,7 +207,7 @@ _checker()
         debug() << "iteration[" << i << "] = " << iterations[i]
                 << " == i+1 = " << i+1
                 << " -- values[" << i << "] = " << values[i]
-                << " == i+(adder++) = " << i+(adder)
+                << " == i+(adder++) = " << i+adder
         ;
         ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
         ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
@@ -284,7 +227,7 @@ _checker()
         debug() << "iteration[" << i << "] = " << iterations[i]
                 << " == i+1 = " << i+1
                 << " -- values[" << i << "] = " << values[i]
-                << " == i+(adder++) = " << i+(adder)
+                << " == i+(adder++) = " << i+adder
         ;
         ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
         ARCANE_ASSERT((values[i] == i+adder), ("Error values"));

--- a/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
+++ b/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
@@ -1,0 +1,298 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* TimeHistoryAdderTestModule.cc                               (C) 2000-2024 */
+/*                                                                           */
+/* Module de test pour les implementations de ITimeHistoryAdder.             */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include <arcane/core/ITimeHistoryMng.h>
+#include <arcane/core/MeshTimeHistoryAdder.h>
+#include <arcane/core/GlobalTimeHistoryAdder.h>
+
+#include "arcane/core/IMesh.h"
+#include "arcane/core/internal/ITimeHistoryMngInternal.h"
+
+#include "arcane/tests/TimeHistoryAdderTest_axl.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace ArcaneTest
+{
+using namespace Arcane;
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class TimeHistoryAdderTestModule
+: public ArcaneTimeHistoryAdderTestObject
+{
+ public:
+
+  explicit TimeHistoryAdderTestModule(const ModuleBuildInfo& mbi);
+
+ public:
+
+  VersionInfo versionInfo() const override { return {1, 0, 0}; }
+  void init() override;
+  void loop() override;
+  void _writer();
+  void _checker();
+  void exit() override;
+};
+
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TimeHistoryAdderTestModule::
+TimeHistoryAdderTestModule(const ModuleBuildInfo& mbi)
+: ArcaneTimeHistoryAdderTestObject(mbi)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void TimeHistoryAdderTestModule::
+init()
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void TimeHistoryAdderTestModule::
+loop()
+{
+  _writer();
+  _checker();
+}
+
+void TimeHistoryAdderTestModule::
+_writer()
+{
+  ISubDomain* sd = subDomain();
+  Integer iteration = globalIteration();
+
+  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA"), iteration++);
+  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA", true, 0), iteration++); // Pas de ++ : normal.
+  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA", true, 1), iteration++);
+
+  GlobalTimeHistoryAdder global_adder(sd->timeHistoryMng());
+  global_adder.addValue(TimeHistoryAddValueArg("BBB"), iteration++);
+  global_adder.addValue(TimeHistoryAddValueArg("BBB", true, 0), iteration++);
+  global_adder.addValue(TimeHistoryAddValueArg("BBB", true, 1), iteration++);
+
+  for(auto mesh : sd->meshes()){
+    MeshTimeHistoryAdder mesh_adder(sd->timeHistoryMng(), mesh->handle());
+    mesh_adder.addValue(TimeHistoryAddValueArg("BBB"), iteration++);
+    mesh_adder.addValue(TimeHistoryAddValueArg("BBB", true, 0), iteration++);
+    mesh_adder.addValue(TimeHistoryAddValueArg("BBB", true, 1), iteration++);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void TimeHistoryAdderTestModule::
+_checker()
+{
+  ISubDomain* sd = subDomain();
+  IParallelMng* pm = parallelMng();
+  Integer iteration = globalIteration();
+  UniqueArray<Int32> iterations;
+  UniqueArray<Real> values;
+
+  Integer adder = 1;
+
+  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("AAA")), iterations, values);
+  for(Integer i = 0; i < iteration; ++i){
+    debug() << "iteration[" << i << "] = " << iterations[i]
+            << " == i+1 = " << i+1
+            << " -- values[" << i << "] = " << values[i]
+            << " == i+(adder++) = " << i+(adder)
+    ;
+    ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+    ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+  }
+  adder++;
+
+  iterations.clear();
+  values.clear();
+  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("AAA", true, 0)), iterations, values);
+  if(pm->commRank() == 0) {
+    for (Integer i = 0; i < iteration; ++i) {
+      debug() << "iteration[" << i << "] = " << iterations[i]
+              << " == i+1 = " << i+1
+              << " -- values[" << i << "] = " << values[i]
+              << " == i+(adder++) = " << i+(adder)
+      ;
+      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+    }
+  }
+  else{
+    ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+    ARCANE_ASSERT((values.empty()), ("Values not empty"));
+  }
+  adder++;
+
+  iterations.clear();
+  values.clear();
+  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("AAA", true, 1)), iterations, values);
+  if(pm->commRank() == 1) {
+    for(Integer i = 0; i < iteration; ++i){
+      debug() << "iteration[" << i << "] = " << iterations[i]
+              << " == i+1 = " << i+1
+              << " -- values[" << i << "] = " << values[i]
+              << " == i+(adder++) = " << i+(adder)
+      ;
+      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+    }
+  }
+  else{
+    ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+    ARCANE_ASSERT((values.empty()), ("Values not empty"));
+  }
+  adder++;
+
+  iterations.clear();
+  values.clear();
+  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB")), iterations, values);
+  for(Integer i = 0; i < iteration; ++i){
+    debug() << "iteration[" << i << "] = " << iterations[i]
+            << " == i+1 = " << i+1
+            << " -- values[" << i << "] = " << values[i]
+            << " == i+(adder++) = " << i+(adder)
+    ;
+    ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+    ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+  }
+  adder++;
+
+  iterations.clear();
+  values.clear();
+  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 0)), iterations, values);
+  if(pm->commRank() == 0) {
+    for (Integer i = 0; i < iteration; ++i) {
+      debug() << "iteration[" << i << "] = " << iterations[i]
+              << " == i+1 = " << i+1
+              << " -- values[" << i << "] = " << values[i]
+              << " == i+(adder++) = " << i+(adder)
+      ;
+      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+    }
+  }
+  else{
+    ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+    ARCANE_ASSERT((values.empty()), ("Values not empty"));
+  }
+  adder++;
+
+  iterations.clear();
+  values.clear();
+  sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 1)), iterations, values);
+  if(pm->commRank() == 1) {
+    for(Integer i = 0; i < iteration; ++i){
+      debug() << "iteration[" << i << "] = " << iterations[i]
+              << " == i+1 = " << i+1
+              << " -- values[" << i << "] = " << values[i]
+              << " == i+(adder++) = " << i+(adder)
+      ;
+      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+    }
+  }
+  else{
+    ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+    ARCANE_ASSERT((values.empty()), ("Values not empty"));
+  }
+  adder++;
+
+  for(auto mesh : sd->meshes()){
+    iterations.clear();
+    values.clear();
+    sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB"), mesh->handle()), iterations, values);
+    for(Integer i = 0; i < iteration; ++i){
+      debug() << "iteration[" << i << "] = " << iterations[i]
+              << " == i+1 = " << i+1
+              << " -- values[" << i << "] = " << values[i]
+              << " == i+(adder++) = " << i+(adder)
+      ;
+      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+    }
+    adder++;
+
+    iterations.clear();
+    values.clear();
+    sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 0), mesh->handle()), iterations, values);
+    if(pm->commRank() == 0) {
+      for (Integer i = 0; i < iteration; ++i) {
+        debug() << "iteration[" << i << "] = " << iterations[i]
+                << " == i+1 = " << i+1
+                << " -- values[" << i << "] = " << values[i]
+                << " == i+(adder++) = " << i+(adder)
+        ;
+        ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+        ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+      }
+    }
+    else{
+      ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+      ARCANE_ASSERT((values.empty()), ("Values not empty"));
+    }
+    adder++;
+
+    iterations.clear();
+    values.clear();
+    sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 1), mesh->handle()), iterations, values);
+    if(pm->commRank() == 1) {
+      for(Integer i = 0; i < iteration; ++i){
+        debug() << "iteration[" << i << "] = " << iterations[i]
+                << " == i+1 = " << i+1
+                << " -- values[" << i << "] = " << values[i]
+                << " == i+(adder++) = " << i+(adder)
+        ;
+        ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
+        ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+      }
+    }
+    else{
+      ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+      ARCANE_ASSERT((values.empty()), ("Values not empty"));
+    }
+    adder++;
+  }
+  iterations.clear();
+  values.clear();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void TimeHistoryAdderTestModule::
+exit()
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ARCANE_REGISTER_MODULE_TIMEHISTORYADDERTEST(TimeHistoryAdderTestModule);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace ArcaneTest
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
+++ b/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
@@ -43,14 +43,13 @@ class TimeHistoryAdderTestModule
 
  public:
 
-  VersionInfo versionInfo() const override { return {1, 0, 0}; }
+  VersionInfo versionInfo() const override { return { 1, 0, 0 }; }
   void init() override;
   void loop() override;
   void _writer();
   void _checker();
   void exit() override;
 };
-
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -100,7 +99,7 @@ _writer()
   // On ajoute une valeur à l'historique "BBB" spécifique au sous-domaine 1.
   global_adder.addValue(TimeHistoryAddValueArg("BBB", true, 1), iteration++);
 
-  for(auto mesh : sd->meshes()){
+  for (auto mesh : sd->meshes()) {
 
     // Création d'un adder spécifique au maillage mesh.
     MeshTimeHistoryAdder mesh_adder(sd->timeHistoryMng(), mesh->handle());
@@ -133,32 +132,30 @@ _checker()
   iterations.clear();
   values.clear();
   sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB")), iterations, values);
-  for(Integer i = 0; i < iteration; ++i){
+  for (Integer i = 0; i < iteration; ++i) {
     debug() << "iteration[" << i << "] = " << iterations[i]
-            << " == i+1 = " << i+1
+            << " == i+1 = " << i + 1
             << " -- values[" << i << "] = " << values[i]
-            << " == i+(adder++) = " << i+adder
-    ;
-    ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-    ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+            << " == i+(adder++) = " << i + adder;
+    ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+    ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
   }
   adder++;
 
   iterations.clear();
   values.clear();
   sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 0)), iterations, values);
-  if(pm->commRank() == 0) {
+  if (pm->commRank() == 0) {
     for (Integer i = 0; i < iteration; ++i) {
       debug() << "iteration[" << i << "] = " << iterations[i]
-              << " == i+1 = " << i+1
+              << " == i+1 = " << i + 1
               << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+adder
-      ;
-      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+              << " == i+(adder++) = " << i + adder;
+      ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
     }
   }
-  else{
+  else {
     ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
     ARCANE_ASSERT((values.empty()), ("Values not empty"));
   }
@@ -167,53 +164,50 @@ _checker()
   iterations.clear();
   values.clear();
   sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 1)), iterations, values);
-  if(pm->commRank() == 1) {
-    for(Integer i = 0; i < iteration; ++i){
+  if (pm->commRank() == 1) {
+    for (Integer i = 0; i < iteration; ++i) {
       debug() << "iteration[" << i << "] = " << iterations[i]
-              << " == i+1 = " << i+1
+              << " == i+1 = " << i + 1
               << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+adder
-      ;
-      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+              << " == i+(adder++) = " << i + adder;
+      ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
     }
   }
-  else{
+  else {
     ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
     ARCANE_ASSERT((values.empty()), ("Values not empty"));
   }
   adder++;
 
-  for(auto mesh : sd->meshes()){
+  for (auto mesh : sd->meshes()) {
     iterations.clear();
     values.clear();
     sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB"), mesh->handle()), iterations, values);
-    for(Integer i = 0; i < iteration; ++i){
+    for (Integer i = 0; i < iteration; ++i) {
       debug() << "iteration[" << i << "] = " << iterations[i]
-              << " == i+1 = " << i+1
+              << " == i+1 = " << i + 1
               << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i+adder
-      ;
-      ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-      ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+              << " == i+(adder++) = " << i + adder;
+      ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
     }
     adder++;
 
     iterations.clear();
     values.clear();
     sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 0), mesh->handle()), iterations, values);
-    if(pm->commRank() == 0) {
+    if (pm->commRank() == 0) {
       for (Integer i = 0; i < iteration; ++i) {
         debug() << "iteration[" << i << "] = " << iterations[i]
-                << " == i+1 = " << i+1
+                << " == i+1 = " << i + 1
                 << " -- values[" << i << "] = " << values[i]
-                << " == i+(adder++) = " << i+adder
-        ;
-        ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-        ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+                << " == i+(adder++) = " << i + adder;
+        ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+        ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
       }
     }
-    else{
+    else {
       ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
       ARCANE_ASSERT((values.empty()), ("Values not empty"));
     }
@@ -222,18 +216,17 @@ _checker()
     iterations.clear();
     values.clear();
     sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB", true, 1), mesh->handle()), iterations, values);
-    if(pm->commRank() == 1) {
-      for(Integer i = 0; i < iteration; ++i){
+    if (pm->commRank() == 1) {
+      for (Integer i = 0; i < iteration; ++i) {
         debug() << "iteration[" << i << "] = " << iterations[i]
-                << " == i+1 = " << i+1
+                << " == i+1 = " << i + 1
                 << " -- values[" << i << "] = " << values[i]
-                << " == i+(adder++) = " << i+adder
-        ;
-        ARCANE_ASSERT((iterations[i] == i+1), ("Error iterations"));
-        ARCANE_ASSERT((values[i] == i+adder), ("Error values"));
+                << " == i+(adder++) = " << i + adder;
+        ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+        ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
       }
     }
-    else{
+    else {
       ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
       ARCANE_ASSERT((values.empty()), ("Values not empty"));
     }

--- a/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
+++ b/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
@@ -11,9 +11,9 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include <arcane/core/ITimeHistoryMng.h>
-#include <arcane/core/MeshTimeHistoryAdder.h>
-#include <arcane/core/GlobalTimeHistoryAdder.h>
+#include "arcane/core/ITimeHistoryMng.h"
+#include "arcane/core/MeshTimeHistoryAdder.h"
+#include "arcane/core/GlobalTimeHistoryAdder.h"
 
 #include "arcane/core/IMesh.h"
 #include "arcane/core/internal/ITimeHistoryMngInternal.h"
@@ -25,7 +25,12 @@
 
 namespace ArcaneTest
 {
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 using namespace Arcane;
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -74,25 +79,44 @@ loop()
   _checker();
 }
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 void TimeHistoryAdderTestModule::
 _writer()
 {
   ISubDomain* sd = subDomain();
   Integer iteration = globalIteration();
 
+  // TODO : Conserve-t-on la méthode adder ?
   sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA"), iteration++);
-  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA", true, 0), iteration++); // Pas de ++ : normal.
+  sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA", true, 0), iteration++);
   sd->timeHistoryMng()->adder()->addValue(TimeHistoryAddValueArg("AAA", true, 1), iteration++);
 
+  // Création d'un adder global.
   GlobalTimeHistoryAdder global_adder(sd->timeHistoryMng());
+
+  // On ajoute une valeur à l'historique "BBB" commun à tous les sous-domaines.
   global_adder.addValue(TimeHistoryAddValueArg("BBB"), iteration++);
+
+  // On ajoute une valeur à l'historique "BBB" spécifique au sous-domaine 0.
   global_adder.addValue(TimeHistoryAddValueArg("BBB", true, 0), iteration++);
+
+  // On ajoute une valeur à l'historique "BBB" spécifique au sous-domaine 1.
   global_adder.addValue(TimeHistoryAddValueArg("BBB", true, 1), iteration++);
 
   for(auto mesh : sd->meshes()){
+
+    // Création d'un adder spécifique au maillage mesh.
     MeshTimeHistoryAdder mesh_adder(sd->timeHistoryMng(), mesh->handle());
+
+    // On ajoute une valeur à l'historique "BBB" spécifique au maillage mesh et commun à tous les sous-domaines.
     mesh_adder.addValue(TimeHistoryAddValueArg("BBB"), iteration++);
+
+    // On ajoute une valeur à l'historique "BBB" spécifique au maillage mesh et au sous-domaine 0.
     mesh_adder.addValue(TimeHistoryAddValueArg("BBB", true, 0), iteration++);
+
+    // On ajoute une valeur à l'historique "BBB" spécifique au maillage mesh et au sous-domaine 1.
     mesh_adder.addValue(TimeHistoryAddValueArg("BBB", true, 1), iteration++);
   }
 }

--- a/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
+++ b/arcane/src/arcane/tests/TimeHistoryAdderTestModule.cc
@@ -132,13 +132,19 @@ _checker()
   iterations.clear();
   values.clear();
   sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB")), iterations, values);
-  for (Integer i = 0; i < iteration; ++i) {
-    debug() << "iteration[" << i << "] = " << iterations[i]
-            << " == i+1 = " << i + 1
-            << " -- values[" << i << "] = " << values[i]
-            << " == i+(adder++) = " << i + adder;
-    ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
-    ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
+  if (pm->commRank() == pm->masterIORank()) {
+    for (Integer i = 0; i < iteration; ++i) {
+      debug() << "iteration[" << i << "] = " << iterations[i]
+              << " == i+1 = " << i + 1
+              << " -- values[" << i << "] = " << values[i]
+              << " == i+(adder++) = " << i + adder;
+      ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+      ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
+    }
+  }
+  else {
+    ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+    ARCANE_ASSERT((values.empty()), ("Values not empty"));
   }
   adder++;
 
@@ -184,13 +190,19 @@ _checker()
     iterations.clear();
     values.clear();
     sd->timeHistoryMng()->_internalApi()->iterationsAndValues(TimeHistoryAddValueArgInternal(TimeHistoryAddValueArg("BBB"), mesh->handle()), iterations, values);
-    for (Integer i = 0; i < iteration; ++i) {
-      debug() << "iteration[" << i << "] = " << iterations[i]
-              << " == i+1 = " << i + 1
-              << " -- values[" << i << "] = " << values[i]
-              << " == i+(adder++) = " << i + adder;
-      ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
-      ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
+    if (pm->commRank() == pm->masterIORank()) {
+      for (Integer i = 0; i < iteration; ++i) {
+        debug() << "iteration[" << i << "] = " << iterations[i]
+                << " == i+1 = " << i + 1
+                << " -- values[" << i << "] = " << values[i]
+                << " == i+(adder++) = " << i + adder;
+        ARCANE_ASSERT((iterations[i] == i + 1), ("Error iterations"));
+        ARCANE_ASSERT((values[i] == i + adder), ("Error values"));
+      }
+    }
+    else {
+      ARCANE_ASSERT((iterations.empty()), ("Iterations not empty"));
+      ARCANE_ASSERT((values.empty()), ("Values not empty"));
     }
     adder++;
 

--- a/arcane/src/arcane/tests/srcs.cmake
+++ b/arcane/src/arcane/tests/srcs.cmake
@@ -76,6 +76,7 @@ set(ARCANE_SOURCES
   SimpleTableOutputUnitTest.cc
   SimpleTableComparatorUnitTest.cc
   StringVariableReplaceTest.cc
+  TimeHistoryAdderTestModule.cc
 )
 
 set(AXL_FILES
@@ -125,5 +126,6 @@ set(AXL_FILES
   SimpleTableComparatorUnitTest
   SimpleTableOutputUnitTest
   StringVariableReplaceTest
+  TimeHistoryAdderTest
 )
 

--- a/arcane/tests/testTimeHistoryAdder-1.arc
+++ b/arcane/tests/testTimeHistoryAdder-1.arc
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<case codename="ArcaneTest" xml:lang="en" codeversion="1.0">
+  <arcane>
+    <title>Test 1</title>
+    <timeloop>TimeHistoryAdderTestModuleLoop</timeloop>
+    <modules>
+      <module name="TimeHistoryAdderTest" active="true" />
+    </modules>
+  </arcane>
+
+  <meshes>
+    <mesh>
+      <generator name="Cartesian2D" >
+        <nb-part-x>2</nb-part-x>
+        <nb-part-y>2</nb-part-y>
+        <origin>0.0 0.0</origin>
+        <x><n>4</n><length>4.0</length></x>
+        <y><n>4</n><length>4.0</length></y>
+      </generator>
+    </mesh>
+    <mesh>
+      <generator name="Cartesian2D" >
+        <nb-part-x>2</nb-part-x>
+        <nb-part-y>2</nb-part-y>
+        <origin>0.0 0.0</origin>
+        <x><n>4</n><length>4.0</length></x>
+        <y><n>4</n><length>4.0</length></y>
+      </generator>
+    </mesh>
+  </meshes>
+
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter">
+      <format-version>3</format-version>
+    </checkpoint-service>
+    <do-dump-at-end>true</do-dump-at-end>
+  </arcane-checkpoint>
+
+  <time-history-mng-test>
+
+  </time-history-mng-test>
+
+
+</case>


### PR DESCRIPTION
- MeshTimeHistoryAdder updated to add all necessary methods;
- Add GlobalTimeHistoryAdder to replace all ITimeHistoryMng `addValue()` methods;
- Add new summary file `time_history.json`;
- Create an unique name for all curves : `support`_SD`sub_domain_id`_`name_of_curve` : 
  - in `time_history.xml` as `name` attribut,
  - in `time_history.json` as `unique-name` attribut,
  - in `curves.acv` as `name` attribut.
- Three new attributs in `curves.acv` : 
  - `base-name` (always present) : the real name of the curve (may not be unique),
  - `support` (optional) : the name of the linked mesh (if created with MeshTimeHistoryAdder, not present otherwise),
  - `sub-domain` (optional) :  subdomain id, if required.