### PR TITLE
Add support to change variable allocator

### DIFF
--- a/arcane/src/arcane/core/ItemGroupInternal.cc
+++ b/arcane/src/arcane/core/ItemGroupInternal.cc
@@ -24,6 +24,7 @@
 #include "arcane/core/ItemPrinter.h"
 #include "arcane/core/MeshPartInfo.h"
 #include "arcane/core/datatype/DataAllocationInfo.h"
+#include "arcane/core/internal/IVariableInternal.h"
 #include "arcane/core/internal/IDataInternal.h"
 #include "arcane/core/internal/ItemGroupImplInternal.h"
 
@@ -556,6 +557,17 @@ void ItemGroupImplInternal::
 notifySimdPaddingDone()
 {
   m_p->m_simd_timestamp = m_p->timestamp();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemGroupImplInternal::
+setMemoryRessourceForItemLocalId(eMemoryRessource mem)
+{
+  VariableArrayInt32* v = m_p->m_variable_items_local_id;
+  if (v)
+    v->variable()->_internalApi()->changeAllocator(MemoryUtils::getAllocationOptions(mem));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/IVariableInternal.h
+++ b/arcane/src/arcane/core/internal/IVariableInternal.h
@@ -52,6 +52,16 @@ class ARCANE_CORE_EXPORT IVariableInternal
    */
   virtual String computeComparisonHashCollective(IHashAlgorithm* hash_algo,
                                                  IData* sorted_data) = 0;
+
+  /*!
+   * \brief Change l'allocateur de la variable.
+   *
+   * Actuellemt valide uniquement pour les variables 1D. Ne fait rien pour
+   * les autres.
+   *
+   * \warning For experimental use only.
+   */
+  virtual void changeAllocator(const MemoryAllocationOptions& alloc_info) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/ItemGroupImplInternal.h
+++ b/arcane/src/arcane/core/internal/ItemGroupImplInternal.h
@@ -56,6 +56,9 @@ class ARCANE_CORE_EXPORT ItemGroupImplInternal
   //! Indique que le padding SIMD des entités à été effectué
   void notifySimdPaddingDone();
 
+  //! Change la ressource mémoire utilisée pour conserver les localId() des entités
+  void setMemoryRessourceForItemLocalId(eMemoryRessource mem);
+
  private:
 
   ItemGroupInternal* m_p = nullptr;


### PR DESCRIPTION
This is for internal use only. It is used to check if a variable is only used on device or host.