### PR TITLE
Use 'dotnet' runtime instead of 'mono' to run python tests

### DIFF
--- a/arcane/src/arcane/tests/ArcaneTest.csproj.in
+++ b/arcane/src/arcane/tests/ArcaneTest.csproj.in
@@ -1,13 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="../CommonDll.props" />
+
   <PropertyGroup Condition="'@_HAS_PYTHON_WRAPPER@' == 'true'">
     <DefineConstants>ARCANE_HAS_DOTNET_PYTHON</DefineConstants>
   </PropertyGroup>
-
 
   <ItemGroup>
     <Compile Include="@CSPATH@/MeshModification.cs" />
@@ -26,8 +23,5 @@
     <ProjectReference Include="../Arcane.Core/Arcane.Core.csproj" />
     <ProjectReference Include="../Arcane.Services/Arcane.Services.csproj" />
     <ProjectReference Include="../Arcane.Launcher/Arcane.Launcher.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'@_HAS_PYTHON_WRAPPER@' == 'true'">
-    <ProjectReference Include="../Arcane.Python/Arcane.Python.csproj" />
   </ItemGroup>
 </Project>

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -1010,7 +1010,7 @@ arcane_add_test(time_history_adder_1 testTimeHistoryAdder-1.arc -c 2 -m 5 -We,AR
 
 #################################################################
 function(arcane_add_python_test_sequential test_name script_name case_file)
-  arcane_add_test_sequential(${test_name} "${ARCANE_TEST_PATH}/testPython-${script_name}.arc" -Z ${ARGN})
+  arcane_add_test_sequential(${test_name} "${ARCANE_TEST_PATH}/testPython-${script_name}.arc" -A,UsingDotNet=1 ${ARGN})
   set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT "PYTHONNET_PYDLL=${Python_LIBRARIES}")
   set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/lib/python")
   set(ARCANE_TEST_PYTHON_SCRIPT ${script_name})

--- a/arcane/src/arcane/tests/Launcher.cs
+++ b/arcane/src/arcane/tests/Launcher.cs
@@ -41,7 +41,7 @@ public class Launcher
 #if ARCANE_HAS_DOTNET_PYTHON
     Arcane.Python.MainInit.Init();
 #endif
-    return ArcaneMain.Run();
+    return ArcaneLauncher.Run();
   }
 
   public static int ExecDirect()

--- a/arcane/tests/python/script2.py
+++ b/arcane/tests/python/script2.py
@@ -1,4 +1,3 @@
-import ArcanePython
 import Arcane
 
 print("Hello (script2) from python")

--- a/arcane/tools/CMakeLists.txt
+++ b/arcane/tools/CMakeLists.txt
@@ -113,6 +113,7 @@ file(MAKE_DIRECTORY ${ARCANE_CSHARP_PROJECT_PATH})
 configure_file(Directory.Build.props ${ARCANE_CSHARP_PROJECT_PATH} COPYONLY)
 configure_file(Directory.Build.targets ${ARCANE_CSHARP_PROJECT_PATH} COPYONLY)
 configure_file(CommonExe.props ${ARCANE_CSHARP_PROJECT_PATH} COPYONLY)
+configure_file(CommonDll.props ${ARCANE_CSHARP_PROJECT_PATH} COPYONLY)
 
 message(STATUS "ARCANE_MSBUILD_ARGS=${ARCANE_MSBUILD_ARGS}")
 

--- a/arcane/tools/CommonDll.props
+++ b/arcane/tools/CommonDll.props
@@ -19,8 +19,6 @@
     <TargetFramework
         Condition="'$(TargetFramework)'=='' and '$(BundledNETCoreAppTargetFrameworkVersion)'!=''"
         >netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
-    <TargetExt>.dll</TargetExt>
-    <OutputType>Exe</OutputType>
-    <UseAppHost>false</UseAppHost>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/arcane/tools/wrapper/launcher/Arcane.Launcher.csproj.in
+++ b/arcane/tools/wrapper/launcher/Arcane.Launcher.csproj.in
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../CommonDll.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+
   <PropertyGroup Condition="'@_HAS_PYTHON_WRAPPER@' == 'true'">
     <DefineConstants>ARCANE_HAS_DOTNET_PYTHON</DefineConstants>
   </PropertyGroup>

--- a/arcane/tools/wrapper/launcher/csharp/ArcaneLauncher.cs
+++ b/arcane/tools/wrapper/launcher/csharp/ArcaneLauncher.cs
@@ -45,7 +45,15 @@ namespace Arcane
   {
     public static int Run()
     {
-      return ArcaneMain.Run();
+      _CheckInitPython();
+      int r = 0;
+      try{
+        r = ArcaneMain.Run();
+      }
+      finally{
+        _ShutdownPython();
+      }
+      return r;
     }
     public static ApplicationInfo ApplicationInfo
     {
@@ -67,9 +75,7 @@ namespace Arcane
     public static void Init(CommandLineArguments args)
     {
       ArcaneLauncher_INTERNAL.Init(args);
-#if ARCANE_HAS_DOTNET_PYTHON
-      Arcane.Python.MainInit.Init();
-#endif
+      _CheckInitPython();
     }
 
     public delegate int DirectSubDomainExecutionContextDelegate(DirectSubDomainExecutionContext ctx);
@@ -86,6 +92,26 @@ namespace Arcane
     {
       var x = new DirectFunctor(d);
       return DirectExecutionWrapper.Run(x);
+    }
+    static bool m_has_python_init;
+    static void _CheckInitPython()
+    {
+      if (!m_has_python_init){
+        _InitPython();
+        m_has_python_init = true;
+      }
+    }
+    static void _InitPython()
+    {
+#if ARCANE_HAS_DOTNET_PYTHON
+      Arcane.Python.MainInit.Init();
+#endif
+    }
+    static void _ShutdownPython()
+    {
+#if ARCANE_HAS_DOTNET_PYTHON
+      Arcane.Python.MainInit.Shutdown();
+#endif
     }
   }
 }

--- a/arcane/tools/wrapper/main/Arcane.Main.csproj.in
+++ b/arcane/tools/wrapper/main/Arcane.Main.csproj.in
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/arcane/tools/wrapper/python/Arcane.Python.csproj.in
+++ b/arcane/tools/wrapper/python/Arcane.Python.csproj.in
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../CommonDll.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 

--- a/arcane/tools/wrapper/python/CMakeLists.txt
+++ b/arcane/tools/wrapper/python/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(ARCANE_SWIG_PYTHON_CSHARP_FILES
   SimplePythonCallerModule
   BasicDotNetPythonExternalPlugin
+  MainInit
 )
 
 arcane_wrapper_add_swig_target(NAME python SOURCE ArcaneSwigPython.i

--- a/arcane/tools/wrapper/python/csharp/BasicDotNetPythonExternalPlugin.cs
+++ b/arcane/tools/wrapper/python/csharp/BasicDotNetPythonExternalPlugin.cs
@@ -14,6 +14,14 @@ namespace Arcane.Python
     public BasicDotNetPythonExternalPlugin(ServiceBuildInfo bi) : base(bi)
     {
     }
+    ~BasicDotNetPythonExternalPlugin()
+    {
+      if (m_python_scope!=null){
+        m_python_scope.Dispose();
+        m_python_scope = null;
+      }
+      //PythonEngine.Shutdown();
+    }
 
     public override void LoadFile(string s)
     {

--- a/arcane/tools/wrapper/python/csharp/MainInit.cs
+++ b/arcane/tools/wrapper/python/csharp/MainInit.cs
@@ -1,0 +1,22 @@
+using Arcane;
+using System;
+using Python.Runtime;
+using System.Threading.Tasks;
+using Numpy;
+
+namespace Arcane.Python
+{
+  public static class MainInit
+  {
+    static public void Init()
+    {
+      // Only useful for loading this assembly
+      Debug.Write("Loading '.Net' python wrapping assembly");
+    }
+    static public void Shutdown()
+    {
+      Debug.Write("Shutdown '.Net' python wrapping assembly");
+      PythonEngine.Shutdown();
+    }
+  }
+}

--- a/arcane/tools/wrapper/python/csharp/SimplePythonCallerModule.cs
+++ b/arcane/tools/wrapper/python/csharp/SimplePythonCallerModule.cs
@@ -40,15 +40,3 @@ class SimplePythonCallerModule
     PythonEngine.Shutdown();
   }
 }
-
-namespace Arcane.Python
-{
-  public static class MainInit
-  {
-    static public void Init()
-    {
-      Console.WriteLine("Loading python wrapping assembly");
-      // Only useful for loading this assembly
-    }
-  }
-}


### PR DESCRIPTION
Also make sure `PythonEngine.Shutdown()` is called at end of test. Without this call, `dotnet` blocks in a deadlock.