### PR TITLE
Add additional capacity when reallocation materials variables

### DIFF
--- a/arcane/src/arcane/core/Variable.cc
+++ b/arcane/src/arcane/core/Variable.cc
@@ -154,6 +154,7 @@ class VariablePrivate
   //!@{ \name Implémentation de IVariableInternal
   String computeComparisonHashCollective(IHashAlgorithm* hash_algo, IData* sorted_data) override;
   void changeAllocator(const MemoryAllocationOptions& alloc_info) override;
+  void resizeWithReserve(Int32 new_size,Int32 additional_capacity) override;
   //!@}
 
  private:
@@ -950,14 +951,23 @@ serialize(ISerializer* sbuffer,IDataOperation* operation)
 /*---------------------------------------------------------------------------*/
 
 void Variable::
-resize(Integer new_size)
+_resizeWithReserve(Int32 new_size,Int32 additional_capacity)
 {
   eItemKind ik = itemKind();
   if (ik!=IK_Unknown){
     ARCANE_FATAL("This call is invalid for item variable. Use resizeFromGroup() instead");
   }
-  _internalResize(new_size,0);
+  _internalResize(new_size, additional_capacity);
   syncReferences();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void Variable::
+resize(Integer new_size)
+{
+  _resizeWithReserve(new_size,0);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1435,6 +1445,15 @@ changeAllocator(const MemoryAllocationOptions& mem_options)
     dx->changeAllocator(mem_options);
     m_variable->syncReferences();
   }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariablePrivate::
+resizeWithReserve(Int32 new_size,Int32 additional_capacity)
+{
+  return m_variable->_resizeWithReserve(new_size,additional_capacity);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/Variable.h
+++ b/arcane/src/arcane/core/Variable.h
@@ -229,6 +229,10 @@ class ARCANE_CORE_EXPORT Variable
   // Temporaire pour test libération mémoire
   bool _wantShrink() const;
 
+  // Accès via VariablePrivate pour l'API interne
+  friend class VariablePrivate;
+  void _resizeWithReserve(Int32 new_size,Int32 additional_capacity);
+
  private:
 
   VariablePrivate* m_p; //!< Implémentation

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -596,8 +596,7 @@ _internalResize(Integer new_size,Integer nb_additional_element)
 template<typename DataType> void VariableArrayT<DataType>::
 resizeWithReserve(Integer n,Integer nb_additional)
 {
-  _internalResize(n,nb_additional);
-  syncReferences();
+  _resizeWithReserve(n,nb_additional);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/IVariableInternal.h
+++ b/arcane/src/arcane/core/internal/IVariableInternal.h
@@ -62,6 +62,9 @@ class ARCANE_CORE_EXPORT IVariableInternal
    * \warning For experimental use only.
    */
   virtual void changeAllocator(const MemoryAllocationOptions& alloc_info) = 0;
+
+  //! Redimensionne la variable en ajoutant une capacité additionnelle
+  virtual void resizeWithReserve(Int32 new_size,Int32 additional_capacity) =0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -249,10 +249,8 @@ class MaterialVariableArrayTraits
   {
     view.copy(v);
   }
-  static void resizeWithReserve(PrivatePartType* var, Integer new_size)
-  {
-    var->resize(new_size);
-  }
+  ARCANE_MATERIALS_EXPORT
+  static void resizeWithReserve(PrivatePartType* var, Integer new_size);
   static Span<std::byte> toBytes(Array2View<DataType> view)
   {
     Span<DataType> s(view.data(),view.totalNbElement());

--- a/arcane/src/arcane/materials/MeshMaterialVariableArray.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableArray.cc
@@ -30,6 +30,7 @@
 #include "arcane/core/VariableRefArray2.h"
 #include "arcane/core/MeshVariable.h"
 #include "arcane/core/ISerializer.h"
+#include "arcane/core/internal/IVariableInternal.h"
 
 #include "arcane/materials/ItemMaterialVariableBaseT.H"
 
@@ -79,6 +80,19 @@ resizeAndFillWithDefault(ValueDataType* data,ContainerType& container,Integer di
   //TODO: faire une version de Array2 qui spécifie une valeur à donner
   // pour initialiser lors d'un resize() (comme pour Array::resize()).
   container.resize(dim1_size,dim2_size);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template<typename DataType> void
+MaterialVariableArrayTraits<DataType>::
+resizeWithReserve(PrivatePartType* var,Integer dim1_size)
+{
+  // Pour éviter de réallouer à chaque fois qu'il y a une augmentation du
+  // nombre de mailles matériaux, alloue un petit peu plus que nécessaire.
+  // Par défaut, on alloue 5% de plus.
+  var->_internalApi()->resizeWithReserve(dim1_size, dim1_size/20);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
@@ -40,6 +40,7 @@
 #include "arcane/core/IParallelExchanger.h"
 #include "arcane/core/ISerializer.h"
 #include "arcane/core/ISerializeMessage.h"
+#include "arcane/core/internal/IVariableInternal.h"
 #include "arcane/core/materials/internal/IMeshComponentInternal.h"
 #include "arcane/core/VariableInfo.h"
 #include "arcane/core/VariableRefArray.h"
@@ -126,15 +127,7 @@ resizeWithReserve(PrivatePartType* var,Integer dim1_size)
   // Pour éviter de réallouer à chaque fois qu'il y a une augmentation du
   // nombre de mailles matériaux, alloue un petit peu plus que nécessaire.
   // Par défaut, on alloue 5% de plus.
-  Integer capacity = var->capacity();
-  Integer reserve_size = 0;
-  if (dim1_size>=capacity && reserve_size>0){
-    Integer additional_size = CheckedConvert::toInteger((Real)dim1_size * 1.05);
-    additional_size = math::max(additional_size,1024);
-    var->resizeWithReserve(dim1_size,additional_size);
-  }
-  else
-    var->resize(dim1_size);
+  var->_internalApi()->resizeWithReserve(dim1_size, dim1_size/20);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The additional capacity is 5% at the moment.
This will reduce the number of reallocation which can be costly when using accelerators.