### PR TITLE
Use 'Int32' for underlying type of 'eDataType'

### DIFF
--- a/arcane/src/arcane/core/datatype/DataTypes.cc
+++ b/arcane/src/arcane/core/datatype/DataTypes.cc
@@ -69,7 +69,7 @@ namespace
 extern "C++" const char*
 dataTypeName(eDataType type)
 {
-  uint8_t v = type;
+  Int32 v = type;
   if (v >= NB_ARCANE_DATA_TYPE)
     return "(Invalid)";
   return N_ALL_NAMES[v];
@@ -110,7 +110,7 @@ dataTypeSize(eDataType type)
 {
   if (type == DT_String)
     ARCANE_THROW(ArgumentException, "datatype 'DT_String' has no size");
-  const uint8_t v = type;
+  const Int32 v = type;
   if (v >= NB_ARCANE_DATA_TYPE)
     ARCANE_THROW(ArgumentException, "Invalid datatype value '{0}'", v);
   return ALL_SIZEOF[v];

--- a/arcane/src/arcane/core/datatype/DataTypes.h
+++ b/arcane/src/arcane/core/datatype/DataTypes.h
@@ -9,8 +9,8 @@
 /*                                                                           */
 /* Définition des types liées aux données.                                   */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_DATATYPES_DATATYPES_H
-#define ARCANE_DATATYPES_DATATYPES_H
+#ifndef ARCANE_CORE_DATATYPES_DATATYPES_H
+#define ARCANE_CORE_DATATYPES_DATATYPES_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -29,7 +29,7 @@ namespace Arcane
 /*!
  * \brief Type d'une donnée.
  */
-enum eDataType : uint8_t
+enum eDataType : Int32
 {
   DT_Byte = 0, //!< Donnée de type octet
   DT_Real, //!< Donnée de type réel
@@ -45,11 +45,11 @@ enum eDataType : uint8_t
   DT_Float16, //!< Donnée de type 'Float16'
   DT_Float32, //!< Donnée de type 'Float32'
   DT_Int8, //!< Donnée de type entier sur 8 bits
-  DT_Unknown  //!< Donnée de type inconnue ou non initialisée
+  DT_Unknown //!< Donnée de type inconnue ou non initialisée
 };
 
 //! Nombre de valeurs de eDataType
-static constexpr uint8_t NB_ARCANE_DATA_TYPE = 15;
+static constexpr Int32 NB_ARCANE_DATA_TYPE = 15;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The size of the enum has changed in Arcane '3.12' (from undefined type to `uint8_t`) but some users use `sizeof(eDataType)` in their code and it's break compatibility. So we explicitly specify `Int32` as the underlying type.
