### PR TITLE
Refactor compilation of C# wrapper to use only one build project

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -645,6 +645,7 @@ set(ARCANE_USE_HIDDEN_VISIBILITY TRUE)
 # Gestion du C#.
 
 include(ArcconDotNet)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/GlobalCSharpTarget.cmake)
 
 # ----------------------------------------------------------------------------
 

--- a/arcane/ceapart/src/arcane/tests/TestDotNet.cmake
+++ b/arcane/ceapart/src/arcane/tests/TestDotNet.cmake
@@ -22,8 +22,7 @@ add_custom_command(OUTPUT ${CSOUTPATH}/MeshMaterialCSharpUnitTest_axl.cs
   COMMAND ${ARCANE_AXL2CC}
   ARGS -i arcane/tests/. --lang c\# -o ${CSOUTPATH} ${CSPATH}/MeshMaterialCSharpUnitTest.axl)
 
-arccon_add_csharp_target(arcanecea_test_cs
-  DOTNET_RUNTIME ${ARCANE_DOTNET_RUNTIME}
+arcane_add_global_csharp_target(arcanecea_test_cs
   BUILD_DIR ${LIBRARY_OUTPUT_PATH}
   ASSEMBLY_NAME ArcaneCeaTest.dll
   PROJECT_PATH ${ARCANE_CSHARP_PROJECT_PATH}/ArcaneCeaTest

--- a/arcane/cmake/GlobalCSharpTarget.cmake
+++ b/arcane/cmake/GlobalCSharpTarget.cmake
@@ -1,0 +1,174 @@
+﻿# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Pour tester l'utilisation d'un cible globale pour le C#
+set(ARCANE_USE_GLOBAL_CSHARP FALSE)
+
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+
+if(ARCANE_USE_GLOBAL_CSHARP)
+  set(ARCANE_DOTNET_PUBLISH_PATH "${CMAKE_BINARY_DIR}/lib")
+  # Fichier pour savoir si on a déjà générer la cible
+  set(ARCANE_DOTNET_PUBLISH_TIMESTAMP "${ARCANE_DOTNET_PUBLISH_PATH}/.dotnet_stamp")
+  # Fichier pour savoir si on a déjà restaurer la cible
+  set(ARCANE_DOTNET_RESTORE_TIMESTAMP "${ARCANE_DOTNET_PUBLISH_PATH}/.dotnet_restore_stamp")
+
+  add_custom_target(arcane_global_csharp_target ALL DEPENDS "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}")
+  add_custom_target(arcane_global_csharp_restore_target ALL DEPENDS "${ARCANE_DOTNET_RESTORE_TIMESTAMP}")
+
+  set(ARGS_DOTNET_RUNTIME "coreclr")
+  set(_msbuild_exe ${ARCCON_MSBUILD_EXEC_${ARGS_DOTNET_RUNTIME}})
+  if (NOT _msbuild_exe)
+    logFatalError("In ${_func_name}: 'msbuild' command for runtime '${ARGS_DOTNET_RUNTIME}' is not available.")
+  endif()
+  # TODO: Faire la restauration avant
+  set(_BUILD_ARGS publish --no-restore BuildAllCSharp.proj /t:Publish /p:PublishDir=${ARCANE_DOTNET_PUBLISH_PATH}/ ${ARGS_MSBUILD_ARGS})
+
+  # Commande de restauration des packages nuget
+  add_custom_command(OUTPUT "${ARCANE_DOTNET_RESTORE_TIMESTAMP}"
+    WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
+    COMMAND ${_msbuild_exe} build BuildAllCSharp.proj /t:Restore
+    COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_RESTORE_TIMESTAMP}
+    COMMENT "Restoring global 'C#' target"
+  )
+
+  # Commande de compilation de la cible
+  add_custom_command(OUTPUT "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}"
+    WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
+    COMMAND ${_msbuild_exe} ${_BUILD_ARGS}
+    COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_PUBLISH_TIMESTAMP}
+    DEPENDS arcane_global_csharp_restore_target
+    COMMENT "Building global 'C#' target"
+  )
+
+  # TODO: Ajouter cible pour le pack
+  # TODO: Ajouter cible pour forcer la compilation
+endif()
+
+
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+#
+# Fonction pour créér une cible 'CMake' à partir d'un projet ou solution C#
+# La compilation de toutes les projets générés par cette fonction sera
+# effectuée en une fois
+#
+# Usage:
+#
+#  arcane_add_global_csharp_target(target_name
+#    BUILD_DIR [target_path]
+#    ASSEMBLY_NAME [assembly_name]
+#    PROJECT_PATH [project_path]
+#    PROJECT_NAME [project_name]
+#    MSBUILD_ARGS [msbuild_args]
+#    DEPENDS [depends]
+#    DOTNET_TARGET_DEPENDS [dotnet_target_depends]
+#    [PACK]
+#  )
+#
+function(arcane_add_global_csharp_target target_name)
+  # Appelle l'ancienne méthode tant que la nouvelle n'est pas finalisée
+  if (NOT ARCANE_USE_GLOBAL_CSHARP)
+    arccon_add_csharp_target(${target_name} DOTNET_RUNTIME coreclr ${ARGN})
+    return()
+  endif()
+  set(_func_name "arcane_add_global_csharp_target")
+  set(options PACK)
+  set(oneValueArgs BUILD_DIR TARGET_PATH ASSEMBLY_NAME PROJECT_NAME PROJECT_PATH)
+  set(multiValueArgs MSBUILD_ARGS DEPENDS DOTNET_TARGET_DEPENDS)
+  set(ARGS_DOTNET_RUNTIME "coreclr")
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  if(ARGS_UNPARSED_ARGUMENTS)
+    logFatalError("In ${_func_name}: unparsed arguments '${ARGS_UNPARSED_ARGUMENTS}'")
+  endif()
+  if (NOT target_name)
+    logFatalError("In ${_func_name}: no 'target_name' specified")
+  endif()
+  if (NOT ${ARGS_DOTNET_RUNTIME} MATCHES "coreclr|mono")
+    logFatalError("In ${_func_name}: Invalid value '${ARGS_DOTNET_RUNTIME}' for DOTNET_RUNTIME. Valid values are 'coreclr' or 'mono'")
+  endif()
+  if (NOT ARGS_BUILD_DIR)
+    logFatalError("In ${_func_name}: BUILD_DIR not specified")
+  endif()
+  if (NOT ARGS_ASSEMBLY_NAME)
+    logFatalError("In ${_func_name}: ASSEMBLY_NAME not specified")
+  endif()
+  if (NOT ARGS_PROJECT_PATH)
+    logFatalError("In ${_func_name}: PROJECT_PATH not specified")
+  endif()
+  if (NOT ARGS_PROJECT_NAME)
+    logFatalError("In ${_func_name}: PROJECT_NAME not specified")
+  endif()
+  set(assembly_name ${ARGS_ASSEMBLY_NAME})
+  set(build_proj_path ${ARGS_PROJECT_PATH}/${ARGS_PROJECT_NAME})
+  set(output_assembly_path ${ARGS_BUILD_DIR}/${assembly_name})
+  set(_msbuild_exe ${ARCCON_MSBUILD_EXEC_${ARGS_DOTNET_RUNTIME}})
+  if (NOT _msbuild_exe)
+    logFatalError("In ${_func_name}: 'msbuild' command for runtime '${ARGS_DOTNET_RUNTIME}' is not available.")
+  endif()
+  set(_BUILD_ARGS ${ARCCON_MSBUILD_ARGS_${ARGS_DOTNET_RUNTIME}} ${ARGS_PROJECT_NAME} /t:Publish /p:PublishDir=${ARGS_BUILD_DIR}/ ${ARGS_MSBUILD_ARGS})
+  # Comme 'cmake' ne propage pas les dépendances de fichiers entre les 'add_custom_command'
+  # et 'add_custom_target', il faut le faire manuellement. Pour cela, on utilise
+  # notre propriété 'DOTNET_DLL_NAME' définie sur les cibles '.Net' et on
+  # ajoute explicitement aux dépendences ce fichier.
+  set(_DOTNET_TARGET_DLL_DEPENDS)
+  if (ARGS_DOTNET_TARGET_DEPENDS)
+    #message(STATUS "ARGS_DOTNET_TARGET_DEPENDS=${ARGS_DOTNET_TARGET_DEPENDS}")
+    foreach(_dtarget ${ARGS_DOTNET_TARGET_DEPENDS})
+      get_target_property(_dtarget_file ${_dtarget} DOTNET_DLL_NAME)
+      #message(STATUS "TARGET ${_dtarget} dll_file=${_dtarget_file}")
+      list(APPEND _DOTNET_TARGET_DLL_DEPENDS ${_dtarget_file})
+    endforeach()
+  endif()
+  message(STATUS "_DOTNET_TARGET_DLL_DEPENDS=${_DOTNET_TARGET_DLL_DEPENDS}")
+  set(_ALL_DEPENDS ${build_proj_path} ${ARGS_DEPENDS} ${_DOTNET_TARGET_DLL_DEPENDS} ${ARGS_DOTNET_TARGET_DEPENDS})
+  #message(STATUS "_ALL_DEPENDS=${_ALL_DEPENDS}")
+
+  if (ARGS_PACK)
+    set(_DO_PACK TRUE)
+  endif()
+  if (_DO_PACK)
+    set(_PACK_DIR ${CMAKE_BINARY_DIR}/nupkgs)
+    file(MAKE_DIRECTORY ${_PACK_DIR})
+    set(_PACK_ARGS ${ARCCON_DOTNET_PACK_ARGS_${ARGS_DOTNET_RUNTIME}} /p:PackageOutputPath=${_PACK_DIR} /p:IncludeSymbols=true ${ARGS_PROJECT_NAME} ${ARGS_MSBUILD_ARGS})
+  endif()
+  # if (_DO_PACK)
+  #   add_custom_command(OUTPUT ${output_assembly_path}
+  #     WORKING_DIRECTORY ${ARGS_PROJECT_PATH}
+  #     COMMAND ${_msbuild_exe} ${_BUILD_ARGS}
+  #     COMMAND ${_msbuild_exe} ${_PACK_ARGS}
+  #     DEPENDS ${_ALL_DEPENDS}
+  #     COMMENT "Building and packing 'C#' target '${target_name}' (expected output '${output_assembly_path}')"
+  #   )
+  # else()
+  #   add_custom_command(OUTPUT ${output_assembly_path}
+  #     WORKING_DIRECTORY ${ARGS_PROJECT_PATH}
+  #     COMMAND ${_msbuild_exe} ${_BUILD_ARGS}
+  #     DEPENDS ${_ALL_DEPENDS}
+  #     COMMENT "Building 'C#' target '${target_name}' (expected output '${output_assembly_path}')"
+  #   )
+  # endif()
+
+  # Ajoute les fichiers à la dépendence de la cible globale
+  set_property(TARGET arcane_global_csharp_target
+    APPEND PROPERTY
+    DEPENDS ${_ALL_DEPENDS}
+  )
+
+  # add_custom_target(${target_name} ALL DEPENDS ${output_assembly_path} ${ARGS_DOTNET_TARGET_DEPENDS})
+  # add_dependencies(arcane_global_csharp_target ${ARGS_DOTNET_TARGET_DEPENDS})
+
+  # add_custom_target(${target_name} ALL DEPENDS arcane_global_csharp_target)
+  add_custom_target(${target_name})
+  add_dependencies(arcane_global_csharp_target ${target_name})
+
+  # Indique que la cible génère la dll '${output_assembly_path}'
+  set_target_properties(${target_name} PROPERTIES DOTNET_DLL_NAME ${output_assembly_path})
+endfunction()
+
+# ----------------------------------------------------------------------------
+# Local Variables:
+# tab-width: 2
+# indent-tabs-mode: nil
+# coding: utf-8-with-signature
+# End:

--- a/arcane/src/arcane/tests/ArcaneTestExe.csproj.in
+++ b/arcane/src/arcane/tests/ArcaneTestExe.csproj.in
@@ -2,6 +2,9 @@
 
   <Import Project="../CommonExe.props" />
 
+  <PropertyGroup>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="@CSPATH@/Main.cs" />
   </ItemGroup>

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -144,8 +144,7 @@ if (TARGET arcane_dotnet_wrapper_services)
     COMMAND ${ARCANE_AXL2CC}
     ARGS -i arcane/tests/. --lang c\# -o ${CSOUTPATH} ${CSPATH}/MeshModification.axl)
 
-  arccon_add_csharp_target(arcane_test_cs
-    DOTNET_RUNTIME ${ARCANE_DOTNET_RUNTIME}
+  arcane_add_global_csharp_target(arcane_test_cs
     BUILD_DIR ${LIBRARY_OUTPUT_PATH}
     ASSEMBLY_NAME ArcaneTest.dll
     PROJECT_PATH ${ARCANE_CSHARP_PROJECT_PATH}/ArcaneTest
@@ -166,8 +165,7 @@ if (TARGET arcane_dotnet_wrapper_services)
     DOTNET_TARGET_DEPENDS dotnet_wrapper_services dotnet_wrapper_launcher
     )
 
-  arccon_add_csharp_target(arcane_test_cs_exe
-    DOTNET_RUNTIME ${ARCANE_DOTNET_RUNTIME}
+  arcane_add_global_csharp_target(arcane_test_cs_exe
     BUILD_DIR ${LIBRARY_OUTPUT_PATH}
     ASSEMBLY_NAME ArcaneTestExe.dll
     PROJECT_PATH ${ARCANE_CSHARP_PROJECT_PATH}/ArcaneTestExe

--- a/arcane/tools/wrapper/ArcaneSwigUtils.cmake
+++ b/arcane/tools/wrapper/ArcaneSwigUtils.cmake
@@ -118,8 +118,7 @@ function(arcane_wrapper_add_csharp_target)
     file(WRITE ${ARCANE_CSHARP_PROJECT_PATH}/${ARGS_PROJECT_NAME}/csfiles.txt ${_OUT_CSHARP_TXT})
   endif()
 
-  arccon_add_csharp_target(${ARGS_TARGET_NAME}
-    DOTNET_RUNTIME ${ARCANE_DOTNET_RUNTIME}
+  arcane_add_global_csharp_target(${ARGS_TARGET_NAME}
     BUILD_DIR ${ARCANE_DOTNET_WRAPPER_INSTALL_DIRECTORY}
     ASSEMBLY_NAME ${ARGS_PROJECT_NAME}.dll
     PROJECT_PATH ${ARCANE_CSHARP_PROJECT_PATH}/${ARGS_PROJECT_NAME}

--- a/arcane/tools/wrapper/BuildAllCSharp.proj.in
+++ b/arcane/tools/wrapper/BuildAllCSharp.proj.in
@@ -1,0 +1,22 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectReferences Include=".\**\*.csproj" />
+  </ItemGroup>
+  <PropertyGroup>
+  </PropertyGroup>
+
+  <Target Name="Build">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Build" Properties="SelfContained=false;PublishSelfContained=false">
+    </MSBuild>
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Restore">
+    </MSBuild>
+  </Target>
+
+  <Target Name="Publish">
+    <MSBuild Projects="@(ProjectReferences)" Targets="Publish">
+    </MSBuild>
+  </Target>
+</Project>

--- a/arcane/tools/wrapper/CMakeLists.txt
+++ b/arcane/tools/wrapper/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 # ----------------------------------------------------------------------------
 
 configure_file(ArcaneSwigConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/ArcaneSwigConfig.cmake @ONLY)
+configure_file(BuildAllCSharp.proj.in ${ARCANE_CSHARP_PROJECT_PATH}/BuildAllCSharp.proj @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ArcaneSwigConfig.cmake
   DESTINATION ${ARCANE_CMAKE_CONFIG_DIR})
 

--- a/arcane/tools/wrapper/main/Arcane.Main.csproj.in
+++ b/arcane/tools/wrapper/main/Arcane.Main.csproj.in
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <!-- Infos pour NuGet -->


### PR DESCRIPTION
The behavior of `dotnet publish` has changed with `.Net 8` and now the published files are always copied to the output directory. This will induce unwanted re-compilation when building Arcane.
This PR aims to use only one build project to compile all the projects needed for the wrapper. This will also accelerate compilation.
This is new behavior is not yet enabled by default.