### PR TITLE
Remove some check in Material compnents in Release mode

### DIFF
--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -457,7 +457,8 @@ forceRecompute(bool compute_all)
     }
   }
 
-  m_material_mng->checkValid();
+  if (arcaneIsCheck())
+    m_material_mng->checkValid();
 
   m_material_mng->syncVariablesReferences();
 

--- a/arcane/src/arcane/materials/ComponentItemInternalData.cc
+++ b/arcane/src/arcane/materials/ComponentItemInternalData.cc
@@ -133,7 +133,10 @@ endCreate()
 void ComponentItemInternalData::
 _resetItemsInternal()
 {
-  RunQueue queue(makeQueue(m_material_mng->runner()));
+  if (!arcaneIsCheck())
+    return;
+
+  RunQueue queue(m_material_mng->runQueue());
 
   {
     ComponentItemSharedInfo* all_env_shared_info = allEnvSharedInfo();


### PR DESCRIPTION
These checks are only implemented for CPU and it hurts performance when running using accelerators.
They can still be enabled if environment variable `ARCANE_CHECK` is set.