### PR TITLE
Minor optimizations in material update

### DIFF
--- a/arcane/src/arcane/materials/MeshEnvironment.cc
+++ b/arcane/src/arcane/materials/MeshEnvironment.cc
@@ -207,7 +207,7 @@ void MeshEnvironment::
 computeMaterialIndexes(ComponentItemInternalData* item_internal_data, RunQueue& queue)
 {
   info(4) << "Compute (V2) indexes for environment name=" << name();
-  const bool is_mono_mat = (nbMaterial() == 1 && (cells().size() == totalNbCellMat()));
+  const bool is_mono_mat = isMonoMaterial();
   if (is_mono_mat) {
     _computeMaterialIndexesMonoMat(item_internal_data, queue);
   }
@@ -628,6 +628,16 @@ checkValid()
   for (IMeshMaterial* mat : m_materials) {
     mat->checkValid();
   }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool MeshEnvironment::
+isMonoMaterial() const
+{
+  bool is_mono_mat = (nbMaterial() == 1 && (cells().size() == totalNbCellMat()));
+  return is_mono_mat;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/AllEnvData.h
+++ b/arcane/src/arcane/materials/internal/AllEnvData.h
@@ -47,6 +47,10 @@ class AllEnvData
 
  public:
 
+  class RecomputeConstituentCellInfos;
+
+ public:
+
   explicit AllEnvData(MeshMaterialMng* mmg);
 
  public:
@@ -95,7 +99,8 @@ class AllEnvData
 
  public:
 
-  void _computeInfosForEnvCells();
+  void _computeInfosForAllEnvCells(RecomputeConstituentCellInfos& work_info);
+  void _computeInfosForEnvCells(RecomputeConstituentCellInfos& work_info);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/MeshEnvironment.h
+++ b/arcane/src/arcane/materials/internal/MeshEnvironment.h
@@ -133,6 +133,9 @@ class MeshEnvironment
   EnvImpurePartItemVectorView impureEnvItems() const override;
   EnvPartItemVectorView partEnvItems(eMatPart part) const override;
 
+  //! Indique si le milieu est mono-matériau
+  bool isMonoMaterial() const;
+
  public:
 
   IMeshComponentInternal* _internalApi() override { return &m_internal_api; }


### PR DESCRIPTION
- Remove usage of a temporary array
- Do not compute number of material per cell when the environment has only one material.