### PR TITLE
Add experimental support to change memory allocator for Variables

### DIFF
--- a/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
+++ b/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
@@ -300,12 +300,8 @@ startInit()
 
   const bool do_change_allocator = true;
   if (do_change_allocator) {
-    info() << "Changing allocator to use device memory";
-    IMemoryAllocator* allocator = platform::getDataMemoryRessourceMng()->getAllocator(mem_ressource);
-    MemoryAllocationOptions mem_opts(allocator);
-    IMeshMaterialVariableInternal* mat_var = m_mat_device_temperature.materialVariable()->_internalApi();
-    for (VariableRef* vref : mat_var->variableReferenceList())
-      vref->variable()->_internalApi()->changeAllocator(mem_opts);
+    info() << "Changing allocator to use device memory to '" << mem_ressource << "'";
+    VariableUtils::experimentalChangeAllocator(m_mat_device_temperature.materialVariable(), mem_ressource);
   }
   {
     eMemoryRessource group_mem_ressource = mem_ressource;

--- a/arcane/src/arcane/core/ItemGroupInternal.cc
+++ b/arcane/src/arcane/core/ItemGroupInternal.cc
@@ -23,8 +23,7 @@
 #include "arcane/core/IMesh.h"
 #include "arcane/core/ItemPrinter.h"
 #include "arcane/core/MeshPartInfo.h"
-#include "arcane/core/datatype/DataAllocationInfo.h"
-#include "arcane/core/internal/IVariableInternal.h"
+#include "arcane/core/VariableUtils.h"
 #include "arcane/core/internal/IDataInternal.h"
 #include "arcane/core/internal/ItemGroupImplInternal.h"
 
@@ -567,7 +566,7 @@ setMemoryRessourceForItemLocalId(eMemoryRessource mem)
 {
   VariableArrayInt32* v = m_p->m_variable_items_local_id;
   if (v)
-    v->variable()->_internalApi()->changeAllocator(MemoryUtils::getAllocationOptions(mem));
+    VariableUtils::experimentalChangeAllocator(v->variable(),mem);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableUtils.cc
+++ b/arcane/src/arcane/core/VariableUtils.cc
@@ -13,6 +13,8 @@
 
 #include "arcane/core/VariableUtils.h"
 
+#include "arcane/utils/MemoryUtils.h"
+
 #include "arcane/accelerator/core/RunQueue.h"
 #include "arcane/accelerator/core/Memory.h"
 
@@ -20,6 +22,7 @@
 #include "arcane/core/IVariable.h"
 #include "arcane/core/VariableRef.h"
 #include "arcane/core/internal/IDataInternal.h"
+#include "arcane/core/internal/IVariableInternal.h"
 #include "arcane/core/datatype/DataAllocationInfo.h"
 #include "arcane/core/materials/MeshMaterialVariableRef.h"
 #include "arcane/core/materials/internal/IMeshMaterialVariableInternal.h"
@@ -94,6 +97,39 @@ markVariableAsMostlyReadOnly(::Arcane::Materials::MeshMaterialVariableRef& var)
   auto vars = var.materialVariable()->_internalApi()->variableReferenceList();
   for (VariableRef* v : vars)
     markVariableAsMostlyReadOnly(v->variable());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableUtils::
+experimentalChangeAllocator(::Arcane::Materials::IMeshMaterialVariable* var,
+                            eMemoryRessource mem)
+{
+  MemoryAllocationOptions mem_opts(MemoryUtils::getAllocationOptions(mem));
+  Arcane::Materials::IMeshMaterialVariableInternal* mat_var = var->_internalApi();
+  for (VariableRef* vref : mat_var->variableReferenceList())
+    vref->variable()->_internalApi()->changeAllocator(mem_opts);
+  var->globalVariable()->_internalApi()->changeAllocator(mem_opts);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableUtils::
+experimentalChangeAllocator(IVariable* var, eMemoryRessource mem)
+{
+  MemoryAllocationOptions mem_opts(MemoryUtils::getAllocationOptions(mem));
+  var->_internalApi()->changeAllocator(mem_opts);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableUtils::
+experimentalChangeAllocator(VariableRef& var, eMemoryRessource mem)
+{
+  experimentalChangeAllocator(var.variable(), mem);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableUtils.h
+++ b/arcane/src/arcane/core/VariableUtils.h
@@ -71,6 +71,19 @@ void markVariableAsMostlyReadOnly(::Arcane::Materials::MeshMaterialVariableRef& 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+extern "C++" ARCANE_CORE_EXPORT
+void experimentalChangeAllocator(::Arcane::Materials::IMeshMaterialVariable* var,
+                                 eMemoryRessource mem);
+
+extern "C++" ARCANE_CORE_EXPORT
+void experimentalChangeAllocator(IVariable* var, eMemoryRessource mem);
+
+extern "C++" ARCANE_CORE_EXPORT
+void experimentalChangeAllocator(VariableRef& var, eMemoryRessource mem);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // namespace Arcane::VariableUtils
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
At the moment it is only for 1D variables and should not be used outside of Arcane.