### PR TITLE
Fix race condition in dotnet first time use experience

### DIFF
--- a/arcane/cmake/GlobalCSharpTarget.cmake
+++ b/arcane/cmake/GlobalCSharpTarget.cmake
@@ -16,7 +16,14 @@ if(ARCANE_USE_GLOBAL_CSHARP)
   add_custom_target(arcane_global_csharp_target ALL DEPENDS "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}")
   add_custom_target(arcane_global_csharp_restore_target ALL DEPENDS "${ARCANE_DOTNET_RESTORE_TIMESTAMP}")
 
-  # TODO: Ajouter cible pour le pack
+  # Cette dépendence n'existe pas réellement mais elle permet de s'assurer qu'il n'y
+  # a qu'une seule cible à la fois qui appelle `dotnet`.
+  # C'est nécessaire pour éviter les erreurs dues à la création de répertoires lors de
+  # la première utilisation de `dotnet` (dans 'Microsoft.DotNet.Configurer.DotnetFirstTimeUseConfigurer.Configure()')
+  if (TARGET dotnet_axl_depend)
+    add_dependencies(arcane_global_csharp_restore_target dotnet_axl_depend)
+  endif()
+
   # TODO: Ajouter cible pour forcer la compilation
 endif()
 

--- a/arcane/tools/CMakeLists.txt
+++ b/arcane/tools/CMakeLists.txt
@@ -229,7 +229,7 @@ arccon_add_csharp_target(dotnet_arcane_utils
   PROJECT_NAME Arcane.Utils/Arcane.Utils.csproj
   MSBUILD_ARGS ${ARCANE_MSBUILD_ARGS}
   PACK
-  )
+)
 
 arccon_add_csharp_target(dotnet_tools
   DOTNET_RUNTIME ${ARCANE_DOTNET_RUNTIME}
@@ -239,7 +239,12 @@ arccon_add_csharp_target(dotnet_tools
   PROJECT_NAME AllTools.sln
   MSBUILD_ARGS ${ARCANE_MSBUILD_ARGS}
   DOTNET_TARGET_DEPENDS dotnet_arcane_utils
-  )
+)
+
+# Voir fichier 'GlobalCSharpTarget' pour explicataion sur cette dépendance
+if (TARGET dotnet_axl_depend)
+  add_dependencies(dotnet_arcane_utils dotnet_axl_depend)
+endif()
 
 # Pour compatibilité avec l'existant (versions 3.11 et antérieures)
 add_custom_target(dotnet_xbuild DEPENDS dotnet_tools)


### PR DESCRIPTION
If target `dotnet_axl` exists, add a dependency to this target to projects using C# to ensure there is only one project
executed at once. This is necessary for the CI because during the first use of `dotnet` there are directory creations and this poses problem if it is executed by several instances at the same time.


