### PR TITLE
Minor improvements in SYCL backend

### DIFF
--- a/arcane/src/arcane/accelerator/RunQueueInternal.h
+++ b/arcane/src/arcane/accelerator/RunQueueInternal.h
@@ -92,7 +92,7 @@ class KernelReducerHelper
 
 #if defined(ARCANE_COMPILING_SYCL)
   //! Applique les fonctors des arguments additionnels.
-  template <typename... ReducerArgs> static inline ARCCORE_DEVICE void
+  template <typename... ReducerArgs> static inline ARCCORE_HOST_DEVICE void
   applyReducerArgs(sycl::nd_item<1> x, ReducerArgs&... reducer_args)
   {
     // Applique les réductions

--- a/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
@@ -282,10 +282,10 @@ SyclRunQueueStream(SyclRunnerRuntime* runtime, const RunQueueBuildInfo& bi)
 : m_runtime(runtime)
 {
   if (bi.isDefault())
-    m_sycl_stream = std::make_unique<sycl::queue>(runtime->defaultDevice());
+    m_sycl_stream = std::make_unique<sycl::queue>(runtime->defaultDevice(), sycl::property::queue::in_order());
   else {
     ARCANE_SYCL_FUNC_NOT_HANDLED;
-    m_sycl_stream = std::make_unique<sycl::queue>(runtime->defaultDevice());
+    m_sycl_stream = std::make_unique<sycl::queue>(runtime->defaultDevice(), sycl::property::queue::in_order());
   }
 }
 

--- a/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
+++ b/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
@@ -248,8 +248,8 @@ MiniWeatherArray(IAcceleratorMng* am, ITraceMng* tm, int nb_cell_x, int nb_cell_
 
   // Rend la file asynchrone
   // Ne le fait pas avec SYCL car cela provoque des résultats faux (avril 2024)
-  if (m_queue.executionPolicy() != eExecutionPolicy::SYCL)
-    m_queue.setAsync(true);
+  //if (m_queue.executionPolicy() != eExecutionPolicy::SYCL)
+  m_queue.setAsync(true);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
- Use `property::queue::in_order` during queue creation
- Implement `RunQueueEvent` for Intel DPC++
- Change the `value_type` of scan iterator to prevent a potential copy during scanning.
- Fix compilation with AdaptiveCpp