### PR TITLE
Add generic version of copy between partial and global values for constituents

### DIFF
--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -397,6 +397,8 @@ if (ARCANE_HAS_ACCELERATOR_API)
   arcane_add_accelerator_test_sequential(material_heat2_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20")
   arcane_add_accelerator_test_sequential(material_heat2_accelerator_noqueue
     "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20" "-We,ARCANE_MATERIALMNG_USE_QUEUE,0")
+  arcane_add_accelerator_test_sequential(material_heat2_accelerator_generic_copy
+    "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20" "-We,ARCANE_USE_GENERIC_COPY_BETWEEN_PURE_AND_PARTIAL,1")
   arcane_add_test_sequential(material_heat4_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-4-opt15.arc" "-m 20")
   arcane_add_accelerator_test_sequential(material_heat4_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-4-opt15.arc" "-m 20")
 endif()

--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -397,8 +397,9 @@ if (ARCANE_HAS_ACCELERATOR_API)
   arcane_add_accelerator_test_sequential(material_heat2_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20")
   arcane_add_accelerator_test_sequential(material_heat2_accelerator_noqueue
     "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20" "-We,ARCANE_MATERIALMNG_USE_QUEUE,0")
-  arcane_add_accelerator_test_sequential(material_heat2_accelerator_generic_copy
+  arcane_add_test_sequential_host_and_accelerator(material_heat2_accelerator_generic_copy
     "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc" "-m 20" "-We,ARCANE_USE_GENERIC_COPY_BETWEEN_PURE_AND_PARTIAL,1")
+
   arcane_add_test_sequential(material_heat4_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-4-opt15.arc" "-m 20")
   arcane_add_accelerator_test_sequential(material_heat4_accelerator "${ARCANE_TEST_PATH}/testMaterialHeat-4-opt15.arc" "-m 20")
 endif()

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -53,6 +53,7 @@ class ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalArgs
   SmallSpan<const Int32> m_indexes_in_multiple;
   bool m_do_copy_between_partial_and_pure = true;
   RunQueue m_queue;
+  bool m_use_generic_copy = false;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -38,11 +38,13 @@ class ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalArgs
                                   SmallSpan<const Int32> local_ids,
                                   SmallSpan<const Int32> indexes_in_multiple,
                                   bool do_copy,
+                                  bool is_global_to_partial,
                                   const RunQueue& queue)
   : m_var_index(var_index)
   , m_local_ids(local_ids)
   , m_indexes_in_multiple(indexes_in_multiple)
   , m_do_copy_between_partial_and_pure(do_copy)
+  , m_is_global_to_partial(is_global_to_partial)
   , m_queue(queue)
   {}
 
@@ -52,8 +54,9 @@ class ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalArgs
   SmallSpan<const Int32> m_local_ids;
   SmallSpan<const Int32> m_indexes_in_multiple;
   bool m_do_copy_between_partial_and_pure = true;
-  RunQueue m_queue;
+  bool m_is_global_to_partial = false;
   bool m_use_generic_copy = false;
+  RunQueue m_queue;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -105,10 +108,7 @@ class ARCANE_CORE_EXPORT IMeshMaterialVariableInternal
                            Integer data_index, Int32ConstArrayView ids, bool allow_null_id) = 0;
 
   //! \internal
-  virtual void copyGlobalToPartial(const CopyBetweenPartialAndGlobalArgs& args) = 0;
-
-  //! \internal
-  virtual void copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
+  virtual void copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
 
   //! \internal
   virtual void initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -81,6 +81,8 @@ AllEnvData(MeshMaterialMng* mmg)
 
   if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_ALLENVDATA_DEBUG_LEVEL", true))
     m_verbose_debug_level = v.value();
+  if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_USE_GENERIC_COPY_BETWEEN_PURE_AND_PARTIAL", true))
+    m_use_generic_copy_between_pure_and_partial = v.value();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -595,13 +597,14 @@ _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args,
   if (do_copy) {
     Int32 index = 0;
     CopyBetweenPartialAndGlobalArgs args2(args);
+    args2.m_use_generic_copy = m_use_generic_copy_between_pure_and_partial;
     auto func2 = [&](IMeshMaterialVariable* mv) {
       auto* mvi = mv->_internalApi();
       args2.m_queue = queue_pool[index];
       if (is_add_operation)
-        mvi->copyGlobalToPartial(args);
+        mvi->copyGlobalToPartial(args2);
       else
-        mvi->copyPartialToGlobal(args);
+        mvi->copyPartialToGlobal(args2);
       ++index;
     };
     functor::apply(m_material_mng, &MeshMaterialMng::visitVariables, func2);

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -567,12 +567,12 @@ _printAllEnvCells(CellVectorView ids)
  * de suppression d'un matériau)
  */
 void AllEnvData::
-_copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args,
-                               bool is_add_operation)
+_copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args)
 {
   if (args.m_local_ids.empty())
     return;
-  bool do_copy = args.m_do_copy_between_partial_and_pure;
+  const bool do_copy = args.m_do_copy_between_partial_and_pure;
+  const bool is_add_operation = args.m_is_global_to_partial;
   RunQueue queue(args.m_queue);
   RunQueue::ScopedAsync sc(&queue);
   // Comme on a modifié des mailles, il faut mettre à jour les valeurs
@@ -601,10 +601,7 @@ _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args,
     auto func2 = [&](IMeshMaterialVariable* mv) {
       auto* mvi = mv->_internalApi();
       args2.m_queue = queue_pool[index];
-      if (is_add_operation)
-        mvi->copyGlobalToPartial(args2);
-      else
-        mvi->copyPartialToGlobal(args2);
+      mvi->copyBetweenPartialAndGlobal(args2);
       ++index;
     };
     functor::apply(m_material_mng, &MeshMaterialMng::visitVariables, func2);

--- a/arcane/src/arcane/materials/CMakeLists.txt
+++ b/arcane/src/arcane/materials/CMakeLists.txt
@@ -16,6 +16,7 @@ arcane_accelerator_add_source_files(
   IncrementalComponentModifier.cc
   MeshComponentPartData.cc
   MeshEnvironment.cc
+  MeshMaterialVariable.cc
   MeshMaterialVariableScalar.cc
   MeshMaterialVariableArray.cc
   MeshMaterialVariableIndexer.cc

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -264,8 +264,9 @@ _switchCellsForMaterials(const MeshMaterial* modified_mat,
       CopyBetweenPartialAndGlobalArgs args(indexer->index(), pure_local_ids,
                                            partial_indexes,
                                            m_do_copy_between_partial_and_pure,
+                                           is_add,
                                            m_queue);
-      m_all_env_data->_copyBetweenPartialsAndGlobals(args, is_add);
+      m_all_env_data->_copyBetweenPartialsAndGlobals(args);
     }
   }
 }
@@ -325,8 +326,9 @@ _switchCellsForEnvironments(const IMeshEnvironment* modified_env,
     if (is_copy) {
       CopyBetweenPartialAndGlobalArgs copy_args(indexer->index(), pure_local_ids,
                                                 partial_indexes,
-                                                m_do_copy_between_partial_and_pure, m_queue);
-      m_all_env_data->_copyBetweenPartialsAndGlobals(copy_args, is_add);
+                                                m_do_copy_between_partial_and_pure, is_add,
+                                                m_queue);
+      m_all_env_data->_copyBetweenPartialsAndGlobals(copy_args);
     }
   }
 }

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -398,32 +398,13 @@ _copyHostViewsToViews(RunQueue* queue)
 
 template <typename Traits> void
 ItemMaterialVariableBase<Traits>::
-_copyGlobalToPartial(const CopyBetweenPartialAndGlobalArgs& args)
-{
-  _copyBetweenPartialInGlobal(args, true);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template<typename Traits> void
-ItemMaterialVariableBase<Traits>::
-_copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args)
-{
-  _copyBetweenPartialInGlobal(args, false);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-template <typename Traits> void
-ItemMaterialVariableBase<Traits>::
-_copyBetweenPartialInGlobal(const CopyBetweenPartialAndGlobalArgs& args, bool is_global_to_partial)
+_copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args)
 {
   Int32 var_index = args.m_var_index + 1;
   PrivatePartType* partial_var = m_vars[var_index];
   if (!_isValidAndUsedAndGlobalUsed(partial_var))
     return;
+  const bool is_global_to_partial = args.m_is_global_to_partial;
   const bool use_generic = args.m_use_generic_copy;
   const RunQueue& queue = args.m_queue;
 

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -400,12 +400,7 @@ template <typename Traits> void
 ItemMaterialVariableBase<Traits>::
 _copyGlobalToPartial(const CopyBetweenPartialAndGlobalArgs& args)
 {
-  Int32 var_index = args.m_var_index;
-  PrivatePartType* partial_var = m_vars[var_index + 1];
-  if (_isValidAndUsedAndGlobalUsed(partial_var)) {
-    Traits::copyTo(m_host_views[0], args.m_local_ids, m_host_views[var_index + 1],
-                   args.m_indexes_in_multiple, args.m_queue);
-  }
+  _copyBetweenPartialInGlobal(args, true);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -415,11 +410,41 @@ template<typename Traits> void
 ItemMaterialVariableBase<Traits>::
 _copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args)
 {
-  Int32 var_index = args.m_var_index;
-  PrivatePartType* partial_var = m_vars[var_index+1];
-  if (_isValidAndUsedAndGlobalUsed(partial_var)) {
-    Traits::copyTo(m_host_views[var_index + 1], args.m_indexes_in_multiple,
-                   m_host_views[0], args.m_local_ids, args.m_queue);
+  _copyBetweenPartialInGlobal(args, false);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template <typename Traits> void
+ItemMaterialVariableBase<Traits>::
+_copyBetweenPartialInGlobal(const CopyBetweenPartialAndGlobalArgs& args, bool is_global_to_partial)
+{
+  Int32 var_index = args.m_var_index + 1;
+  PrivatePartType* partial_var = m_vars[var_index];
+  if (!_isValidAndUsedAndGlobalUsed(partial_var))
+    return;
+  const bool use_generic = args.m_use_generic_copy;
+  const RunQueue& queue = args.m_queue;
+
+  auto input = m_host_views[var_index];
+  auto output = m_host_views[0];
+  auto output_indexes = args.m_local_ids;
+  auto input_indexes = args.m_indexes_in_multiple;
+
+  if (is_global_to_partial) {
+    std::swap(input, output);
+    std::swap(output_indexes, input_indexes);
+  }
+  if (use_generic) {
+    Int32 data_type_size = dataTypeSize();
+    Span<const std::byte> input_bytes(Traits::toBytes(input));
+    Span<std::byte> output_bytes(Traits::toBytes(output));
+    _genericCopyTo(input_bytes, input_indexes,
+                   output_bytes, output_indexes, queue, data_type_size);
+  }
+  else {
+    Traits::copyTo(input, input_indexes, output, output_indexes, queue);
   }
 }
 

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -141,18 +141,9 @@ restoreData(IMeshComponent* component,IData* data,Integer data_index,
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialVariablePrivate::
-copyGlobalToPartial(const CopyBetweenPartialAndGlobalArgs& args)
+copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args)
 {
-  m_variable->_copyGlobalToPartial(args);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void MeshMaterialVariablePrivate::
-copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args)
-{
-  m_variable->_copyPartialToGlobal(args);
+  m_variable->_copyBetweenPartialAndGlobal(args);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -150,8 +150,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariable
   virtual void _saveData(IMeshComponent* component,IData* data) =0;
   virtual void _restoreData(IMeshComponent* component,IData* data,Integer data_index,
                             Int32ConstArrayView ids,bool allow_null_id) =0;
-  virtual void _copyGlobalToPartial(const CopyBetweenPartialAndGlobalArgs& args) = 0;
-  virtual void _copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
+  virtual void _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
   virtual void _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
   virtual void _syncReferences(bool update_views) = 0;
   virtual void _resizeForIndexer(Int32 index, RunQueue& queue) = 0;
@@ -318,14 +317,9 @@ class ItemMaterialVariableBase
   void _restoreData(IMeshComponent* component,IData* data,Integer data_index,
                     Int32ConstArrayView ids,bool allow_null_id) override;
   ARCANE_MATERIALS_EXPORT
-  void _copyGlobalToPartial(const CopyBetweenPartialAndGlobalArgs& args) override;
-  ARCANE_MATERIALS_EXPORT
-  void _copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
+  void _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
   ARCANE_MATERIALS_EXPORT
   void _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
-
-  ARCANE_MATERIALS_EXPORT
-  void _copyBetweenPartialInGlobal(const CopyBetweenPartialAndGlobalArgs& args, bool is_global_to_partial);
 
   ARCANE_MATERIALS_EXPORT void fillPartialValuesWithGlobalValues() override;
   ARCANE_MATERIALS_EXPORT void

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -159,6 +159,14 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariable
  private:
 
   static SmallSpan<const Int32> _toInt32Indexes(SmallSpan<const MatVarIndex> indexes);
+
+ public:
+
+  static void _genericCopyTo(Span<const std::byte> input,
+                             SmallSpan<const Int32> input_indexes,
+                             Span<std::byte> output,
+                             SmallSpan<const Int32> output_indexes,
+                             const RunQueue& queue, Int32 data_type_size);
 };
 
 /*---------------------------------------------------------------------------*/
@@ -315,6 +323,9 @@ class ItemMaterialVariableBase
   void _copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
   ARCANE_MATERIALS_EXPORT
   void _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
+
+  ARCANE_MATERIALS_EXPORT
+  void _copyBetweenPartialInGlobal(const CopyBetweenPartialAndGlobalArgs& args, bool is_global_to_partial);
 
   ARCANE_MATERIALS_EXPORT void fillPartialValuesWithGlobalValues() override;
   ARCANE_MATERIALS_EXPORT void

--- a/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
@@ -16,11 +16,7 @@
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/ScopedPtr.h"
 #include "arcane/utils/ITraceMng.h"
-#include "arcane/utils/Real2.h"
-#include "arcane/utils/Real3.h"
-#include "arcane/utils/Real2x2.h"
-#include "arcane/utils/Real3x3.h"
-#include "arcane/utils/Array2.h"
+#include "arcane/utils/NumericTypes.h"
 #include "arcane/utils/CheckedConvert.h"
 
 #include "arcane/materials/MaterialVariableBuildInfo.h"
@@ -53,7 +49,6 @@
 #include "arcane/core/parallel/IStat.h"
 #include "arcane/core/datatype/DataTypeTraits.h"
 #include "arcane/core/datatype/DataStorageBuildInfo.h"
-#include "arcane/core/VariableDataTypeTraits.h"
 
 #include <vector>
 
@@ -84,7 +79,10 @@ saveData(IMeshComponent* component,IData* data,
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename DataType> void
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template <typename DataType> void
 MaterialVariableScalarTraits<DataType>::
 copyTo(SmallSpan<const DataType> input, SmallSpan<const Int32> input_indexes,
        SmallSpan<DataType> output, SmallSpan<const Int32> output_indexes,

--- a/arcane/src/arcane/materials/internal/AllEnvData.h
+++ b/arcane/src/arcane/materials/internal/AllEnvData.h
@@ -84,6 +84,9 @@ class AllEnvData
   ComponentItemInternalData m_item_internal_data;
   Int64 m_current_mesh_timestamp = -1;
 
+  //! Vrai si on utilise une version générique pour les copies entre pure et partiel
+  bool m_use_generic_copy_between_pure_and_partial = false;
+
  private:
 
   void _computeNbEnvAndNbMatPerCell();

--- a/arcane/src/arcane/materials/internal/AllEnvData.h
+++ b/arcane/src/arcane/materials/internal/AllEnvData.h
@@ -90,8 +90,7 @@ class AllEnvData
  private:
 
   void _computeNbEnvAndNbMatPerCell();
-  void _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args,
-                                      bool is_add_operation);
+  void _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args);
   void _computeAndResizeEnvItemsInternal();
   bool _isFullVerbose() const;
   void _rebuildMaterialsAndEnvironmentsFromGroups();

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
@@ -72,9 +72,7 @@ class MeshMaterialVariablePrivate
   void restoreData(IMeshComponent* component, IData* data, Integer data_index,
                    Int32ConstArrayView ids, bool allow_null_id) override;
 
-  void copyGlobalToPartial(const CopyBetweenPartialAndGlobalArgs& args) override;
-
-  void copyPartialToGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
+  void copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
 
   void initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
 

--- a/arcane/src/arcane/tests/ArcaneTests.cmake
+++ b/arcane/src/arcane/tests/ArcaneTests.cmake
@@ -387,6 +387,12 @@ macro(arcane_add_accelerator_test_message_passing_hybrid test_name)
   endif()
 endmacro()
 
+macro(arcane_add_test_sequential_host_and_accelerator test_name case_file)
+  arcane_add_test_sequential(${test_name} ${case_file} ${ARGN})
+  arcane_add_test_sequential_task(${test_name} ${case_file} 4 ${ARGN})
+  arcane_add_accelerator_test_sequential(${test_name} ${case_file} ${ARGN})
+endmacro()
+
 # ----------------------------------------------------------------------------
 # Local Variables:
 # tab-width: 2


### PR DESCRIPTION
This version will be used to do all the copies in one kernel.