### PR TITLE
Minor improvements in accelerator API

### DIFF
--- a/arcane/src/arcane/accelerator/RunCommandEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandEnumerate.h
@@ -217,7 +217,7 @@ _applyItems(RunCommand& command, typename TraitsType::ContainerType items, const
   using BuilderType = TraitsType::BuilderType;
   impl::RunCommandLaunchInfo launch_info(command, vsize);
   const eExecutionPolicy exec_policy = launch_info.executionPolicy();
-  launch_info.computeLoopRunInfo(vsize);
+  launch_info.computeLoopRunInfo();
   launch_info.beginExecute();
   switch (exec_policy) {
   case eExecutionPolicy::CUDA:

--- a/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/RunCommandLaunchInfo.cc
@@ -29,20 +29,11 @@ namespace Arcane::Accelerator::impl
 /*---------------------------------------------------------------------------*/
 
 RunCommandLaunchInfo::
-RunCommandLaunchInfo(RunCommand& command)
+RunCommandLaunchInfo(RunCommand& command, Int64 total_loop_size)
 : m_command(command)
+, m_total_loop_size(total_loop_size)
 {
-  _begin();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-RunCommandLaunchInfo::
-RunCommandLaunchInfo(RunCommand& command,Int64 total_loop_size)
-: m_command(command)
-{
-  m_thread_block_info = computeThreadBlockInfo(total_loop_size);
+  m_thread_block_info = _computeThreadBlockInfo();
   _begin();
 }
 
@@ -126,13 +117,14 @@ _internalStreamImpl()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+//! Calcule le nombre de block/thread/grille du noyau en fonction de \a full_size
 auto RunCommandLaunchInfo::
-computeThreadBlockInfo(Int64 full_size) const -> ThreadBlockInfo
+_computeThreadBlockInfo() const -> ThreadBlockInfo
 {
   int threads_per_block = m_command.nbThreadPerBlock();
   if (threads_per_block<=0)
     threads_per_block = 256;
-  Int64 big_b = (full_size + threads_per_block - 1) / threads_per_block;
+  Int64 big_b = (m_total_loop_size + threads_per_block - 1) / threads_per_block;
   int blocks_per_grid = CheckedConvert::toInt32(big_b);
   return { blocks_per_grid, threads_per_block };
 }
@@ -141,7 +133,7 @@ computeThreadBlockInfo(Int64 full_size) const -> ThreadBlockInfo
 /*---------------------------------------------------------------------------*/
 
 ParallelLoopOptions RunCommandLaunchInfo::
-computeParallelLoopOptions(Int64 full_size) const
+computeParallelLoopOptions() const
 {
   ParallelLoopOptions opt = m_command.parallelLoopOptions();
   const bool use_dynamic_compute = false;
@@ -153,7 +145,7 @@ computeParallelLoopOptions(Int64 full_size) const
       nb_thread = TaskFactory::nbAllowedThread();
     if (nb_thread <= 0)
       nb_thread = 1;
-    Int32 grain_size = static_cast<Int32>((double)full_size / (nb_thread * 10.0));
+    Int32 grain_size = static_cast<Int32>((double)m_total_loop_size / (nb_thread * 10.0));
     opt.setGrainSize(grain_size);
   }
   return opt;
@@ -163,12 +155,12 @@ computeParallelLoopOptions(Int64 full_size) const
 /*---------------------------------------------------------------------------*/
 
 void RunCommandLaunchInfo::
-computeLoopRunInfo(Int64 full_size)
+computeLoopRunInfo()
 {
   if (m_has_exec_begun)
     ARCANE_FATAL("computeLoopRunInfo() has to be called before beginExecute()");
   ForLoopTraceInfo lti(m_command.traceInfo(), m_command.kernelName());
-  m_loop_run_info = ForLoopRunInfo(computeParallelLoopOptions(full_size), lti);
+  m_loop_run_info = ForLoopRunInfo(computeParallelLoopOptions(), lti);
   m_loop_run_info.setExecStat(m_command._internalCommandExecStat());
 }
 

--- a/arcane/src/arcane/accelerator/RunCommandLaunchInfo.h
+++ b/arcane/src/arcane/accelerator/RunCommandLaunchInfo.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommandLaunchInfo.h                                      (C) 2000-2022 */
+/* RunCommandLaunchInfo.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Informations pour l'exécution d'une 'RunCommand'.                         */
 /*---------------------------------------------------------------------------*/
@@ -45,8 +45,6 @@ class ARCANE_ACCELERATOR_EXPORT RunCommandLaunchInfo
 
  public:
 
-  ARCANE_DEPRECATED_REASON("Use RunCommandLaunchInfo(RunCommand&,Int64) overload")
-  RunCommandLaunchInfo(RunCommand& command);
   RunCommandLaunchInfo(RunCommand& command, Int64 total_loop_size);
   ~RunCommandLaunchInfo();
   RunCommandLaunchInfo(const RunCommandLaunchInfo&) = delete;
@@ -75,17 +73,17 @@ class ARCANE_ACCELERATOR_EXPORT RunCommandLaunchInfo
   //! Informations sur le nombre de block/thread/grille du noyau à lancer.
   ThreadBlockInfo threadBlockInfo() const { return m_thread_block_info; }
 
-  //! Calcul le nombre de block/thread/grille du noyau en fonction de \a full_size
-  ThreadBlockInfo computeThreadBlockInfo(Int64 full_size) const;
-
   //! Calcul les informations pour les boucles multi-thread
-  ParallelLoopOptions computeParallelLoopOptions(Int64 full_size) const;
+  ParallelLoopOptions computeParallelLoopOptions() const;
 
   //! Calcule la valeur de loopRunInfo()
-  void computeLoopRunInfo(Int64 full_size);
+  void computeLoopRunInfo();
 
-  //! Informations d'exéctution de la boucle
+  //! Informations d'exécution de la boucle
   const ForLoopRunInfo& loopRunInfo() const { return m_loop_run_info; }
+
+  //! Taille totale de la boucle
+  Int64 totalLoopSize() const { return m_total_loop_size; }
 
  public:
 
@@ -101,11 +99,13 @@ class ARCANE_ACCELERATOR_EXPORT RunCommandLaunchInfo
   eExecutionPolicy m_exec_policy = eExecutionPolicy::Sequential;
   ThreadBlockInfo m_thread_block_info;
   ForLoopRunInfo m_loop_run_info;
+  Int64 m_total_loop_size = 0;
 
  private:
 
   void _begin();
   void _doEndKernelLaunch();
+  ThreadBlockInfo _computeThreadBlockInfo() const;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/RunCommandLoop.h
+++ b/arcane/src/arcane/accelerator/RunCommandLoop.h
@@ -53,7 +53,7 @@ _applyGenericLoop(RunCommand& command,LoopBoundType<N> bounds,const Lambda& func
     arcaneSequentialFor(bounds,func);
     break;
   case eExecutionPolicy::Thread:
-    arcaneParallelFor(bounds,launch_info.computeParallelLoopOptions(vsize),func);
+    arcaneParallelFor(bounds, launch_info.computeParallelLoopOptions(), func);
     break;
   default:
     ARCANE_FATAL("Invalid execution policy '{0}'",exec_policy);

--- a/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.h
@@ -611,7 +611,7 @@ _applyEnvCells(RunCommand& command, ContainerType items, const Lambda& func)
 
   RunCommandLaunchInfo launch_info(command, vsize);
   const eExecutionPolicy exec_policy = launch_info.executionPolicy();
-  launch_info.computeLoopRunInfo(vsize);
+  launch_info.computeLoopRunInfo();
   launch_info.beginExecute();
   switch (exec_policy) {
   case eExecutionPolicy::CUDA:

--- a/arcane/src/arcane/accelerator/RunQueueInternal.h
+++ b/arcane/src/arcane/accelerator/RunQueueInternal.h
@@ -255,14 +255,13 @@ _applyKernelHIP(impl::RunCommandLaunchInfo& launch_info,const HipKernel& kernel,
  * \param func fonction à exécuter par le noyau
  * \param args arguments de la fonction lambda
  */
-template<typename SyclKernel,typename Lambda,typename LambdaArgs> void
-_applyKernelSYCL(impl::RunCommandLaunchInfo& launch_info,SyclKernel kernel,Lambda& func,[[maybe_unused]] const LambdaArgs& args)
+template <typename SyclKernel, typename Lambda, typename LambdaArgs> void
+_applyKernelSYCL(impl::RunCommandLaunchInfo& launch_info, SyclKernel kernel, Lambda& func, [[maybe_unused]] const LambdaArgs& args)
 {
 #if defined(ARCANE_COMPILING_SYCL)
-  auto [b,t] = launch_info.threadBlockInfo();
   sycl::queue* s = reinterpret_cast<sycl::queue*>(launch_info._internalStreamImpl());
-  s->parallel_for(sycl::range<1>(args.nbElement()),
-                  [=](sycl::id<1> i){ kernel(i,args,func); });
+  sycl::range<1> loop_size = launch_info.totalLoopSize();
+  s->parallel_for(loop_size, [=](sycl::id<1> i) { kernel(i, args, func); });
 #else
   ARCANE_UNUSED(launch_info);
   ARCANE_UNUSED(kernel);

--- a/arcane/src/arcane/accelerator/core/AcceleratorCore.cc
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCore.cc
@@ -288,8 +288,8 @@ getPointerAccessibility(eExecutionPolicy policy, const void* ptr, PointerAttribu
 }
 
 extern "C++" void impl::
-arcaneCheckPointerIsAcccessible(eExecutionPolicy policy, const void* ptr,
-                                const char* name, const TraceInfo& ti)
+arcaneCheckPointerIsAccessible(eExecutionPolicy policy, const void* ptr,
+                               const char* name, const TraceInfo& ti)
 {
   return impl::RuntimeStaticInfo::checkPointerIsAcccessible(policy, ptr, name, ti);
 }

--- a/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
@@ -236,8 +236,8 @@ using Arcane::Accelerator::isAcceleratorPolicy;
  * Lève une exception FatalErrorException si ce n'est pas le cas.
  */
 extern "C++" ARCANE_ACCELERATOR_CORE_EXPORT void
-arcaneCheckPointerIsAcccessible(RunQueue* queue, const void* ptr,
-                                const char* name, const TraceInfo& ti);
+arcaneCheckPointerIsAccessible(RunQueue* queue, const void* ptr,
+                               const char* name, const TraceInfo& ti);
 
 /*!
  * \brief Vérifie si \a ptr est accessible pour une exécution sur \a runner.
@@ -245,8 +245,8 @@ arcaneCheckPointerIsAcccessible(RunQueue* queue, const void* ptr,
  * Lève une exception FatalErrorException si ce n'est pas le cas.
  */
 extern "C++" ARCANE_ACCELERATOR_CORE_EXPORT void
-arcaneCheckPointerIsAcccessible(Runner* runner, const void* ptr,
-                                const char* name, const TraceInfo& ti);
+arcaneCheckPointerIsAccessible(Runner* runner, const void* ptr,
+                               const char* name, const TraceInfo& ti);
 
 /*!
  * \brief Vérifie si \a ptr est accessible pour une exécution \a policy.
@@ -254,14 +254,14 @@ arcaneCheckPointerIsAcccessible(Runner* runner, const void* ptr,
  * Lève une exception FatalErrorException si ce n'est pas le cas.
  */
 extern "C++" ARCANE_ACCELERATOR_CORE_EXPORT void
-arcaneCheckPointerIsAcccessible(eExecutionPolicy policy, const void* ptr,
-                                const char* name, const TraceInfo& ti);
+arcaneCheckPointerIsAccessible(eExecutionPolicy policy, const void* ptr,
+                               const char* name, const TraceInfo& ti);
 
 template <typename T> inline void
-arcaneCheckPointerIsAcccessible(T& queue_or_runner, const void* ptr,
-                                const char* name, const TraceInfo& ti)
+arcaneCheckPointerIsAccessible(T& queue_or_runner, const void* ptr,
+                               const char* name, const TraceInfo& ti)
 {
-  arcaneCheckPointerIsAcccessible(&queue_or_runner, ptr, name, ti);
+  arcaneCheckPointerIsAccessible(&queue_or_runner, ptr, name, ti);
 }
 
 } // namespace Arcane::Accelerator::impl
@@ -274,7 +274,7 @@ arcaneCheckPointerIsAcccessible(T& queue_or_runner, const void* ptr,
  * Lance une exception si ce n'est pas le cas.
  */
 #define ARCANE_CHECK_ACCESSIBLE_POINTER_ALWAYS(queue_or_runner_or_policy, ptr) \
-  ::Arcane::Accelerator::impl::arcaneCheckPointerIsAcccessible((queue_or_runner_or_policy), (ptr), #ptr, A_FUNCINFO)
+  ::Arcane::Accelerator::impl::arcaneCheckPointerIsAccessible((queue_or_runner_or_policy), (ptr), #ptr, A_FUNCINFO)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunQueue.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueue.cc
@@ -325,8 +325,8 @@ getPointerAccessibility(RunQueue* queue, const void* ptr, PointerAttribute* ptr_
 }
 
 extern "C++" void impl::
-arcaneCheckPointerIsAcccessible(RunQueue* queue, const void* ptr,
-                                const char* name, const TraceInfo& ti)
+arcaneCheckPointerIsAccessible(RunQueue* queue, const void* ptr,
+                               const char* name, const TraceInfo& ti)
 {
   if (!queue || queue->isNull())
     return;

--- a/arcane/src/arcane/accelerator/core/RunQueue.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueue.cc
@@ -70,8 +70,8 @@ RunQueue(const RunQueue& x)
 /*---------------------------------------------------------------------------*/
 
 RunQueue::
-RunQueue(RunQueue&& x)
-: m_p(std::move(x.m_p))
+RunQueue(RunQueue&& x) noexcept
+: m_p(x.m_p)
 {
 }
 
@@ -90,9 +90,9 @@ operator=(const RunQueue& x)
 /*---------------------------------------------------------------------------*/
 
 RunQueue& RunQueue::
-operator=(RunQueue&& x)
+operator=(RunQueue&& x) noexcept
 {
-  m_p = std::move(x.m_p);
+  m_p = x.m_p;
   return (*this);
 }
 
@@ -113,7 +113,7 @@ RunQueue::
 void RunQueue::
 _checkNotNull() const
 {
-  if (!m_p.get())
+  if (!m_p)
     ARCANE_FATAL("Invalid operation on null RunQueue");
 }
 

--- a/arcane/src/arcane/accelerator/core/RunQueue.h
+++ b/arcane/src/arcane/accelerator/core/RunQueue.h
@@ -98,8 +98,8 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
 
   RunQueue(const RunQueue&);
   RunQueue& operator=(const RunQueue&);
-  RunQueue(RunQueue&&);
-  RunQueue& operator=(RunQueue&&);
+  RunQueue(RunQueue&&) noexcept;
+  RunQueue& operator=(RunQueue&&) noexcept;
 
  public:
 

--- a/arcane/src/arcane/accelerator/core/Runner.cc
+++ b/arcane/src/arcane/accelerator/core/Runner.cc
@@ -489,8 +489,8 @@ getPointerAccessibility(Runner* runner, const void* ptr, PointerAttribute* ptr_a
 }
 
 extern "C++" void impl::
-arcaneCheckPointerIsAcccessible(Runner* runner, const void* ptr,
-                                const char* name, const TraceInfo& ti)
+arcaneCheckPointerIsAccessible(Runner* runner, const void* ptr,
+                               const char* name, const TraceInfo& ti)
 {
   if (!runner)
     return;


### PR DESCRIPTION
- Simplify usage of `RunCommandLaunchInfo`
- Make `noexcept` the move constructor and operator of `RunQueue`
- Fix syntax error in internal function `arcaneCheckPointerIsAcccessible`