### PR TITLE
Reduce number of synchronizations in some tests

### DIFF
--- a/arcane/tests/testParallel-synchronize2.arc
+++ b/arcane/tests/testParallel-synchronize2.arc
@@ -24,6 +24,6 @@
 
   <parallel-tester>
     <test-id>None</test-id>
-    <nb-test-sync>5</nb-test-sync>
+    <nb-test-sync>3</nb-test-sync>
   </parallel-tester>
 </cas>


### PR DESCRIPTION
The goal is to reduce execution time of some MPI tests in debug mode when oversubscribing.