### PR TITLE
Fix potential multiple conversion between UTF-16 and UTF-8 for 'String'

### DIFF
--- a/arccore/src/base/arccore/base/StringImpl.cc
+++ b/arccore/src/base/arccore/base/StringImpl.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StringImpl.cc                                               (C) 2000-2023 */
+/* StringImpl.cc                                               (C) 2000-2024 */
 /*                                                                           */
 /* Implémentation d'une chaîne de caractère UTf-8 ou UTF-16.                 */
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/tests/TestString.cc
+++ b/arccore/src/base/tests/TestString.cc
@@ -79,8 +79,27 @@ TEST(String, Utf8AndUtf16)
       std::cout << "Utf16: " << std::hex << x << "\n";
     ASSERT_EQ(big_endian_ref_vector, utf16_vector);
     Span<const UChar> utf16_bytes(utf16_vector.data(), utf16_vector.size());
+    std::cout << "Utf16_size=" << utf16_bytes.smallView() << "\n";
+
+    std::cout << "BEFORE_CREATE_STR2\n";
     String str2(utf16_bytes.smallView());
+    std::cout << "str1.utf16=" << str1.utf16() << "\n";
+    std::cout << "str2.utf16=" << str2.utf16() << "\n";
+
+    bool is_same = (str1 == str2);
+
+    std::cout << "is_same=" << is_same << "\n";
     ASSERT_EQ(str1, str2);
+
+    std::cout << "str1.utf16=" << str1.utf16() << "\n";
+    std::cout << "str2.utf16=" << str2.utf16() << "\n";
+    std::cout.flush();
+
+    ASSERT_EQ(str1.utf16().size(), 6);
+    ASSERT_EQ(str2.utf16().size(), 6);
+
+    ASSERT_EQ(str1.utf8().size(), str2.utf8().size());
+    ASSERT_EQ(str1.utf16().size(), str2.utf16().size());
   }
   {
     String str2;

--- a/arccore/src/base/tests/TestString.cc
+++ b/arccore/src/base/tests/TestString.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This bug only occurs if we use deprecated `String::utf16()` method.
