### PR TITLE
Begin support for SYCL backend of accelerator API

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -918,9 +918,11 @@ if(DEFINED ARCANE_ACCELERATOR_MODE)
   elseif (ARCANE_ACCELERATOR_MODE STREQUAL "ROCMHIP" )
     set (ARCANE_WANT_HIP TRUE)
     # TODO: vérifier qu'on utilise bien 'hipcc'
+  elseif (ARCANE_ACCELERATOR_MODE STREQUAL "DPCPPSYCL" )
+    set (ARCANE_WANT_DPCPPSYCL TRUE)
   else()
     message(FATAL_ERROR "Unsupported ARCANE_ACCELERATOR_MODE '${ARCANE_ACCELERATOR_MODE}'."
-      "Valid values are 'CUDANVCC' or 'ROCMHIP'")
+      "Valid values are 'CUDANVCC', 'ROCMHIP' ou 'DPCPPSYCL")
   endif()
   set (ARCANE_ACCELERATOR_MODE ${ARCANE_ACCELERATOR_MODE} CACHE STRING "Accelerator Mode" FORCE)
   set (ARCANE_HAS_ACCELERATOR TRUE)
@@ -928,33 +930,44 @@ endif()
 
 # ----------------------------------------------------------------------------
 
-if (ARCANE_ACCELERATOR_MODE STREQUAL "ROCMHIP")
-  # Il faut au moins CMake 3.21 pour qu'il reconnaise langage HIP
-  enable_language(HIP)
-  add_subdirectory(src/arcane/accelerator/hip)
-endif()
-if (ARCANE_ACCELERATOR_MODE STREQUAL "CUDANVCC")
-  # Pour le support du C++20 avec NVCC, il faut au moins cmake 3.26
-  message(STATUS "CMake 3.26 is required for CUDA C++20 support in Arcane. Checking it")
-  cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
+if (ARCANE_HAS_ACCELERATOR)
+  if (ARCANE_ACCELERATOR_MODE STREQUAL "ROCMHIP")
+    # Il faut au moins CMake 3.21 pour qu'il reconnaise langage HIP
+    enable_language(HIP)
+    add_subdirectory(src/arcane/accelerator/hip)
+  elseif(ARCANE_ACCELERATOR_MODE STREQUAL "CUDANVCC")
+    # Pour le support du C++20 avec NVCC, il faut au moins cmake 3.26
+    message(STATUS "CMake 3.26 is required for CUDA C++20 support in Arcane. Checking it")
+    cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
 
-  # A partir de CMake 3.18, il faut spécifier une architecture GPU pour CUDA
-  if (NOT CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES 50 60 70 80)
+    # A partir de CMake 3.18, il faut spécifier une architecture GPU pour CUDA
+    if (NOT CMAKE_CUDA_ARCHITECTURES)
+      set(CMAKE_CUDA_ARCHITECTURES 50 60 70 80)
+    endif()
+    enable_language(CUDA)
+    add_subdirectory(src/arcane/accelerator/cuda)
+  elseif(ARCANE_ACCELERATOR_MODE STREQUAL "DPCPPSYCL")
+    add_subdirectory(src/arcane/accelerator/sycl)
+  else()
+    message(FATAL_ERROR "Unsupported Accelerator Mode : ${ARCANE_ACCELERATOR_MODE}")
   endif()
-  enable_language(CUDA)
-  add_subdirectory(src/arcane/accelerator/cuda)
 endif()
 
 add_subdirectory(src/arcane/accelerator/core)
 if (ARCANE_HAS_ACCELERATOR_API)
   add_subdirectory(src/arcane/accelerator)
 endif()
-if (ARCANE_ACCELERATOR_MODE STREQUAL "ROCMHIP" )
-  add_subdirectory(src/arcane/accelerator/hip/runtime)
-endif()
-if (ARCANE_ACCELERATOR_MODE STREQUAL "CUDANVCC")
-  add_subdirectory(src/arcane/accelerator/cuda/runtime)
+
+if (ARCANE_HAS_ACCELERATOR)
+  if (ARCANE_ACCELERATOR_MODE STREQUAL "ROCMHIP" )
+    add_subdirectory(src/arcane/accelerator/hip/runtime)
+  elseif(ARCANE_ACCELERATOR_MODE STREQUAL "CUDANVCC")
+    add_subdirectory(src/arcane/accelerator/cuda/runtime)
+  elseif(ARCANE_ACCELERATOR_MODE STREQUAL "DPCPPSYCL")
+    add_subdirectory(src/arcane/accelerator/sycl/runtime)
+  else()
+    message(FATAL_ERROR "Unsupported Accelerator Mode : ${ARCANE_ACCELERATOR_MODE}")
+  endif()
 endif()
 
 # ----------------------------------------------------------------------------

--- a/arcane/cmake/Functions.cmake
+++ b/arcane/cmake/Functions.cmake
@@ -481,6 +481,12 @@ macro(arcane_accelerator_add_source_files)
       set_source_files_properties(${_x} PROPERTIES LANGUAGE HIP)
     endforeach()
   endif()
+  if (ARCANE_ACCELERATOR_MODE STREQUAL "DPCPPSYCL")
+    foreach(_x ${ARGN})
+      message(STATUS "Add SYCL language to file '${_x}'")
+      set_source_files_properties(${_x} PROPERTIES COMPILE_FLAGS "-fsycl")
+    endforeach()
+  endif()
 endmacro()
 
 # ----------------------------------------------------------------------------

--- a/arcane/src/arcane/accelerator/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/CMakeLists.txt
@@ -17,7 +17,8 @@ target_link_libraries(arcane_accelerator PUBLIC
   arcane_accelerator_core
   "$<TARGET_NAME_IF_EXISTS:arcane_accelerator_cuda>"
   "$<TARGET_NAME_IF_EXISTS:arcane_accelerator_hip>"
-  )
+  "$<TARGET_NAME_IF_EXISTS:arcane_accelerator_sycl>"
+)
 
 # Cette cible est optionnelle pour éviter que le code n'utilisant
 # pas les accélérateurs ait besoin d'un runtime accélérateur

--- a/arcane/src/arcane/accelerator/sycl/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/sycl/CMakeLists.txt
@@ -1,0 +1,43 @@
+﻿# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Backend Arcane pour SYCL
+
+set(ARCANE_SOURCES
+  SyclAccelerator.cc
+  SyclAccelerator.h
+  )
+
+# Créé une cible interface pour propager les options de compilation
+# communes pour la compilation SYCL
+
+add_library(arcane_sycl_compile_flags INTERFACE)
+
+target_compile_options(arcane_sycl_compile_flags INTERFACE
+  # Pas d'option spécifique pour l'instant
+)
+target_link_options(arcane_sycl_compile_flags INTERFACE
+  "-lsycl"
+)
+install(TARGETS arcane_sycl_compile_flags EXPORT ArcaneTargets)
+
+arcane_add_library(arcane_accelerator_sycl
+  INPUT_PATH ${Arcane_SOURCE_DIR}/src
+  RELATIVE_PATH arcane/accelerator/sycl
+  FILES ${ARCANE_SOURCES}
+  )
+target_compile_options(arcane_accelerator_sycl PRIVATE "-fsycl")
+
+target_link_libraries(arcane_accelerator_sycl PUBLIC
+  arcane_core arcane_sycl_compile_flags
+)
+
+# ----------------------------------------------------------------------------
+
+arcane_register_library(arcane_accelerator_sycl  OPTIONAL)
+
+# ----------------------------------------------------------------------------
+# Local Variables:
+# tab-width: 2
+# indent-tabs-mode: nil
+# coding: utf-8-with-signature
+# End:

--- a/arcane/src/arcane/accelerator/sycl/SyclAccelerator.cc
+++ b/arcane/src/arcane/accelerator/sycl/SyclAccelerator.cc
@@ -1,0 +1,199 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* SyclAccelerator.cc                                          (C) 2000-2024 */
+/*                                                                           */
+/* Backend 'SYCL' pour les accélérateurs.                                    */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/accelerator/sycl/SyclAccelerator.h"
+
+#include "arcane/utils/PlatformUtils.h"
+#include "arcane/utils/Array.h"
+#include "arcane/utils/TraceInfo.h"
+#include "arcane/utils/NotSupportedException.h"
+#include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/IMemoryAllocator.h"
+
+#include <iostream>
+
+namespace Arcane::Accelerator::Sycl
+{
+
+using namespace Arccore;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+sycl::queue* global_default_queue = nullptr;
+namespace
+{
+  sycl::queue& _defaultQueue()
+  {
+    return *global_default_queue;
+  }
+} // namespace
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Classe de base d'un allocateur spécifique pour 'Sycl'.
+ */
+class SyclMemoryAllocatorBase
+: public Arccore::AlignedMemoryAllocator3
+{
+ public:
+
+  SyclMemoryAllocatorBase()
+  : AlignedMemoryAllocator3(128)
+  {}
+
+  bool hasRealloc(MemoryAllocationArgs) const override { return true; }
+  AllocatedMemoryInfo allocate(MemoryAllocationArgs args, Int64 new_size) override
+  {
+    sycl::queue& q = _defaultQueue();
+    void* out = nullptr;
+    _allocate(&out, new_size, args, q);
+    if (!out)
+      ARCANE_FATAL("Can not allocate memory size={0}", new_size);
+    Int64 a = reinterpret_cast<Int64>(out);
+    if ((a % 128) != 0)
+      ARCANE_FATAL("Bad alignment for SYCL allocator: offset={0}", (a % 128));
+    return { out, new_size };
+  }
+  AllocatedMemoryInfo reallocate(MemoryAllocationArgs args, AllocatedMemoryInfo current_ptr, Int64 new_size) override
+  {
+    sycl::queue& q = _defaultQueue();
+    AllocatedMemoryInfo a = allocate(args, new_size);
+    q.submit([&](sycl::handler& cgh) {
+      cgh.memcpy(a.baseAddress(), current_ptr.baseAddress(), current_ptr.size());
+    });
+    q.wait();
+
+    deallocate(args, current_ptr);
+    return a;
+  }
+  void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr) override
+  {
+    sycl::queue& q = _defaultQueue();
+    _deallocate(ptr.baseAddress(), args, q);
+  }
+
+ protected:
+
+  virtual void _allocate(void** ptr, size_t new_size, MemoryAllocationArgs, sycl::queue& q) = 0;
+  virtual void _deallocate(void* ptr, MemoryAllocationArgs, sycl::queue& q) = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class UnifiedMemorySyclMemoryAllocator
+: public SyclMemoryAllocatorBase
+{
+ protected:
+
+  void _allocate(void** ptr, size_t new_size, MemoryAllocationArgs, sycl::queue& q) override
+  {
+    *ptr = sycl::malloc_shared(new_size, q);
+  }
+  void _deallocate(void* ptr, MemoryAllocationArgs, sycl::queue& q) override
+  {
+    sycl::free(ptr, q);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class HostPinnedSyclMemoryAllocator
+: public SyclMemoryAllocatorBase
+{
+ protected:
+
+  void _allocate(void** ptr, size_t new_size, MemoryAllocationArgs, sycl::queue& q) override
+  {
+    // TODO: Faire host-pinned
+    *ptr = sycl::malloc_host(new_size, q);
+  }
+  void _deallocate(void* ptr, MemoryAllocationArgs, sycl::queue& q) override
+  {
+    sycl::free(ptr, q);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class DeviceSyclMemoryAllocator
+: public SyclMemoryAllocatorBase
+{
+ protected:
+
+  void _allocate(void** ptr, size_t new_size, MemoryAllocationArgs, sycl::queue& q) override
+  {
+    *ptr = sycl::malloc_device(new_size, q);
+  }
+  void _deallocate(void* ptr, MemoryAllocationArgs, sycl::queue& q) override
+  {
+    sycl::free(ptr, q);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace
+{
+  UnifiedMemorySyclMemoryAllocator unified_memory_sycl_memory_allocator;
+  HostPinnedSyclMemoryAllocator host_pinned_sycl_memory_allocator;
+  DeviceSyclMemoryAllocator device_sycl_memory_allocator;
+} // namespace
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator
+{
+
+Arccore::IMemoryAllocator* Sycl::
+getSyclMemoryAllocator()
+{
+  return &unified_memory_sycl_memory_allocator;
+}
+
+Arccore::IMemoryAllocator* Sycl::
+getSyclDeviceMemoryAllocator()
+{
+  return &device_sycl_memory_allocator;
+}
+
+Arccore::IMemoryAllocator* Sycl::
+getSyclUnifiedMemoryAllocator()
+{
+  return &unified_memory_sycl_memory_allocator;
+}
+
+Arccore::IMemoryAllocator* Sycl::
+getSyclHostPinnedMemoryAllocator()
+{
+  return &host_pinned_sycl_memory_allocator;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/sycl/SyclAccelerator.h
+++ b/arcane/src/arcane/accelerator/sycl/SyclAccelerator.h
@@ -1,0 +1,56 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* SyclAccelerator.h                                           (C) 2000-2024 */
+/*                                                                           */
+/* Backend 'SYCL' pour les accélérateurs.                                    */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_ACCELERATOR_SYCL_SYCLACCELERATOR_H
+#define ARCANE_ACCELERATOR_SYCL_SYCLACCELERATOR_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/UtilsTypes.h"
+
+#include <sycl/sycl.hpp>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#ifdef ARCANE_COMPONENT_arcane_sycl
+#define ARCANE_SYCL_EXPORT ARCANE_EXPORT
+#else
+#define ARCANE_SYCL_EXPORT ARCANE_IMPORT
+#endif
+
+namespace Arcane::Accelerator::Sycl
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+extern "C++" ARCANE_SYCL_EXPORT Arccore::IMemoryAllocator*
+getSyclMemoryAllocator();
+
+extern "C++" ARCANE_SYCL_EXPORT Arccore::IMemoryAllocator*
+getSyclDeviceMemoryAllocator();
+
+extern "C++" ARCANE_SYCL_EXPORT Arccore::IMemoryAllocator*
+getSyclUnifiedMemoryAllocator();
+
+extern "C++" ARCANE_SYCL_EXPORT Arccore::IMemoryAllocator*
+getSyclHostPinnedMemoryAllocator();
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::Sycl
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/accelerator/sycl/runtime/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/sycl/runtime/CMakeLists.txt
@@ -1,0 +1,37 @@
+﻿# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Runtime Arcane pour HIP
+
+set(ARCANE_SOURCES
+  SyclAcceleratorRuntime.cc
+  )
+
+arcane_add_library(arcane_accelerator_sycl_runtime
+  INPUT_PATH ${Arcane_SOURCE_DIR}/src
+  RELATIVE_PATH arcane/accelerator/sycl/runtime
+  FILES ${ARCANE_SOURCES}
+  )
+
+target_compile_options(arcane_accelerator_sycl_runtime PRIVATE "-fsycl")
+
+target_link_libraries(arcane_accelerator_sycl_runtime PUBLIC
+  arcane_accelerator arcane_sycl_compile_flags
+  )
+
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+
+add_executable(arcane_accelerator_sycl_test TestMain.cc)
+target_link_libraries(arcane_accelerator_sycl_test PUBLIC arcane_accelerator_sycl_runtime)
+
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+
+arcane_register_library(arcane_accelerator_sycl_runtime OPTIONAL)
+
+# ----------------------------------------------------------------------------
+# Local Variables:
+# tab-width: 2
+# indent-tabs-mode: nil
+# coding: utf-8-with-signature
+# End:

--- a/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
@@ -1,0 +1,155 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* SyclAcceleratorRuntime.cc                                   (C) 2000-2024 */
+/*                                                                           */
+/* Runtime pour 'SYCL'.                                                      */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/accelerator/sycl/SyclAccelerator.h"
+
+#include "arcane/utils/PlatformUtils.h"
+#include "arcane/utils/Array.h"
+#include "arcane/utils/TraceInfo.h"
+#include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/NotImplementedException.h"
+#include "arcane/utils/IMemoryRessourceMng.h"
+#include "arcane/utils/OStringStream.h"
+#include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
+
+#include "arcane/accelerator/core/RunQueueBuildInfo.h"
+#include "arcane/accelerator/core/Memory.h"
+#include "arcane/accelerator/core/internal/IRunnerRuntime.h"
+#include "arcane/accelerator/core/internal/AcceleratorCoreGlobalInternal.h"
+#include "arcane/accelerator/core/IRunQueueStream.h"
+#include "arcane/accelerator/core/IRunQueueEventImpl.h"
+#include "arcane/accelerator/core/DeviceInfoList.h"
+#include "arcane/accelerator/core/RunQueue.h"
+#include "arcane/accelerator/core/internal/RunCommandImpl.h"
+
+#include <iostream>
+
+namespace Arcane::Accelerator::Sycl
+{
+
+using namespace Arccore;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class SyclRunnerRuntime
+: public impl::IRunnerRuntime
+{
+ public:
+
+  void notifyBeginLaunchKernel() override
+  {
+  }
+  void notifyEndLaunchKernel() override
+  {
+  }
+  void barrier() override
+  {
+    ARCANE_FATAL("NYI");
+  }
+  eExecutionPolicy executionPolicy() const override
+  {
+    ARCANE_FATAL("NYI");
+  }
+  impl::IRunQueueStream* createStream(const RunQueueBuildInfo& bi) override
+  {
+    ARCANE_FATAL("NYI");
+  }
+  impl::IRunQueueEventImpl* createEventImpl() override
+  {
+    ARCANE_FATAL("NYI");
+  }
+  impl::IRunQueueEventImpl* createEventImplWithTimer() override
+  {
+    ARCANE_FATAL("NYI");
+  }
+  void setMemoryAdvice(ConstMemoryView buffer, eMemoryAdvice advice, DeviceId device_id) override
+  {
+    ARCANE_FATAL("NYI");
+  }
+  void unsetMemoryAdvice(ConstMemoryView buffer, eMemoryAdvice advice, DeviceId device_id) override
+  {
+    ARCANE_FATAL("NYI");
+  }
+
+  void setCurrentDevice(DeviceId device_id) final
+  {
+    ARCANE_FATAL("NYI");
+  }
+  const IDeviceInfoList* deviceInfoList() override { return &m_device_info_list; }
+
+  void getPointerAttribute(PointerAttribute& attribute, const void* ptr) override
+  {
+    ARCANE_FATAL("NYI");
+  }
+
+  void fillDevices();
+
+ private:
+
+  bool m_is_verbose = false;
+  impl::DeviceInfoList m_device_info_list;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void SyclRunnerRuntime::
+fillDevices()
+{
+  std::cout << "FILLING DEVICES\n";
+  for (auto platform : sycl::platform::get_platforms()) {
+    std::cout << "Platform: "
+              << platform.get_info<sycl::info::platform::name>()
+              << std::endl;
+
+    for (auto device : platform.get_devices()) {
+      std::cout << "\tDevice: "
+                << device.get_info<sycl::info::device::name>()
+                << std::endl;
+    }
+  }
+  std::cout << "END FILLING DEVICES\n";
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::Sycl
+
+namespace
+{
+Arcane::Accelerator::Sycl::SyclRunnerRuntime global_sycl_runtime;
+} // namespace
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// Cette fonction est le point d'entrée utilisé lors du chargement
+// dynamique de cette bibliothèque
+extern "C" ARCANE_EXPORT void
+arcaneRegisterAcceleratorRuntimesycl()
+{
+  using namespace Arcane;
+  using namespace Arcane::Accelerator::Sycl;
+  Arcane::platform::setAcceleratorHostMemoryAllocator(getSyclMemoryAllocator());
+  IMemoryRessourceMngInternal* mrm = platform::getDataMemoryRessourceMng()->_internal();
+  mrm->setIsAccelerator(true);
+  mrm->setAllocator(eMemoryRessource::UnifiedMemory, getSyclUnifiedMemoryAllocator());
+  mrm->setAllocator(eMemoryRessource::HostPinned, getSyclHostPinnedMemoryAllocator());
+  mrm->setAllocator(eMemoryRessource::Device, getSyclDeviceMemoryAllocator());
+  global_sycl_runtime.fillDevices();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/sycl/runtime/TestMain.cc
+++ b/arcane/src/arcane/accelerator/sycl/runtime/TestMain.cc
@@ -1,0 +1,40 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* TestMain.cc                                                 (C) 2000-2024 */
+/*                                                                           */
+/* Fichier main pour lancer les tests de base SYCL.                          */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/ArcaneGlobal.h"
+#include "arcane/utils/Exception.h"
+
+#include <iostream>
+
+extern "C" ARCANE_EXPORT void
+arcaneRegisterAcceleratorRuntimesycl();
+
+int
+main(int argc,char* argv[])
+{
+  std::cout << "TESTMAIN\n";
+  int r = 0;
+  try{
+    arcaneRegisterAcceleratorRuntimesycl();
+    ARCANE_UNUSED(argc);
+    ARCANE_UNUSED(argv);
+    r = 0;
+  }
+  catch(const Arcane::Exception& e){
+    std::cerr << "Exception e=" << e << "\n";
+  }
+  catch(const std::exception& e){
+    std::cerr << "Exception e=" << e.what() << "\n";
+  }
+  return r;
+}


### PR DESCRIPTION
At the moment, only add configuration and minimal runtime to check compilation with Intel DPC++ implementation of SYCL.