### PR TITLE
Optimize computation of ItemGroup children group for cartesian mesh

### DIFF
--- a/arcane/src/arcane/cartesianmesh/CartesianMesh.cc
+++ b/arcane/src/arcane/cartesianmesh/CartesianMesh.cc
@@ -31,6 +31,7 @@
 #include "arcane/core/ICartesianMeshGenerationInfo.h"
 #include "arcane/core/MeshEvents.h"
 #include "arcane/core/MeshKind.h"
+#include "arcane/core/internal/IMeshInternal.h"
 
 #include "arcane/cartesianmesh/ICartesianMesh.h"
 #include "arcane/cartesianmesh/CartesianConnectivity.h"
@@ -856,6 +857,12 @@ getReference(const MeshHandleOrMesh& mesh_handle_or_mesh,bool create)
       ARCANE_FATAL("The mesh {0} is not yet created",h.meshName());
     ICartesianMesh* cm = arcaneCreateCartesianMesh(mesh);
     udlist->setData(name,new AutoDestroyUserData<ICartesianMesh>(cm));
+
+    // Indique que le maillage est cartésien
+    MeshKind mk = mesh->meshKind();
+    mk.setMeshStructure(eMeshStructure::Cartesian);
+    mesh->_internalApi()->setMeshKind(mk);
+
     return cm;
   }
   AutoDestroyUserData<ICartesianMesh>* adud = dynamic_cast<AutoDestroyUserData<ICartesianMesh>*>(ud);

--- a/arcane/src/arcane/core/ItemGroupImpl.cc
+++ b/arcane/src/arcane/core/ItemGroupImpl.cc
@@ -22,6 +22,7 @@
 #include "arcane/core/ItemGroup.h"
 #include "arcane/core/IMesh.h"
 #include "arcane/core/MeshPartInfo.h"
+#include "arcane/core/MeshKind.h"
 #include "arcane/core/ItemPrinter.h"
 #include "arcane/core/IItemOperationByBasicType.h"
 #include "arcane/core/ItemGroupComputeFunctor.h"
@@ -1457,11 +1458,19 @@ _computeChildrenByTypeV2()
 {
   ItemGroup that_group(this);
   Int32 nb_item = size();
-  ItemTypeMng* type_mng = m_p->mesh()->itemTypeMng();
-  ITraceMng* trace = m_p->mesh()->traceMng();
+  IMesh* mesh = m_p->mesh();
+  ItemTypeMng* type_mng = mesh->itemTypeMng();
+  ITraceMng* trace = mesh->traceMng();
   bool is_verbose = m_p->m_is_debug_apply_operation;
   if (is_verbose)
     trace->info() << "ItemGroupImpl::_computeChildrenByTypeV2 for " << name();
+
+  // Si le maillage est cartésien, on sait que toutes les entités ont le même type
+  if (nb_item>0 && mesh->meshKind().meshStructure()==eMeshStructure::Cartesian){
+    ItemInfoListView lv(m_p->m_item_family->itemInfoListView());
+    m_p->m_unique_children_type = ItemTypeId{lv.typeId(m_p->itemsLocalId()[0])};
+    return;
+  }
 
   Int32 nb_basic_item_type = ItemTypeMng::nbBasicItemType();
   m_p->m_unique_children_type = ItemTypeId{IT_NullType};

--- a/arcane/src/arcane/core/internal/IMeshInternal.h
+++ b/arcane/src/arcane/core/internal/IMeshInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IMeshInternal.h                                             (C) 2000-2023 */
+/* IMeshInternal.h                                             (C) 2000-2024 */
 /*                                                                           */
 /* Partie interne à Arcane de IMesh.                                         */
 /*---------------------------------------------------------------------------*/
@@ -33,6 +33,16 @@ class ARCANE_CORE_EXPORT IMeshInternal
  public:
 
   virtual ~IMeshInternal() = default;
+
+ public:
+
+  /*!
+   * \brief Positionne le type de maillage.
+   *
+   * Pour l'instant il ne faut utiliser cette méthode que pour spécifier
+   * la structure du maillage (eMeshStructure).
+   */
+  virtual void setMeshKind(const MeshKind& v) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -160,9 +160,16 @@ class DynamicMesh::InternalApi
 {
  public:
 
-  InternalApi(DynamicMesh* mesh)
+  explicit InternalApi(DynamicMesh* mesh)
   : m_mesh(mesh)
   {
+  }
+
+ public:
+
+  void setMeshKind(const MeshKind& v)
+  {
+    m_mesh->m_mesh_kind = v;
   }
 
  private:
@@ -830,6 +837,12 @@ endAllocate()
   m_is_allocated = true;
   if (arcaneIsCheck())
     checkValidMesh();
+
+  // Affiche les statistiques du nouveau maillage
+  {
+    MeshStats ms(traceMng(),this,m_parallel_mng);
+    ms.dumpStats();
+  }
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
At the moment we iterate on all items of `ItemGroup` to fill the number of elements for each item kind.
For cartesian mesh, we are sure there is only one kind of item so we can skip this computation. 