### PR TITLE
Make utilitary function 'MemoryUtils::copy()' available in public API

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -475,7 +475,8 @@ class CudaMemoryCopier
 : public IMemoryCopier
 {
   void copy(ConstMemoryView from, [[maybe_unused]] eMemoryRessource from_mem,
-            MutableMemoryView to, [[maybe_unused]] eMemoryRessource to_mem, RunQueue* queue) override
+            MutableMemoryView to, [[maybe_unused]] eMemoryRessource to_mem,
+            const RunQueue* queue) override
   {
     if (queue){
       queue->copyMemory(MemoryCopyArgs(to.bytes(),from.bytes()).addAsync(queue->isAsync()));

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -396,7 +396,8 @@ class HipMemoryCopier
 : public IMemoryCopier
 {
   void copy(ConstMemoryView from, [[maybe_unused]] eMemoryRessource from_mem,
-            MutableMemoryView to, [[maybe_unused]] eMemoryRessource to_mem, RunQueue* queue) override
+            MutableMemoryView to, [[maybe_unused]] eMemoryRessource to_mem,
+            const RunQueue* queue) override
   {
     if (queue){
       queue->copyMemory(MemoryCopyArgs(to.bytes(),from.bytes()).addAsync(queue->isAsync()));

--- a/arcane/src/arcane/utils/MemoryRessourceMng.cc
+++ b/arcane/src/arcane/utils/MemoryRessourceMng.cc
@@ -75,7 +75,8 @@ class DefaultHostMemoryCopier
  public:
 
   void copy(ConstMemoryView from, eMemoryRessource from_mem,
-            MutableMemoryView to, eMemoryRessource to_mem, [[maybe_unused]] RunQueue* queue) override
+            MutableMemoryView to, eMemoryRessource to_mem,
+            [[maybe_unused]] const RunQueue* queue) override
   {
     // Sans support accélérateur, on peut juste faire un 'memcpy' si la mémoire
     // est accessible depuis le CPU
@@ -158,7 +159,7 @@ setAllocator(eMemoryRessource r, IMemoryAllocator* allocator)
 
 void MemoryRessourceMng::
 copy(ConstMemoryView from, eMemoryRessource from_mem,
-     MutableMemoryView to, eMemoryRessource to_mem, RunQueue* queue)
+     MutableMemoryView to, eMemoryRessource to_mem, const RunQueue* queue)
 {
   Int64 from_size = from.bytes().size();
   Int64 to_size = to.bytes().size();

--- a/arcane/src/arcane/utils/MemoryRessourceMng.cc
+++ b/arcane/src/arcane/utils/MemoryRessourceMng.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryRessourceMng.cc                                       (C) 2000-2023 */
+/* MemoryRessourceMng.cc                                       (C) 2000-2024 */
 /*                                                                           */
 /* Gestion des ressources mémoire pour les CPU et accélérateurs.             */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.cc
+++ b/arcane/src/arcane/utils/MemoryUtils.cc
@@ -15,6 +15,8 @@
 
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/MemoryAllocator.h"
+#include "arcane/utils/IMemoryRessourceMng.h"
+#include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -61,6 +63,17 @@ computeCapacity(Int64 size)
   else if (size > 500000)
     new_capacity = static_cast<Int64>(static_cast<double>(size) * 1.5);
   return new_capacity;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MemoryUtils::
+copy(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queue)
+{
+  IMemoryRessourceMng* mrm = platform::getDataMemoryRessourceMng();
+  eMemoryRessource mem_type = eMemoryRessource::Unknown;
+  mrm->_internal()->copy(source, mem_type, destination, mem_type, queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -16,6 +16,7 @@
 
 #include "arcane/utils/MemoryRessource.h"
 #include "arcane/utils/UtilsTypes.h"
+#include "arcane/utils/MemoryView.h"
 
 #include "arccore/collections/MemoryAllocationArgs.h"
 
@@ -100,6 +101,29 @@ checkResizeArrayWithCapacity(Array<DataType>& array, Int64 new_size, bool force_
     return true;
   }
   return false;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+//! Copie de \a source vers \a destination en utilisant la file \a queue.
+extern "C++" ARCANE_UTILS_EXPORT void
+copy(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queue = nullptr);
+
+//! Copie de \a source vers \a destination en utilisant la file \a queue.
+template <typename DataType> inline void
+copy(Span<DataType> destination, Span<const DataType> source, const RunQueue* queue = nullptr)
+{
+  ConstMemoryView input(asBytes(source));
+  MutableMemoryView output(asWritableBytes(destination));
+  copy(output, input, queue);
+}
+
+//! Copie de \a source vers \a destination en utilisant la file \a queue.
+template <typename DataType> inline void
+copy(SmallSpan<DataType> destination, SmallSpan<const DataType> source, const RunQueue* queue = nullptr)
+{
+  copy(Span<DataType>(destination), Span<const DataType>(source), queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/IMemoryCopier.h
+++ b/arcane/src/arcane/utils/internal/IMemoryCopier.h
@@ -41,7 +41,8 @@ class ARCANE_UTILS_EXPORT IMemoryCopier
    * \a queue peut-être nul.
    */
   virtual void copy(ConstMemoryView from, eMemoryRessource from_mem,
-                    MutableMemoryView to, eMemoryRessource to_mem, RunQueue* queue) = 0;
+                    MutableMemoryView to, eMemoryRessource to_mem,
+                    const RunQueue* queue) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/IMemoryRessourceMngInternal.h
+++ b/arcane/src/arcane/utils/internal/IMemoryRessourceMngInternal.h
@@ -36,7 +36,7 @@ class ARCANE_UTILS_EXPORT IMemoryRessourceMngInternal
  public:
 
   virtual void copy(ConstMemoryView from, eMemoryRessource from_mem,
-                    MutableMemoryView to, eMemoryRessource to_mem, RunQueue* queue) = 0;
+                    MutableMemoryView to, eMemoryRessource to_mem, const RunQueue* queue) = 0;
 
  public:
 

--- a/arcane/src/arcane/utils/internal/IMemoryRessourceMngInternal.h
+++ b/arcane/src/arcane/utils/internal/IMemoryRessourceMngInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IMemoryRessourceMngInternal.h                               (C) 2000-2023 */
+/* IMemoryRessourceMngInternal.h                               (C) 2000-2024 */
 /*                                                                           */
 /* Partie interne à Arcane de 'IMemoryRessourceMng'.                         */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/MemoryRessourceMng.h
+++ b/arcane/src/arcane/utils/internal/MemoryRessourceMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IMemoryRessourceMng.h                                       (C) 2000-2023 */
+/* IMemoryRessourceMng.h                                       (C) 2000-2024 */
 /*                                                                           */
 /* Gestion des ressources mémoire pour les CPU et accélérateurs.             */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/MemoryRessourceMng.h
+++ b/arcane/src/arcane/utils/internal/MemoryRessourceMng.h
@@ -46,7 +46,7 @@ class ARCANE_UTILS_EXPORT MemoryRessourceMng
  public:
 
   void copy(ConstMemoryView from, eMemoryRessource from_mem,
-            MutableMemoryView to, eMemoryRessource to_mem, RunQueue* queue) override;
+            MutableMemoryView to, eMemoryRessource to_mem, const RunQueue* queue) override;
 
  public:
 

--- a/arcane/src/arcane/utils/tests/TestMemory.cc
+++ b/arcane/src/arcane/utils/tests/TestMemory.cc
@@ -10,11 +10,8 @@
 #include "arcane/utils/MemoryView.h"
 #include "arcane/utils/UniqueArray.h"
 #include "arcane/utils/Exception.h"
-
-#include "arcane/utils/Real2.h"
-#include "arcane/utils/Real3.h"
-#include "arcane/utils/Real2x2.h"
-#include "arcane/utils/Real3x3.h"
+#include "arcane/utils/MemoryUtils.h"
+#include "arcane/utils/NumericTypes.h"
 
 #include <random>
 
@@ -125,9 +122,9 @@ class MemoryTester
       to.copyFromIndexesHost(from, copy_indexes);
       ASSERT_EQ(array2, array3);
       ConstMemoryView view2(array1.view());
-      ASSERT_EQ(view2.bytes(),asBytes(array1));
-      ConstMemoryView view3(array1.view(),1);
-      ASSERT_EQ(view3.bytes(),asBytes(array1));
+      ASSERT_EQ(view2.bytes(), asBytes(array1));
+      ConstMemoryView view3(array1.view(), 1);
+      ASSERT_EQ(view3.bytes(), asBytes(array1));
     }
 
     // Teste MutableMemoryView::copyToIndexesHost()
@@ -173,6 +170,33 @@ TEST(Memory, Basic)
   catch (const Exception& ex) {
     std::cerr << "ERROR=" << ex << "\n";
     throw;
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(Memory, Copy)
+{
+  Int32 n = 2500;
+  UniqueArray<Int32> r1(n);
+  for (Int32 i = 0; i < n; ++i)
+    r1[i] = i + 1;
+
+  {
+    UniqueArray<Int32> r2(n);
+    Span<Int32> r2_view(r2);
+    Span<const Int32> r1_view(r1);
+    MemoryUtils::copy(r2_view, r1_view);
+    ASSERT_EQ(r1, r2);
+  }
+
+  {
+    UniqueArray<Int32> r3(n);
+    SmallSpan<Int32> r3_view(r3.view());
+    SmallSpan<const Int32> r1_view(r1.view());
+    MemoryUtils::copy(r3_view, r1_view);
+    ASSERT_EQ(r1, r3);
   }
 }
 


### PR DESCRIPTION
This function is aware of accelerator and allow transfers between host and device memory.