### PR TITLE
Use 'GC.Server' configuration for '.Net 8'

### DIFF
--- a/arcane/src/arcane/tests/ArcaneTestExe.csproj.in
+++ b/arcane/src/arcane/tests/ArcaneTestExe.csproj.in
@@ -5,6 +5,10 @@
   <PropertyGroup>
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Needed with .Net 8 to prevent FPE in garbage collection -->
+    <ServerGarbageCollection Condition="'$(TargetFramework)'=='net8' or $(TargetFramework)=='netcoreapp8.0'">true</ServerGarbageCollection>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="@CSPATH@/Main.cs" />
   </ItemGroup>

--- a/arcane/tools/wrapper/main/Arcane.Main.csproj.in
+++ b/arcane/tools/wrapper/main/Arcane.Main.csproj.in
@@ -8,6 +8,11 @@
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Needed with .Net 8 to prevent FPE in garbage collection -->
+    <ServerGarbageCollection Condition="'$(TargetFramework)'=='net8' or $(TargetFramework)=='netcoreapp8.0'">true</ServerGarbageCollection>
+  </PropertyGroup>
+
   <!-- Infos pour NuGet -->
   <PropertyGroup>
     <PackageVersion>@ARCANE_VERSION@</PackageVersion>


### PR DESCRIPTION
With `.Net 8`, there may be speculative division by zero during garbage collection. Because with Arcane FPE are enabled, this leads to a SIGFPE. To prevent that, we use the `GC.Server` setting to switch to server GC which does not do this speculative division per zero. This problem is fixed in `.Net 9` (see https://github.com/dotnet/runtime/pull/93517)