### PR TITLE
Various improvements in 'MemoryUtils'

### DIFF
--- a/arcane/src/arcane/impl/ArrayData.cc
+++ b/arcane/src/arcane/impl/ArrayData.cc
@@ -30,9 +30,8 @@
 #include "arcane/utils/ArrayShape.h"
 #include "arcane/utils/MemoryAllocator.h"
 #include "arcane/utils/MemoryView.h"
+#include "arcane/utils/MemoryUtils.h"
 #include "arcane/utils/PlatformUtils.h"
-#include "arcane/utils/IMemoryRessourceMng.h"
-#include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
 
 #include "arcane/core/datatype/DataAllocationInfo.h"
 #include "arcane/core/datatype/DataStorageBuildInfo.h"
@@ -709,11 +708,7 @@ changeAllocator(const MemoryAllocationOptions& alloc_info)
   // Tant qu'il n'y a pas l'API dans Arccore, il faut faire la copie à la
   // main pour ne pas avoir de plantage si l'allocateur est uniquement sur
   // un accélérateur
-  IMemoryRessourceMng* mrm = platform::getDataMemoryRessourceMng();
-  eMemoryRessource mem_type = eMemoryRessource::Unknown;
-  ConstMemoryView input_view(asBytes(m_value));
-  MutableMemoryView output_view(asWritableBytes(new_value));
-  mrm->_internal()->copy(input_view, mem_type, output_view, mem_type, nullptr);
+  MemoryUtils::copy(new_value.span(), m_value.constSpan());
 
   std::swap(m_value,new_value);
   m_allocation_info.setMemoryLocationHint(alloc_info.memoryLocationHint());

--- a/arcane/src/arcane/utils/DualUniqueArray.cc
+++ b/arcane/src/arcane/utils/DualUniqueArray.cc
@@ -13,12 +13,8 @@
 
 #include "arcane/utils/DualUniqueArray.h"
 
-#include "arcane/utils/String.h"
-#include "arcane/utils/FatalErrorException.h"
-#include "arcane/utils/PlatformUtils.h"
-#include "arcane/utils/IMemoryRessourceMng.h"
 #include "arcane/utils/MemoryView.h"
-#include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
+#include "arcane/utils/MemoryUtils.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -32,10 +28,7 @@ namespace Arcane
 void DualUniqueArrayBase::
 _memoryCopy(Span<const std::byte> from, Span<std::byte> to)
 {
-  IMemoryRessourceMng* mrm = platform::getDataMemoryRessourceMng();
-  eMemoryRessource from_mem = eMemoryRessource::Unknown;
-  eMemoryRessource to_mem = eMemoryRessource::Unknown;
-  mrm->_internal()->copy(ConstMemoryView(from), from_mem, MutableMemoryView(to), to_mem, nullptr);
+  MemoryUtils::copy(MutableMemoryView(to), ConstMemoryView(from));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.cc
+++ b/arcane/src/arcane/utils/MemoryUtils.cc
@@ -46,6 +46,16 @@ getDefaultDataAllocator(eMemoryLocationHint hint)
 /*---------------------------------------------------------------------------*/
 
 MemoryAllocationOptions MemoryUtils::
+getAllocationOptions(eMemoryRessource mem_ressource)
+{
+  IMemoryAllocator* allocator = platform::getDataMemoryRessourceMng()->getAllocator(mem_ressource);
+  return MemoryAllocationOptions(allocator);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+MemoryAllocationOptions MemoryUtils::
 getAllocatorForMostlyReadOnlyData()
 {
   return getDefaultDataAllocator(eMemoryLocationHint::HostAndDeviceMostlyRead);

--- a/arcane/src/arcane/utils/MemoryUtils.cc
+++ b/arcane/src/arcane/utils/MemoryUtils.cc
@@ -67,12 +67,13 @@ getAllocatorForMostlyReadOnlyData()
 Int64 MemoryUtils::impl::
 computeCapacity(Int64 size)
 {
-  Int64 new_capacity = size * 2;
+  double d_size = static_cast<double>(size);
+  double d_new_capacity = d_size * 1.8;
   if (size > 5000000)
-    new_capacity = static_cast<Int64>(static_cast<double>(size) * 1.2);
+    d_new_capacity = d_size * 1.2;
   else if (size > 500000)
-    new_capacity = static_cast<Int64>(static_cast<double>(size) * 1.5);
-  return new_capacity;
+    d_new_capacity = d_size * 1.5;
+  return static_cast<Int64>(d_new_capacity);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.cc
+++ b/arcane/src/arcane/utils/MemoryUtils.cc
@@ -79,11 +79,11 @@ computeCapacity(Int64 size)
 /*---------------------------------------------------------------------------*/
 
 void MemoryUtils::
-copy(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queue)
+copy(MutableMemoryView destination, eMemoryRessource destination_mem,
+     ConstMemoryView source, eMemoryRessource source_mem, const RunQueue* queue)
 {
   IMemoryRessourceMng* mrm = platform::getDataMemoryRessourceMng();
-  eMemoryRessource mem_type = eMemoryRessource::Unknown;
-  mrm->_internal()->copy(source, mem_type, destination, mem_type, queue);
+  mrm->_internal()->copy(source, destination_mem, destination, source_mem, queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -31,11 +31,10 @@ namespace Arcane::MemoryUtils
 /*!
  * \brief Allocateur par défaut pour les données.
  *
- * Cette allocateur utilise celui getAcceleratorHostMemoryAllocator()
- * s'il est disponible, sinon il utilise un allocateur aligné.
- *
- * Il est garanti que l'allocateur retourné permettra d'utiliser la donnée
- * à la fois sur accélerateur et sur l'hôte si cela est disponible.
+ * Si un runtime accélérateur est initialisé, l'allocateur retourné permet
+ * d'allouer en mémoire unifiée et donc la zone allouée sera accessible à la
+ * fois sur l'accélérateur et sur l'hôte. Sinon, retourne un allocateur
+ * aligné.
  *
  * Il est garanti que l'alignement est au moins celui retourné par
  * AlignedMemoryAllocator::Simd().
@@ -49,7 +48,8 @@ getDefaultDataAllocator();
  * \brief Allocateur par défaut pour les données avec informations sur
  * la localisation attendue.
  *
- * \sa getDefaultDataAllocator()
+ * Cette fonction retourne l'allocateur de getDefaulDataAllocator() mais
+ * ajoute les informations de gestion mémoire spécifiées par \a hint.
  */
 extern "C++" ARCANE_UTILS_EXPORT MemoryAllocationOptions
 getDefaultDataAllocator(eMemoryLocationHint hint);
@@ -57,13 +57,25 @@ getDefaultDataAllocator(eMemoryLocationHint hint);
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Allocateur par défaut pour les données essentiellements en
+ * \brief Allocateur par défaut pour les données essentiellement en
  * lecture.
  *
  * Cet appel est équivalent à getDefaultDataAllocator(eMemoryLocationHint::HostAndDeviceMostlyRead).
  */
 extern "C++" ARCANE_UTILS_EXPORT MemoryAllocationOptions
 getAllocatorForMostlyReadOnlyData();
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Allocateur par défaut pour la ressource \a mem_ressource.
+ *
+ * Lève une exception si aucune allocateur n'est disponible pour la ressource
+ * (par exemple si on demande eMemoryRessource::Device et qu'il n'y a pas de
+ * support pour les accélérateurs.
+ */
+extern "C++" ARCANE_UTILS_EXPORT MemoryAllocationOptions
+getAllocationOptions(eMemoryRessource mem_ressource);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -102,21 +102,24 @@ namespace impl
  * Si le tableau est redimensionné, on réserve une capacité supplémentaire
  * pour éviter de réallouer à chaque fois.
  *
- * \retval true si un redimensionnement a eu lieu
- * \retval false sinon
+ * \retval 2 si on a réalloué via reserve()
+ * \retval 1 si on a re-dimensionné sans réallouer.
+ * \retval 0 si aucune opération n'a eu lieu.
  */
-template <typename DataType> inline bool
+template <typename DataType> inline Int32
 checkResizeArrayWithCapacity(Array<DataType>& array, Int64 new_size, bool force_resize)
 {
+  Int32 ret_value = 0;
   Int64 s = array.largeSize();
   if (new_size > s || force_resize) {
+    ret_value = 1;
     if (new_size > array.capacity()) {
       array.reserve(impl::computeCapacity(new_size));
+      ret_value = 2;
     }
     array.resize(new_size);
-    return true;
   }
-  return false;
+  return ret_value;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -73,6 +73,10 @@ getAllocatorForMostlyReadOnlyData();
  * Lève une exception si aucune allocateur n'est disponible pour la ressource
  * (par exemple si on demande eMemoryRessource::Device et qu'il n'y a pas de
  * support pour les accélérateurs.
+ *
+ * La ressource eMemoryRessource::UnifiedMemory est toujours disponible. Si
+ * aucun runtime accélérateur n'est chargé, alors c'est équivalent à
+ * eMemoryRessource::Host.
  */
 extern "C++" ARCANE_UTILS_EXPORT MemoryAllocationOptions
 getAllocationOptions(eMemoryRessource mem_ressource);
@@ -117,10 +121,31 @@ checkResizeArrayWithCapacity(Array<DataType>& array, Int64 new_size, bool force_
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie de \a source vers \a destination en utilisant la file \a queue.
+ *
+ * Il est possible de spécifier la ressource mémoire où se trouve la source
+ * et la destination. Si on ne les connait pas, il est préférable d'utiliser
+ * la surcharge copy(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queue).
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copy(MutableMemoryView destination, eMemoryRessource destination_mem,
+     ConstMemoryView source, eMemoryRessource source_mem,
+     const RunQueue* queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 //! Copie de \a source vers \a destination en utilisant la file \a queue.
-extern "C++" ARCANE_UTILS_EXPORT void
-copy(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queue = nullptr);
+inline void
+copy(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queue = nullptr)
+{
+  eMemoryRessource mem_type = eMemoryRessource::Unknown;
+  copy(destination, mem_type, source, mem_type, queue);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 //! Copie de \a source vers \a destination en utilisant la file \a queue.
 template <typename DataType> inline void

--- a/arcane/src/arcane/utils/NumArray.cc
+++ b/arcane/src/arcane/utils/NumArray.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* NumArray.cc                                                 (C) 2000-2023 */
+/* NumArray.cc                                                 (C) 2000-2024 */
 /*                                                                           */
 /* Tableaux multi-dimensionnel pour les types numériques sur accélérateur.   */
 /*---------------------------------------------------------------------------*/
@@ -13,11 +13,9 @@
 
 #include "arcane/utils/NumArray.h"
 
-#include "arcane/utils/PlatformUtils.h"
-#include "arcane/utils/IMemoryRessourceMng.h"
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/MemoryView.h"
-#include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
+#include "arcane/utils/MemoryUtils.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -28,7 +26,7 @@ namespace Arcane::impl
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-IMemoryAllocator* NumArrayBaseCommon::
+MemoryAllocationOptions NumArrayBaseCommon::
 _getDefaultAllocator()
 {
   return _getDefaultAllocator(eMemoryRessource::UnifiedMemory);
@@ -37,10 +35,10 @@ _getDefaultAllocator()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-IMemoryAllocator* NumArrayBaseCommon::
+MemoryAllocationOptions NumArrayBaseCommon::
 _getDefaultAllocator(eMemoryRessource r)
 {
-  return platform::getDataMemoryRessourceMng()->getAllocator(r);
+  return MemoryUtils::getAllocationOptions(r);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -51,7 +49,7 @@ _checkHost(eMemoryRessource r)
 {
   if (r == eMemoryRessource::Host || r == eMemoryRessource::UnifiedMemory)
     return;
-  ARCANE_FATAL("Invalid access from '{0}' ressource memory to host memory",(int)r);
+  ARCANE_FATAL("Invalid access from '{0}' ressource memory to host memory", (int)r);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -61,8 +59,7 @@ void NumArrayBaseCommon::
 _memoryAwareCopy(Span<const std::byte> from, eMemoryRessource from_mem,
                  Span<std::byte> to, eMemoryRessource to_mem, RunQueue* queue)
 {
-  IMemoryRessourceMng* mrm = platform::getDataMemoryRessourceMng();
-  mrm->_internal()->copy(ConstMemoryView(from), from_mem, MutableMemoryView(to), to_mem, queue);
+  MemoryUtils::copy(MutableMemoryView(to), to_mem, ConstMemoryView(from), from_mem, queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/NumArrayContainer.h
+++ b/arcane/src/arcane/utils/NumArrayContainer.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* NumArrayContainer.h                                         (C) 2000-2023 */
+/* NumArrayContainer.h                                         (C) 2000-2024 */
 /*                                                                           */
 /* Conteneur pour la classe 'NumArray'.                                      */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/NumArrayContainer.h
+++ b/arcane/src/arcane/utils/NumArrayContainer.h
@@ -34,8 +34,8 @@ class ARCANE_UTILS_EXPORT NumArrayBaseCommon
 {
  protected:
 
-  static IMemoryAllocator* _getDefaultAllocator();
-  static IMemoryAllocator* _getDefaultAllocator(eMemoryRessource r);
+  static MemoryAllocationOptions _getDefaultAllocator();
+  static MemoryAllocationOptions _getDefaultAllocator(eMemoryRessource r);
   static void _checkHost(eMemoryRessource r);
   static void _memoryAwareCopy(Span<const std::byte> from, eMemoryRessource from_mem,
                                Span<std::byte> to, eMemoryRessource to_mem, RunQueue* queue);
@@ -71,7 +71,7 @@ class NumArrayContainer
 
  private:
 
-  explicit NumArrayContainer(IMemoryAllocator* a)
+  explicit NumArrayContainer(const MemoryAllocationOptions& a)
   : BaseClass()
   {
     this->_initFromAllocator(a, 0);
@@ -91,7 +91,7 @@ class NumArrayContainer
   }
 
   NumArrayContainer(const ThatClass& rhs)
-  : NumArrayContainer(rhs.allocator())
+  : NumArrayContainer(rhs.allocationOptions())
   {
     m_memory_ressource = rhs.m_memory_ressource;
     _resizeAndCopy(rhs);


### PR DESCRIPTION
- Change the default reserve multiplier in `MemoryUtils::computeCapacity()` from `2.0` to `1.8`.
- Add overload to `MemoryUtils::copy()` with information about memory ressource for source and destination
- Add `MemoryUtils::getAllocationOptions()` to get memory options for a `eMemoryRessource`.
- Use these new methods in `NumArray` and for various copy.