### PR TITLE
Remove usage of standard header file 'execution'

### DIFF
--- a/arcane/src/arcane/accelerator/Scan.h
+++ b/arcane/src/arcane/accelerator/Scan.h
@@ -23,8 +23,6 @@
 #include "arcane/accelerator/CommonUtils.h"
 #include "arcane/accelerator/RunCommandLaunchInfo.h"
 
-#include <execution>
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
This header file include the TBB version used with the libstdc++ and this may conflicts with the version used by Arcane.