### PR TITLE
in 'ArcaneConfig.cmake', load accelerator configuration if available

### DIFF
--- a/arcane/cmake/ArcaneConfig.cmake.in
+++ b/arcane/cmake/ArcaneConfig.cmake.in
@@ -156,6 +156,7 @@ macro(arcane_internal_enable_hip)
   endif()
 endmacro()
 
+# ----------------------------------------------------------------------------
 # Macro pour activer le support des accélérateurs.
 # A utiliser avant les autres commandes 'arcane_accelerator_...'
 macro(arcane_accelerator_enable)
@@ -167,6 +168,12 @@ macro(arcane_accelerator_enable)
   endif()
 endmacro()
 
+# Active les accélérateurs si Arcane a été compilé avec ce support
+if(ARCANE_HAS_ACCELERATOR_API)
+  arcane_accelerator_enable()
+endif()
+
+# ----------------------------------------------------------------------------
 # Indique que les fichiers passés en argument doivent être compilés avec le support accélérateur
 # correspondant.
 function(arcane_accelerator_add_source_files)
@@ -184,6 +191,7 @@ function(arcane_accelerator_add_source_files)
   endif()
 endfunction()
 
+# ----------------------------------------------------------------------------
 # Ajoute à la cible 'target_name' les informations nécessaires pour utiliser
 # les accélérateurs. Il faut avoir appeler 'arcane_enable_cuda' avant.
 function(arcane_accelerator_add_to_target target_name)


### PR DESCRIPTION
This is needed because some targets (`arcane_materials`, `arcane_full`) needs accelerator runtime