### PR TITLE
Use 'Sequential' message passing service for sequential tests

### DIFF
--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -278,22 +278,22 @@ arcane_add_test_parallel(cartesian3d_grid_partitioning_12proc testCartesianMesh3
 # Ces tests ont besoin d'Aleph
 # TODO: faire des tests sans avoir besoin de Aleph
 if (TARGET arcane_aleph_hypre)
-  ARCANE_ADD_TEST_SEQUENTIAL(cartesianMeshGenerator testCartesianMeshGenerator.arc "-m 1")
+  arcane_add_test_parallel(cartesianMeshGenerator testCartesianMeshGenerator.arc 1 "-m 1")
   ARCANE_ADD_TEST_PARALLEL(cartesianMeshGenerator testCartesianMeshGenerator.arc 8 "-m 1")
 
-  ARCANE_ADD_TEST_SEQUENTIAL(cartesianMeshGenerator2D testCartesianMeshGenerator2D.arc)
+  arcane_add_test_parallel(cartesianMeshGenerator2D testCartesianMeshGenerator2D.arc 1)
   ARCANE_ADD_TEST_PARALLEL(cartesianMeshGenerator2D testCartesianMeshGenerator2D.arc 4)
 
-  ARCANE_ADD_TEST_SEQUENTIAL(cartesianMeshGenerator2D-meshservice testCartesianMeshGenerator2D-meshservice.arc)
+  arcane_add_test_parallel(cartesianMeshGenerator2D-meshservice testCartesianMeshGenerator2D-meshservice.arc 1)
   ARCANE_ADD_TEST_PARALLEL(cartesianMeshGenerator2D-meshservice testCartesianMeshGenerator2D-meshservice.arc 4)
 
-  ARCANE_ADD_TEST_SEQUENTIAL(cartesianMeshGeneratorModulo testCartesianMeshGeneratorModulo.arc)
+  arcane_add_test_parallel(cartesianMeshGeneratorModulo testCartesianMeshGeneratorModulo.arc 1)
   ARCANE_ADD_TEST_PARALLEL(cartesianMeshGeneratorModulo testCartesianMeshGeneratorModulo.arc 3)
 
-  ARCANE_ADD_TEST_SEQUENTIAL(cartesianMeshGeneratorOrigin testCartesianMeshGeneratorOrigin.arc)
+  arcane_add_test_parallel(cartesianMeshGeneratorOrigin testCartesianMeshGeneratorOrigin.arc 1)
   ARCANE_ADD_TEST_PARALLEL(cartesianMeshGeneratorOrigin testCartesianMeshGeneratorOrigin.arc 4)
 
-  ARCANE_ADD_TEST_SEQUENTIAL(cartesianMeshGeneratorOrigin2D testCartesianMeshGeneratorOrigin2D.arc)
+  arcane_add_test_parallel(cartesianMeshGeneratorOrigin2D testCartesianMeshGeneratorOrigin2D.arc 1)
   ARCANE_ADD_TEST_PARALLEL(cartesianMeshGeneratorOrigin2D testCartesianMeshGeneratorOrigin2D.arc 4)
 endif()
 

--- a/arcane/cmake/GlobalCSharpCommand.cmake
+++ b/arcane/cmake/GlobalCSharpCommand.cmake
@@ -7,7 +7,7 @@ if(ARCANE_USE_GLOBAL_CSHARP)
   if (NOT _msbuild_exe)
     logFatalError("In ${_func_name}: 'msbuild' command for runtime '${ARGS_DOTNET_RUNTIME}' is not available.")
   endif()
-  set(ARGS_MSBUILD_ARGS "/p:BinDir=${ARCANE_CSHARP_PROJECT_PATH}")
+  set(ARGS_MSBUILD_ARGS "/p:BinDir=${ARCANE_CSHARP_PROJECT_PATH}/bin_dir/")
   set(_RESTORE_BUILD_ARGS build BuildAllCSharp.proj /t:Restore ${ARGS_MSBUILD_ARGS} )
   set(_BUILD_ARGS publish --no-restore BuildAllCSharp.proj /t:PublishAndPack /p:PublishDir=${ARCANE_DOTNET_PUBLISH_PATH}/ ${ARGS_MSBUILD_ARGS} )
 

--- a/arcane/src/arcane/impl/ArcaneMain.cc
+++ b/arcane/src/arcane/impl/ArcaneMain.cc
@@ -316,6 +316,8 @@ class ArcaneMainAutoDetectRuntimeHelper
     if (x->m_nb_autodetect > 0)
       return x->m_autodetect_return_value;
 
+    ArcaneMain::_setArcaneLibraryPath();
+
     std::chrono::high_resolution_clock clock;
 
     // TODO: rendre thread-safe
@@ -705,7 +707,6 @@ _checkCreateDynamicLibraryLoader()
   auto x = platform::getDynamicLibraryLoader();
   if (!x) {
     platform::setDynamicLibraryLoader(createGlibDynamicLibraryLoader());
-    _setArcaneLibraryPath();
   }
 }
 

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
@@ -487,13 +487,19 @@ namespace Arcane.ExecDrivers.Common
           Console.WriteLine("ArgsForArcane: {0}", x);
         }
         if (m_properties.NbIteration >= 1) {
-          args.Add("-arcane_opt");
-          args.Add("max_iteration");
-          args.Add(m_properties.NbIteration.ToString());
+          args.Add("-A,MaxIteration="+m_properties.NbIteration.ToString());
         }
         if (current_exec != 0) {
           args.Add("-arcane_opt");
           args.Add("continue");
+        }
+        // En séquentiel pure, ne charge pas l'environnement MPI.
+        // Cela permet de gagner du temps lors de l'initialisation et de permettre
+        // de lancer directement l'exécutable sans passer par 'mpiexec'.
+        if (m_properties.NbProc==0 && m_properties.NbSharedMemorySubDomain==0){
+          string env_parallel_service = Utils.GetEnvironmentVariable("ARCANE_PARALLEL_SERVICE");
+          if (String.IsNullOrEmpty(env_parallel_service))
+            args.Add("-A,MessagePassingService=Sequential");
         }
         if (OnAddAdditionalArgs != null)
           OnAddAdditionalArgs(this);


### PR DESCRIPTION
Initializing MPI environment may take some time (1s) with some runtime so disabling initialization will accelerate the CI.
It will also allow launching the sequential tests without having to use launcher (i.e: `mpiexec`).