### PR TITLE
Add Ubuntu 24.04 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
     executor: <<parameters.arch>>
     docker:
-      - image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_<<parameters.image_version>>_20240522
+      - image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_<<parameters.image_version>>_20240530
 
     steps:
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
 
     executor: <<parameters.arch>>
     docker:
-      - image: ghcr.io/arcaneframework/ubuntu-2204:gcc-12_clang-16_<<parameters.image_version>>_20230906
+      - image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_<<parameters.image_version>>_20240522
 
     steps:
       - when:

--- a/.github/workflows/build_tests_all.yml
+++ b/.github/workflows/build_tests_all.yml
@@ -38,7 +38,7 @@ jobs:
 
           - image_short: 'U24_G14_C18'
             image_long: 'ubuntu-2404:gcc-14_clang-18'
-            image_date: '20240522'
+            image_date: '20240530'
             image_args: '-DARCCORE_CXX_STANDARD=23'
             image_cuda: false
 

--- a/.github/workflows/build_tests_all.yml
+++ b/.github/workflows/build_tests_all.yml
@@ -1,4 +1,4 @@
-name: '[All] Build/Install/Test Arcane Framework (Ubuntu 20.04-22.04 / GCC 11-12 / CLang 13-16 / CUDA 12.2 / Minimal-Full / Release-Debug)'
+name: '[All] Build/Install/Test Arcane Framework (Ubuntu 20.04-22.04-24.04 / GCC 11-12-14 / CLang 13-15-16-18 / CUDA 12.2 / Minimal-Full / Release-Debug)'
 # Attention : GitHub limite à 20 tests à la fois.
 
 on:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_short: [ 'U20_G11_C13', 'U22_G12_C16', 'U22_G12_C15_CU122' ]
+        image_short: [ 'U20_G11_C13', 'U22_G12_C16', 'U22_G12_C15_CU122', 'U24_G14_C18' ]
         version_short: [ 'F', 'M' ]
         compilo: [ 'CLang', 'GCC' ]
         type_build: [ 'Debug', 'Release' ]
@@ -25,7 +25,7 @@ jobs:
 
           - image_short: 'U22_G12_C16'
             image_long: 'ubuntu-2204:gcc-12_clang-16'
-            image_date: '20230808'
+            image_date: '20230906'
             image_args: '-DARCCORE_CXX_STANDARD=23'
             image_cuda: false
 
@@ -35,6 +35,12 @@ jobs:
             # Disable googletest with CUDA because it requires a GPU driver
             image_args: '-DARCCORE_CXX_STANDARD=20 -DARCANE_EXECUTE_ACCELERATOR_GOOGLETEST=OFF'
             image_cuda: true
+
+          - image_short: 'U24_G14_C18'
+            image_long: 'ubuntu-2404:gcc-14_clang-18'
+            image_date: '20240522'
+            image_args: '-DARCCORE_CXX_STANDARD=23'
+            image_cuda: false
 
           - version_short: 'M'
             version_long: 'minimal'
@@ -74,65 +80,3 @@ jobs:
       excluded_tests: ${{ matrix.excluded_tests }}
       excluded_tests_with_labels: ${{ matrix.excluded_tests_with_labels }}
       cache_key_prefix: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo}}_${{matrix.mpi}}_${{matrix.type_build}}
-
-  build-install-test-split:
-    strategy:
-      fail-fast: false
-      matrix:
-        image_short: [ 'U20_G11_C13', 'U22_G12_C16' ]
-        version_short: [ 'F', 'M' ]
-        compilo: [ 'CLang', 'GCC' ]
-        type_build: [ 'Debug', 'Release' ]
-        mpi: [ 'OpenMPI', 'MPICH' ]
-
-        include:
-          - image_short: 'U20_G11_C13'
-            image_long: 'ubuntu-2004:gcc-11_clang-13'
-            image_date: '20230808'
-            image_cuda: false
-
-          - image_short: 'U22_G12_C16'
-            image_long: 'ubuntu-2204:gcc-12_clang-16'
-            image_date: '20230808'
-            image_args: '-DARCCORE_CXX_STANDARD=23'
-            image_cuda: false
-
-          - version_short: 'M'
-            version_long: 'minimal'
-            version_args: '-DARCANE_DISABLE_PERFCOUNTER_TESTS=ON'
-
-          - version_short: 'F'
-            version_long: 'full'
-            version_args: '-DARCANE_DISABLE_PERFCOUNTER_TESTS=ON
-              -DARCANE_DEFAULT_PARTITIONER=Metis
-              -DPTScotch_INCLUDE_DIR="/usr/include/scotch"'
-
-          - type_build: 'Release'
-            excluded_tests: ''
-            excluded_tests_with_labels: 'LARGE_HYBRID'
-
-          - type_build: 'Debug'
-            excluded_tests: ''
-            excluded_tests_with_labels: 'LARGE_HYBRID'
-
-        exclude:
-          - version_short: 'F'
-            mpi: 'MPICH'
-
-
-    name: '[${{matrix.image_short}}_${{matrix.version_short}}][Split]_${{matrix.compilo}}_${{matrix.mpi}}_${{matrix.type_build}}'
-    # La partie 'uses' est déterminée à la compilation, donc on ne peut pas mettre de variable ${{}}.
-    uses: 'arcaneframework/gh_actions/.github/workflows/reusable_test_split_framework.yml@v1'
-    with:
-      image: ghcr.io/arcaneframework/${{matrix.image_long}}_${{matrix.version_long}}_${{matrix.image_date}}
-      compilo: ${{ matrix.compilo }}
-      mpi: ${{ matrix.mpi }}
-      with_cuda: ${{ matrix.image_cuda }}
-      type_build: ${{ matrix.type_build }}
-      cmake_additionnal_args: '${{ matrix.image_args }} ${{ matrix.version_args }}'
-      verbose: true
-      with_samples: true
-      execute_tests: ${{ !matrix.image_cuda }}
-      excluded_tests: ${{ matrix.excluded_tests }}
-      excluded_tests_with_labels: ${{ matrix.excluded_tests_with_labels }}
-      cache_key_prefix: ${{matrix.image_short}}_${{matrix.version_short}}_${{matrix.compilo}}_${{matrix.mpi}}_${{matrix.type_build}}_split

--- a/.github/workflows/build_tests_rand.yml
+++ b/.github/workflows/build_tests_rand.yml
@@ -24,7 +24,7 @@ jobs:
 
           - image_short: 'U24_G14_C18'
             image_long: 'ubuntu-2404:gcc-14_clang-18'
-            image_date: '20240522'
+            image_date: '20240530'
             image_args: '-DARCCORE_CXX_STANDARD=23'
             image_cuda: false
 

--- a/.github/workflows/build_tests_rand.yml
+++ b/.github/workflows/build_tests_rand.yml
@@ -1,4 +1,4 @@
-name: '[Rand] Build/Install/Test Arcane Framework (Ubuntu 20.04-22.04 / GCC 11-12 / CLang 16 / Full / Debug)'
+name: '[Rand] Build/Install/Test Arcane Framework (Ubuntu 22.04-24.04 / GCC 12-14 / CLang 16-18 / Full / Debug)'
 
 on:
   schedule:
@@ -10,21 +10,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_short: [ 'U20_G11_C13', 'U22_G12_C16' ]
+        image_short: [ 'U22_G12_C16', 'U24_G14_C18' ]
         version_short: [ 'F' ]
         compilo: [ 'CLang', 'GCC' ]
         type_build: [ 'Debug' ]
 
         include:
-          - image_short: 'U20_G11_C13'
-            image_long: 'ubuntu-2004:gcc-11_clang-13'
-            image_date: '20230808'
-            image_args: '-DARCCORE_CXX_STANDARD=20'
-            image_cuda: false
-
           - image_short: 'U22_G12_C16'
             image_long: 'ubuntu-2204:gcc-12_clang-16'
-            image_date: '20230808'
+            image_date: '20230906'
+            image_args: '-DARCCORE_CXX_STANDARD=23'
+            image_cuda: false
+
+          - image_short: 'U24_G14_C18'
+            image_long: 'ubuntu-2404:gcc-14_clang-18'
+            image_date: '20240522'
             image_args: '-DARCCORE_CXX_STANDARD=23'
             image_cuda: false
 
@@ -36,10 +36,6 @@ jobs:
           - type_build: 'Debug'
             excluded_tests: '^.*([3-9]proc|[1-9][0-9]+proc|[5-9]thread|[1-9][0-9]+thread).*$'
             excluded_tests_with_labels: 'LARGE_HYBRID'
-
-        exclude:
-          - image_short: 'U20_G11_C13'
-            compilo: 'CLang'
 
 
     name: '[${{matrix.image_short}}_${{matrix.version_short}}]_${{matrix.compilo}}_${{matrix.mpi}}_${{matrix.type_build}}'

--- a/.github/workflows/build_tests_release.yml
+++ b/.github/workflows/build_tests_release.yml
@@ -57,7 +57,7 @@ jobs:
 
           - image_short: 'U24_G14_C18'
             image_long: 'ubuntu-2404:gcc-14_clang-18'
-            image_date: '20240522'
+            image_date: '20240530'
             image_args: '-DARCCORE_CXX_STANDARD=23'
             image_cuda: false
 

--- a/.github/workflows/build_tests_release.yml
+++ b/.github/workflows/build_tests_release.yml
@@ -1,4 +1,4 @@
-name: '[Check] Build/Install/Test Arcane Framework (Ubuntu 20.04-22.04 / GCC 11-12 / CLang 13-16 / CUDA 12.2 / Minimal-Full)'
+name: '[Check] Build/Install/Test Arcane Framework (Ubuntu 22.04-24.04 / GCC 12-14 / CLang 15-16-18 / CUDA 12.2 / Minimal-Full)'
 
 on:
   push:
@@ -35,21 +35,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_short: [ 'U20_G11_C13', 'U22_G12_C16', 'U22_G12_C15_CU122' ]
+        image_short: [ 'U22_G12_C16', 'U22_G12_C15_CU122', 'U24_G14_C18' ]
         version_short: [ 'F', 'M' ]
         compilo: [ 'CLang', 'GCC' ]
         type_build: [ 'Check' ]
         mpi: [ 'OpenMPI', 'MPICH' ]
 
         include:
-          - image_short: 'U20_G11_C13'
-            image_long: 'ubuntu-2004:gcc-11_clang-13'
-            image_date: '20230808'
-            image_cuda: false
-
           - image_short: 'U22_G12_C16'
             image_long: 'ubuntu-2204:gcc-12_clang-16'
-            image_date: '20230808'
+            image_date: '20230906'
             image_args: '-DARCCORE_CXX_STANDARD=23'
             image_cuda: false
 
@@ -59,6 +54,12 @@ jobs:
             # Disable googletest with CUDA because it requires a GPU driver
             image_args: '-DARCCORE_CXX_STANDARD=20 -DARCANE_EXECUTE_ACCELERATOR_GOOGLETEST=OFF'
             image_cuda: true
+
+          - image_short: 'U24_G14_C18'
+            image_long: 'ubuntu-2404:gcc-14_clang-18'
+            image_date: '20240522'
+            image_args: '-DARCCORE_CXX_STANDARD=23'
+            image_cuda: false
 
           - version_short: 'M'
             version_long: 'minimal'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -46,7 +46,7 @@ jobs:
     name: Codecov
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_full_20240522
+      image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_full_20240530
 
     steps:
       # On place la source à la racine pour éviter

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -46,7 +46,7 @@ jobs:
     name: Codecov
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/arcaneframework/ubuntu-2204:gcc-12_clang-16_full_20230808
+      image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_full_20240522
 
     steps:
       # On place la source à la racine pour éviter

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,7 +17,7 @@ jobs:
     name: ubuntu coverity
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/arcaneframework/ubuntu-2204:gcc-12_clang-16_full_20230808
+      image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_full_20240522
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,7 +17,7 @@ jobs:
     name: ubuntu coverity
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_full_20240522
+      image: ghcr.io/arcaneframework/ubuntu-2404:gcc-14_clang-18_full_20240530
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Update Ubuntu 22.04 image date,
- Remove 'split' part in 'All' CI,
- Add Ubuntu 24.04 in 'All', 'Rand', 'Release', 'Codecov', 'Coverity' and 'CircleCI' CIs,
- Remove Ubuntu 20.04 in 'Release' CI.