### PR TITLE
Update CMake files to remove some warnings with recent versions of CMake

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -34,6 +34,12 @@ if(POLICY CMP0111)
   cmake_policy(SET CMP0111 NEW)
 endif()
 
+# A partir de 3.27:
+# find_package() uses upper-case <PACKAGENAME>_ROOT variables.
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
+
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
 # Positionne CMAKE_BUILD_TYPE si ARCANE_BUILD_TYPE est défini ou

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -673,25 +673,6 @@ set(ARCANE_AXL2CC ${AXLSTAR_AXL2CC})
 message(STATUS "Arcane: axl2cc is '${ARCANE_AXL2CC}'")
 
 # ----------------------------------------------------------------------------
-
-# TODO: regarder le code retour et arreter la configuration si besoin
-macro(ARCANE_EXEC_CLR exe_name)
-  if(WIN32)
-    if(VERBOSE)
-      exec_program(${exe_name} ARGS ${ARGN})
-    else()
-      exec_program(${exe_name} ARGS ${ARGN} OUTPUT_VARIABLE ARCANE_EXEC_CLR_OUT)
-    endif()
-  else()
-    if(VERBOSE)
-      exec_program(${MONO_EXEC} ARGS ${exe_name} ${ARGN})
-    else()
-      exec_program(${MONO_EXEC} ARGS ${exe_name} ${ARGN} OUTPUT_VARIABLE ARCANE_EXEC_CLR_OUT)
-    endif()
-  endif()
-endmacro()
-
-# ----------------------------------------------------------------------------
 # Recherche 'googletest' pour les tests unitaires
 find_package(GTest)
 if (GTEST_FOUND)

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -1162,7 +1162,7 @@ endmacro()
 
 function(ARCANE_WRITE_CONFIG_STR str filename)
   file(WRITE ${CMAKE_BINARY_DIR}/lib/${filename}.gen ${str})
-  exec_program(${CMAKE_COMMAND} ARGS -E copy_if_different ${CMAKE_BINARY_DIR}/lib/${filename}.gen ${CMAKE_BINARY_DIR}/${filename})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/lib/${filename}.gen ${CMAKE_BINARY_DIR}/${filename})
   install(FILES ${CMAKE_BINARY_DIR}/${filename} DESTINATION include)
 endfunction()
 

--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -271,13 +271,13 @@ endif()
 # qui ne sont pas dans les dépots arcane (pour des raisons de taille)
 function(ARCANE_CEA_COPY_MESH mesh_name)
   if (ARCANE_ADDITIONAL_MESHES_PATH)
-    exec_program(${CMAKE_COMMAND} ARGS -E copy_if_different ${ARCANE_ADDITIONAL_MESHES_PATH}/${mesh_name}
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARCANE_ADDITIONAL_MESHES_PATH}/${mesh_name}
       ${ARCANE_TEST_PATH}/${mesh_name})
   endif()
 endfunction()
 function(ARCANE_CEA_COPY_MESH_DIRECTORY mesh_dir_name)
   if (ARCANE_ADDITIONAL_MESHES_PATH)
-    exec_program(${CMAKE_COMMAND} ARGS -E copy_directory ${ARCANE_ADDITIONAL_MESHES_PATH}/${mesh_dir_name}
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${ARCANE_ADDITIONAL_MESHES_PATH}/${mesh_dir_name}
       ${ARCANE_TEST_PATH}/${mesh_dir_name})
   endif()
 endfunction()

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -218,13 +218,13 @@ include(ArcaneTests.cmake)
 # ----------------------------------------------------------------------------
 
 function(ARCANE_COPY_MESH orig_mesh_name mesh_name ext)
-  exec_program(${CMAKE_COMMAND} ARGS -E copy_if_different ${ARCANESRCROOT}/maillages/${orig_mesh_name}.${ext}
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARCANESRCROOT}/maillages/${orig_mesh_name}.${ext}
     ${ARCANE_TEST_PATH}/${mesh_name}.${ext})
-  exec_program(${CMAKE_COMMAND} ARGS -E copy_if_different ${ARCANESRCROOT}/maillages/${orig_mesh_name}.vtkfaces.${ext}
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARCANESRCROOT}/maillages/${orig_mesh_name}.vtkfaces.${ext}
     ${ARCANE_TEST_PATH}/${mesh_name}.${ext}faces.${ext})
 endfunction()
 function(ARCANE_COPY_MESH_DIRECT orig_mesh_name)
-  exec_program(${CMAKE_COMMAND} ARGS -E copy_if_different ${ARCANESRCROOT}/maillages/${orig_mesh_name}
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ARCANESRCROOT}/maillages/${orig_mesh_name}
     ${ARCANE_TEST_PATH}/${orig_mesh_name})
 endfunction()
 


### PR DESCRIPTION
- Use `execute_process` instead of `exec_program`
- Add policy `CMP0144` to enable `<PACKAGE_NAME>_ROOT`  (in uppercase)  to find a package.