### PR TITLE
Tighten partial variable creation checks

### DIFF
--- a/arcane/src/arcane/core/ArcaneException.cc
+++ b/arcane/src/arcane/core/ArcaneException.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneException.cc                                          (C) 2000-2020 */
+/* ArcaneException.cc                                          (C) 2000-2024 */
 /*                                                                           */
 /* Exceptions lancées par l'architecture.                                    */
 /*---------------------------------------------------------------------------*/
@@ -141,6 +141,32 @@ explain(std::ostream& m) const
     << "' has already been declared\n"
     << "as '" << m_valid_var->itemKind() << '.' << m_valid_var->dataType()
     << "." << m_valid_var->dimension()
+    << "'";
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+BadPartialVariableItemGroupNameException::
+BadPartialVariableItemGroupNameException(const TraceInfo& where,IVariable* prv,
+                                         const String& item_group_name)
+: Exception("BadVariableKindType",where)
+, m_valid_var(prv)
+, m_item_group_name(item_group_name)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void BadPartialVariableItemGroupNameException::
+explain(std::ostream& m) const
+{
+  m << "Wrong partial variable type:\n"
+    << "Partial Variable '" << m_valid_var->name() << "'\n";
+  m << "declared on item group '" << m_item_group_name
+    << "' has already been declared\n"
+    << "on item group '" << m_valid_var->itemGroupName()
     << "'";
 }
 

--- a/arcane/src/arcane/core/ArcaneException.h
+++ b/arcane/src/arcane/core/ArcaneException.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneException.h                                           (C) 2000-2020 */
+/* ArcaneException.h                                           (C) 2000-2024 */
 /*                                                                           */
 /* Exceptions lancées par Arcane.                                            */
 /*---------------------------------------------------------------------------*/
@@ -151,6 +151,36 @@ class ARCANE_CORE_EXPORT BadVariableKindTypeException
   eDataType m_data_type;
   int m_dimension;
 };
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \internal
+ * \brief Exception sur un nom de groupe d'items de variable partielle non valide.
+ *
+ * Cette exception est envoyée lorsqu'on essaye de référencer une variable partielle
+ * qui existe déjà dans un autre module avec un nom de groupe d'items
+ * différent.
+ */
+class ARCANE_CORE_EXPORT BadPartialVariableItemGroupNameException
+: public Exception
+{
+ public:
+
+  BadPartialVariableItemGroupNameException(const TraceInfo& where,IVariable* valid_var,
+                                           const String& item_group_name);
+  ~BadPartialVariableItemGroupNameException() ARCANE_NOEXCEPT override {}
+
+ public:
+
+  void explain(std::ostream& m) const override;
+
+ private:
+
+  IVariable *m_valid_var;
+  String m_item_group_name;
+};
+
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/Variable.cc
+++ b/arcane/src/arcane/core/Variable.cc
@@ -1072,7 +1072,7 @@ _checkSetItemGroup()
     ARCANE_FATAL("Cannot add variable ({0}) on a own group (name={1})",
                  fullName(),internal->name());
   if (isPartial()) {
-    if (group_name.null())
+    if (group_name.empty())
       ARCANE_FATAL("Cannot create a partial variable with an empty item_group_name");
     debug(Trace::High) << "Attach ItemGroupPartialVariableObserver from " << fullName() 
                        << " to " << m_p->m_item_group.name();

--- a/arcane/src/arcane/core/Variable.cc
+++ b/arcane/src/arcane/core/Variable.cc
@@ -1072,6 +1072,8 @@ _checkSetItemGroup()
     ARCANE_FATAL("Cannot add variable ({0}) on a own group (name={1})",
                  fullName(),internal->name());
   if (isPartial()) {
+    if (group_name.null())
+      ARCANE_FATAL("Cannot create a partial variable with an empty item_group_name");
     debug(Trace::High) << "Attach ItemGroupPartialVariableObserver from " << fullName() 
                        << " to " << m_p->m_item_group.name();
     internal->attachObserver(this,new ItemGroupPartialVariableObserver(this));

--- a/arcane/src/arcane/impl/VariableMng.cc
+++ b/arcane/src/arcane/impl/VariableMng.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -370,6 +370,11 @@ checkVariable(const VariableInfo& infos)
         infos.dimension()!=var->dimension()){
       throw BadVariableKindTypeException(A_FUNCINFO,var,infos.itemKind(),
                                          infos.dataType(),infos.dimension());
+    }
+    // For partial variable: if exists already must be defined on the same group, otherwise fatal
+    if (infos.isPartial()) {
+      if (infos.itemGroupName() != var->itemGroupName())
+        throw BadPartialVariableItemGroupNameException(A_FUNCINFO, var, infos.itemGroupName());
     }
   }
   return var;


### PR DESCRIPTION
Prevent Partial Variable creation : 
* with no group name 
* with a group name different from an already existing Partial variable with the same name

No change if the groupe name refers to an non-existing group : the group is created empty.