### PR TITLE
Refactor 'RUNCOMMAND_ENUMERATE' and add support to keep the iteration index

### DIFF
--- a/arcane/src/arcane/accelerator/RunCommandEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandEnumerate.h
@@ -23,6 +23,8 @@
 #include "arcane/core/ItemGroup.h"
 #include "arcane/core/Concurrency.h"
 
+#include <concepts>
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -32,38 +34,74 @@ namespace Arcane::Accelerator::impl
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
+ * \brief Concept pour contraintre les valeurs dans RUNCOMMAND_ENUMERATE.
+ *
+ * Le type  doit être un type d'entité (Cell, Node, ...) ou un
+ * type de numéro local (CellLocalId, NodeLocalId, ...)
+ */
+template <typename T>
+concept RunCommandEnumerateIteratorConcept = std::derived_from<T, Item> || std::derived_from<T, ItemLocalId>;
+
+//! Template pour connaitre le type d'entité associé à T
+template <typename T>
+class RunCommandItemEnumeratorSubTraitsT
+{
+ public:
+
+  using ItemType = T;
+};
+
+//! Spécialisation pour ItemLocalIdT.
+template <typename T>
+class RunCommandItemEnumeratorSubTraitsT<ItemLocalIdT<T>>
+{
+ public:
+
+  using ItemType = typename ItemLocalIdT<T>::ItemType;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
  * \brief Caractéristiques d'un énumérateur d'une commande sur les entités.
  *
  * Cette classe doit être spécialisée et définir un type \a ValueType
  * qui correspond au type de retour de 'operator*' de l'énumérateur.
+ *
+ * \a IteratorValueType_ doit être un type d'entité (Cell, Node, ...) ou un
+ * type de numéro local (CellLocalId, NodeLocalId, ...)
  */
-template <typename ItemType>
+template <RunCommandEnumerateIteratorConcept IteratorValueType_>
 class RunCommandItemEnumeratorTraitsT
 {
  public:
 
+  using ItemType = typename RunCommandItemEnumeratorSubTraitsT<IteratorValueType_>::ItemType;
+  using LocalIdType = ItemTraitsT<ItemType>::LocalIdType;
   using ValueType = ItemTraitsT<ItemType>::LocalIdType;
+  using ContainerType = ItemVectorViewT<ItemType>;
 
  public:
 
-  static ItemVectorViewT<ItemType> createContainer(const ItemGroupT<ItemType>& group)
+  explicit RunCommandItemEnumeratorTraitsT(const ItemGroupT<ItemType>& group)
+  : m_items(group.view())
+  {}
+  explicit RunCommandItemEnumeratorTraitsT(const ItemVectorViewT<ItemType>& vector_view)
+  : m_items(vector_view)
   {
-    return group.view();
   }
-  static ItemVectorViewT<ItemType> createContainer(const ItemVectorViewT<ItemType>& vector_view)
-  {
-    return vector_view;
-  }
+
+ public:
+
+  ItemVectorViewT<ItemType> m_items;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template <typename ItemType, typename Lambda>
-void _doIndirectThreadLambda(ItemVectorViewT<ItemType> sub_items, const Lambda& func)
+template <typename LocalIdType, typename ContainerType, typename Lambda>
+void _doIndirectThreadLambda(ContainerType sub_items, const Lambda& func)
 {
-  typedef typename ItemType::LocalIdType LocalIdType;
-
   auto privatizer = privatize(func);
   auto& body = privatizer.privateCopy();
 
@@ -77,14 +115,15 @@ void _doIndirectThreadLambda(ItemVectorViewT<ItemType> sub_items, const Lambda& 
 /*!
  * \brief Applique l'enumération \a func sur la liste d'entité \a items.
  */
-template <typename ItemType, typename Lambda> void
-_applyItems(RunCommand& command, ItemVectorViewT<ItemType> items, const Lambda& func)
+template <typename TraitsType, typename Lambda> void
+_applyItems(RunCommand& command, typename TraitsType::ContainerType items, const Lambda& func)
 {
   // TODO: fusionner la partie commune avec 'applyLoop'
   Integer vsize = items.size();
   if (vsize == 0)
     return;
-  typedef typename ItemType::LocalIdType LocalIdType;
+  using LocalIdType = typename TraitsType::LocalIdType;
+  using ItemType = typename TraitsType::ItemType;
   impl::RunCommandLaunchInfo launch_info(command, vsize);
   const eExecutionPolicy exec_policy = launch_info.executionPolicy();
   launch_info.computeLoopRunInfo(vsize);
@@ -105,7 +144,7 @@ _applyItems(RunCommand& command, ItemVectorViewT<ItemType> items, const Lambda& 
   case eExecutionPolicy::Thread:
     arcaneParallelForeach(items, launch_info.loopRunInfo(),
                           [&](ItemVectorViewT<ItemType> sub_items) {
-                            impl::_doIndirectThreadLambda(sub_items, func);
+                            impl::_doIndirectThreadLambda<LocalIdType>(sub_items, func);
                           });
     break;
   default:
@@ -124,61 +163,72 @@ namespace Arcane::Accelerator
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-//! Applique la lambda \a func sur l'intervalle d'itération donnée par \a bounds
-template <typename ItemType, typename Lambda> void
-run(RunCommand& command, const ItemGroupT<ItemType>& items, const Lambda& func)
+template <typename TraitsType, typename Lambda> void
+run(RunCommand& command, const TraitsType& traits, const Lambda& func)
 {
-  impl::_applyItems<ItemType>(command, items.view(), func);
+  impl::_applyItems<TraitsType>(command, traits.m_items, func);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template <typename ItemType, typename Lambda> void
-run(RunCommand& command, ItemVectorViewT<ItemType> items, const Lambda& func)
-{
-  impl::_applyItems<ItemType>(command, items, func);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template <typename ItemType>
+template <typename TraitsType>
 class ItemRunCommand
 {
  public:
 
-  ItemRunCommand(RunCommand& command, const ItemVectorViewT<ItemType>& items)
+  ItemRunCommand(RunCommand& command, const TraitsType& traits)
   : m_command(command)
-  , m_items(items)
+  , m_traits(traits)
   {
   }
   RunCommand& m_command;
-  ItemVectorViewT<ItemType> m_items;
+  const TraitsType& m_traits;
 };
 
-template <typename ItemType> ItemRunCommand<ItemType>
-operator<<(RunCommand& command, const ItemGroupT<ItemType>& items)
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template <typename ItemType> auto
+operator<<(RunCommand& command, const impl::RunCommandItemEnumeratorTraitsT<ItemType>& traits)
 {
-  return ItemRunCommand<ItemType>(command, items.view());
+  using TraitsType = impl::RunCommandItemEnumeratorTraitsT<ItemType>;
+  return ItemRunCommand<TraitsType>(command, traits);
 }
 
-template <typename ItemType> ItemRunCommand<ItemType>
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+// Cette méthode est conservée pour compatibilité avec l'existant.
+// A rendre obsolète mi-2024
+template <typename ItemType> auto
 operator<<(RunCommand& command, const ItemVectorViewT<ItemType>& items)
 {
-  return ItemRunCommand<ItemType>(command, items);
+  using TraitsType = impl::RunCommandItemEnumeratorTraitsT<ItemType>;
+  return ItemRunCommand<TraitsType>(command, TraitsType(items));
 }
 
-template <typename ItemType, typename Lambda>
-void operator<<(ItemRunCommand<ItemType>&& nr, const Lambda& f)
+// Cette méthode est conservée pour compatibilité avec l'existant.
+// A rendre obsolète mi-2024
+template <typename ItemType> auto
+operator<<(RunCommand& command, const ItemGroupT<ItemType>& items)
 {
-  run(nr.m_command, nr.m_items, f);
+  using TraitsType = impl::RunCommandItemEnumeratorTraitsT<ItemType>;
+  return ItemRunCommand<TraitsType>(command, TraitsType(items));
 }
 
-template <typename ItemType, typename Lambda>
-void operator<<(ItemRunCommand<ItemType>& nr, const Lambda& f)
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template <typename TraitsType, typename Lambda>
+void operator<<(ItemRunCommand<TraitsType>&& nr, const Lambda& f)
 {
-  run(nr.m_command, nr.m_items, f);
+  run(nr.m_command, nr.m_traits, f);
+}
+
+template <typename TraitsType, typename Lambda>
+void operator<<(ItemRunCommand<TraitsType>& nr, const Lambda& f)
+{
+  run(nr.m_command, nr.m_traits, f);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -188,10 +238,26 @@ void operator<<(ItemRunCommand<ItemType>& nr, const Lambda& f)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-//! Macro pour itérer sur un groupe d'entités
+/*!
+ * \brief Macro pour itérer sur accélérateur sur un groupe d'entités.
+ *
+ * Conceptuellement, cela est équivalent à la boucle suivante:
+ *
+ * \code
+ * for( ItemTypeName iter_name : item_group ){
+ *    ...
+ * }
+ * \endcode
+ *
+ * \a ItemTypeName doit être un type de numéro local (CellLocalId, NodeLocalId).
+ * L'utilisation du nom du type de l'entité (Cell, Node, ...) est possible mais est
+ * obsolète et il est équivalent à utiliser le type du numéro local (par exemple
+ * il faut remplacer \a Cell par \a CellLocalId).
+ * \a iter_name est le nom de la variable contenant la valeur courante de l'itérateur.
+ * \a item_group est le nom du ItemGroup ou ItemVectorView associé
+ */
 #define RUNCOMMAND_ENUMERATE(ItemTypeName, iter_name, item_group) \
-  A_FUNCINFO << ::Arcane::Accelerator::impl::RunCommandItemEnumeratorTraitsT<ItemTypeName>::createContainer(item_group) \
+  A_FUNCINFO << ::Arcane::Accelerator::impl::RunCommandItemEnumeratorTraitsT<ItemTypeName>(item_group) \
              << [=] ARCCORE_HOST_DEVICE(::Arcane::Accelerator::impl::RunCommandItemEnumeratorTraitsT<ItemTypeName>::ValueType iter_name)
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/RunCommandEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandEnumerate.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommandEnumerate.h                                       (C) 2000-2023 */
+/* RunCommandEnumerate.h                                       (C) 2000-2024 */
 /*                                                                           */
 /* Macros pour exécuter une boucle sur une liste d'entités.                  */
 /*---------------------------------------------------------------------------*/
@@ -26,27 +26,48 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-namespace Arcane::Accelerator
+namespace Arcane::Accelerator::impl
 {
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-namespace impl
+/*!
+ * \brief Caractéristiques d'un énumérateur d'une commande sur les entités.
+ *
+ * Cette classe doit être spécialisée et définir un type \a ValueType
+ * qui correspond au type de retour de 'operator*' de l'énumérateur.
+ */
+template <typename ItemType>
+class RunCommandItemEnumeratorTraitsT
 {
+ public:
+
+  using ValueType = ItemTraitsT<ItemType>::LocalIdType;
+
+ public:
+
+  static ItemVectorViewT<ItemType> createContainer(const ItemGroupT<ItemType>& group)
+  {
+    return group.view();
+  }
+  static ItemVectorViewT<ItemType> createContainer(const ItemVectorViewT<ItemType>& vector_view)
+  {
+    return vector_view;
+  }
+};
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename ItemType,typename Lambda>
-void _doIndirectThreadLambda(ItemVectorViewT<ItemType> sub_items,const Lambda& func)
+template <typename ItemType, typename Lambda>
+void _doIndirectThreadLambda(ItemVectorViewT<ItemType> sub_items, const Lambda& func)
 {
   typedef typename ItemType::LocalIdType LocalIdType;
 
   auto privatizer = privatize(func);
   auto& body = privatizer.privateCopy();
 
-  ENUMERATE_ITEM(iitem,sub_items){
+  ENUMERATE_ITEM (iitem, sub_items) {
     body(LocalIdType(iitem.itemLocalId()));
   }
 }
@@ -56,116 +77,122 @@ void _doIndirectThreadLambda(ItemVectorViewT<ItemType> sub_items,const Lambda& f
 /*!
  * \brief Applique l'enumération \a func sur la liste d'entité \a items.
  */
-template<typename ItemType,typename Lambda> void
-_applyItems(RunCommand& command,ItemVectorViewT<ItemType> items,const Lambda& func)
+template <typename ItemType, typename Lambda> void
+_applyItems(RunCommand& command, ItemVectorViewT<ItemType> items, const Lambda& func)
 {
   // TODO: fusionner la partie commune avec 'applyLoop'
   Integer vsize = items.size();
-  if (vsize==0)
+  if (vsize == 0)
     return;
   typedef typename ItemType::LocalIdType LocalIdType;
-  impl::RunCommandLaunchInfo launch_info(command,vsize);
+  impl::RunCommandLaunchInfo launch_info(command, vsize);
   const eExecutionPolicy exec_policy = launch_info.executionPolicy();
   launch_info.computeLoopRunInfo(vsize);
   launch_info.beginExecute();
-  switch(exec_policy){
+  switch (exec_policy) {
   case eExecutionPolicy::CUDA:
-    _applyKernelCUDA(launch_info,ARCANE_KERNEL_CUDA_FUNC(doIndirectGPULambda)<ItemType,Lambda>,func,items.localIds());
+    _applyKernelCUDA(launch_info, ARCANE_KERNEL_CUDA_FUNC(doIndirectGPULambda) < ItemType, Lambda >, func, items.localIds());
     break;
   case eExecutionPolicy::HIP:
-    _applyKernelHIP(launch_info,ARCANE_KERNEL_HIP_FUNC(doIndirectGPULambda)<ItemType,Lambda>,func,items.localIds());
+    _applyKernelHIP(launch_info, ARCANE_KERNEL_HIP_FUNC(doIndirectGPULambda) < ItemType, Lambda >, func, items.localIds());
     break;
   case eExecutionPolicy::Sequential:
-    ENUMERATE_NO_TRACE_(ItemType,iitem,items){
+    ENUMERATE_NO_TRACE_(ItemType, iitem, items)
+    {
       func(LocalIdType(iitem.itemLocalId()));
     }
     break;
   case eExecutionPolicy::Thread:
-    arcaneParallelForeach(items,launch_info.loopRunInfo(),
-                          [&](ItemVectorViewT<ItemType> sub_items)
-                          {
-                            impl::_doIndirectThreadLambda(sub_items,func);
+    arcaneParallelForeach(items, launch_info.loopRunInfo(),
+                          [&](ItemVectorViewT<ItemType> sub_items) {
+                            impl::_doIndirectThreadLambda(sub_items, func);
                           });
     break;
   default:
-    ARCANE_FATAL("Invalid execution policy '{0}'",exec_policy);
+    ARCANE_FATAL("Invalid execution policy '{0}'", exec_policy);
   }
   launch_info.endExecute();
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+} // namespace Arcane::Accelerator::impl
 
-} // End namespace impl
+namespace Arcane::Accelerator
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 //! Applique la lambda \a func sur l'intervalle d'itération donnée par \a bounds
-template<typename ItemType,typename Lambda> void
-run(RunCommand& command,const ItemGroupT<ItemType>& items,const Lambda& func)
+template <typename ItemType, typename Lambda> void
+run(RunCommand& command, const ItemGroupT<ItemType>& items, const Lambda& func)
 {
-  impl::_applyItems<ItemType>(command,items.view(),func);
+  impl::_applyItems<ItemType>(command, items.view(), func);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename ItemType,typename Lambda> void
-run(RunCommand& command,ItemVectorViewT<ItemType> items,const Lambda& func)
+template <typename ItemType, typename Lambda> void
+run(RunCommand& command, ItemVectorViewT<ItemType> items, const Lambda& func)
 {
-  impl::_applyItems<ItemType>(command,items,func);
+  impl::_applyItems<ItemType>(command, items, func);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename ItemType>
+template <typename ItemType>
 class ItemRunCommand
 {
  public:
-  ItemRunCommand(RunCommand& command,const ItemVectorViewT<ItemType>& items)
-  : m_command(command), m_items(items)
+
+  ItemRunCommand(RunCommand& command, const ItemVectorViewT<ItemType>& items)
+  : m_command(command)
+  , m_items(items)
   {
   }
   RunCommand& m_command;
   ItemVectorViewT<ItemType> m_items;
 };
 
-template<typename ItemType> ItemRunCommand<ItemType>
-operator<<(RunCommand& command,const ItemGroupT<ItemType>& items)
+template <typename ItemType> ItemRunCommand<ItemType>
+operator<<(RunCommand& command, const ItemGroupT<ItemType>& items)
 {
-  return ItemRunCommand<ItemType>(command,items.view());
+  return ItemRunCommand<ItemType>(command, items.view());
 }
 
-template<typename ItemType> ItemRunCommand<ItemType>
-operator<<(RunCommand& command,const ItemVectorViewT<ItemType>& items)
+template <typename ItemType> ItemRunCommand<ItemType>
+operator<<(RunCommand& command, const ItemVectorViewT<ItemType>& items)
 {
-  return ItemRunCommand<ItemType>(command,items);
+  return ItemRunCommand<ItemType>(command, items);
 }
 
-template<typename ItemType,typename Lambda>
-void operator<<(ItemRunCommand<ItemType>&& nr,const Lambda& f)
+template <typename ItemType, typename Lambda>
+void operator<<(ItemRunCommand<ItemType>&& nr, const Lambda& f)
 {
-  run(nr.m_command,nr.m_items,f);
+  run(nr.m_command, nr.m_items, f);
 }
-template<typename ItemType,typename Lambda>
-void operator<<(ItemRunCommand<ItemType>& nr,const Lambda& f)
+
+template <typename ItemType, typename Lambda>
+void operator<<(ItemRunCommand<ItemType>& nr, const Lambda& f)
 {
-  run(nr.m_command,nr.m_items,f);
+  run(nr.m_command, nr.m_items, f);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace Arcane::Accelerator
+} // namespace Arcane::Accelerator
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-//! Macro pour itérer un groupe d'entités
-#define RUNCOMMAND_ENUMERATE(ItemNameType,iter_name,item_group)         \
-  A_FUNCINFO << item_group << [=] ARCCORE_HOST_DEVICE (ItemNameType##LocalId iter_name)
+//! Macro pour itérer sur un groupe d'entités
+#define RUNCOMMAND_ENUMERATE(ItemTypeName, iter_name, item_group) \
+  A_FUNCINFO << ::Arcane::Accelerator::impl::RunCommandItemEnumeratorTraitsT<ItemTypeName>::createContainer(item_group) \
+             << [=] ARCCORE_HOST_DEVICE(::Arcane::Accelerator::impl::RunCommandItemEnumeratorTraitsT<ItemTypeName>::ValueType iter_name)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.h
@@ -706,10 +706,10 @@ void operator<<(MatCellRunCommand&& nr, const Lambda& func)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-//! Macro pour itérer un matériau ou un milieu
+//! Macro pour itérer sur un matériau ou un milieu
 #define RUNCOMMAND_MAT_ENUMERATE(MatItemNameType, iter_name, env_or_mat_vector) \
-  A_FUNCINFO << Arcane::Accelerator::RunCommandMatItemEnumeratorTraitsT<MatItemNameType>::createContainer(env_or_mat_vector) \
-             << [=] ARCCORE_HOST_DEVICE(Arcane::Accelerator::RunCommandMatItemEnumeratorTraitsT<MatItemNameType>::EnumeratorType iter_name)
+  A_FUNCINFO << ::Arcane::Accelerator::RunCommandMatItemEnumeratorTraitsT<MatItemNameType>::createContainer(env_or_mat_vector) \
+  << [=] ARCCORE_HOST_DEVICE(::Arcane::Accelerator::RunCommandMatItemEnumeratorTraitsT<MatItemNameType>::EnumeratorType iter_name)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/RunQueueInternal.h
+++ b/arcane/src/arcane/accelerator/RunQueueInternal.h
@@ -67,10 +67,10 @@ ARCCORE_HOST_DEVICE auto privatize(const T& item) -> Privatizer<T>
 
 #if defined(ARCANE_COMPILING_CUDA) || defined(ARCANE_COMPILING_HIP)
 
-template<typename ItemType,typename Lambda> __global__
+template<typename BuilderType,typename Lambda> __global__
 void doIndirectGPULambda(SmallSpan<const Int32> ids,Lambda func)
 {
-  typedef typename ItemType::LocalIdType LocalIdType;
+  using LocalIdType = BuilderType::ValueType;
 
   auto privatizer = privatize(func);
   auto& body = privatizer.privateCopy();
@@ -80,7 +80,7 @@ void doIndirectGPULambda(SmallSpan<const Int32> ids,Lambda func)
     LocalIdType lid(ids[i]);
     //if (i<10)
     //printf("CUDA %d lid=%d\n",i,lid.localId());
-    body(lid);
+    body(BuilderType::create(i,lid));
   }
 }
 

--- a/arcane/src/arcane/accelerator/RunQueueInternal.h
+++ b/arcane/src/arcane/accelerator/RunQueueInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunQueueInternal.h                                          (C) 2000-2023 */
+/* RunQueueInternal.h                                          (C) 2000-2024 */
 /*                                                                           */
 /* Implémentation de la gestion d'une file d'exécution sur accélérateur.     */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemFunctor.cc
+++ b/arcane/src/arcane/core/ItemFunctor.cc
@@ -1,17 +1,17 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemFunctor.cc                                              (C) 2000-2023 */
+/* ItemFunctor.cc                                              (C) 2000-2024 */
 /*                                                                           */
 /* Fonctor sur les entités.                                                  */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ItemFunctor.h"
+#include "arcane/core/ItemFunctor.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -47,12 +47,14 @@ AbstractItemRangeFunctor(ItemVectorView items_view,Integer grain_size)
 /*---------------------------------------------------------------------------*/
 
 ItemVectorView AbstractItemRangeFunctor::
-_view(Integer begin_block,Integer nb_block) const
+_view(Integer begin_block, Integer nb_block, Int32* true_begin) const
 {
   // Converti (begin_block,nb_block) en (begin,size) correspondant à m_items.
   Integer begin = begin_block * m_block_size;
   Integer nb_item = m_items.size();
   Integer size = math::min(nb_block * m_block_size,nb_item-begin);
+  if (true_begin)
+    *true_begin = begin;
   return m_items.subView(begin,size);
 }
 

--- a/arcane/src/arcane/core/ItemLocalId.h
+++ b/arcane/src/arcane/core/ItemLocalId.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemLocalId.h                                               (C) 2000-2023 */
+/* ItemLocalId.h                                               (C) 2000-2024 */
 /*                                                                           */
 /* Index local sur une entité du maillage.                                   */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemLocalId.h
+++ b/arcane/src/arcane/core/ItemLocalId.h
@@ -83,12 +83,13 @@ class ARCANE_CORE_EXPORT ItemLocalId
  * \ingroup Mesh
  * \brief Index d'une entité \a ItemType dans une variable.
  */
-template <typename ItemType>
+template <typename ItemType_>
 class ItemLocalIdT
 : public ItemLocalId
 {
  public:
 
+  using ItemType = ItemType_;
   using ThatClass = ItemLocalIdT<ItemType>;
 
  public:

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -683,6 +683,7 @@ if (ARCANE_HAS_ACCELERATOR_API)
   arcane_add_test_sequential(acceleratorviews1 testAcceleratorViews-1.arc)
   arcane_add_test_sequential_task(acceleratorviews1 testAcceleratorViews-1.arc 4)
   arcane_add_accelerator_test_sequential(acceleratorviews1 testAcceleratorViews-1.arc)
+  arcane_add_accelerator_test_parallel(acceleratorviews1 testAcceleratorViews-1.arc 4)
 
   arcane_add_test_sequential(accelerator_reduce1 testAcceleratorReduce-1.arc)
   arcane_add_test_sequential_task(accelerator_reduce1 testAcceleratorReduce-1.arc 4)

--- a/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AcceleratorViewsUnitTest.cc                                 (C) 2000-2023 */
+/* AcceleratorViewsUnitTest.cc                                 (C) 2000-2024 */
 /*                                                                           */
 /* Service de test des vues pour les accelerateurs.                          */
 /*---------------------------------------------------------------------------*/
@@ -15,6 +15,7 @@
 
 #include "arcane/core/BasicUnitTest.h"
 #include "arcane/core/ServiceFactory.h"
+#include "arcane/core/IItemFamily.h"
 
 #include "arcane/accelerator/core/Runner.h"
 #include "arcane/accelerator/core/Memory.h"
@@ -70,6 +71,7 @@ class AcceleratorViewsUnitTest
 
   void _executeTest1();
   void _executeTest2();
+  void _executeTest3();
   void _executeTestReal2x2();
   void _executeTestReal3x3();
   void _executeTest2Real3x3();
@@ -85,7 +87,7 @@ class AcceleratorViewsUnitTest
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_REGISTER_CASE_OPTIONS_NOAXL_FACTORY(AcceleratorViewsUnitTest,IUnitTest,
+ARCANE_REGISTER_CASE_OPTIONS_NOAXL_FACTORY(AcceleratorViewsUnitTest, IUnitTest,
                                            AcceleratorViewsUnitTest);
 
 /*---------------------------------------------------------------------------*/
@@ -94,12 +96,12 @@ ARCANE_REGISTER_CASE_OPTIONS_NOAXL_FACTORY(AcceleratorViewsUnitTest,IUnitTest,
 AcceleratorViewsUnitTest::
 AcceleratorViewsUnitTest(const ServiceBuildInfo& sb)
 : BasicUnitTest(sb)
-, m_cell_array1(VariableBuildInfo(sb.mesh(),"CellArray1"))
-, m_cell_array2(VariableBuildInfo(sb.mesh(),"CellArray2"))
-, m_cell1_real2(VariableBuildInfo(sb.mesh(),"Cell1Real2"))
-, m_cell1_real3(VariableBuildInfo(sb.mesh(),"Cell1Real3"))
-, m_cell1_real2x2(VariableBuildInfo(sb.mesh(),"Cell1Real2x2"))
-, m_cell1_real3x3(VariableBuildInfo(sb.mesh(),"Cell1Real3x3"))
+, m_cell_array1(VariableBuildInfo(sb.mesh(), "CellArray1"))
+, m_cell_array2(VariableBuildInfo(sb.mesh(), "CellArray2"))
+, m_cell1_real2(VariableBuildInfo(sb.mesh(), "Cell1Real2"))
+, m_cell1_real3(VariableBuildInfo(sb.mesh(), "Cell1Real3"))
+, m_cell1_real2x2(VariableBuildInfo(sb.mesh(), "Cell1Real2x2"))
+, m_cell1_real3x3(VariableBuildInfo(sb.mesh(), "Cell1Real3x3"))
 {
 }
 
@@ -133,10 +135,10 @@ void AcceleratorViewsUnitTest::
 _setCellArrayValue(Integer seed)
 {
   Integer n = m_cell_array1.arraySize();
-  ENUMERATE_CELL(icell,allCells()){
+  ENUMERATE_CELL (icell, allCells()) {
     Int32 lid = icell.itemLocalId();
-    for (Integer i=0; i<n; ++i ){
-      m_cell_array1[icell][i] = Real((i+1) + lid + seed);
+    for (Integer i = 0; i < n; ++i) {
+      m_cell_array1[icell][i] = Real((i + 1) + lid + seed);
     }
   }
 }
@@ -150,8 +152,8 @@ _checkCellArrayValue(const String& message) const
   ValueChecker vc(A_FUNCINFO);
   Integer n = m_cell_array1.arraySize();
   info() << "Check CELL ARRAY VALUE n=" << n << " message=" << message;
-  ENUMERATE_CELL(icell,allCells()){
-    vc.areEqual(m_cell_array1[icell],m_cell_array2[icell],message);
+  ENUMERATE_CELL (icell, allCells()) {
+    vc.areEqual(m_cell_array1[icell], m_cell_array2[icell], message);
   }
 }
 
@@ -163,6 +165,7 @@ executeTest()
 {
   _executeTest1();
   _executeTest2();
+  _executeTest3();
   _executeTestReal2x2();
   _executeTestReal3x3();
   _executeTest2Real3x3();
@@ -186,10 +189,10 @@ _executeTest1()
     int seed = 37;
     _setCellArrayValue(seed);
 
-    auto in_cell_array1 = ax::viewIn(command,m_cell_array1);
-    auto out_cell_array2 = ax::viewOut(command,m_cell_array2);
+    auto in_cell_array1 = ax::viewIn(command, m_cell_array1);
+    auto out_cell_array2 = ax::viewOut(command, m_cell_array2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (CellLocalId, vi, allCells())
     {
       out_cell_array2[vi].copy(in_cell_array1[vi]);
     };
@@ -201,12 +204,12 @@ _executeTest1()
     int seed = 23;
     _setCellArrayValue(seed);
 
-    auto in_cell_array1 = ax::viewIn(command,m_cell_array1);
-    auto out_cell_array2 = ax::viewOut(command,m_cell_array2);
+    auto in_cell_array1 = viewIn(command, m_cell_array1);
+    auto out_cell_array2 = viewOut(command, m_cell_array2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (CellLocalId, vi, allCells())
     {
-      for (Integer i=0; i<dim2_size; ++i )
+      for (Integer i = 0; i < dim2_size; ++i)
         out_cell_array2[vi][i] = in_cell_array1[vi][i];
     };
     _checkCellArrayValue("View2");
@@ -216,10 +219,10 @@ _executeTest1()
     int seed = 53;
     _setCellArrayValue(seed);
 
-    auto in_cell_array1 = ax::viewInOut(command,m_cell_array1);
-    auto out_cell_array2 = ax::viewOut(command,m_cell_array2);
+    auto in_cell_array1 = viewInOut(command, m_cell_array1);
+    auto out_cell_array2 = viewOut(command, m_cell_array2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (CellLocalId, vi, allCells())
     {
       out_cell_array2[vi].copy(in_cell_array1[vi]);
     };
@@ -231,10 +234,10 @@ _executeTest1()
     int seed = 93;
     _setCellArrayValue(seed);
 
-    auto in_cell_array1 = ax::viewIn(command,m_cell_array1);
-    auto out_cell_array2 = ax::viewInOut(command,m_cell_array2);
+    auto in_cell_array1 = ax::viewIn(command, m_cell_array1);
+    auto out_cell_array2 = ax::viewInOut(command, m_cell_array2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       out_cell_array2[vi].copy(in_cell_array1[vi]);
     };
@@ -246,10 +249,10 @@ _executeTest1()
     int seed = 43;
     _setCellArrayValue(seed);
 
-    auto inout_cell_array1 = ax::viewInOut(command,m_cell_array1);
-    auto out_cell_array2 = ax::viewInOut(command,m_cell_array2);
+    auto inout_cell_array1 = ax::viewInOut(command, m_cell_array1);
+    auto out_cell_array2 = ax::viewInOut(command, m_cell_array2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       out_cell_array2[vi].copy(inout_cell_array1[vi]);
     };
@@ -267,14 +270,14 @@ _executeTest2()
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real2 = ax::viewInOut(command,m_cell1_real2);
+    auto inout_cell1_real2 = viewInOut(command, m_cell1_real2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real2 ref_v;
-      ref_v[0] = 2.0+v;
-      ref_v[1] = 3.0+v;
+      ref_v[0] = 2.0 + v;
+      ref_v[1] = 3.0 + v;
       inout_cell1_real2[vi].setX(ref_v[0]);
       inout_cell1_real2[vi].setY(ref_v[1]);
     };
@@ -284,14 +287,14 @@ _executeTest2()
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real2 = ax::viewInOut(command,m_cell1_real2);
+    auto inout_cell1_real2 = ax::viewInOut(command, m_cell1_real2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real2 ref_v;
-      ref_v[0] = 4.0+v;
-      ref_v[1] = 5.0+v;
+      ref_v[0] = 4.0 + v;
+      ref_v[1] = 5.0 + v;
       inout_cell1_real2[vi][0] = ref_v[0];
       inout_cell1_real2[vi][1] = ref_v[1];
     };
@@ -301,15 +304,15 @@ _executeTest2()
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real3 = ax::viewInOut(command,m_cell1_real3);
+    auto inout_cell1_real3 = ax::viewInOut(command, m_cell1_real3);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real3 ref_v;
-      ref_v[0] = 2.0+v;
-      ref_v[1] = 3.0+v;
-      ref_v[2] = 4.0+v;
+      ref_v[0] = 2.0 + v;
+      ref_v[1] = 3.0 + v;
+      ref_v[2] = 4.0 + v;
       inout_cell1_real3[vi].setX(ref_v[0]);
       inout_cell1_real3[vi].setY(ref_v[1]);
       inout_cell1_real3[vi].setZ(ref_v[2]);
@@ -320,15 +323,15 @@ _executeTest2()
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real3 = ax::viewInOut(command,m_cell1_real3);
+    auto inout_cell1_real3 = ax::viewInOut(command, m_cell1_real3);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real3 ref_v;
-      ref_v[0] = 6.0+v;
-      ref_v[1] = 7.0+v;
-      ref_v[2] = 8.0+v;
+      ref_v[0] = 6.0 + v;
+      ref_v[1] = 7.0 + v;
+      ref_v[2] = 8.0 + v;
       inout_cell1_real3[vi][0] = ref_v[0];
       inout_cell1_real3[vi][1] = ref_v[1];
       inout_cell1_real3[vi][2] = ref_v[2];
@@ -341,22 +344,54 @@ _executeTest2()
 /*---------------------------------------------------------------------------*/
 
 void AcceleratorViewsUnitTest::
+_executeTest3()
+{
+  info() << "ExecuteTest3";
+  auto queue = makeQueue(m_runner);
+  auto command = makeCommand(queue);
+
+  Integer dim2_size = m_cell_array1.arraySize();
+  CellGroup own_cells = allCells().own();
+  Int32 max_local_id = own_cells.itemFamily()->maxLocalId();
+  NumArray<Int32, MDDim1> checked_local_ids(max_local_id);
+  checked_local_ids.fill(-1, &queue);
+  {
+    // Remplit out_checked_local_ids avec le i-ème localId() du groupe.
+    auto out_checked_local_ids = ax::viewOut(command, checked_local_ids);
+    command << RUNCOMMAND_ENUMERATE (IteratorWithIndex<CellLocalId>, vi, own_cells)
+    {
+      out_checked_local_ids[vi.index()] = vi.value();
+    };
+    // Vérifie tout est OK.
+    ENUMERATE_ (Cell, icell, own_cells) {
+      Int32 my_lid = icell.itemLocalId();
+      Int32 computed_lid = checked_local_ids[icell.index()];
+      if (my_lid != computed_lid)
+        ARCANE_FATAL("Bad computed local id ref={0} computed={1}", my_lid, computed_lid);
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void AcceleratorViewsUnitTest::
 _executeTestReal2x2()
 {
   info() << "Execute Test Real2x2";
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real2x2 = ax::viewInOut(command,m_cell1_real2x2);
+    auto inout_cell1_real2x2 = ax::viewInOut(command, m_cell1_real2x2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real2x2 ref_v;
-      ref_v[0][0] = 2.0+v;
-      ref_v[1][0] = 3.0+v;
-      ref_v[0][1] = 4.0+v;
-      ref_v[1][1] = 5.0+v;
+      ref_v[0][0] = 2.0 + v;
+      ref_v[1][0] = 3.0 + v;
+      ref_v[0][1] = 4.0 + v;
+      ref_v[1][1] = 5.0 + v;
       inout_cell1_real2x2[vi].setXX(ref_v[0][0]);
       inout_cell1_real2x2[vi].setYX(ref_v[1][0]);
       inout_cell1_real2x2[vi].setXY(ref_v[0][1]);
@@ -368,16 +403,16 @@ _executeTestReal2x2()
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real2x2 = ax::viewInOut(command,m_cell1_real2x2);
+    auto inout_cell1_real2x2 = ax::viewInOut(command, m_cell1_real2x2);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real2x2 ref_v;
-      ref_v[0][0] = 2.0+v;
-      ref_v[1][0] = 3.0+v;
-      ref_v[0][1] = 4.0+v;
-      ref_v[1][1] = 5.0+v;
+      ref_v[0][0] = 2.0 + v;
+      ref_v[1][0] = 3.0 + v;
+      ref_v[0][1] = 4.0 + v;
+      ref_v[1][1] = 5.0 + v;
       inout_cell1_real2x2[vi][0][0] = ref_v[0][0];
       inout_cell1_real2x2[vi][1][0] = ref_v[1][0];
       inout_cell1_real2x2[vi][0][1] = ref_v[0][1];
@@ -397,23 +432,23 @@ _executeTestReal3x3()
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real3x3 = ax::viewInOut(command,m_cell1_real3x3);
+    auto inout_cell1_real3x3 = ax::viewInOut(command, m_cell1_real3x3);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real3x3 ref_v;
-      ref_v[0][0] = 2.0+v;
-      ref_v[1][0] = 3.0+v;
-      ref_v[2][0] = 4.0+v;
+      ref_v[0][0] = 2.0 + v;
+      ref_v[1][0] = 3.0 + v;
+      ref_v[2][0] = 4.0 + v;
 
-      ref_v[0][1] = 5.0+v;
-      ref_v[1][1] = 6.0+v;
-      ref_v[2][1] = 7.0+v;
+      ref_v[0][1] = 5.0 + v;
+      ref_v[1][1] = 6.0 + v;
+      ref_v[2][1] = 7.0 + v;
 
-      ref_v[0][2] = 8.0+v;
-      ref_v[1][2] = 9.0+v;
-      ref_v[2][2] = 10.0+v;
+      ref_v[0][2] = 8.0 + v;
+      ref_v[1][2] = 9.0 + v;
+      ref_v[2][2] = 10.0 + v;
 
       inout_cell1_real3x3[vi].setXX(ref_v[0][0]);
       inout_cell1_real3x3[vi].setYX(ref_v[1][0]);
@@ -441,23 +476,23 @@ _executeTest2Real3x3()
   {
     auto queue = makeQueue(m_runner);
     auto command = makeCommand(queue);
-    auto inout_cell1_real3x3 = ax::viewInOut(command,m_cell1_real3x3);
+    auto inout_cell1_real3x3 = ax::viewInOut(command, m_cell1_real3x3);
 
-    command << RUNCOMMAND_ENUMERATE(Cell,vi,allCells())
+    command << RUNCOMMAND_ENUMERATE (Cell, vi, allCells())
     {
       Real v = static_cast<Real>(vi.localId());
       Real3x3 ref_v;
-      ref_v[0][0] = 5.0+v;
-      ref_v[1][0] = 6.0+v;
-      ref_v[2][0] = 7.0+v;
+      ref_v[0][0] = 5.0 + v;
+      ref_v[1][0] = 6.0 + v;
+      ref_v[2][0] = 7.0 + v;
 
-      ref_v[0][1] = 8.0+v;
-      ref_v[1][1] = 9.0+v;
-      ref_v[2][1] = 10.0+v;
+      ref_v[0][1] = 8.0 + v;
+      ref_v[1][1] = 9.0 + v;
+      ref_v[2][1] = 10.0 + v;
 
-      ref_v[0][2] = 11.0+v;
-      ref_v[1][2] = 12.0+v;
-      ref_v[2][2] = 13.0+v;
+      ref_v[0][2] = 11.0 + v;
+      ref_v[1][2] = 12.0 + v;
+      ref_v[2][2] = 13.0 + v;
 
       inout_cell1_real3x3[vi].setX(ref_v[0]);
       inout_cell1_real3x3[vi].setY(ref_v[1]);
@@ -474,13 +509,13 @@ void AcceleratorViewsUnitTest::
 _checkResultReal2(Real to_add)
 {
   ValueChecker vc(A_FUNCINFO);
-  ENUMERATE_(Cell,vi,allCells()){
+  ENUMERATE_ (Cell, vi, allCells()) {
     Real vbase = static_cast<Real>(vi.itemLocalId());
     Real v = to_add + vbase;
-    Real rx = 0.0+v;
-    Real ry = 1.0+v;
-    vc.areEqual(rx,m_cell1_real2[vi].x,"CheckX");
-    vc.areEqual(ry,m_cell1_real2[vi].y,"CheckY");
+    Real rx = 0.0 + v;
+    Real ry = 1.0 + v;
+    vc.areEqual(rx, m_cell1_real2[vi].x, "CheckX");
+    vc.areEqual(ry, m_cell1_real2[vi].y, "CheckY");
   }
 }
 
@@ -491,15 +526,15 @@ void AcceleratorViewsUnitTest::
 _checkResultReal3(Real to_add)
 {
   ValueChecker vc(A_FUNCINFO);
-  ENUMERATE_(Cell,vi,allCells()){
+  ENUMERATE_ (Cell, vi, allCells()) {
     Real vbase = static_cast<Real>(vi.itemLocalId());
     Real v = to_add + vbase;
-    Real rx = 0.0+v;
-    Real ry = 1.0+v;
-    Real rz = 2.0+v;
-    vc.areEqual(rx,m_cell1_real3[vi].x,"CheckX");
-    vc.areEqual(ry,m_cell1_real3[vi].y,"CheckY");
-    vc.areEqual(rz,m_cell1_real3[vi].z,"CheckZ");
+    Real rx = 0.0 + v;
+    Real ry = 1.0 + v;
+    Real rz = 2.0 + v;
+    vc.areEqual(rx, m_cell1_real3[vi].x, "CheckX");
+    vc.areEqual(ry, m_cell1_real3[vi].y, "CheckY");
+    vc.areEqual(rz, m_cell1_real3[vi].z, "CheckZ");
   }
 }
 
@@ -510,17 +545,17 @@ void AcceleratorViewsUnitTest::
 _checkResultReal2x2(Real to_add)
 {
   ValueChecker vc(A_FUNCINFO);
-  ENUMERATE_(Cell,vi,allCells()){
+  ENUMERATE_ (Cell, vi, allCells()) {
     Real vbase = static_cast<Real>(vi.itemLocalId());
     Real v = to_add + vbase;
-    Real rxx = 0.0+v;
-    Real ryx = 1.0+v;
-    Real rxy = 2.0+v;
-    Real ryy = 3.0+v;
-    vc.areEqual(rxx,m_cell1_real2x2[vi].x.x,"Real2x2CheckXX");
-    vc.areEqual(rxy,m_cell1_real2x2[vi].x.y,"Real2x2CheckXY");
-    vc.areEqual(ryx,m_cell1_real2x2[vi].y.x,"Real2x2CheckYX");
-    vc.areEqual(ryy,m_cell1_real2x2[vi].y.y,"Real2x2CheckYY");
+    Real rxx = 0.0 + v;
+    Real ryx = 1.0 + v;
+    Real rxy = 2.0 + v;
+    Real ryy = 3.0 + v;
+    vc.areEqual(rxx, m_cell1_real2x2[vi].x.x, "Real2x2CheckXX");
+    vc.areEqual(rxy, m_cell1_real2x2[vi].x.y, "Real2x2CheckXY");
+    vc.areEqual(ryx, m_cell1_real2x2[vi].y.x, "Real2x2CheckYX");
+    vc.areEqual(ryy, m_cell1_real2x2[vi].y.y, "Real2x2CheckYY");
   }
 }
 
@@ -531,29 +566,29 @@ void AcceleratorViewsUnitTest::
 _checkResultReal3x3(Real to_add)
 {
   ValueChecker vc(A_FUNCINFO);
-  ENUMERATE_(Cell,vi,allCells()){
+  ENUMERATE_ (Cell, vi, allCells()) {
     Real vbase = static_cast<Real>(vi.itemLocalId());
     Real v = to_add + vbase;
-    Real rxx = 0.0+v;
-    Real ryx = 1.0+v;
-    Real rzx = 2.0+v;
-    Real rxy = 3.0+v;
-    Real ryy = 4.0+v;
-    Real rzy = 5.0+v;
-    Real rxz = 6.0+v;
-    Real ryz = 7.0+v;
-    Real rzz = 8.0+v;
-    vc.areEqual(rxx,m_cell1_real3x3[vi].x.x,"Real3x3CheckXX");
-    vc.areEqual(ryx,m_cell1_real3x3[vi].y.x,"Real3x3CheckYX");
-    vc.areEqual(rzx,m_cell1_real3x3[vi].z.x,"Real3x3CheckZX");
+    Real rxx = 0.0 + v;
+    Real ryx = 1.0 + v;
+    Real rzx = 2.0 + v;
+    Real rxy = 3.0 + v;
+    Real ryy = 4.0 + v;
+    Real rzy = 5.0 + v;
+    Real rxz = 6.0 + v;
+    Real ryz = 7.0 + v;
+    Real rzz = 8.0 + v;
+    vc.areEqual(rxx, m_cell1_real3x3[vi].x.x, "Real3x3CheckXX");
+    vc.areEqual(ryx, m_cell1_real3x3[vi].y.x, "Real3x3CheckYX");
+    vc.areEqual(rzx, m_cell1_real3x3[vi].z.x, "Real3x3CheckZX");
 
-    vc.areEqual(rxy,m_cell1_real3x3[vi].x.y,"Real3x3CheckXY");
-    vc.areEqual(ryy,m_cell1_real3x3[vi].y.y,"Real3x3CheckYY");
-    vc.areEqual(rzy,m_cell1_real3x3[vi].z.y,"Real3x3CheckZY");
+    vc.areEqual(rxy, m_cell1_real3x3[vi].x.y, "Real3x3CheckXY");
+    vc.areEqual(ryy, m_cell1_real3x3[vi].y.y, "Real3x3CheckYY");
+    vc.areEqual(rzy, m_cell1_real3x3[vi].z.y, "Real3x3CheckZY");
 
-    vc.areEqual(rxz,m_cell1_real3x3[vi].x.z,"Real3x3CheckXZ");
-    vc.areEqual(ryz,m_cell1_real3x3[vi].y.z,"Real3x3CheckYZ");
-    vc.areEqual(rzz,m_cell1_real3x3[vi].z.z,"Real3x3CheckZZ");
+    vc.areEqual(rxz, m_cell1_real3x3[vi].x.z, "Real3x3CheckXZ");
+    vc.areEqual(ryz, m_cell1_real3x3[vi].y.z, "Real3x3CheckYZ");
+    vc.areEqual(rzz, m_cell1_real3x3[vi].z.z, "Real3x3CheckZZ");
   }
 }
 
@@ -570,25 +605,25 @@ _executeTestMemoryCopy()
     dest_mem = eMemoryRessource::Device;
 
   const int nb_value = 100000;
-  NumArray<Int32,MDDim1> a(nb_value,source_mem);
-  NumArray<Int32,MDDim1> b(nb_value,source_mem);
-  NumArray<Int32,MDDim1> c(nb_value,source_mem);
+  NumArray<Int32, MDDim1> a(nb_value, source_mem);
+  NumArray<Int32, MDDim1> b(nb_value, source_mem);
+  NumArray<Int32, MDDim1> c(nb_value, source_mem);
 
   // Initialise les tableaux
-  for( int i=0; i<nb_value; ++i ){
+  for (int i = 0; i < nb_value; ++i) {
     a(i) = i + 3;
     b[i] = i + 5;
   }
 
-  NumArray<Int32,MDDim1> d_a(nb_value,dest_mem);
-  NumArray<Int32,MDDim1> d_b(nb_value,dest_mem);
-  NumArray<Int32,MDDim1> d_c(nb_value,dest_mem);
+  NumArray<Int32, MDDim1> d_a(nb_value, dest_mem);
+  NumArray<Int32, MDDim1> d_b(nb_value, dest_mem);
+  NumArray<Int32, MDDim1> d_c(nb_value, dest_mem);
 
   // Copie explicitement les données dans le device
   // Test la construction en donnant les tailles explicitement.
   auto queue = makeQueue(m_runner);
-  queue.copyMemory(ax::MemoryCopyArgs(d_a.bytes().data(),a.bytes().data(),nb_value*sizeof(Int32)).addAsync());
-  queue.copyMemory(ax::MemoryCopyArgs(d_b.bytes().data(),b.bytes().data(),nb_value*sizeof(Int32)).addAsync());
+  queue.copyMemory(ax::MemoryCopyArgs(d_a.bytes().data(), a.bytes().data(), nb_value * sizeof(Int32)).addAsync());
+  queue.copyMemory(ax::MemoryCopyArgs(d_b.bytes().data(), b.bytes().data(), nb_value * sizeof(Int32)).addAsync());
 
   {
     auto command = makeCommand(queue);
@@ -600,17 +635,16 @@ _executeTestMemoryCopy()
     {
       out_c(iter) = in_a[iter] + in_b(iter);
     };
-
   }
   // Recopie du device vers l'hôte
   queue.copyMemory(ax::MemoryCopyArgs(MutableMemoryView(c.bytes()), ConstMemoryView(d_c.bytes())));
 
   // Vérifie que tout est OK.
   // Initialise les tableaux
-  for( int i=0; i<nb_value; ++i ){
-    Int32 expected_value = (i+3) + (i+5);
-    if (c(i)!=expected_value)
-      ARCANE_FATAL("Bad value index={0} value={1} expected={2}",i,c(i),expected_value);
+  for (int i = 0; i < nb_value; ++i) {
+    Int32 expected_value = (i + 3) + (i + 5);
+    if (c(i) != expected_value)
+      ARCANE_FATAL("Bad value index={0} value={1} expected={2}", i, c(i), expected_value);
   }
 }
 
@@ -627,37 +661,37 @@ _executeTestVariableCopy()
   auto queue = makeQueue(m_runner);
   queue.setAsync(true);
 
-  VariableCellReal2 test_cell1_real2(VariableBuildInfo(mesh(),"TestCell1Real2"));
-  VariableCellReal3 test_cell1_real3(VariableBuildInfo(mesh(),"TestCell1Real3"));
-  VariableCellReal2x2 test_cell1_real2x2(VariableBuildInfo(mesh(),"TestCell1Real2x2"));
-  VariableCellReal3x3 test_cell1_real3x3(VariableBuildInfo(mesh(),"TestCell1Real3x3"));
-  VariableCellArrayReal test_cell1_array(VariableBuildInfo(mesh(),"TestCellArrayReal2"));
-  VariableCellArrayReal test_cell2_array(VariableBuildInfo(mesh(),"TestCellArrayReal3"));
-  VariableCellReal2 test2_cell1_real2(VariableBuildInfo(mesh(),"Test2Cell1Real2"));
+  VariableCellReal2 test_cell1_real2(VariableBuildInfo(mesh(), "TestCell1Real2"));
+  VariableCellReal3 test_cell1_real3(VariableBuildInfo(mesh(), "TestCell1Real3"));
+  VariableCellReal2x2 test_cell1_real2x2(VariableBuildInfo(mesh(), "TestCell1Real2x2"));
+  VariableCellReal3x3 test_cell1_real3x3(VariableBuildInfo(mesh(), "TestCell1Real3x3"));
+  VariableCellArrayReal test_cell1_array(VariableBuildInfo(mesh(), "TestCellArrayReal2"));
+  VariableCellArrayReal test_cell2_array(VariableBuildInfo(mesh(), "TestCellArrayReal3"));
+  VariableCellReal2 test2_cell1_real2(VariableBuildInfo(mesh(), "Test2Cell1Real2"));
 
   test_cell1_array.resize(m_cell_array1.arraySize());
   test_cell2_array.resize(m_cell_array2.arraySize());
 
-  test_cell1_real2.copy(m_cell1_real2,&queue);
-  test_cell1_real3.copy(m_cell1_real3,&queue);
-  test_cell1_real2x2.copy(m_cell1_real2x2,&queue);
-  test_cell1_real3x3.copy(m_cell1_real3x3,&queue);
-  test2_cell1_real2.copy(m_cell1_real2,nullptr);
-  test_cell1_array.copy(m_cell_array1,&queue);
-  test_cell2_array.copy(m_cell_array2,nullptr);
+  test_cell1_real2.copy(m_cell1_real2, &queue);
+  test_cell1_real3.copy(m_cell1_real3, &queue);
+  test_cell1_real2x2.copy(m_cell1_real2x2, &queue);
+  test_cell1_real3x3.copy(m_cell1_real3x3, &queue);
+  test2_cell1_real2.copy(m_cell1_real2, nullptr);
+  test_cell1_array.copy(m_cell_array1, &queue);
+  test_cell2_array.copy(m_cell_array2, nullptr);
   queue.barrier();
 
-  vc.areEqualArray(test_cell1_real2._internalSpan(),m_cell1_real2._internalSpan(),"CompareReal2");
-  vc.areEqualArray(test_cell1_real3._internalSpan(),m_cell1_real3._internalSpan(),"CompareReal3");
-  vc.areEqualArray(test_cell1_real2x2._internalSpan(),m_cell1_real2x2._internalSpan(),"CompareReal2x2");
-  vc.areEqualArray(test_cell1_real3x3._internalSpan(),m_cell1_real3x3._internalSpan(),"CompareReal3x3");
-  vc.areEqualArray(test2_cell1_real2._internalSpan(),m_cell1_real2._internalSpan(),"CompareReal2 Test2");
+  vc.areEqualArray(test_cell1_real2._internalSpan(), m_cell1_real2._internalSpan(), "CompareReal2");
+  vc.areEqualArray(test_cell1_real3._internalSpan(), m_cell1_real3._internalSpan(), "CompareReal3");
+  vc.areEqualArray(test_cell1_real2x2._internalSpan(), m_cell1_real2x2._internalSpan(), "CompareReal2x2");
+  vc.areEqualArray(test_cell1_real3x3._internalSpan(), m_cell1_real3x3._internalSpan(), "CompareReal3x3");
+  vc.areEqualArray(test2_cell1_real2._internalSpan(), m_cell1_real2._internalSpan(), "CompareReal2 Test2");
 
-  vc.areEqualArray(test_cell1_array._internalSpan(),m_cell_array1._internalSpan(),"CompareRealArray1");
+  vc.areEqualArray(test_cell1_array._internalSpan(), m_cell_array1._internalSpan(), "CompareRealArray1");
   {
     Span2<const double> v1(test_cell2_array.asArray());
     Span2<const double> v2(m_cell_array2.asArray());
-    vc.areEqualArray(v1,v2,"CompareRealArray2");
+    vc.areEqualArray(v1, v2, "CompareRealArray2");
   }
 }
 


### PR DESCRIPTION
- Allow `RUNCOMMAND_ENUMERATE` to be used with template argument.
- Allow argument of type `ItemLocalId` (like `CellLocalId`, `NodeLocalId`) for the type of iterator
- Add template class `IteratorWithIndex` to wrap the index of the iteration around the iterator value type.