### PR TITLE
Use lazy evaluation to re-compute informations in MeshComponentPartData

### DIFF
--- a/arcane/src/arcane/core/materials/ComponentItemInternal.h
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.h
@@ -131,6 +131,7 @@ class ARCANE_CORE_EXPORT ComponentItemSharedInfo
   friend class ComponentCell;
   friend class CellToAllEnvCellConverter;
   friend class AllEnvCellVectorView;
+  friend class ConstituentItemVectorImpl;
 
   static const int MAT_INDEX_OFFSET = 10;
 

--- a/arcane/src/arcane/core/materials/ComponentItemVector.cc
+++ b/arcane/src/arcane/core/materials/ComponentItemVector.cc
@@ -56,25 +56,6 @@ _setItems(ConstArrayView<ConstituentItemIndex> globals,
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ComponentItemVector::
-_setMatVarIndexes(ConstArrayView<MatVarIndex> globals,
-                  ConstArrayView<MatVarIndex> multiples)
-{
-  m_p->_setMatVarIndexes(globals, multiples);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ComponentItemVector::
-_setLocalIds(ConstArrayView<Int32> globals, ConstArrayView<Int32> multiples)
-{
-  m_p->_setLocalIds(globals, multiples);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 ComponentItemVectorView ComponentItemVector::
 view() const
 {

--- a/arcane/src/arcane/core/materials/ComponentItemVector.h
+++ b/arcane/src/arcane/core/materials/ComponentItemVector.h
@@ -47,10 +47,6 @@ class IConstituentItemVectorImpl
 
  protected:
 
-  virtual void _setMatVarIndexes(ConstArrayView<MatVarIndex> globals,
-                                 ConstArrayView<MatVarIndex> multiples) = 0;
-  virtual void _setLocalIds(ConstArrayView<Int32> globals,
-                            ConstArrayView<Int32> multiples) = 0;
   virtual ComponentItemVectorView _view() const = 0;
   virtual ComponentPurePartItemVectorView _pureItems() const = 0;
   virtual ComponentImpurePartItemVectorView _impureItems() const = 0;
@@ -87,9 +83,6 @@ class IConstituentItemVectorImpl
  */
 class ARCANE_CORE_EXPORT ComponentItemVector
 {
-  friend class EnvCellVector;
-  friend class MatCellVector;
-
  public:
 
   //! Constructeur de recopie. Cette instance fait ensuite référence à \a rhs
@@ -129,7 +122,7 @@ class ARCANE_CORE_EXPORT ComponentItemVector
   //! Liste des entités impures (partielles) du composant
   ComponentImpurePartItemVectorView impureItems() const;
 
- private:
+ protected:
 
   ConstArrayView<MatVarIndex> _matvarIndexes() const;
   ConstituentItemLocalIdListView _constituentItemListView() const;
@@ -138,9 +131,6 @@ class ARCANE_CORE_EXPORT ComponentItemVector
 
   void _setItems(ConstArrayView<ConstituentItemIndex> globals,
                  ConstArrayView<ConstituentItemIndex> multiples);
-  void _setMatVarIndexes(ConstArrayView<MatVarIndex> globals,
-                         ConstArrayView<MatVarIndex> multiples);
-  void _setLocalIds(ConstArrayView<Int32> globals, ConstArrayView<Int32> multiples);
   ConstArrayView<Int32> _localIds() const;
   IMeshMaterialMng* _materialMng() const;
   IMeshComponent* _component() const;

--- a/arcane/src/arcane/core/materials/EnvItemVector.cc
+++ b/arcane/src/arcane/core/materials/EnvItemVector.cc
@@ -53,32 +53,22 @@ EnvCellVector(CellVectorView view,IMeshEnvironment* environment)
 void EnvCellVector::
 _build(CellVectorView view)
 {
-  FixedArray<UniqueArray<ConstituentItemIndex>,2> internals;
-  FixedArray<UniqueArray<MatVarIndex>,2> matvar_indexes;
-  FixedArray<UniqueArray<Int32>,2> local_ids;
+  FixedArray<UniqueArray<ConstituentItemIndex>, 2> item_indexes;
   IMeshComponent* my_component = _component();
+
   ENUMERATE_ALLENVCELL(iallenvcell,_materialMng()->view(view)){
     AllEnvCell all_env_cell = *iallenvcell;
     ENUMERATE_CELL_ENVCELL(ienvcell,all_env_cell){
       EnvCell ec = *ienvcell;
       if (ec.component()==my_component){
         MatVarIndex idx = ec._varIndex();
-        if (idx.arrayIndex()==0){
-          internals[0].add(ec._constituentItemIndex());
-          matvar_indexes[0].add(idx);
-          local_ids[0].add(ec.globalCell().localId());
-        }
-        else{
-          internals[1].add(ec._constituentItemIndex());
-          matvar_indexes[1].add(idx);
-          local_ids[1].add(ec.globalCell().localId());
-        }
+        ConstituentItemIndex cii = ec._constituentItemIndex();
+        Int32 array_index = (idx.arrayIndex() == 0) ? 0 : 1;
+        item_indexes[array_index].add(cii);
       }
     }
   }
-  this->_setItems(internals[0],internals[1]);
-  this->_setMatVarIndexes(matvar_indexes[0],matvar_indexes[1]);
-  this->_setLocalIds(local_ids[0],local_ids[1]);
+  this->_setItems(item_indexes[0], item_indexes[1]);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/MatItemVector.cc
+++ b/arcane/src/arcane/core/materials/MatItemVector.cc
@@ -50,9 +50,7 @@ MatCellVector(CellVectorView view,IMeshMaterial* material)
 void MatCellVector::
 _build(CellVectorView view)
 {
-  FixedArray<UniqueArray<ConstituentItemIndex>,2> internals;
-  FixedArray<UniqueArray<MatVarIndex>,2> matvar_indexes;
-  FixedArray<UniqueArray<Int32>,2> local_ids;
+  FixedArray<UniqueArray<ConstituentItemIndex>, 2> item_indexes;
   IMeshComponent* my_component = _component();
 
   ENUMERATE_ALLENVCELL(iallenvcell,_materialMng()->view(view)){
@@ -62,23 +60,14 @@ _build(CellVectorView view)
         MatCell mc = *imatcell;
         if (mc.component()==my_component){
           MatVarIndex idx = mc._varIndex();
-          if (idx.arrayIndex()==0){
-            internals[0].add(mc._constituentItemIndex());
-            matvar_indexes[0].add(idx);
-            local_ids[0].add(mc.globalCell().localId());
-          }
-          else{
-            internals[1].add(mc._constituentItemIndex());
-            matvar_indexes[1].add(idx);
-            local_ids[1].add(mc.globalCell().localId());
-          }
+          ConstituentItemIndex cii = mc._constituentItemIndex();
+          Int32 array_index = (idx.arrayIndex() == 0) ? 0 : 1;
+          item_indexes[array_index].add(cii);
         }
       }
     }
   }
-  this->_setItems(internals[0],internals[1]);
-  this->_setMatVarIndexes(matvar_indexes[0],matvar_indexes[1]);
-  this->_setLocalIds(local_ids[0],local_ids[1]);
+  this->_setItems(item_indexes[0], item_indexes[1]);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
+++ b/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
@@ -35,7 +35,7 @@ ConstituentItemVectorImpl(IMeshComponent* component)
 , m_component(component)
 , m_matvar_indexes(platform::getDefaultDataAllocator())
 , m_items_local_id(platform::getDefaultDataAllocator())
-  , m_part_data(std::make_unique<MeshComponentPartData>(component,String()))
+, m_part_data(std::make_unique<MeshComponentPartData>(component, String()))
 {
   Int32 level = -1;
   if (component->isMaterial())
@@ -44,8 +44,8 @@ ConstituentItemVectorImpl(IMeshComponent* component)
     level = LEVEL_ENVIRONMENT;
   else
     ARCANE_FATAL("Bad internal type of component");
-  ComponentItemSharedInfo* shared_info = m_material_mng->_internalApi()->componentItemSharedInfo(level);
-  m_constituent_list = std::make_unique<ConstituentItemLocalIdList>(shared_info,String());
+  m_component_shared_info = m_material_mng->_internalApi()->componentItemSharedInfo(level);
+  m_constituent_list = std::make_unique<ConstituentItemLocalIdList>(m_component_shared_info, String());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -65,43 +65,51 @@ ConstituentItemVectorImpl(const ComponentItemVectorView& rhs)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ConstituentItemVectorImpl::
-_setMatVarIndexes(ConstArrayView<MatVarIndex> globals,
-                  ConstArrayView<MatVarIndex> multiples)
-{
-  Integer nb_global = globals.size();
-  Integer nb_multiple = multiples.size();
-
-  m_matvar_indexes.resize(nb_global + nb_multiple);
-
-  m_matvar_indexes.subView(0, nb_global).copy(globals);
-  m_matvar_indexes.subView(nb_global, nb_multiple).copy(multiples);
-  m_part_data->_setFromMatVarIndexes(globals, multiples);
-}
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 void ConstituentItemVectorImpl::
-_setLocalIds(ConstArrayView<Int32> globals, ConstArrayView<Int32> multiples)
+_setItems(ConstArrayView<ConstituentItemIndex> globals,
+          ConstArrayView<ConstituentItemIndex> multiples)
 {
-  Integer nb_global = globals.size();
-  Integer nb_multiple = multiples.size();
+  m_constituent_list->copyPureAndPartial(globals, multiples);
 
-  m_items_local_id.resize(nb_global + nb_multiple);
+  // TODO: Ne pas remettre à jour systématiquement les
+  // 'm_items_local_id' mais ne le faire qu'à la demande
+  // car ils ne sont pas utilisés souvent.
+  Int32 nb_pure = globals.size();
+  Int32 nb_impure = multiples.size();
 
-  m_items_local_id.subView(0, nb_global).copy(globals);
-  m_items_local_id.subView(nb_global, nb_multiple).copy(multiples);
+  m_matvar_indexes.resize(nb_pure + nb_impure);
+  m_items_local_id.resize(nb_pure + nb_impure);
+
+  ComponentItemSharedInfo* cisi = m_component_shared_info;
+
+  for (Int32 i = 0; i < nb_pure; ++i) {
+    ConstituentItemIndex cii = globals[i];
+    m_matvar_indexes[i] = cisi->_varIndex(cii);
+    m_items_local_id[i] = cisi->_globalItemBase(cii).localId();
+  }
+
+  for (Int32 i = 0; i < nb_impure; ++i) {
+    ConstituentItemIndex cii = multiples[i];
+    m_matvar_indexes[nb_pure + i] = cisi->_varIndex(cii);
+    m_items_local_id[nb_pure + i] = cisi->_globalItemBase(cii).localId();
+  }
+
+  // Mise à jour de MeshComponentPartData
+  auto mvi_pure_view = m_matvar_indexes.subView(0, nb_pure);
+  auto mvi_impure_view = m_matvar_indexes.subView(nb_pure, nb_impure);
+  m_part_data->_setFromMatVarIndexes(mvi_pure_view, mvi_impure_view);
 }
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 ComponentItemVectorView ConstituentItemVectorImpl::
 _view() const
 {
-  return ComponentItemVectorView(m_component, m_matvar_indexes,
-                                 m_constituent_list->view(), m_items_local_id);
+  return { m_component, m_matvar_indexes,
+           m_constituent_list->view(), m_items_local_id };
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
+++ b/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
@@ -76,22 +76,7 @@ _setMatVarIndexes(ConstArrayView<MatVarIndex> globals,
 
   m_matvar_indexes.subView(0, nb_global).copy(globals);
   m_matvar_indexes.subView(nb_global, nb_multiple).copy(multiples);
-
-  {
-    Int32Array& idx = m_part_data->_mutableValueIndexes(eMatPart::Pure);
-    idx.resize(nb_global);
-    for (Integer i = 0; i < nb_global; ++i)
-      idx[i] = globals[i].valueIndex();
-  }
-
-  {
-    Int32Array& idx = m_part_data->_mutableValueIndexes(eMatPart::Impure);
-    idx.resize(nb_multiple);
-    for (Integer i = 0; i < nb_multiple; ++i)
-      idx[i] = multiples[i].valueIndex();
-  }
-
-  m_part_data->_notifyValueIndexesChanged(nullptr);
+  m_part_data->_setFromMatVarIndexes(globals, multiples);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/ConstituentItemVectorImpl.h
+++ b/arcane/src/arcane/materials/internal/ConstituentItemVectorImpl.h
@@ -52,10 +52,6 @@ class ConstituentItemVectorImpl
 
  private:
 
-  void _setMatVarIndexes(ConstArrayView<MatVarIndex> globals,
-                         ConstArrayView<MatVarIndex> multiples) override;
-  void _setLocalIds(ConstArrayView<Int32> globals,
-                    ConstArrayView<Int32> multiples) override;
   ComponentItemVectorView _view() const override;
   ComponentPurePartItemVectorView _pureItems() const override
   {
@@ -78,10 +74,7 @@ class ConstituentItemVectorImpl
     return m_matvar_indexes;
   }
   void _setItems(ConstArrayView<ConstituentItemIndex> globals,
-                 ConstArrayView<ConstituentItemIndex> multiples) override
-  {
-    m_constituent_list->copyPureAndPartial(globals, multiples);
-  }
+                 ConstArrayView<ConstituentItemIndex> multiples) override;
 
  public:
 
@@ -91,6 +84,7 @@ class ConstituentItemVectorImpl
   UniqueArray<Int32> m_items_local_id;
   std::unique_ptr<MeshComponentPartData> m_part_data;
   std::unique_ptr<ConstituentItemLocalIdList> m_constituent_list;
+  ComponentItemSharedInfo* m_component_shared_info = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/ConstituentItemVectorImpl.h
+++ b/arcane/src/arcane/materials/internal/ConstituentItemVectorImpl.h
@@ -14,8 +14,10 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/TraceAccessor.h"
 #include "arccore/base/ReferenceCounterImpl.h"
+
+#include "arcane/utils/TraceAccessor.h"
+#include "arcane/utils/Functor.h"
 
 #include "arcane/core/materials/ComponentItemVector.h"
 #include "arcane/core/materials/internal/ConstituentItemLocalIdList.h"
@@ -76,6 +78,10 @@ class ConstituentItemVectorImpl
   void _setItems(ConstArrayView<ConstituentItemIndex> globals,
                  ConstArrayView<ConstituentItemIndex> multiples) override;
 
+ private:
+
+  void _recomputePartData();
+
  public:
 
   IMeshMaterialMng* m_material_mng = nullptr;
@@ -85,6 +91,12 @@ class ConstituentItemVectorImpl
   std::unique_ptr<MeshComponentPartData> m_part_data;
   std::unique_ptr<ConstituentItemLocalIdList> m_constituent_list;
   ComponentItemSharedInfo* m_component_shared_info = nullptr;
+
+  FunctorT<ConstituentItemVectorImpl> m_recompute_part_data_functor;
+  // Seulement utile pour le re-calcul à la volée
+  Int32 m_nb_pure = 0;
+  // Seulement utile pour le re-calcul à la volée
+  Int32 m_nb_impure = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/MeshComponentData.h
+++ b/arcane/src/arcane/materials/internal/MeshComponentData.h
@@ -15,6 +15,7 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/TraceAccessor.h"
+#include "arcane/utils/Functor.h"
 
 #include "arcane/core/ItemGroup.h"
 #include "arcane/core/materials/MatItem.h"
@@ -139,10 +140,12 @@ class MeshComponentData
   ConstituentItemLocalIdList m_constituent_local_id_list;
 
   MeshComponentPartData* m_part_data = nullptr;
+  FunctorT<MeshComponentData> m_recompute_part_data_functor;
 
  private:
 
   void _setPartInfo();
+  void _rebuildPartDataDirect();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/MeshComponentPartData.h
+++ b/arcane/src/arcane/materials/internal/MeshComponentPartData.h
@@ -48,16 +48,27 @@ class MeshComponentPartData
 
   IMeshComponent* component() const { return m_component; }
 
-  void checkValid() const;
+  void checkValid();
 
   //! Vue sur la partie pure
-  ComponentPurePartItemVectorView pureView() const;
+  ComponentPurePartItemVectorView pureView();
 
   //! Vue sur la partie impure
-  ComponentImpurePartItemVectorView impureView() const;
+  ComponentImpurePartItemVectorView impureView();
 
   //! Vue sur la partie \a part
-  ComponentPartItemVectorView partView(eMatPart part) const;
+  ComponentPartItemVectorView partView(eMatPart part);
+
+  /*
+   * \brief Fonctor pour recalculer les parties pures et impures suite à une modification.
+   *
+   * Si ce fonctor n'est pas positionné, alors il faut mettre à jour manuellement
+   * l'instance via l'appel à _setFromMatVarIndexes(). \a func doit rester valide
+   * durant toute la durée de vie de cette instance
+   */
+  void setRecomputeFunctor(IFunctor* func) { m_compute_functor = func; }
+
+  void setNeedRecompute() { m_is_need_recompute = true; }
 
  public:
 
@@ -83,10 +94,17 @@ class MeshComponentPartData
   //! Liste des ComponentItem pour ce constituant.
   ConstituentItemLocalIdListView m_constituent_list_view;
 
+  IFunctor* m_compute_functor = nullptr;
+  bool m_is_need_recompute = false;
+
  public:
 
   // Cette fonction est privée mais doit être rendue publique pour compiler avec CUDA.
   void _notifyValueIndexesChanged(RunQueue* queue);
+
+ private:
+
+  void _checkNeedRecompute();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/MeshComponentPartData.h
+++ b/arcane/src/arcane/materials/internal/MeshComponentPartData.h
@@ -38,10 +38,6 @@ namespace Arcane::Materials
 class MeshComponentPartData
 : public TraceAccessor
 {
-  friend class MeshComponentData;
-  friend class ComponentItemVector;
-  friend class ConstituentItemVectorImpl;
-
  public:
 
   MeshComponentPartData(IMeshComponent* component,const String& debug_name);
@@ -65,33 +61,10 @@ class MeshComponentPartData
 
  public:
 
-  Int32ConstArrayView valueIndexes(eMatPart k) const
-  {
-    return m_value_indexes[(Int32)k];
-  }
-
-  Int32ConstArrayView itemIndexes(eMatPart k) const
-  {
-    return m_items_internal_indexes[(Int32)k];
-  }
-
- private:
-
-  void _setConstituentListView(const ConstituentItemLocalIdListView& v)
-  {
-    m_constituent_list_view = v;
-  }
-
-  //! Il faut appeler notifyValueIndexesChanged() après modification du tableau.
-  Int32Array& _mutableValueIndexes(eMatPart k)
-  {
-    return m_value_indexes[(Int32)k];
-  }
-
- public:
-
+  void _setConstituentListView(const ConstituentItemLocalIdListView& v);
   void _setFromMatVarIndexes(ConstArrayView<MatVarIndex> matvar_indexes, RunQueue& queue);
-  void _notifyValueIndexesChanged(RunQueue* queue);
+  void _setFromMatVarIndexes(ConstArrayView<MatVarIndex> globals,
+                             ConstArrayView<MatVarIndex> multiples);
 
  private:
 
@@ -109,6 +82,11 @@ class MeshComponentPartData
 
   //! Liste des ComponentItem pour ce constituant.
   ConstituentItemLocalIdListView m_constituent_list_view;
+
+ public:
+
+  // Cette fonction est privée mais doit être rendue publique pour compiler avec CUDA.
+  void _notifyValueIndexesChanged(RunQueue* queue);
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Computing information in `MeshComponentPartData` is costly and it is done every time we modify materials. 
With lazy evalution these information are only computed if needed.