### PR TITLE
Fix test 'task1_taskmax' with more than 32 cores

### DIFF
--- a/arcane/src/arcane/tests/TaskUnitTest.cc
+++ b/arcane/src/arcane/tests/TaskUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TaskUnitTest.cc                                             (C) 2000-2023 */
+/* TaskUnitTest.cc                                             (C) 2000-2024 */
 /*                                                                           */
 /* Service de test des tâches.                                               */
 /*---------------------------------------------------------------------------*/
@@ -163,7 +163,7 @@ class Test3
     for( Integer i=0; i<3; ++ i){
       Integer v = TaskFactory::verboseLevel();
       TaskFactory::setVerboseLevel(3);
-      Integer grain_size = 50*i;
+      Integer grain_size = 10*i;
       _reset();
       info() << "Test Deterministic partitionner N=" << i << " grain_size=" << grain_size
              << " nb_item=" << nodes.size();

--- a/arcane/tests/testTask-1.arc
+++ b/arcane/tests/testTask-1.arc
@@ -7,7 +7,7 @@
  </arcane>
 
  <maillage>
-  <meshgenerator><sod><x>100</x><y>5</y><z>5</z></sod></meshgenerator>
+  <meshgenerator><sod><x>100</x><y>15</y><z>5</z></sod></meshgenerator>
  </maillage>
 
  <module-test-unitaire>


### PR DESCRIPTION
This test uses as many tasks as the number of available cores but it was not big enough to work with a big number of tasks.  Increase the size of the mesh to fix that.