### PR TITLE
Remove an #if DEBUG condition on a class member

### DIFF
--- a/alien/standalone/src/refsemantic/alien/ref/data/scalar/Vector.h
+++ b/alien/standalone/src/refsemantic/alien/ref/data/scalar/Vector.h
@@ -75,13 +75,13 @@ class ALIEN_REFSEMANTIC_EXPORT Vector final : public IVector
 
  private:
   std::shared_ptr<MultiVectorImpl> m_impl;
-#ifdef DEBUG
+//#ifdef DEBUG
   std::string m_name = "UnamedVector";
 
  public:
   void setName(std::string name) { m_name = name; }
   std::string const& name() const { return m_name; }
-#endif
+//#endif
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Causes errors for build and execution if the application has debug mode and uses a release-built ArcaneFramework. More generally others #if DEBUG inside functions or methods should be removed since it breaks ODR rule and may lead to several problems.