### PR TITLE
Remove memory attribute 'MostlyReadOnly' for 'ItemGroup'

### DIFF
--- a/arcane/src/arcane/core/ItemGroupImpl.cc
+++ b/arcane/src/arcane/core/ItemGroupImpl.cc
@@ -1385,7 +1385,7 @@ _initChildrenByTypeV2()
   Int32 nb_basic_item_type= ItemTypeMng::nbBasicItemType();
   m_p->m_children_by_type_ids.resize(nb_basic_item_type);
   for( Integer i=0; i<nb_basic_item_type; ++i ){
-    m_p->m_children_by_type_ids[i] = UniqueArray<Int32>{MemoryUtils::getAllocatorForMostlyReadOnlyData()};
+    m_p->m_children_by_type_ids[i] = UniqueArray<Int32>{MemoryUtils::getDefaultDataAllocator()};
   }
 }
 

--- a/arcane/src/arcane/core/ItemGroupInternal.cc
+++ b/arcane/src/arcane/core/ItemGroupInternal.cc
@@ -98,13 +98,13 @@ _init()
 {
   if (m_item_family)
     m_full_name = m_item_family->fullName() + "_" + m_name;
-  // Si maillage associé et pas un groupe enfant alors les données du groupe
+
+  // Si un maillage est associé et qu'on n'est un groupe enfant alors les données du groupe
   // sont conservées dans une variable.
   if (m_mesh && !m_parent){
     int property = IVariable::PSubDomainDepend | IVariable::PPrivate;
     VariableBuildInfo vbi(m_mesh,m_variable_name,property);
     m_variable_items_local_id = new VariableArrayInt32(vbi);
-    m_variable_items_local_id->variable()->setAllocationInfo(DataAllocationInfo(eMemoryLocationHint::HostAndDeviceMostlyRead));
     m_items_local_id = &m_variable_items_local_id->_internalTrueData()->_internalDeprecatedValue();
     updateTimestamp();
   }


### PR DESCRIPTION
It is not useful in many usages and has huge performance impact if the `ItemGroup` if often changing.