### PR TITLE
Add additional variables in test MaterialHeatModule

### DIFF
--- a/arcane/ceapart/src/arcane/tests/MaterialHeatTest.axl
+++ b/arcane/ceapart/src/arcane/tests/MaterialHeatTest.axl
@@ -19,6 +19,9 @@
     <simple name="verbosity-level" type="int32" default="0">
       <description>Verbosity level</description>
     </simple>
+    <simple name="nb-additional-variable" type="int32" default="2">
+      <description>Number of additional variables to create</description>
+    </simple>
 
     <!-- Infos sur les materiaux -->
     <complex name="material" type="Material" minOccurs="1" maxOccurs="unbounded">


### PR DESCRIPTION
This allows to better see the influence on performance of copies and initialization of variables when updating constituents.