### PR TITLE
Do not keep modification flags between two uses of 'MeshMaterialModifier'

### DIFF
--- a/arcane/src/arcane/materials/MeshMaterialModifier.cc
+++ b/arcane/src/arcane/materials/MeshMaterialModifier.cc
@@ -37,6 +37,7 @@ MeshMaterialModifier(IMeshMaterialMng* mm)
 {
   if (!m_impl)
     ARCANE_FATAL("Can not create 'MeshMaterialModifier' because IMeshMaterialMng is not yet initialized");
+  m_impl->reset();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialModifierImpl.cc
+++ b/arcane/src/arcane/materials/MeshMaterialModifierImpl.cc
@@ -399,6 +399,17 @@ _updateEnvironmentsNoOptimize()
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialModifierImpl::
+reset()
+{
+  m_do_copy_between_partial_and_pure = true;
+  m_do_init_new_items = true;
+  m_is_keep_work_buffer = true;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MeshMaterialModifierImpl::
 beginUpdate()
 {
   m_material_mng->info(4) << "BEGIN_UPDATE_MAT";

--- a/arcane/src/arcane/materials/internal/MeshMaterialModifierImpl.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialModifierImpl.h
@@ -66,6 +66,8 @@ class MeshMaterialModifierImpl
 
  public:
 
+  void reset();
+
   void addCells(IMeshMaterial* mat, SmallSpan<const Int32> ids);
   void removeCells(IMeshMaterial* mat, SmallSpan<const Int32> ids);
 


### PR DESCRIPTION
This should fix random failure in test `material_eos_cs_coreclr`.
