### PR TITLE
Allow using 'HostPinned' memory ressource if no accelerator is available

### DIFF
--- a/arcane/src/arcane/accelerator/Filterer.cc
+++ b/arcane/src/arcane/accelerator/Filterer.cc
@@ -44,9 +44,7 @@ _nbOutputElement() const
 void GenericFilteringBase::
 _allocate()
 {
-  eMemoryRessource r = eMemoryRessource::Host;
-  if (m_queue && isAcceleratorPolicy(m_queue->executionPolicy()))
-    r = eMemoryRessource::HostPinned;
+  eMemoryRessource r = eMemoryRessource::HostPinned;
   if (m_host_nb_out_storage.memoryRessource()!=r)
     m_host_nb_out_storage = NumArray<Int32,MDDim1>(r);
   m_host_nb_out_storage.resize(1);    

--- a/arcane/src/arcane/accelerator/Partitioner.cc
+++ b/arcane/src/arcane/accelerator/Partitioner.cc
@@ -45,9 +45,7 @@ _nbFirstPart() const
 void GenericPartitionerBase::
 _allocate()
 {
-  eMemoryRessource r = eMemoryRessource::Host;
-  if (m_queue && isAcceleratorPolicy(m_queue->executionPolicy()))
-    r = eMemoryRessource::HostPinned;
+  eMemoryRessource r = eMemoryRessource::HostPinned;
   if (m_host_nb_list1_storage.memoryRessource() != r)
     m_host_nb_list1_storage = NumArray<Int32, MDDim1>(r);
   m_host_nb_list1_storage.resize(1);

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -515,6 +515,7 @@ arcaneRegisterAcceleratorRuntimecuda()
   initializeCudaMemoryAllocators();
   Arcane::platform::setAcceleratorHostMemoryAllocator(getCudaMemoryAllocator());
   IMemoryRessourceMngInternal* mrm = platform::getDataMemoryRessourceMng()->_internal();
+  mrm->setIsAccelerator(true);
   mrm->setAllocator(eMemoryRessource::UnifiedMemory, getCudaUnifiedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::HostPinned, getCudaHostPinnedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::Device, getCudaDeviceMemoryAllocator());

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -435,6 +435,7 @@ arcaneRegisterAcceleratorRuntimehip()
   Arcane::Accelerator::impl::setHIPRunQueueRuntime(&global_hip_runtime);
   Arcane::platform::setAcceleratorHostMemoryAllocator(getHipMemoryAllocator());
   IMemoryRessourceMngInternal* mrm = platform::getDataMemoryRessourceMng()->_internal();
+  mrm->setIsAccelerator(true);
   mrm->setAllocator(eMemoryRessource::UnifiedMemory, getHipUnifiedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::HostPinned, getHipHostPinnedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::Device, getHipDeviceMemoryAllocator());

--- a/arcane/src/arcane/utils/internal/IMemoryRessourceMngInternal.h
+++ b/arcane/src/arcane/utils/internal/IMemoryRessourceMngInternal.h
@@ -40,9 +40,14 @@ class ARCANE_UTILS_EXPORT IMemoryRessourceMngInternal
 
  public:
 
+  //! Positionne l'allocateur pour la ressource \a r
   virtual void setAllocator(eMemoryRessource r, IMemoryAllocator* allocator) = 0;
 
+  //! Positionne l'instance gérant les copies.
   virtual void setCopier(IMemoryCopier* copier) = 0;
+
+  //! Indique si un accélérateur est disponible.
+  virtual void setIsAccelerator(bool v) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/MemoryRessourceMng.h
+++ b/arcane/src/arcane/utils/internal/MemoryRessourceMng.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IMemoryRessourceMng.h                                       (C) 2000-2024 */
+/* MemoryRessourceMng.h                                        (C) 2000-2024 */
 /*                                                                           */
 /* Gestion des ressources mémoire pour les CPU et accélérateurs.             */
 /*---------------------------------------------------------------------------*/
@@ -15,6 +15,7 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/IMemoryRessourceMng.h"
+#include "arcane/utils/FixedArray.h"
 #include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
 
 #include <memory>
@@ -52,6 +53,7 @@ class ARCANE_UTILS_EXPORT MemoryRessourceMng
 
   void setAllocator(eMemoryRessource r, IMemoryAllocator* allocator) override;
   void setCopier(IMemoryCopier* copier) override { m_copier = copier; }
+  void setIsAccelerator(bool v) override { m_is_accelerator = v; }
 
  public:
 
@@ -65,9 +67,10 @@ class ARCANE_UTILS_EXPORT MemoryRessourceMng
 
  private:
 
-  std::array<IMemoryAllocator*, NB_MEMORY_RESSOURCE> m_allocators;
+  FixedArray<IMemoryAllocator*, NB_MEMORY_RESSOURCE> m_allocators;
   std::unique_ptr<IMemoryCopier> m_default_memory_copier;
   IMemoryCopier* m_copier = nullptr;
+  bool m_is_accelerator = false;
 
  private:
 


### PR DESCRIPTION
In that case we use `eMemoryRessource::Host` instead.