### PR TITLE
Add support to change value of additional capacity ratio for MeshMaterialMng

### DIFF
--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -389,7 +389,11 @@ foreach(test_index 1 2 3 4)
 endforeach()
 if (ARCANE_HAS_ACCELERATOR_API)
   arcane_add_test_sequential(material_heat2_opt15_2small testMaterialHeat-2-small-opt15.arc "-We,ARCANE_DEBUG_MATERIAL_MODIFIER,2")
-  arcane_add_test_sequential(material_heat2_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20")
+  arcane_add_test_sequential(material_heat2_accelerator
+    "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc"
+    "-We,ARCANE_MATERIALMNG_ADDITIONAL_CAPACITY_RATIO,0.5"
+    "-m 20"
+  )
   arcane_add_accelerator_test_sequential(material_heat2_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20")
   arcane_add_accelerator_test_sequential(material_heat2_accelerator_noqueue
     "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20" "-We,ARCANE_MATERIALMNG_USE_QUEUE,0")

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -287,6 +287,15 @@ build()
     }
   }
 
+  // Choix du ratio de capacité additionelle
+  {
+    if (auto v = Convert::Type<Real>::tryParseFromEnvironment("ARCANE_MATERIALMNG_ADDITIONAL_CAPACITY_RATIO", true)){
+      if (v>=0.0){
+        m_additional_capacity_ratio = v.value();
+        info() << "Set additional capacity ratio to " << m_additional_capacity_ratio;
+      }
+    }
+  }
 
   m_exchange_mng->build();
   // Si les traces des énumérateurs sur les entités sont actives, active celles

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -303,7 +303,7 @@ class MeshMaterialMng
   Runner& runner() const { return m_runner_info->m_runner; }
   RunQueue& runQueue() const { return m_runner_info->m_run_queue; }
   Accelerator::RunQueuePool& asyncRunQueuePool() const { return m_runner_info->m_async_queue_pool; }
-  Real additionalCapacityRatio() const { return 0.05; }
+  Real additionalCapacityRatio() const { return m_additional_capacity_ratio; }
   //@}
 
  private:
@@ -339,6 +339,7 @@ class MeshMaterialMng
   bool m_is_allocate_scalar_environment_variable_as_material = false;
   bool m_is_use_material_value_when_removing_partial_value = false;
   int m_modification_flags = 0;
+  Real m_additional_capacity_ratio = 0.05;
 
   Mutex m_variable_lock;
 


### PR DESCRIPTION
At the moment this in only available via environment variable `ARCANE_MATERIALMNG_ADDITIONAL_CAPACITY_RATIO`