### PR TITLE
Minor improvements for accelerator API

### DIFF
--- a/arcane/src/arcane/accelerator/NumArrayViews.h
+++ b/arcane/src/arcane/accelerator/NumArrayViews.h
@@ -50,7 +50,7 @@ class NumArrayViewBase
 
   // Pour l'instant n'utilise pas encore \a command
   // mais il ne faut pas le supprimer
-  explicit NumArrayViewBase(RunCommand&)
+  explicit NumArrayViewBase(const ViewBuildInfo&)
   {
   }
 
@@ -76,7 +76,7 @@ class NumArrayView
 
  public:
 
-  NumArrayView(RunCommand& command, SpanType v)
+  NumArrayView(const ViewBuildInfo& command, SpanType v)
   : NumArrayViewBase(command)
   , m_values(v)
   {}
@@ -162,7 +162,7 @@ class NumArrayView
  * \brief Vue en écriture.
  */
 template <typename DataType, typename Extents, typename LayoutPolicy> auto
-viewOut(RunCommand& command, NumArray<DataType, Extents, LayoutPolicy>& var)
+viewOut(const ViewBuildInfo& command, NumArray<DataType, Extents, LayoutPolicy>& var)
 {
   using Accessor = DataViewSetter<DataType>;
   return NumArrayView<Accessor, Extents, LayoutPolicy>(command, var.span());
@@ -175,7 +175,7 @@ viewOut(RunCommand& command, NumArray<DataType, Extents, LayoutPolicy>& var)
  * \brief Vue en lecture/écriture.
  */
 template <typename DataType, typename Extents, typename LayoutPolicy> auto
-viewInOut(RunCommand& command, NumArray<DataType, Extents, LayoutPolicy>& v)
+viewInOut(const ViewBuildInfo& command, NumArray<DataType, Extents, LayoutPolicy>& v)
 {
   using Accessor = DataViewGetterSetter<DataType>;
   return NumArrayView<Accessor, Extents, LayoutPolicy>(command, v.span());
@@ -187,7 +187,7 @@ viewInOut(RunCommand& command, NumArray<DataType, Extents, LayoutPolicy>& v)
  * \brief Vue en lecture.
  */
 template <typename DataType, typename Extents, typename LayoutType> auto
-viewIn(RunCommand& command, const NumArray<DataType, Extents, LayoutType>& v)
+viewIn(const ViewBuildInfo& command, const NumArray<DataType, Extents, LayoutType>& v)
 {
   using Accessor = DataViewGetter<DataType>;
   return NumArrayView<Accessor, Extents, LayoutType>(command, v.constSpan());

--- a/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommandLaunchInfo.cc                                     (C) 2000-2022 */
+/* RunCommandLaunchInfo.cc                                     (C) 2000-2024 */
 /*                                                                           */
 /* Informations pour l'exécution d'une 'RunCommand'.                         */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
@@ -63,7 +63,7 @@ RunCommandLaunchInfo::
 void RunCommandLaunchInfo::
 _begin()
 {
-  RunQueue& queue = m_command._internalQueue();
+  const RunQueue& queue = m_command._internalQueue();
   m_exec_policy = queue.executionPolicy();
   m_queue_stream = queue._internalStream();
   m_runtime = queue._internalRuntime();
@@ -109,7 +109,7 @@ _doEndKernelLaunch()
   m_is_notify_end_kernel_done = true;
   m_command._internalNotifyEndLaunchKernel();
 
-  RunQueue& q = m_command._internalQueue();
+  const RunQueue& q = m_command._internalQueue();
   if (!q.isAsync())
     q.barrier();
 }

--- a/arcane/src/arcane/accelerator/SpanViews.h
+++ b/arcane/src/arcane/accelerator/SpanViews.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SpanViews.h                                                 (C) 2000-2023 */
+/* SpanViews.h                                                 (C) 2000-2024 */
 /*                                                                           */
 /* Gestion des vues pour les 'Span' pour les accélérateurs.                  */
 /*---------------------------------------------------------------------------*/
@@ -48,7 +48,7 @@ class SpanViewBase
 
   // Pour l'instant n'utilise pas encore \a command
   // mais il ne faut pas le supprimer
-  explicit SpanViewBase(RunCommand&)
+  explicit SpanViewBase(const ViewBuildInfo&)
   {
   }
 
@@ -72,7 +72,7 @@ class SpanView
 
  public:
 
-  SpanView(RunCommand& command, SpanType v)
+  SpanView(const ViewBuildInfo& command, SpanType v)
   : SpanViewBase(command)
   , m_values(v)
   {}
@@ -98,7 +98,7 @@ class SpanView
  * \brief Vue en écriture.
  */
 template <typename DataType> auto
-viewOut(RunCommand& command, Span<DataType>& var)
+viewOut(const ViewBuildInfo& command, Span<DataType>& var)
 {
   using Accessor = DataViewSetter<DataType>;
   return SpanView<Accessor>(command, var);
@@ -110,7 +110,7 @@ viewOut(RunCommand& command, Span<DataType>& var)
  * \brief Vue en écriture.
  */
 template <typename DataType> auto
-viewOut(RunCommand& command, Array<DataType>& var)
+viewOut(const ViewBuildInfo& command, Array<DataType>& var)
 {
   using Accessor = DataViewSetter<DataType>;
   return SpanView<Accessor>(command, var.span());
@@ -122,7 +122,7 @@ viewOut(RunCommand& command, Array<DataType>& var)
  * \brief Vue en lecture/écriture.
  */
 template <typename DataType> auto
-viewInOut(RunCommand& command, Span<DataType>& var)
+viewInOut(const ViewBuildInfo& command, Span<DataType>& var)
 {
   using Accessor = DataViewGetterSetter<DataType>;
   return SpanView<Accessor>(command, var);
@@ -134,7 +134,7 @@ viewInOut(RunCommand& command, Span<DataType>& var)
  * \brief Vue en lecture/écriture.
  */
 template <typename DataType> auto
-viewInOut(RunCommand& command, Array<DataType>& var)
+viewInOut(const ViewBuildInfo& command, Array<DataType>& var)
 {
   using Accessor = DataViewGetterSetter<DataType>;
   return SpanView<Accessor>(command, var.span());
@@ -146,7 +146,7 @@ viewInOut(RunCommand& command, Array<DataType>& var)
  * \brief Vue en lecture.
  */
 template <typename DataType> auto
-viewIn(RunCommand& command, const Span<DataType>& var)
+viewIn(const ViewBuildInfo& command, const Span<DataType>& var)
 {
   using Accessor = DataViewGetter<DataType>;
   return SpanView<Accessor>(command, var);
@@ -158,7 +158,7 @@ viewIn(RunCommand& command, const Span<DataType>& var)
  * \brief Vue en lecture.
  */
 template <typename DataType> auto
-viewIn(RunCommand& command, const Array<DataType>& var)
+viewIn(const ViewBuildInfo& command, const Array<DataType>& var)
 {
   using Accessor = DataViewGetter<DataType>;
   return SpanView<Accessor>(command, var.span());

--- a/arcane/src/arcane/accelerator/VariableViews.cc
+++ b/arcane/src/arcane/accelerator/VariableViews.cc
@@ -38,7 +38,7 @@ namespace Arcane::Accelerator
 VariableViewBase::
 VariableViewBase(RunCommand& command, IVariable* var)
 {
-  RunQueue& q = command.m_run_queue;
+  const RunQueue& q = command.m_run_queue;
   if (q._isAutoPrefetchCommand())
     VariableUtils::prefetchVariableAsync(var, &q);
 }

--- a/arcane/src/arcane/accelerator/VariableViews.cc
+++ b/arcane/src/arcane/accelerator/VariableViews.cc
@@ -36,9 +36,9 @@ namespace Arcane::Accelerator
 /*---------------------------------------------------------------------------*/
 
 VariableViewBase::
-VariableViewBase(RunCommand& command, IVariable* var)
+VariableViewBase(const ViewBuildInfo& vbi, IVariable* var)
 {
-  const RunQueue& q = command.m_run_queue;
+  const RunQueue& q = vbi.queue();
   if (q._isAutoPrefetchCommand())
     VariableUtils::prefetchVariableAsync(var, &q);
 }

--- a/arcane/src/arcane/accelerator/VariableViews.h
+++ b/arcane/src/arcane/accelerator/VariableViews.h
@@ -44,7 +44,7 @@ class ARCANE_ACCELERATOR_EXPORT VariableViewBase
 {
  public:
 
-  VariableViewBase(RunCommand& command,IVariable* var);
+  VariableViewBase(const ViewBuildInfo& command,IVariable* var);
 };
 
 /*---------------------------------------------------------------------------*/
@@ -125,7 +125,7 @@ class ItemVariableScalarOutViewT
 
  public:
 
-  ItemVariableScalarOutViewT(RunCommand& command,IVariable* var,SmallSpan<DataType> v)
+  ItemVariableScalarOutViewT(const ViewBuildInfo& command,IVariable* var,SmallSpan<DataType> v)
   : VariableViewBase(command,var), m_values(v.data()),
     m_size(v.size()){}
 
@@ -189,7 +189,7 @@ class ItemVariableScalarInViewT
 
  public:
 
-  ItemVariableScalarInViewT(RunCommand& command,IVariable* var,SmallSpan<const DataType> v)
+  ItemVariableScalarInViewT(const ViewBuildInfo& command,IVariable* var,SmallSpan<const DataType> v)
   : VariableViewBase(command,var), m_values(v){}
 
   //! Opérateur d'accès vectoriel avec indirection.
@@ -245,7 +245,7 @@ class ItemVariableArrayInViewT
 
  public:
 
-  ItemVariableArrayInViewT(RunCommand& command,IVariable* var,SmallSpan2<const DataType> v)
+  ItemVariableArrayInViewT(const ViewBuildInfo& command,IVariable* var,SmallSpan2<const DataType> v)
   : VariableViewBase(command,var), m_values(v){}
 
   //! Opérateur d'accès pour l'entité \a item
@@ -287,7 +287,7 @@ class ItemVariableArrayOutViewT
 
  public:
 
-  ItemVariableArrayOutViewT(RunCommand& command,IVariable* var,SmallSpan2<DataType> v)
+  ItemVariableArrayOutViewT(const ViewBuildInfo& command,IVariable* var,SmallSpan2<DataType> v)
   : VariableViewBase(command,var), m_values(v){}
 
   //! Opérateur d'accès pour l'entité \a item
@@ -346,7 +346,7 @@ class ItemVariableRealNScalarOutViewT
  public:
 
   //! Construit la vue
-  ItemVariableRealNScalarOutViewT(RunCommand& command,IVariable* var,SmallSpan<DataType> v)
+  ItemVariableRealNScalarOutViewT(const ViewBuildInfo& command,IVariable* var,SmallSpan<DataType> v)
   : VariableViewBase(command,var), m_values(v.data()), m_size(v.size()){}
 
   //! Opérateur d'accès vectoriel avec indirection.
@@ -412,7 +412,7 @@ class ItemVariableRealNScalarOutViewT
  * \brief Vue en écriture.
  */
 template<typename ItemType,typename DataType> auto
-viewOut(RunCommand& command,MeshVariableScalarRefT<ItemType,DataType>& var)
+viewOut(const ViewBuildInfo& command,MeshVariableScalarRefT<ItemType,DataType>& var)
 {
   using Accessor = DataViewSetter<DataType>;
   return ItemVariableScalarOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -422,7 +422,7 @@ viewOut(RunCommand& command,MeshVariableScalarRefT<ItemType,DataType>& var)
  * \brief Vue en écriture.
  */
 template<typename ItemType> auto
-viewOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real3>& var)
+viewOut(const ViewBuildInfo& command,MeshVariableScalarRefT<ItemType,Real3>& var)
 {
   using Accessor = DataViewSetter<Real3>;
   return ItemVariableRealNScalarOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -432,7 +432,7 @@ viewOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real3>& var)
  * \brief Vue en écriture.
  */
 template<typename ItemType> auto
-viewOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real2>& var)
+viewOut(const ViewBuildInfo& command,MeshVariableScalarRefT<ItemType,Real2>& var)
 {
   using Accessor = DataViewSetter<Real2>;
   return ItemVariableRealNScalarOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -442,7 +442,7 @@ viewOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real2>& var)
  * \brief Vue en écriture.
  */
 template<typename ItemType,typename DataType> auto
-viewOut(RunCommand& command,MeshVariableArrayRefT<ItemType,DataType>& var)
+viewOut(const ViewBuildInfo& command,MeshVariableArrayRefT<ItemType,DataType>& var)
 {
   using Accessor = View1DSetter<DataType>;
   return ItemVariableArrayOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -454,7 +454,7 @@ viewOut(RunCommand& command,MeshVariableArrayRefT<ItemType,DataType>& var)
  * \brief Vue en lecture/écriture.
  */
 template<typename ItemType,typename DataType> auto
-viewInOut(RunCommand& command,MeshVariableScalarRefT<ItemType,DataType>& var)
+viewInOut(const ViewBuildInfo& command,MeshVariableScalarRefT<ItemType,DataType>& var)
 {
   using Accessor = DataViewGetterSetter<DataType>;
   return ItemVariableScalarOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -464,7 +464,7 @@ viewInOut(RunCommand& command,MeshVariableScalarRefT<ItemType,DataType>& var)
  * \brief Vue en lecture/écriture.
  */
 template<typename ItemType> auto
-viewInOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real3>& var)
+viewInOut(const ViewBuildInfo& command,MeshVariableScalarRefT<ItemType,Real3>& var)
 {
   using Accessor = DataViewGetterSetter<Real3>;
   return ItemVariableRealNScalarOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -474,7 +474,7 @@ viewInOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real3>& var)
  * \brief Vue en lecture/écriture.
  */
 template<typename ItemType> auto 
-viewInOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real2>& var)
+viewInOut(const ViewBuildInfo& command,MeshVariableScalarRefT<ItemType,Real2>& var)
 {
   using Accessor = DataViewGetterSetter<Real2>;
   return ItemVariableRealNScalarOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -484,7 +484,7 @@ viewInOut(RunCommand& command,MeshVariableScalarRefT<ItemType,Real2>& var)
  * \brief Vue en lecture/écriture.
  */
 template<typename ItemType,typename DataType> auto
-viewInOut(RunCommand& command,MeshVariableArrayRefT<ItemType,DataType>& var)
+viewInOut(const ViewBuildInfo& command,MeshVariableArrayRefT<ItemType,DataType>& var)
 {
   using Accessor = View1DGetterSetter<DataType>;
   return ItemVariableArrayOutViewT<ItemType,Accessor>(command,var.variable(),var.asArray());
@@ -496,7 +496,7 @@ viewInOut(RunCommand& command,MeshVariableArrayRefT<ItemType,DataType>& var)
  * \brief Vue en lecture.
  */
 template<typename ItemType,typename DataType> auto
-viewIn(RunCommand& command,const MeshVariableScalarRefT<ItemType,DataType>& var)
+viewIn(const ViewBuildInfo& command,const MeshVariableScalarRefT<ItemType,DataType>& var)
 {
   return ItemVariableScalarInViewT<ItemType,DataType>(command,var.variable(),var.asArray());
 }
@@ -505,7 +505,7 @@ viewIn(RunCommand& command,const MeshVariableScalarRefT<ItemType,DataType>& var)
  * \brief Vue en lecture.
  */
 template<typename ItemType,typename DataType> auto
-viewIn(RunCommand& command,const MeshVariableArrayRefT<ItemType,DataType>& var)
+viewIn(const ViewBuildInfo& command,const MeshVariableArrayRefT<ItemType,DataType>& var)
 {
   return ItemVariableArrayInViewT<ItemType,DataType>(command,var.variable(),var.asArray());
 }

--- a/arcane/src/arcane/accelerator/core/AcceleratorCore.cc
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCore.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AcceleratorCore.cc                                          (C) 2000-2023 */
+/* AcceleratorCore.cc                                          (C) 2000-2024 */
 /*                                                                           */
 /* Déclarations générales pour le support des accélérateurs.                 */
 /*---------------------------------------------------------------------------*/
@@ -18,6 +18,8 @@
 
 #include "arcane/accelerator/core/DeviceInfoList.h"
 #include "arcane/accelerator/core/PointerAttribute.h"
+#include "arcane/accelerator/core/ViewBuildInfo.h"
+#include "arcane/accelerator/core/RunCommand.h"
 
 #include <iostream>
 
@@ -209,8 +211,8 @@ getPointerAccessibility(eExecutionPolicy policy, const void* ptr, PointerAttribu
   if (attr.isValid()) {
     if (isAcceleratorPolicy(policy))
       return attr.devicePointer() ? ePointerAccessibility::Yes : ePointerAccessibility::No;
-    else{
-      if (attr.memoryType()==ePointerMemoryType::Unregistered)
+    else {
+      if (attr.memoryType() == ePointerMemoryType::Unregistered)
         return ePointerAccessibility::Yes;
       return attr.hostPointer() ? ePointerAccessibility::Yes : ePointerAccessibility::No;
     }
@@ -259,12 +261,22 @@ arcaneCheckPointerIsAcccessible(eExecutionPolicy policy, const void* ptr,
 /*---------------------------------------------------------------------------*/
 
 std::ostream&
-operator<<(std::ostream& o,const PointerAttribute& a)
+operator<<(std::ostream& o, const PointerAttribute& a)
 {
   o << "(mem_type=" << a.memoryType() << ", ptr=" << a.originalPointer()
     << ", host_ptr=" << a.hostPointer()
     << ", device_ptr=" << a.devicePointer() << " device=" << a.device() << ")";
-  return o; 
+  return o;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+//! Créé instance associée a la commande \a command.
+ViewBuildInfo::
+ViewBuildInfo(RunCommand& command)
+: m_queue(command._internalQueue())
+{
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
@@ -55,6 +55,7 @@ class DeviceId;
 class DeviceInfo;
 class IDeviceInfoList;
 class PointerAttribute;
+class ViewBuildInfo;
 enum class eMemoryAdvice;
 
 namespace impl

--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -28,7 +28,7 @@ namespace Arcane::Accelerator
 /*---------------------------------------------------------------------------*/
 
 RunCommand::
-RunCommand(RunQueue& run_queue)
+RunCommand(const RunQueue& run_queue)
 : m_run_queue(run_queue)
 , m_p(run_queue._getCommandImpl())
 {

--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommand.cc                                               (C) 2000-2023 */
+/* RunCommand.cc                                               (C) 2000-2024 */
 /*                                                                           */
 /* Gestion d'une commande sur accélérateur.                                  */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunCommand.h
+++ b/arcane/src/arcane/accelerator/core/RunCommand.h
@@ -42,7 +42,8 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
   friend impl::IReduceMemoryImpl* impl::internalGetOrCreateReduceMemoryImpl(RunCommand* command);
   friend impl::RunCommandLaunchInfo;
   friend impl::RunQueueImpl;
-  friend class VariableViewBase;
+  friend class ViewBuildInfo;
+
   friend RunCommand makeCommand(const RunQueue& run_queue);
   friend RunCommand makeCommand(const RunQueue* run_queue);
 

--- a/arcane/src/arcane/accelerator/core/RunCommand.h
+++ b/arcane/src/arcane/accelerator/core/RunCommand.h
@@ -43,8 +43,8 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
   friend impl::RunCommandLaunchInfo;
   friend impl::RunQueueImpl;
   friend class VariableViewBase;
-  friend RunCommand makeCommand(RunQueue& run_queue);
-  friend RunCommand makeCommand(RunQueue* run_queue);
+  friend RunCommand makeCommand(const RunQueue& run_queue);
+  friend RunCommand makeCommand(const RunQueue* run_queue);
 
  public:
 
@@ -52,7 +52,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
 
  protected:
 
-  explicit RunCommand(RunQueue& run_queue);
+  explicit RunCommand(const RunQueue& run_queue);
 
  public:
 
@@ -119,7 +119,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
  private:
 
   //! \internal
-  RunQueue& _internalQueue() { return m_run_queue; }
+  const RunQueue& _internalQueue() const { return m_run_queue; }
   static impl::RunCommandImpl* _internalCreateImpl(impl::RunQueueImpl* queue);
   static void _internalDestroyImpl(impl::RunCommandImpl* p);
 
@@ -129,7 +129,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
 
  private:
 
-  RunQueue& m_run_queue;
+  const RunQueue& m_run_queue;
   impl::RunCommandImpl* m_p;
 };
 

--- a/arcane/src/arcane/accelerator/core/RunQueue.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueue.cc
@@ -100,7 +100,7 @@ RunQueue::
 /*---------------------------------------------------------------------------*/
 
 void RunQueue::
-barrier()
+barrier() const
 {
   m_p->_internalBarrier();
 }
@@ -136,7 +136,7 @@ _internalStream() const
 /*---------------------------------------------------------------------------*/
 
 impl::RunCommandImpl* RunQueue::
-_getCommandImpl()
+_getCommandImpl() const
 {
   return m_p->_internalCreateOrGetRunCommandImpl();
 }
@@ -154,7 +154,7 @@ platformStream()
 /*---------------------------------------------------------------------------*/
 
 void RunQueue::
-copyMemory(const MemoryCopyArgs& args)
+copyMemory(const MemoryCopyArgs& args) const
 {
   _internalStream()->copyMemory(args);
 }
@@ -163,7 +163,7 @@ copyMemory(const MemoryCopyArgs& args)
 /*---------------------------------------------------------------------------*/
 
 void RunQueue::
-prefetchMemory(const MemoryPrefetchArgs& args)
+prefetchMemory(const MemoryPrefetchArgs& args) const
 {
   _internalStream()->prefetchMemory(args);
 }

--- a/arcane/src/arcane/accelerator/core/RunQueue.h
+++ b/arcane/src/arcane/accelerator/core/RunQueue.h
@@ -97,12 +97,12 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
   //! Indique si la file d'exécution est asynchrone.
   bool isAsync() const;
   //! Bloque tant que toutes les commandes associées à la file ne sont pas terminées.
-  void barrier();
+  void barrier() const;
 
   //! Copie des informations entre deux zones mémoires
-  void copyMemory(const MemoryCopyArgs& args);
+  void copyMemory(const MemoryCopyArgs& args) const;
   //! Effectue un préfetching de la mémoire
-  void prefetchMemory(const MemoryPrefetchArgs& args);
+  void prefetchMemory(const MemoryPrefetchArgs& args) const;
 
   //! Enregistre l'état de l'instance dans \a event.
   void recordEvent(RunQueueEvent& event);
@@ -130,7 +130,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
 
   impl::IRunnerRuntime* _internalRuntime() const;
   impl::IRunQueueStream* _internalStream() const;
-  impl::RunCommandImpl* _getCommandImpl();
+  impl::RunCommandImpl* _getCommandImpl() const;
 
   // Pour VariableViewBase
   friend class VariableViewBase;
@@ -150,7 +150,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
  * \brief Créé une commande associée à la file \a run_queue.
  */
 inline RunCommand
-makeCommand(RunQueue& run_queue)
+makeCommand(const RunQueue& run_queue)
 {
   return RunCommand(run_queue);
 }
@@ -159,7 +159,7 @@ makeCommand(RunQueue& run_queue)
  * \brief Créé une commande associée à la file \a run_queue.
  */
 inline RunCommand
-makeCommand(RunQueue* run_queue)
+makeCommand(const RunQueue* run_queue)
 {
   ARCANE_CHECK_POINTER(run_queue);
   return RunCommand(*run_queue);

--- a/arcane/src/arcane/accelerator/core/ViewBuildInfo.h
+++ b/arcane/src/arcane/accelerator/core/ViewBuildInfo.h
@@ -5,28 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ViewsCommon.h                                               (C) 2000-2024 */
+/* ViewBuildInfo.h                                             (C) 2000-2024 */
 /*                                                                           */
-/* Types de base pour la gestion des vues pour les accélérateurs.            */
+/* Informations pour construire une vue pour les données sur accélérateur.   */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ACCELERATOR_VIEWSCOMMON_H
-#define ARCANE_ACCELERATOR_VIEWSCOMMON_H
+#ifndef ARCANE_ACCELERATOR_CORE_VIEWBUILDINFO_H
+#define ARCANE_ACCELERATOR_CORE_VIEWBUILDINFO_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/accelerator/AcceleratorGlobal.h"
+#include "arcane/accelerator/core/AcceleratorCoreGlobal.h"
 
-#include "arcane/core/DataView.h"
-#include "arcane/accelerator/core/ViewBuildInfo.h"
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \file ViewsCommon.h
- *
- * Ce fichier contient les déclarations des types pour gérer
- * les vues pour les accélérateurs.
- */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -35,17 +24,46 @@ namespace Arcane::Accelerator
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations pour construire une vue pour les données sur accélérateur.
+ *
+ * Les instances de cette classes sont temporaires et ne doivent pas être
+ * conservées au dela de la durée de vie de la RunCommand ou RunQueue utilisées
+ * pour leur création.
+ */
+class ARCANE_ACCELERATOR_CORE_EXPORT ViewBuildInfo
+{
+ public:
 
-template <typename DataType> using DataViewSetter = Arcane::DataViewSetter<DataType>;
-template <typename DataType> using DataViewGetterSetter = Arcane::DataViewGetterSetter<DataType>;
-template <typename DataType> using DataViewGetter = Arcane::DataViewGetter<DataType>;
+  //! Créé instance associée a la file \a queue.
+  ViewBuildInfo(const RunQueue& queue)
+  : m_queue(queue)
+  {}
+  //! Créé instance associée a la file \a queue.
+  ViewBuildInfo(const RunQueue* queue)
+  : m_queue(*queue)
+  {}
+  //! Créé instance associée a la commande \a command.
+  ViewBuildInfo(RunCommand& command);
+
+ public:
+
+  const RunQueue& queue() const { return m_queue; }
+
+ private:
+
+  const RunQueue& m_queue;
+};
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // namespace Arcane::Accelerator
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane::Accelerator
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif
+#endif  

--- a/arcane/src/arcane/accelerator/core/srcs.cmake
+++ b/arcane/src/arcane/accelerator/core/srcs.cmake
@@ -31,6 +31,7 @@ set( ARCANE_SOURCES
   RunQueueImpl.h
   RunQueueImpl.cc
   RunQueueRuntime.cc
+  ViewBuildInfo.h
   internal/IRunnerRuntime.h
   internal/AcceleratorCoreGlobalInternal.h
   internal/MemoryTracer.h

--- a/arcane/src/arcane/core/VariableUtils.cc
+++ b/arcane/src/arcane/core/VariableUtils.cc
@@ -42,7 +42,7 @@ using namespace Arcane::Accelerator;
 /*---------------------------------------------------------------------------*/
 
 void VariableUtils::
-prefetchVariableAsync(IVariable* var, RunQueue* queue_or_null)
+prefetchVariableAsync(IVariable* var, const RunQueue* queue_or_null)
 {
   ARCANE_CHECK_POINTER(var);
   if (!queue_or_null)
@@ -61,7 +61,7 @@ prefetchVariableAsync(IVariable* var, RunQueue* queue_or_null)
 /*---------------------------------------------------------------------------*/
 
 void VariableUtils::
-prefetchVariableAsync(VariableRef& var, RunQueue* queue_or_null)
+prefetchVariableAsync(VariableRef& var, const RunQueue* queue_or_null)
 {
   return prefetchVariableAsync(var.variable(), queue_or_null);
 }

--- a/arcane/src/arcane/core/VariableUtils.h
+++ b/arcane/src/arcane/core/VariableUtils.h
@@ -36,14 +36,14 @@ namespace Arcane::VariableUtils
  * L'opération est asynchrone.
  */
 extern "C++" ARCANE_CORE_EXPORT
-void prefetchVariableAsync(IVariable* var, RunQueue* queue_or_null);
+void prefetchVariableAsync(IVariable* var, const RunQueue* queue_or_null);
 
 /*!
  * \brief Pré-copie la mémoire associée à la variable \a var.
  * \sa void prefetchVariableAsync(IVariable* var, RunQueue* queue_or_null);
  */
 extern "C++" ARCANE_CORE_EXPORT
-void prefetchVariableAsync(VariableRef& var, RunQueue* queue_or_null);
+void prefetchVariableAsync(VariableRef& var, const RunQueue* queue_or_null);
 
 /*!
  * \brief Indique que la variable est essentiellement en lecture.

--- a/arcane/src/arcane/core/materials/ComponentItem.h
+++ b/arcane/src/arcane/core/materials/ComponentItem.h
@@ -332,7 +332,7 @@ template <typename ComponentCellType> class CellComponentCellEnumeratorT
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-CellComponentCellEnumerator ComponentCell::
+ARCCORE_HOST_DEVICE CellComponentCellEnumerator ComponentCell::
 subItems() const
 {
   return CellComponentCellEnumerator(*this);

--- a/arcane/src/arcane/materials/MeshEnvironment.cc
+++ b/arcane/src/arcane/materials/MeshEnvironment.cc
@@ -42,6 +42,7 @@
 #include "arcane/accelerator/RunQueue.h"
 #include "arcane/accelerator/RunCommandLoop.h"
 #include "arcane/accelerator/Scan.h"
+#include "arcane/accelerator/SpanViews.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -238,7 +239,7 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data, RunQueue& 
     Int32 nb_id = local_ids.size();
     {
       Accelerator::GenericScanner scanner(queue);
-      SmallSpan<Int32> cells_index_view(cells_index);
+      auto cells_index_view = viewOut(queue, cells_index);
 
       auto getter = [=] ARCCORE_HOST_DEVICE(Int32 index) -> Int32 {
         return constituent_item_list_view._constituenItemBase(index).nbSubItem();
@@ -252,12 +253,12 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data, RunQueue& 
     }
   }
   {
-    SmallSpan<ConstituentItemIndex> cells_env_view(cells_env);
-    SmallSpan<const Int32> cells_index_view(cells_index);
-    SmallSpan<Int32> cells_pos_view(cells_pos);
+    auto command = makeCommand(queue);
+    auto cells_env_view = viewOut(command, cells_env);
+    auto cells_index_view = viewIn(command, cells_index);
+    auto cells_pos_view = viewOut(command, cells_pos);
     Int32 nb_id = local_ids.size();
 
-    auto command = makeCommand(queue);
     command << RUNCOMMAND_LOOP1(iter, nb_id)
     {
       auto [z] = iter();
@@ -284,15 +285,15 @@ computeMaterialIndexes(ComponentItemInternalData* item_internal_data, RunQueue& 
 
       mat->resizeItemsInternal(var_indexer->nbItem());
 
-      SmallSpan<const MatVarIndex> matvar_indexes = var_indexer->matvarIndexes();
-      SmallSpan<const Int32> local_ids = var_indexer->localIds();
+      auto command = makeCommand(queue);
+      auto matvar_indexes = viewIn(command, var_indexer->matvarIndexes());
+      auto local_ids = viewIn(command, var_indexer->localIds());
       SmallSpan<Int32> cells_pos_view(cells_pos);
-      SmallSpan<const ConstituentItemIndex> cells_env_view(cells_env);
+      auto cells_env_view = viewIn(command, cells_env);
       ComponentItemSharedInfo* mat_shared_info = item_internal_data->matSharedInfo();
       ComponentItemInternalRange mat_item_internal_range(item_internal_data->matItemsInternalRange(env_id));
       SmallSpan<ConstituentItemIndex> mat_id_list = mat->componentData()->m_constituent_local_id_list.mutableLocalIds();
       const Int32 nb_id = local_ids.size();
-      auto command = makeCommand(queue);
       command << RUNCOMMAND_LOOP1(iter, nb_id)
       {
         auto [z] = iter();


### PR DESCRIPTION
- Use `const RunQueue&` instead of `RunQueue&` in several methods
- Allow building of views with a `RunQueue` ou `RunCommand` argument.
- Add support for accelerator views for `SmallSpan`.