### PR TITLE
Improve service options in service/module description pages

### DIFF
--- a/arcane/doc/generate_axl_infos.sh.in
+++ b/arcane/doc/generate_axl_infos.sh.in
@@ -4,6 +4,7 @@ SOURCE_PATH=@CMAKE_SOURCE_DIR@
 AXL_OUTPATH=${BUILD_PATH}/share/axl
 mkdir ${AXL_OUTPATH}
 mkdir ${AXL_OUTPATH}/dox
+mkdir ${AXL_OUTPATH}/dox/snippets
 mkdir ${AXL_OUTPATH}/final_axl
 #${BUILD_PATH}/bin/axlcopy install -b ${SOURCE_PATH}/src -o ${AXL_OUTPATH} arcane/std
 export STDENV_CODE_NAME=Arcane
@@ -11,5 +12,6 @@ ${BUILD_PATH}/bin/arcane_test_driver launch -arcane_opt arcane_internal
 /bin/rm ${AXL_OUTPATH}/final_axl/*.axl
 /bin/rm ${AXL_OUTPATH}/dox/*.dox
 /bin/rm ${AXL_OUTPATH}/dox/*.md
+/bin/rm ${AXL_OUTPATH}/dox/snippets/*.md
 ${BUILD_PATH}/bin/axldoc --generate-final -a ${BUILD_PATH}/lib/arcane_internal.xml -o ${AXL_OUTPATH}/final_axl ${AXL_OUTPATH}
 ${BUILD_PATH}/bin/axldoc -u @IS_FOR@ -a ${AXL_OUTPATH}/final_axl/final_internal.xml @ARCANEDOC_AXLDOC_LEGACY@ -o ${AXL_OUTPATH}/dox ${AXL_OUTPATH}/final_axl/*.axl

--- a/arcane/doc/theme/css/custom.css
+++ b/arcane/doc/theme/css/custom.css
@@ -376,3 +376,19 @@ details[open] summary::before {
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
+
+/*
+ * Début : Personnalisation de la partie axldoc.
+ */
+#FullDescServiceModule {
+  color: var(--page-foreground-color) !important;
+  text-shadow: none;
+}
+
+/*
+ * Fin : Personnalisation de la partie axldoc.
+ */
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/doc/theme/css/custom.css
+++ b/arcane/doc/theme/css/custom.css
@@ -381,11 +381,15 @@ details[open] summary::before {
 /*
  * Début : Personnalisation de la partie axldoc.
  */
-#FullDescServiceModule {
+.full_desc_service_module {
   color: var(--page-foreground-color) !important;
   text-shadow: none;
 }
 
+.label_option_type {
+  font-size: 8pt !important;
+  font-weight: bold;
+}
 /*
  * Fin : Personnalisation de la partie axldoc.
  */

--- a/arcane/doc/userdoc.doxyfile
+++ b/arcane/doc/userdoc.doxyfile
@@ -1077,7 +1077,7 @@ EXAMPLE_PATH           = @ARCANE_CEA_SOURCE_PATH@/src/arcane/tests \
                          @ARCANESRCROOT@/samples_build/samples \
                          @Arcane_SOURCE_DIR@/src/arcane/tests \
                          @ARCANESRCROOT@/doc/doc_common/chap_build_install/subchap_prerequisites/snippets \
-                         @DOC_OUTPUT_DIR@/share/axl/dox
+                         @DOC_OUTPUT_DIR@/share/axl/dox/snippets
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/arcane/doc/userdoc.doxyfile
+++ b/arcane/doc/userdoc.doxyfile
@@ -1076,7 +1076,8 @@ EXAMPLE_PATH           = @ARCANE_CEA_SOURCE_PATH@/src/arcane/tests \
                          @Arcane_SOURCE_DIR@/src/arcane/tests/accelerator \
                          @ARCANESRCROOT@/samples_build/samples \
                          @Arcane_SOURCE_DIR@/src/arcane/tests \
-                         @ARCANESRCROOT@/doc/doc_common/chap_build_install/subchap_prerequisites/snippets
+                         @ARCANESRCROOT@/doc/doc_common/chap_build_install/subchap_prerequisites/snippets \
+                         @DOC_OUTPUT_DIR@/share/axl/dox
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationFile.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationFile.cs
@@ -79,6 +79,11 @@ namespace Arcane.AxlDoc
     {
       string file_name = String.Format ("{0}.md", m_page_name);
       string full_name = Path.Combine (m_output_path, file_name);
+
+      string snippet_name = String.Format ("snippet_{0}", m_page_name);
+      string snippet_file_name = String.Format ("{0}.md", snippet_name);
+      string snippet_full_name = Path.Combine (m_output_path, snippet_file_name);
+
       using (TextWriter tw = new StreamWriter (full_name, false, Utils.WriteEncoding)) {
         tw.WriteLine ("# {1} {{#{0}}}\n", m_page_name, m_page_title);
         string main_desc_string = m_main_desc_stream.ToString ();
@@ -94,9 +99,15 @@ namespace Arcane.AxlDoc
           else{
             tw.WriteLine ("\n## Summary of options\n");
           }
+
+          // if(false){
+          //   tw.WriteLine ("\\snippet{{doc}} {0} {1}", snippet_file_name, snippet_name);
+          // }
+          // else{
           tw.WriteLine("<ul>");
           tw.Write (m_brief_stream.ToString ());
           tw.WriteLine ("</ul>");
+          // }
         }
         if (!string.IsNullOrEmpty (m_full_stream.ToString ())) {
           if(m_language == "fr"){
@@ -107,6 +118,17 @@ namespace Arcane.AxlDoc
           }
           tw.Write(m_full_stream.ToString());
         }
+      }
+
+      // Génération des fichiers snippets avec les options des services/modules.
+      // Attention : Pour que ça fonctionne, il faut ajouter le dossier de sortie dans
+      // la partie "EXAMPLE_PATH" du .doxyfile.
+      using (TextWriter tw = new StreamWriter (snippet_full_name, false, Utils.WriteEncoding)) {
+        tw.WriteLine ("//![{0}]", snippet_name);
+        tw.WriteLine("<ul>");
+        tw.Write (m_brief_stream.ToString ());
+        tw.WriteLine ("</ul>");
+        tw.WriteLine ("//![{0}]", snippet_name);
       }
     }
 

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationFile.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationFile.cs
@@ -82,7 +82,7 @@ namespace Arcane.AxlDoc
 
       string snippet_name = String.Format ("snippet_{0}", m_page_name);
       string snippet_file_name = String.Format ("{0}.md", snippet_name);
-      string snippet_full_name = Path.Combine (m_output_path, snippet_file_name);
+      string snippet_full_name = Path.Combine (m_output_path, "snippets", snippet_file_name);
 
       using (TextWriter tw = new StreamWriter (full_name, false, Utils.WriteEncoding)) {
         tw.WriteLine ("# {1} {{#{0}}}\n", m_page_name, m_page_title);

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
@@ -134,11 +134,11 @@ namespace Arcane.AxlDoc
 
         if(m_code_info.Language == "fr"){
           _WriteHtmlOnly(m_full_stream, "<br>");
-          m_full_stream.WriteLine("Le nombre de sous-options étant trop élevé, \\subpage " + DoxygenDocumentationUtils.AnchorName(o) + " \"une page dédiée a été générée\".\n");
+          m_full_stream.WriteLine("Le nombre de sous-options étant trop élevé, \\subpage {0} \"une page dédiée a été générée\".\n", DoxygenDocumentationUtils.AnchorName(o));
         }
         else{
           _WriteHtmlOnly(m_full_stream, "<br>");
-          m_full_stream.WriteLine("The number of suboptions is too high. \\subpage " + DoxygenDocumentationUtils.AnchorName(o) + " \"A subpage has been generated\".\n");
+          m_full_stream.WriteLine("The number of suboptions is too high. \\subpage {0} \"A subpage has been generated\".\n", DoxygenDocumentationUtils.AnchorName(o));
         }
 
         _WriteAfterCode();
@@ -354,35 +354,43 @@ namespace Arcane.AxlDoc
           //Console.WriteLine("SERVICE TYPE FOUND={0}",o.Type);
           _WriteHtmlOnly(m_full_stream, "<div class='full_desc_service_module ServiceTable'>");
           if(m_code_info.Language == "fr"){
-            m_full_stream.WriteLine ("<dl><dt>Valeur{0} possible{0} pour le tag <i>name</i> :</dt>",
-                                     (interface_info.Services.Count>1)?"s":"");
+            _WriteHtmlOnly(m_full_stream, String.Format("<dl><dt>Valeur{0} possible{0} pour le tag <i>name</i> :</dt>",
+                                     (interface_info.Services.Count>1)?"s":""));
           }
           else{
-            m_full_stream.WriteLine ("<dl><dt>Possible value{0} for tag <i>name</i>:</dt>",
-                                     (interface_info.Services.Count>1)?"s":"");
+            _WriteHtmlOnly(m_full_stream, String.Format("<dl><dt>Possible value{0} for tag <i>name</i>:</dt>",
+                                     (interface_info.Services.Count>1)?"s":""));
           }
-          foreach (CodeServiceInfo csi in interface_info.Services) {
-            //Console.WriteLine("SERVICE TYPE FOUND={0} {1} {2}",o.Type,csi.Name,csi.FileBaseName);
 
+          // Ajout des différents services disponibles pour cette option.
+          // Avec un aperçu des options de ces services.
+          foreach (CodeServiceInfo csi in interface_info.Services) {
             _WriteHtmlOnly(m_full_stream, "<details>");
             _WriteHtmlOnly(m_full_stream, "<summary>");
-            if (csi.FileBaseName != null) {
-              m_full_stream.WriteLine ("\\ref axldoc_service_{0} \"{1}\"<br/>", csi.FileBaseName, csi.Name);
-            } else {
+            if (String.IsNullOrEmpty(csi.FileBaseName)) {
               m_full_stream.WriteLine ("{0}", csi.Name);
-            }
-            _WriteHtmlOnly(m_full_stream, "</summary>");
+              _WriteHtmlOnly(m_full_stream, "</summary>");
+              _WriteHtmlOnly(m_full_stream, "</details>");
+            } 
+            else {
+              m_full_stream.WriteLine ("\\ref axldoc_service_{0} \"{1}\"<br/>", csi.FileBaseName, csi.Name);
+              _WriteHtmlOnly(m_full_stream, "</summary>");
 
-            if(m_code_info.Language == "fr"){
-              m_full_stream.WriteLine ("Liste des options :");
-            }
-            else{
-              m_full_stream.WriteLine ("Summary of options:");
-            }
+              if(m_code_info.Language == "fr"){
+                m_full_stream.WriteLine ("Liste des options du service \\ref axldoc_service_{0} \"{1}\" :", csi.FileBaseName, csi.Name);
+              }
+              else{
+                m_full_stream.WriteLine ("Summary of options of \\ref axldoc_service_{0} \"{1}\" service:", csi.FileBaseName, csi.Name);
+              }
 
-            _WriteHtmlOnly(m_full_stream, "</details>");
+              // Attention : Pour que ça fonctionne, il faut ajouter le dossier de sortie dans
+              // la partie "EXAMPLE_PATH" du .doxyfile.
+              m_full_stream.WriteLine("\n\\snippet{{doc}} snippet_axldoc_service_{0}.md snippet_axldoc_service_{0}\n", csi.FileBaseName);
+
+              _WriteHtmlOnly(m_full_stream, "</details>");
+            }
           }
-          m_full_stream.WriteLine ("</dl>");
+          _WriteHtmlOnly(m_full_stream, "</dl>");
           _WriteHtmlOnly(m_full_stream, "</div>");
         }
       }

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
@@ -354,7 +354,7 @@ namespace Arcane.AxlDoc
           //Console.WriteLine("SERVICE TYPE FOUND={0}",o.Type);
           _WriteHtmlOnly(m_full_stream, "<div class='full_desc_service_module ServiceTable'>");
           if(m_code_info.Language == "fr"){
-            m_full_stream.WriteLine ("<dl><dt>Valeur{0} possible{0} pour le tag <i>name</i>:</dt>",
+            m_full_stream.WriteLine ("<dl><dt>Valeur{0} possible{0} pour le tag <i>name</i> :</dt>",
                                      (interface_info.Services.Count>1)?"s":"");
           }
           else{
@@ -363,11 +363,24 @@ namespace Arcane.AxlDoc
           }
           foreach (CodeServiceInfo csi in interface_info.Services) {
             //Console.WriteLine("SERVICE TYPE FOUND={0} {1} {2}",o.Type,csi.Name,csi.FileBaseName);
+
+            _WriteHtmlOnly(m_full_stream, "<details>");
+            _WriteHtmlOnly(m_full_stream, "<summary>");
             if (csi.FileBaseName != null) {
-              m_full_stream.WriteLine ("<dd>\\ref axldoc_service_{0} \"{1}\"<br/></dd>", csi.FileBaseName, csi.Name);
+              m_full_stream.WriteLine ("\\ref axldoc_service_{0} \"{1}\"<br/>", csi.FileBaseName, csi.Name);
             } else {
-              m_full_stream.WriteLine ("<dd>{0}</dd>", csi.Name);
+              m_full_stream.WriteLine ("{0}", csi.Name);
             }
+            _WriteHtmlOnly(m_full_stream, "</summary>");
+
+            if(m_code_info.Language == "fr"){
+              m_full_stream.WriteLine ("Liste des options :");
+            }
+            else{
+              m_full_stream.WriteLine ("Summary of options:");
+            }
+
+            _WriteHtmlOnly(m_full_stream, "</details>");
           }
           m_full_stream.WriteLine ("</dl>");
           _WriteHtmlOnly(m_full_stream, "</div>");
@@ -375,7 +388,7 @@ namespace Arcane.AxlDoc
       }
       _WriteAfterDescriptionsBeforeLabels();
 
-      _WriteLabels(color, "ServiceInstance");
+      _WriteLabels(color, "Service Instance");
 
       _WriteAfterLabelsBeforeCode();
 

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
@@ -116,20 +116,21 @@ namespace Arcane.AxlDoc
     {
       OptionTypeCounterVisitor otc = new OptionTypeCounterVisitor ();
       o.AcceptChildren (otc, x => m_config.private_app_pages.Filter(x));
+      string color = "purple";
 
       if (m_config.max_display_size > 0 && otc.NbTotalOption > m_config.max_display_size) {
 
-        _WriteHtmlOnly(m_full_stream, "<div class=\"ComplexOptionInfoBlock\">");
+        _WriteHtmlOnly(m_full_stream, "<div class='ComplexOptionInfoBlock'>");
 
-        _WriteColoredTitle("purple", o, true);
+        _WriteColoredTitle(color, o, true);
 
-        _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: purple;\">");
-        _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
+        _WriteBeforeDescriptions(color);
 
         _AddFullDescription(o);
 
-        _WriteHtmlOnly(m_full_stream, "</div>");
-        _WriteHtmlOnly(m_full_stream, "<div class=\"memdoc\">");
+        _WriteAfterDescriptionsBeforeLabels();
+        _WriteLabels(color, "Complex");
+        _WriteAfterLabelsBeforeCode();
 
         if(m_code_info.Language == "fr"){
           _WriteHtmlOnly(m_full_stream, "<br>");
@@ -140,8 +141,7 @@ namespace Arcane.AxlDoc
           m_full_stream.WriteLine("The number of suboptions is too high. \\subpage " + DoxygenDocumentationUtils.AnchorName(o) + " \"A subpage has been generated\".\n");
         }
 
-        _WriteHtmlOnly(m_full_stream, "</div>");
-        _WriteHtmlOnly(m_full_stream, "</div>");
+        _WriteAfterCode();
         _WriteHtmlOnly(m_full_stream, "</div>");
 
         _AddBriefDescription(o, true);
@@ -159,23 +159,24 @@ namespace Arcane.AxlDoc
         df.Write ();
       }
       else {
-        _WriteHtmlOnly(m_full_stream, "<div class=\"ComplexOptionInfoBlock\">");
+        _WriteHtmlOnly(m_full_stream, "<div class='ComplexOptionInfoBlock'>");
 
         // La partie "détail des méthodes" de doxygen se compose de trois parties :
         // - Un titre (h2 de classe .memtitle)
         // - Une partie "sous-titre" (div de classe .memitem.memproto)
         // - Une partie "description" (div de classe .memitem.memdoc)
 
-        _WriteColoredTitle ("purple", o, false);
+        _WriteColoredTitle (color, o, false);
 
-        _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: purple;\">");
-        _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
+        _WriteBeforeDescriptions(color);
 
         _AddBriefDescription(o, false);
         _AddFullDescription (o);
 
-        _WriteHtmlOnly(m_full_stream, "</div>");
-        _WriteHtmlOnly(m_full_stream, "<div class=\"memdoc\">");
+        _WriteAfterDescriptionsBeforeLabels();
+        _WriteLabels(color, "Complex");
+        _WriteAfterLabelsBeforeCode();
+
         if (otc.NbTotalOption > 0) {
           m_brief_stream.WriteLine ("<ul>");
           if (m_config.do_sort != SortMode.None)
@@ -185,8 +186,8 @@ namespace Arcane.AxlDoc
           m_brief_stream.WriteLine ("</ul>");
         }
         _WriteCode(o);
-        _WriteHtmlOnly(m_full_stream, "</div>");
-        _WriteHtmlOnly(m_full_stream, "</div>");
+        _WriteAfterCode();
+        
         _WriteHtmlOnly(m_full_stream, "</div><!-- End of ComplexOptionInfoBlock -->"); // Pour ComplexOptionInfoBlock
       }
     }
@@ -198,7 +199,8 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteColoredTitle ("olive", o, false);
+      string color = "olive";
+      _WriteColoredTitle (color, o, false);
       XmlDocument owner_doc = o.Node.OwnerDocument;
       XmlElement desc_elem = o.DescriptionElement;
       // Construit dans \a enum_list_element
@@ -244,8 +246,7 @@ namespace Arcane.AxlDoc
         tr.AppendChild (td2);
       }
       // enum_list_element.AppendChild (owner_doc.CreateElement ("br"));
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: olive;\">");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
+      _WriteBeforeDescriptions(color);
       _AddBriefDescription (o, false);
       if (desc_elem != null) {
         XmlElement elem_description = desc_elem.SelectSingleNode ("enum-description") as XmlElement;
@@ -259,11 +260,13 @@ namespace Arcane.AxlDoc
       }
       //m_full_stream.Write(enum_list_element.OuterXml);
       _AddFullDescription (o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memdoc\">");
+
+      _WriteAfterDescriptionsBeforeLabels();
+      _WriteLabels(color, "Enumeration");
+      _WriteAfterLabelsBeforeCode();
+
       _WriteCode(o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
-      _WriteHtmlOnly(m_full_stream, "</div>");
+      _WriteAfterCode();
     }
 
     public void VisitExtended (ExtendedOptionInfo o)
@@ -273,18 +276,20 @@ namespace Arcane.AxlDoc
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
 
-      _WriteColoredTitle ("teal", o, false);
+      string color = "teal";
+      _WriteColoredTitle (color, o, false);
 
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: teal;\">");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
+      _WriteBeforeDescriptions(color);
+
       _AddBriefDescription (o, false);
       _AddFullDescription (o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
 
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memdoc\">");
+      _WriteAfterDescriptionsBeforeLabels();
+      _WriteLabels(color, "Extended");
+      _WriteAfterLabelsBeforeCode();
+
       _WriteCode(o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
-      _WriteHtmlOnly(m_full_stream, "</div>");
+      _WriteAfterCode();
     }
 
     public void VisitScript (ScriptOptionInfo o)
@@ -293,18 +298,20 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteColoredTitle ("red", o, false);
+      string color = "red";
+      _WriteColoredTitle (color, o, false);
 
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: red;\">");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
+      _WriteBeforeDescriptions(color);
+
       _AddBriefDescription (o, false);
       _AddFullDescription (o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
 
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memdoc\">");
+      _WriteAfterDescriptionsBeforeLabels();
+      _WriteLabels(color, "Script");
+      _WriteAfterLabelsBeforeCode();
+
       _WriteCode(o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
-      _WriteHtmlOnly(m_full_stream, "</div>");
+      _WriteAfterCode();
     }
 
     public void VisitSimple (SimpleOptionInfo o)
@@ -313,21 +320,20 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteColoredTitle ("green", o, false);
+      string color = "green";
 
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: green;\">");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
-      // m_full_stream.WriteLine("<p>TYPE={0}</p>",o.Type);
-      // if (o.DefaultValue!=null)
-      //   m_full_stream.WriteLine("<p>DEFAULT={0}</p>",o.DefaultValue);
+      _WriteColoredTitle (color, o, false);
+      _WriteBeforeDescriptions(color);
+
       _AddBriefDescription (o, false);
       _AddFullDescription (o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
 
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memdoc\">");
+      _WriteAfterDescriptionsBeforeLabels();
+      _WriteLabels(color, "Simple");
+      _WriteAfterLabelsBeforeCode();
+
       _WriteCode(o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
-      _WriteHtmlOnly(m_full_stream, "</div>");
+      _WriteAfterCode();
     }
 
     public void VisitServiceInstance (ServiceInstanceOptionInfo o)
@@ -336,17 +342,17 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteColoredTitle ("DodgerBlue", o, false);
+      string color = "DodgerBlue";
+      _WriteColoredTitle (color, o, false);
       //m_full_stream.WriteLine("<p>SERVICE TYPE={0}</p>",o.Type);
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: DodgerBlue;\">");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
+      _WriteBeforeDescriptions(color);
       _AddBriefDescription (o, false);
       _AddFullDescription (o);
       CodeInterfaceInfo interface_info = null;
       if (m_code_info.Interfaces.TryGetValue (o.Type, out interface_info)) {
         if (interface_info.Services.Count>0) {
           //Console.WriteLine("SERVICE TYPE FOUND={0}",o.Type);
-          _WriteHtmlOnly(m_full_stream, "<div class='ServiceTable' id='FullDescServiceModule'>");
+          _WriteHtmlOnly(m_full_stream, "<div class='full_desc_service_module ServiceTable'>");
           if(m_code_info.Language == "fr"){
             m_full_stream.WriteLine ("<dl><dt>Valeur{0} possible{0} pour le tag <i>name</i>:</dt>",
                                      (interface_info.Services.Count>1)?"s":"");
@@ -367,11 +373,15 @@ namespace Arcane.AxlDoc
           _WriteHtmlOnly(m_full_stream, "</div>");
         }
       }
-      _WriteHtmlOnly(m_full_stream, "</div>");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memdoc\">");
+      _WriteAfterDescriptionsBeforeLabels();
+
+      _WriteLabels(color, "ServiceInstance");
+
+      _WriteAfterLabelsBeforeCode();
+
       _WriteCode(o);
-      _WriteHtmlOnly(m_full_stream, "</div>");
-      _WriteHtmlOnly(m_full_stream, "</div>");
+
+      _WriteAfterCode();
     }
 
     private void _WriteDescription (int i, Option option, XmlElement desc_elem, TextWriter stream)
@@ -436,7 +446,7 @@ namespace Arcane.AxlDoc
 
     private void _AddFullDescription (int i, Option option, XmlElement desc_elem)
     {
-      _WriteHtmlOnly(m_full_stream, "<div class='OptionFullDescription' id='FullDescServiceModule'>");
+      _WriteHtmlOnly(m_full_stream, "<div class='full_desc_service_module OptionFullDescription'>");
       _WriteDescription (i, option, desc_elem, m_full_stream);
       // Passage en \htmlonly car s'il y a une liste non numéroté :
       // - 
@@ -497,10 +507,53 @@ namespace Arcane.AxlDoc
       m_brief_stream.WriteLine ("</li>");
     }
 
+    private void _WriteBeforeDescriptions(string color)
+    {
+      _WriteHtmlOnly(m_full_stream, "<div class='memitem' style='border-color: " + color + ";'>");
+      _WriteHtmlOnly(m_full_stream, "<div class='memproto'>");
+
+      _WriteHtmlOnly(m_full_stream, "<table class='mlabels'>");
+      _WriteHtmlOnly(m_full_stream, "<tbody>");
+      _WriteHtmlOnly(m_full_stream, "<tr>");
+      _WriteHtmlOnly(m_full_stream, "<td class='mlabels-left'>");
+    }
+
+    private void _WriteAfterDescriptionsBeforeLabels()
+    {
+      _WriteHtmlOnly(m_full_stream, "</td>");
+      _WriteHtmlOnly(m_full_stream, "<td class='mlabels-right'>");
+      _WriteHtmlOnly(m_full_stream, "<span class='mlabels'>");
+    }
+
+    private void _WriteLabels(string color, string text)
+    {
+      _WriteHtmlOnly(m_full_stream, "<span class='label_option_type mlabel' style='background: " + color + ";'>" + text + "</span>");
+    }
+
+    private void _WriteAfterLabelsBeforeCode()
+    {
+      _WriteHtmlOnly(m_full_stream, "</span>");
+      _WriteHtmlOnly(m_full_stream, "</td>");
+
+      _WriteHtmlOnly(m_full_stream, "</tr>");
+      _WriteHtmlOnly(m_full_stream, "</tbody>");
+      _WriteHtmlOnly(m_full_stream, "</table>");
+
+      _WriteHtmlOnly(m_full_stream, "</div>");
+
+      _WriteHtmlOnly(m_full_stream, "<div class='memdoc'>");
+    }
+
+    private void _WriteAfterCode()
+    {
+      _WriteHtmlOnly(m_full_stream, "</div>");
+      _WriteHtmlOnly(m_full_stream, "</div>");
+    }
+
     private void _WriteColoredTitle (string color, Option o, bool option_with_subpage)
     {
-      _WriteHtmlOnly(m_full_stream, "<h2 class='memtitle' style='border-color: " + color + ";'>");
-      _WriteHtmlOnly (m_full_stream, "<font color = \"" + color + "\" >");
+      _WriteHtmlOnly(m_full_stream, "<h2 class='memtitle' style='border-color: " + color + "; background: linear-gradient(" + color + ", 0.01%, var(--fragment-background));'>");
+      _WriteHtmlOnly (m_full_stream, "<font style='color: var(--page-foreground-color) !important;' >");
       _WriteTitle (o, option_with_subpage);
       _WriteHtmlOnly (m_full_stream, "</font>");
       _WriteHtmlOnly(m_full_stream, "</h2>");

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
@@ -360,7 +360,7 @@ namespace Arcane.AxlDoc
       if (m_code_info.Interfaces.TryGetValue (o.Type, out interface_info)) {
         if (interface_info.Services.Count>0) {
           //Console.WriteLine("SERVICE TYPE FOUND={0}",o.Type);
-          _WriteHtmlOnly(m_full_stream, "<div class=\"ServiceTable\">");
+          _WriteHtmlOnly(m_full_stream, "<div class='ServiceTable' id='FullDescServiceModule'>");
           if(m_code_info.Language == "fr"){
             m_full_stream.WriteLine ("<dl><dt>Valeur{0} possible{0} pour le tag <i>name</i>:</dt>",
                                      (interface_info.Services.Count>1)?"s":"");
@@ -450,7 +450,7 @@ namespace Arcane.AxlDoc
 
     private void _AddFullDescription (int i, Option option, XmlElement desc_elem)
     {
-      _WriteHtmlOnly(m_full_stream, "<div class='OptionFullDescription'>");
+      _WriteHtmlOnly(m_full_stream, "<div class='OptionFullDescription' id='FullDescServiceModule'>");
       _WriteDescription (i, option, desc_elem, m_full_stream);
       // Passage en \htmlonly car s'il y a une liste non numéroté :
       // - 

--- a/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
+++ b/axlstar/Axlstar.AxlDoc/Arcane.AxlDoc/DoxygenDocumentationVisitor.cs
@@ -120,11 +120,9 @@ namespace Arcane.AxlDoc
       if (m_config.max_display_size > 0 && otc.NbTotalOption > m_config.max_display_size) {
 
         _WriteHtmlOnly(m_full_stream, "<div class=\"ComplexOptionInfoBlock\">");
-        _WriteHtmlOnly(m_full_stream, "<h2 class=\"memtitle\" style=\"border-color: purple;\">");
 
         _WriteColoredTitle("purple", o, true);
 
-        _WriteHtmlOnly(m_full_stream, "</h2>");
         _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: purple;\">");
         _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
 
@@ -167,11 +165,9 @@ namespace Arcane.AxlDoc
         // - Un titre (h2 de classe .memtitle)
         // - Une partie "sous-titre" (div de classe .memitem.memproto)
         // - Une partie "description" (div de classe .memitem.memdoc)
-        _WriteHtmlOnly(m_full_stream, "<h2 class=\"memtitle\" style=\"border-color: purple;\">");
 
         _WriteColoredTitle ("purple", o, false);
 
-        _WriteHtmlOnly(m_full_stream, "</h2>");
         _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: purple;\">");
         _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
 
@@ -202,9 +198,7 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteHtmlOnly(m_full_stream, "<h2 class=\"memtitle\" style=\"border-color: olive;\">");
       _WriteColoredTitle ("olive", o, false);
-      _WriteHtmlOnly(m_full_stream, "</h2>");
       XmlDocument owner_doc = o.Node.OwnerDocument;
       XmlElement desc_elem = o.DescriptionElement;
       // Construit dans \a enum_list_element
@@ -278,10 +272,8 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteHtmlOnly(m_full_stream, "<h2 class=\"memtitle\" style=\"border-color: teal;\">");
 
       _WriteColoredTitle ("teal", o, false);
-      _WriteHtmlOnly(m_full_stream, "</h2>");
 
       _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: teal;\">");
       _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
@@ -301,11 +293,9 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteHtmlOnly(m_full_stream, "<h2 class=\"memtitle\" style=\"border-color: teal;\">");
-      _WriteColoredTitle ("teal", o, false);
-      _WriteHtmlOnly(m_full_stream, "</h2>");
+      _WriteColoredTitle ("red", o, false);
 
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: teal;\">");
+      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: red;\">");
       _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
       _AddBriefDescription (o, false);
       _AddFullDescription (o);
@@ -323,9 +313,7 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteHtmlOnly(m_full_stream, "<h2 class=\"memtitle\" style=\"border-color: green;\">");
       _WriteColoredTitle ("green", o, false);
-      _WriteHtmlOnly(m_full_stream, "</h2>");
 
       _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: green;\">");
       _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
@@ -348,11 +336,9 @@ namespace Arcane.AxlDoc
       // - Un titre (h2 de classe .memtitle)
       // - Une partie "sous-titre" (div de classe .memitem.memproto)
       // - Une partie "description" (div de classe .memitem.memdoc)
-      _WriteHtmlOnly(m_full_stream, "<h2 class=\"memtitle\" style=\"border-color: green;\">");
-      _WriteColoredTitle ("green", o, false);
+      _WriteColoredTitle ("DodgerBlue", o, false);
       //m_full_stream.WriteLine("<p>SERVICE TYPE={0}</p>",o.Type);
-      _WriteHtmlOnly(m_full_stream, "</h2>");
-      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: green;\">");
+      _WriteHtmlOnly(m_full_stream, "<div class=\"memitem\" style=\"border-color: DodgerBlue;\">");
       _WriteHtmlOnly(m_full_stream, "<div class=\"memproto\">");
       _AddBriefDescription (o, false);
       _AddFullDescription (o);
@@ -513,9 +499,11 @@ namespace Arcane.AxlDoc
 
     private void _WriteColoredTitle (string color, Option o, bool option_with_subpage)
     {
+      _WriteHtmlOnly(m_full_stream, "<h2 class='memtitle' style='border-color: " + color + ";'>");
       _WriteHtmlOnly (m_full_stream, "<font color = \"" + color + "\" >");
       _WriteTitle (o, option_with_subpage);
       _WriteHtmlOnly (m_full_stream, "</font>");
+      _WriteHtmlOnly(m_full_stream, "</h2>");
     }
 
     // option_with_subpage est utile pour les options complexes ayant plus de 30 sous-options.


### PR DESCRIPTION
And, in service/module description pages :
- change the color of option titles (from “option type color” to “foreground color”),
- change the color of “script” and “service” option types,
- add labels in the options list to indicate the type of option,
- add snippets generation with the list of service options inside,
- add these generated snippets to the list of services available in the “service” option type in the list of service/module options.