### PR TITLE
Do SIMD padding for ItemGroup only if explicitly asked

### DIFF
--- a/arcane/src/arcane/core/Concurrency.h
+++ b/arcane/src/arcane/core/Concurrency.h
@@ -1,24 +1,24 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Concurrency.h                                               (C) 2000-2022 */
+/* Concurrency.h                                               (C) 2000-2024 */
 /*                                                                           */
 /* Classes gérant la concurrence (tâches, boucles parallèles, ...)           */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_CONCURRENCY_H
-#define ARCANE_CONCURRENCY_H
+#ifndef ARCANE_CORE_CONCURRENCY_H
+#define ARCANE_CORE_CONCURRENCY_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/ConcurrencyUtils.h"
 
-#include "arcane/Item.h"
-#include "arcane/ItemFunctor.h"
-#include "arcane/ItemGroup.h"
+#include "arcane/core/Item.h"
+#include "arcane/core/ItemFunctor.h"
+#include "arcane/core/ItemGroup.h"
 
 #include <arcane/core/materials/MatItem.h>
 
@@ -115,7 +115,7 @@ template <typename InstanceType, typename ItemType> inline void
 arcaneParallelForeach(const ItemGroup& items, const ForLoopRunInfo& run_info,
                       InstanceType* instance, void (InstanceType::*function)(ItemVectorViewT<ItemType> items))
 {
-  arcaneParallelForeach(items.view(), run_info, instance, function);
+  arcaneParallelForeach(items._paddedView(), run_info, instance, function);
 }
 
 /*!
@@ -139,7 +139,7 @@ template <typename InstanceType, typename ItemType> inline void
 arcaneParallelForeach(const ItemGroup& items,
                       InstanceType* instance, void (InstanceType::*function)(ItemVectorViewT<ItemType> items))
 {
-  arcaneParallelForeach(items.view(), ForLoopRunInfo(), instance, function);
+  arcaneParallelForeach(items._paddedView(), ForLoopRunInfo(), instance, function);
 }
 
 /*!
@@ -163,7 +163,7 @@ template <typename LambdaType> inline void
 arcaneParallelForeach(const ItemGroup& items, const ParallelLoopOptions& options,
                       const LambdaType& lambda_function)
 {
-  arcaneParallelForeach(items.view(), ForLoopRunInfo(options), lambda_function);
+  arcaneParallelForeach(items._paddedView(), ForLoopRunInfo(options), lambda_function);
 }
 
 /*!
@@ -185,7 +185,7 @@ arcaneParallelForeach(const ItemVectorView& items_view, const LambdaType& lambda
 template <typename LambdaType> inline void
 arcaneParallelForeach(const ItemGroup& items, const LambdaType& lambda_function)
 {
-  arcaneParallelForeach(items.view(), lambda_function);
+  arcaneParallelForeach(items._paddedView(), lambda_function);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -298,7 +298,7 @@ namespace Parallel
   Foreach(const ItemGroup& items, const ParallelLoopOptions& options, InstanceType* instance,
           void (InstanceType::*function)(ItemVectorViewT<ItemType> items))
   {
-    Foreach(items.view(), options, instance, function);
+    Foreach(items._paddedView(), options, instance, function);
   }
 
   /*!
@@ -319,7 +319,7 @@ namespace Parallel
   [[deprecated("Year2021: Use Arcane::arcaneParallelForeach() instead")]] inline void
   Foreach(const ItemGroup& items, InstanceType* instance, void (InstanceType::*function)(ItemVectorViewT<ItemType> items))
   {
-    Foreach(items.view(), instance, function);
+    Foreach(items._paddedView(), instance, function);
   }
 
   /*!
@@ -343,7 +343,7 @@ namespace Parallel
   [[deprecated("Year2021: Use Arcane::arcaneParallelForeach() instead")]] inline void
   Foreach(const ItemGroup& items, const ParallelLoopOptions& options, const LambdaType& lambda_function)
   {
-    Foreach(items.view(), options, lambda_function);
+    Foreach(items._paddedView(), options, lambda_function);
   }
 
   /*!
@@ -364,7 +364,7 @@ namespace Parallel
   [[deprecated("Year2021: Use Arcane::arcaneParallelForeach() instead")]] inline void
   Foreach(const ItemGroup& items, const LambdaType& lambda_function)
   {
-    Foreach(items.view(), lambda_function);
+    Foreach(items._paddedView(), lambda_function);
   }
 
   /*!

--- a/arcane/src/arcane/core/ItemGroup.cc
+++ b/arcane/src/arcane/core/ItemGroup.cc
@@ -542,7 +542,7 @@ enumerator() const
 {
   if (null())
     return ItemEnumerator();
-  m_impl->checkNeedUpdate();
+  m_impl->_checkNeedUpdateNoPadding();
   return ItemEnumerator(m_impl->itemInfoListView(),m_impl->itemsLocalId(),m_impl.get());
 }
 
@@ -554,8 +554,24 @@ _simdEnumerator() const
 {
   if (null())
     return ItemEnumerator();
-  m_impl->checkNeedUpdate();
+  m_impl->_checkNeedUpdateWithPadding();
   return ItemEnumerator(m_impl->itemInfoListView(),m_impl->itemsLocalId(),m_impl.get());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ItemVectorView ItemGroup::
+_view(bool do_padding) const
+{
+  if (null())
+    return ItemVectorView();
+  m_impl->_checkNeedUpdate(do_padding);
+  Int32 flags = 0;
+  if (m_impl->isContigousLocalIds())
+    flags |= ItemIndexArrayView::F_Contigous;
+  // TODO: gérer l'offset
+  return ItemVectorView(m_impl->itemFamily(),ItemIndexArrayView(m_impl->itemsLocalId(),0,flags));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -564,14 +580,16 @@ _simdEnumerator() const
 ItemVectorView ItemGroup::
 view() const
 {
-  if (null())
-    return ItemVectorView();
-  m_impl->checkNeedUpdate();
-  Int32 flags = 0;
-  if (m_impl->isContigousLocalIds())
-    flags |= ItemIndexArrayView::F_Contigous;
-  // TODO: gérer l'offset
-  return ItemVectorView(m_impl->itemFamily(),ItemIndexArrayView(m_impl->itemsLocalId(),0,flags));
+  return _view(false);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ItemVectorView ItemGroup::
+_paddedView() const
+{
+  return _view(true);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemGroup.cc
+++ b/arcane/src/arcane/core/ItemGroup.cc
@@ -549,6 +549,18 @@ enumerator() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+ItemEnumerator ItemGroup::
+_simdEnumerator() const
+{
+  if (null())
+    return ItemEnumerator();
+  m_impl->checkNeedUpdate();
+  return ItemEnumerator(m_impl->itemInfoListView(),m_impl->itemsLocalId(),m_impl.get());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 ItemVectorView ItemGroup::
 view() const
 {

--- a/arcane/src/arcane/core/ItemGroup.h
+++ b/arcane/src/arcane/core/ItemGroup.h
@@ -329,7 +329,14 @@ class ARCANE_CORE_EXPORT ItemGroup
 
   //! Enumérateur sur les entités du groupe.
   ItemEnumerator enumerator() const;
-  
+
+ private:
+
+  template <typename T>
+  friend class SimdItemEnumeratorContainerTraits;
+  //! Enumérateur sur les entités du groupe pour la vectorisation
+  ItemEnumerator _simdEnumerator() const;
+
  protected:
 
   //! Représentation interne du groupe.
@@ -429,7 +436,7 @@ class ItemGroupT
   {
     return ItemEnumeratorT<T>::fromItemEnumerator(ItemGroup::enumerator());
   }
-  
+
  protected:
 
   void _assign(const ItemGroup& from)

--- a/arcane/src/arcane/core/ItemGroup.h
+++ b/arcane/src/arcane/core/ItemGroup.h
@@ -320,6 +320,9 @@ class ARCANE_CORE_EXPORT ItemGroup
     return m_impl->checkIsSorted();
   }
 
+  //! Vue sur les entités du groupe avec padding pour la vectorisation
+  ItemVectorView _paddedView() const;
+
  public:
 
   //! API interne à Arcane
@@ -349,6 +352,8 @@ class ARCANE_CORE_EXPORT ItemGroup
   {
     return impl->itemKind()==ik ? impl : ItemGroupImpl::checkSharedNull();
   }
+
+  ItemVectorView _view(bool do_padding) const;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemGroupImpl.cc
+++ b/arcane/src/arcane/core/ItemGroupImpl.cc
@@ -1148,9 +1148,18 @@ _checkNeedUpdateNoPadding()
 /*---------------------------------------------------------------------------*/
 
 bool ItemGroupImpl::
-checkNeedUpdate()
+_checkNeedUpdateWithPadding()
 {
   return _checkNeedUpdate(true);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool ItemGroupImpl::
+checkNeedUpdate()
+{
+  return _checkNeedUpdate(false);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemGroupImpl.h
+++ b/arcane/src/arcane/core/ItemGroupImpl.h
@@ -491,6 +491,7 @@ class ARCANE_CORE_EXPORT ItemGroupImpl
   //! Supprime les entités \a items_local_id du groupe
   void _removeItems(SmallSpan<const Int32> items_local_id);
   bool _checkNeedUpdateNoPadding();
+  bool _checkNeedUpdateWithPadding();
   bool _checkNeedUpdate(bool do_padding);
 };
 

--- a/arcane/src/arcane/core/SimdItem.h
+++ b/arcane/src/arcane/core/SimdItem.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SimdItem.h                                                  (C) 2000-2022 */
+/* SimdItem.h                                                  (C) 2000-2024 */
 /*                                                                           */
 /* Types des entités et des énumérateurs des entités pour la vectorisation.  */
 /*---------------------------------------------------------------------------*/
@@ -511,42 +511,69 @@ typedef SimdItemT<Cell> SimdCell;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#define ENUMERATE_SIMD_(type,iname,view)                         \
-  for( A_TRACE_ITEM_ENUMERATOR(SimdItemEnumeratorT< type >) iname((view).enumerator() A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
+template <typename ItemType>
+class SimdItemEnumeratorContainerTraits
+{
+ public:
 
-#define ENUMERATE_SIMD_GENERIC(type,iname,view)                         \
-  for( A_TRACE_ITEM_ENUMERATOR(SimdItemEnumeratorT< type >) iname((view).enumerator() A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
+  static ItemEnumeratorT<ItemType> getSimdEnumerator(const ItemGroupT<ItemType>& g)
+  {
+    return g.enumerator();
+  }
+  static ItemEnumeratorT<ItemType> getSimdEnumerator(const ItemVectorViewT<ItemType>& g)
+  {
+    return g.enumerator();
+  }
+
+  // Pour compatibilité avec l'existant
+  // Si on est ici cela signifie que le type 'T' n'est pas un type Arcane.
+  // Il faudrait à terme interdire cet appel (par exemple fin 2025)
+  template <typename T>
+  static ItemEnumeratorT<ItemType> getSimdEnumerator(const T& g)
+  {
+    return g.enumerator();
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#define ENUMERATE_SIMD_(type, iname, view) \
+  for (A_TRACE_ITEM_ENUMERATOR(SimdItemEnumeratorT<type>) iname(::Arcane::SimdItemEnumeratorContainerTraits<type>::getSimdEnumerator(view) A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname)
+
+// TODO: A supprimer. Utiliser ENUMERATE_SIMD_ à la place
+#define ENUMERATE_SIMD_GENERIC(type, iname, view) \
+  ENUMERATE_SIMD_(type,iname,view)
 
 /*!
  * \ingroup ArcaneSimd
  * \brief Enumérateur SIMD sur un groupe ou liste de noeuds.
  */
-#define ENUMERATE_SIMD_NODE(name,group) ENUMERATE_SIMD_GENERIC(::Arcane::Node,name,group)
+#define ENUMERATE_SIMD_NODE(name, group) ENUMERATE_SIMD_(::Arcane::Node, name, group)
 
 /*!
  * \ingroup ArcaneSimd
  * \brief Enumérateur SIMD sur un groupe ou liste d'arêtes.
  */
-#define ENUMERATE_SIMD_EDGE(name,group) ENUMERATE_SIMD_GENERIC(::Arcane::Edge,name,group)
+#define ENUMERATE_SIMD_EDGE(name, group) ENUMERATE_SIMD_(::Arcane::Edge, name, group)
 
 /*!
  * \ingroup ArcaneSimd
  * \brief Enumérateur SIMD sur un groupe ou liste de faces.
  */
-#define ENUMERATE_SIMD_FACE(name,group) ENUMERATE_SIMD_GENERIC(::Arcane::Face,name,group)
+#define ENUMERATE_SIMD_FACE(name, group) ENUMERATE_SIMD_(::Arcane::Face, name, group)
 
 /*!
  * \ingroup ArcaneSimd
  * \brief Enumérateur SIMD sur un groupe ou liste de mailles.
  */
-#define ENUMERATE_SIMD_CELL(name,group) ENUMERATE_SIMD_GENERIC(::Arcane::Cell,name,group)
+#define ENUMERATE_SIMD_CELL(name, group) ENUMERATE_SIMD_(::Arcane::Cell, name, group)
 
 /*!
  * \ingroup ArcaneSimd
  * \brief Enumérateur SIMD sur un groupe ou liste de particles.
  */
-#define ENUMERATE_SIMD_PARTICLE(name,group) ENUMERATE_SIMD_GENERIC(::Arcane::Particle,name,group)
-
+#define ENUMERATE_SIMD_PARTICLE(name, group) ENUMERATE_SIMD_(::Arcane::Particle, name, group)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/SimdItem.h
+++ b/arcane/src/arcane/core/SimdItem.h
@@ -386,9 +386,16 @@ class ARCANE_CORE_EXPORT SimdItemEnumeratorBase
 
   // TODO: Gérer les m_local_id_offset pour cette classe
 
+  // TODO: Fin 2024, rendre certains constructeurs internes à Arcane et rendre
+  // obsolètes les autres.
+  // Faire de même avec les classes dérivées
+
   SimdItemEnumeratorBase() = default;
+
+  // TODO: Rendre interne à Arcane
   SimdItemEnumeratorBase(const ItemInternalVectorView& view)
   : SimdEnumeratorBase(view.localIds()), m_shared_info(view.m_shared_info) {}
+  // TODO: Rendre interne à Arcane
   SimdItemEnumeratorBase(const ItemEnumerator& rhs)
   : SimdEnumeratorBase(rhs.m_view.m_local_ids,rhs.count()), m_shared_info(rhs.m_item.m_shared_info) {}
 
@@ -516,11 +523,13 @@ class SimdItemEnumeratorContainerTraits
 {
  public:
 
-  static ItemEnumeratorT<ItemType> getSimdEnumerator(const ItemGroupT<ItemType>& g)
+  static SimdItemEnumeratorT<ItemType> getSimdEnumerator(const ItemGroupT<ItemType>& g)
   {
-    return g.enumerator();
+    return g._simdEnumerator();
   }
-  static ItemEnumeratorT<ItemType> getSimdEnumerator(const ItemVectorViewT<ItemType>& g)
+  // Créé un itérateur à partir d'un ItemVectorView. Il faut que ce dernier ait un padding
+  // de la taille du vecteur.
+  static SimdItemEnumeratorT<ItemType> getSimdEnumerator(const ItemVectorViewT<ItemType>& g)
   {
     return g.enumerator();
   }
@@ -529,7 +538,7 @@ class SimdItemEnumeratorContainerTraits
   // Si on est ici cela signifie que le type 'T' n'est pas un type Arcane.
   // Il faudrait à terme interdire cet appel (par exemple fin 2025)
   template <typename T>
-  static ItemEnumeratorT<ItemType> getSimdEnumerator(const T& g)
+  static SimdItemEnumeratorT<ItemType> getSimdEnumerator(const T& g)
   {
     return g.enumerator();
   }


### PR DESCRIPTION
The SIMD padding is only needed when we use `ENUMERATE_SIMD_` macro (directly or inside a parallel loop).
So this PR changes the default behaviour to only do padding in this case.

Because the padding is done on the CPU side, always doing the padding may lead to round-trip  between CPU and GPU memory if the `ItemGroup` is updated (via `addItems()` or `removeItems()`) on GPU.