### PR TITLE
Make 'ArrayView' and 'ConstArrayView' trivially copyable

### DIFF
--- a/arccore/src/base/arccore/base/ArrayView.h
+++ b/arccore/src/base/arccore/base/ArrayView.h
@@ -132,8 +132,7 @@ class ArrayView
   constexpr ArrayView() noexcept : m_size(0), m_ptr(nullptr) {}
 
   //! Constructeur de recopie depuis une autre vue
-  constexpr ArrayView(const ArrayView<T>& from) noexcept
-  : m_size(from.m_size), m_ptr(from.m_ptr) {}
+  ArrayView(const ArrayView<T>& from) = default;
 
   //! Construit une vue sur une zone mémoire commencant par \a ptr et
   // contenant \a asize éléments.
@@ -568,11 +567,8 @@ class ConstArrayView
   //! Construit un tableau avec \a s élément
   constexpr ConstArrayView(Integer s,const_pointer ptr) noexcept
   : m_size(s), m_ptr(ptr) {}
-  /*! \brief Constructeur par copie.
-   * \warning Seul le pointeur est copié. Aucune copie mémoire n'est effectuée.
-   */
-  constexpr ConstArrayView(const ConstArrayView<T>& from) noexcept
-  : m_size(from.m_size), m_ptr(from.m_ptr) {}
+  //! Constructeur par copie.
+  ConstArrayView(const ConstArrayView<T>& from) = default;
   /*!
    * \brief Constructeur par copie.
    * \warning Seul le pointeur est copié. Aucune copie mémoire n'est effectuée.

--- a/arccore/src/base/tests/TestArrayView.cc
+++ b/arccore/src/base/tests/TestArrayView.cc
@@ -13,6 +13,7 @@
 #include "arccore/base/Array4View.h"
 
 #include <vector>
+#include <type_traits>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -693,6 +694,28 @@ TEST(ArrayView, SubViewInterval)
   _testSubPartInterval<ConstArrayView<Int64>>();
   _testSubPartInterval<Span<Int64>>();
   _testSubPartInterval<SmallSpan<Int64>>();
+}
+
+TEST(ArrayView,Copyable)
+{
+  using namespace Arccore;
+  ASSERT_TRUE(std::is_trivially_copyable_v<ArrayView<int>>);
+  ASSERT_TRUE(std::is_trivially_copyable_v<ConstArrayView<int>>);
+
+  ASSERT_TRUE(std::is_trivially_copyable_v<Array2View<int>>);
+  ASSERT_TRUE(std::is_trivially_copyable_v<ConstArray2View<int>>);
+
+  ASSERT_TRUE(std::is_trivially_copyable_v<Array3View<int>>);
+  ASSERT_TRUE(std::is_trivially_copyable_v<ConstArray3View<int>>);
+
+  ASSERT_TRUE(std::is_trivially_copyable_v<Array4View<int>>);
+  ASSERT_TRUE(std::is_trivially_copyable_v<ConstArray4View<int>>);
+
+  ASSERT_TRUE(std::is_trivially_copyable_v<Span<int>>);
+  ASSERT_TRUE(std::is_trivially_copyable_v<Span<const int>>);
+
+  ASSERT_TRUE(std::is_trivially_copyable_v<Span2<int>>);
+  ASSERT_TRUE(std::is_trivially_copyable_v<Span2<const int>>);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
We only need to remove custom copy constructor to make them trivially copyable.