### PR TITLE
Improve global C# target dependencies

### DIFF
--- a/arcane/cmake/GlobalCSharpCommand.cmake
+++ b/arcane/cmake/GlobalCSharpCommand.cmake
@@ -10,8 +10,14 @@ set(ARGS_MSBUILD_ARGS "/p:BinDir=${ARCANE_CSHARP_PROJECT_PATH}/bin_dir/")
 set(_RESTORE_BUILD_ARGS build BuildAllCSharp.proj /t:Restore ${ARGS_MSBUILD_ARGS} )
 set(_BUILD_ARGS publish --no-restore BuildAllCSharp.proj /t:PublishAndPack /p:PublishDir=${ARCANE_DOTNET_PUBLISH_PATH}/ ${ARGS_MSBUILD_ARGS} )
 
+# Liste de toutes les dépendances pour la cible 'arcane_global_csharp_target'
 get_property(_ALL_DEPEND_LIST TARGET arcane_global_csharp_target
   PROPERTY ARCANE_ALL_DEPENDS
+)
+# Liste des dépendances '*.csproj' pour la cible 'arcane_global_csharp_target'
+# Si les fichiers projets sont modifiés il faut refaire un 'restore'
+get_property(_CSHARP_PROJECT_DEPEND_LIST TARGET arcane_global_csharp_target
+  PROPERTY ARCANE_CSHARP_PROJECT_DEPENDS
 )
 set(_PACK_DIR ${CMAKE_BINARY_DIR}/nupkgs)
 file(MAKE_DIRECTORY ${_PACK_DIR})
@@ -23,6 +29,7 @@ if (ARCANE_HAS_DOTNET_WRAPPER)
     WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
     COMMAND ${_msbuild_exe} ${_RESTORE_BUILD_ARGS}
     COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_RESTORE_TIMESTAMP}
+    DEPENDS ${_CSHARP_PROJECT_DEPEND_LIST}
     COMMENT "Restoring global 'C#' target"
   )
 

--- a/arcane/cmake/GlobalCSharpCommand.cmake
+++ b/arcane/cmake/GlobalCSharpCommand.cmake
@@ -11,7 +11,7 @@ set(_RESTORE_BUILD_ARGS build BuildAllCSharp.proj /t:Restore ${ARGS_MSBUILD_ARGS
 set(_BUILD_ARGS publish --no-restore BuildAllCSharp.proj /t:PublishAndPack /p:PublishDir=${ARCANE_DOTNET_PUBLISH_PATH}/ ${ARGS_MSBUILD_ARGS} )
 
 get_property(_ALL_DEPEND_LIST TARGET arcane_global_csharp_target
-  PROPERTY DEPENDS
+  PROPERTY ARCANE_ALL_DEPENDS
 )
 set(_PACK_DIR ${CMAKE_BINARY_DIR}/nupkgs)
 file(MAKE_DIRECTORY ${_PACK_DIR})

--- a/arcane/cmake/GlobalCSharpCommand.cmake
+++ b/arcane/cmake/GlobalCSharpCommand.cmake
@@ -1,55 +1,51 @@
 ﻿# ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
 
-if(ARCANE_USE_GLOBAL_CSHARP)
-  set(ARGS_DOTNET_RUNTIME "coreclr")
-  set(_msbuild_exe ${ARCCON_MSBUILD_EXEC_${ARGS_DOTNET_RUNTIME}})
-  if (NOT _msbuild_exe)
-    logFatalError("In ${_func_name}: 'msbuild' command for runtime '${ARGS_DOTNET_RUNTIME}' is not available.")
-  endif()
-  set(ARGS_MSBUILD_ARGS "/p:BinDir=${ARCANE_CSHARP_PROJECT_PATH}/bin_dir/")
-  set(_RESTORE_BUILD_ARGS build BuildAllCSharp.proj /t:Restore ${ARGS_MSBUILD_ARGS} )
-  set(_BUILD_ARGS publish --no-restore BuildAllCSharp.proj /t:PublishAndPack /p:PublishDir=${ARCANE_DOTNET_PUBLISH_PATH}/ ${ARGS_MSBUILD_ARGS} )
+set(ARGS_DOTNET_RUNTIME "coreclr")
+set(_msbuild_exe ${ARCCON_MSBUILD_EXEC_${ARGS_DOTNET_RUNTIME}})
+if (NOT _msbuild_exe)
+  logFatalError("In ${_func_name}: 'msbuild' command for runtime '${ARGS_DOTNET_RUNTIME}' is not available.")
+endif()
+set(ARGS_MSBUILD_ARGS "/p:BinDir=${ARCANE_CSHARP_PROJECT_PATH}/bin_dir/")
+set(_RESTORE_BUILD_ARGS build BuildAllCSharp.proj /t:Restore ${ARGS_MSBUILD_ARGS} )
+set(_BUILD_ARGS publish --no-restore BuildAllCSharp.proj /t:PublishAndPack /p:PublishDir=${ARCANE_DOTNET_PUBLISH_PATH}/ ${ARGS_MSBUILD_ARGS} )
 
-  get_property(_ALL_DEPEND_LIST TARGET arcane_global_csharp_target
-    PROPERTY DEPENDS
+get_property(_ALL_DEPEND_LIST TARGET arcane_global_csharp_target
+  PROPERTY DEPENDS
+)
+set(_PACK_DIR ${CMAKE_BINARY_DIR}/nupkgs)
+file(MAKE_DIRECTORY ${_PACK_DIR})
+set(_PACK_ARGS /p:PackageOutputPath=${_PACK_DIR} /p:IncludeSymbols=true)
+
+if (ARCANE_HAS_DOTNET_WRAPPER)
+  # Commande de restauration des packages nuget
+  add_custom_command(OUTPUT "${ARCANE_DOTNET_RESTORE_TIMESTAMP}"
+    WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
+    COMMAND ${_msbuild_exe} ${_RESTORE_BUILD_ARGS}
+    COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_RESTORE_TIMESTAMP}
+    COMMENT "Restoring global 'C#' target"
   )
-  set(_PACK_DIR ${CMAKE_BINARY_DIR}/nupkgs)
-  file(MAKE_DIRECTORY ${_PACK_DIR})
-  set(_PACK_ARGS /p:PackageOutputPath=${_PACK_DIR} /p:IncludeSymbols=true)
 
-  if (ARCANE_HAS_DOTNET_WRAPPER)
-    # Commande de restauration des packages nuget
-    add_custom_command(OUTPUT "${ARCANE_DOTNET_RESTORE_TIMESTAMP}"
-      WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
-      COMMAND ${_msbuild_exe} ${_RESTORE_BUILD_ARGS}
-      COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_RESTORE_TIMESTAMP}
-      COMMENT "Restoring global 'C#' target"
-    )
+  message(STATUS "Adding Custom command for C#")
 
-    message(STATUS "Adding Custom command for C#")
-
-    # Commande de compilation de la cible
-    add_custom_command(OUTPUT "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}"
-      WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
-      COMMAND ${_msbuild_exe} ${_BUILD_ARGS} ${_PACK_ARGS}
-      COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_PUBLISH_TIMESTAMP}
-      DEPENDS arcane_global_csharp_restore_target ${_ALL_DEPEND_LIST}
-      COMMENT "Building and packing global 'C#' target"
-    )
-  else()
-    # Si le wrapper n'est pas actif, on créé une commande qui ne fait rien
-    add_custom_command(OUTPUT "${ARCANE_DOTNET_RESTORE_TIMESTAMP}"
-      WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
-      COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_RESTORE_TIMESTAMP}
-    )
-    add_custom_command(OUTPUT "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}"
-      WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
-      COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_PUBLISH_TIMESTAMP}
-    )
-  endif()
-
-  # TODO: Ajouter cible pour forcer la compilation
+  # Commande de compilation de la cible
+  add_custom_command(OUTPUT "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}"
+    WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
+    COMMAND ${_msbuild_exe} ${_BUILD_ARGS} ${_PACK_ARGS}
+    COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_PUBLISH_TIMESTAMP}
+    DEPENDS arcane_global_csharp_restore_target ${_ALL_DEPEND_LIST}
+    COMMENT "Building and packing global 'C#' target"
+  )
+else()
+  # Si le wrapper n'est pas actif, on créé une commande qui ne fait rien
+  add_custom_command(OUTPUT "${ARCANE_DOTNET_RESTORE_TIMESTAMP}"
+    WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
+    COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_RESTORE_TIMESTAMP}
+  )
+  add_custom_command(OUTPUT "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}"
+    WORKING_DIRECTORY "${ARCANE_CSHARP_PROJECT_PATH}"
+    COMMAND ${CMAKE_COMMAND} -E touch ${ARCANE_DOTNET_PUBLISH_TIMESTAMP}
+  )
 endif()
 
 # ----------------------------------------------------------------------------

--- a/arcane/cmake/GlobalCSharpTarget.cmake
+++ b/arcane/cmake/GlobalCSharpTarget.cmake
@@ -1,37 +1,30 @@
 ﻿# ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
-# Pour tester l'utilisation d'un cible globale pour le C#
-option(ARCANE_USE_GLOBAL_CSHARP "True if we use global C# project (experimental)" ON)
 
-# ----------------------------------------------------------------------------
-# ----------------------------------------------------------------------------
+set(ARCANE_DOTNET_PUBLISH_PATH "${CMAKE_BINARY_DIR}/lib")
+# Fichier pour savoir si on a déjà générer la cible
+set(ARCANE_DOTNET_PUBLISH_TIMESTAMP "${ARCANE_DOTNET_PUBLISH_PATH}/.dotnet_stamp")
+# Fichier pour savoir si on a déjà restaurer la cible
+set(ARCANE_DOTNET_RESTORE_TIMESTAMP "${ARCANE_DOTNET_PUBLISH_PATH}/.dotnet_restore_stamp")
 
-if(ARCANE_USE_GLOBAL_CSHARP)
-  set(ARCANE_DOTNET_PUBLISH_PATH "${CMAKE_BINARY_DIR}/lib")
-  # Fichier pour savoir si on a déjà générer la cible
-  set(ARCANE_DOTNET_PUBLISH_TIMESTAMP "${ARCANE_DOTNET_PUBLISH_PATH}/.dotnet_stamp")
-  # Fichier pour savoir si on a déjà restaurer la cible
-  set(ARCANE_DOTNET_RESTORE_TIMESTAMP "${ARCANE_DOTNET_PUBLISH_PATH}/.dotnet_restore_stamp")
+add_custom_target(arcane_global_csharp_target ALL DEPENDS "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}")
+add_custom_target(arcane_global_csharp_restore_target ALL DEPENDS "${ARCANE_DOTNET_RESTORE_TIMESTAMP}")
 
-  add_custom_target(arcane_global_csharp_target ALL DEPENDS "${ARCANE_DOTNET_PUBLISH_TIMESTAMP}")
-  add_custom_target(arcane_global_csharp_restore_target ALL DEPENDS "${ARCANE_DOTNET_RESTORE_TIMESTAMP}")
-
-  # Cette dépendence n'existe pas réellement mais elle permet de s'assurer qu'il n'y
-  # a qu'une seule cible à la fois qui appelle `dotnet`.
-  # C'est nécessaire pour éviter les erreurs dues à la création de répertoires lors de
-  # la première utilisation de `dotnet` (dans 'Microsoft.DotNet.Configurer.DotnetFirstTimeUseConfigurer.Configure()')
-  if (TARGET dotnet_axl_depend)
-    add_dependencies(arcane_global_csharp_restore_target dotnet_axl_depend)
-  endif()
-
-  # Cible pour forcer la recompilation et la restauration
-  add_custom_target(force_arcane_global_csharp
-      WORKING_DIRECTORY ${ARGS_PROJECT_PATH}
-      COMMAND ${CMAKE_COMMAND} -E remove "${ARCANE_DOTNET_RESTORE_TIMESTAMP}"
-      COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target arcane_global_csharp_target
-      COMMENT "Force Building global 'C#' target"
-      )
+# Cette dépendence n'existe pas réellement mais elle permet de s'assurer qu'il n'y
+# a qu'une seule cible à la fois qui appelle `dotnet`.
+# C'est nécessaire pour éviter les erreurs dues à la création de répertoires lors de
+# la première utilisation de `dotnet` (dans 'Microsoft.DotNet.Configurer.DotnetFirstTimeUseConfigurer.Configure()')
+if (TARGET dotnet_axl_depend)
+  add_dependencies(arcane_global_csharp_restore_target dotnet_axl_depend)
 endif()
+
+# Cible pour forcer la recompilation et la restauration
+add_custom_target(force_arcane_global_csharp
+  WORKING_DIRECTORY ${ARGS_PROJECT_PATH}
+  COMMAND ${CMAKE_COMMAND} -E remove "${ARCANE_DOTNET_RESTORE_TIMESTAMP}"
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target arcane_global_csharp_target
+  COMMENT "Force Building global 'C#' target"
+)
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------

--- a/arcane/cmake/GlobalCSharpTarget.cmake
+++ b/arcane/cmake/GlobalCSharpTarget.cmake
@@ -48,10 +48,6 @@ add_custom_target(force_arcane_global_csharp
 #
 function(arcane_add_global_csharp_target target_name)
   # Appelle l'ancienne méthode tant que la nouvelle n'est pas finalisée
-  if (NOT ARCANE_USE_GLOBAL_CSHARP)
-    arccon_add_csharp_target(${target_name} DOTNET_RUNTIME coreclr ${ARGN})
-    return()
-  endif()
   set(_func_name "arcane_add_global_csharp_target")
   set(options PACK)
   set(oneValueArgs BUILD_DIR TARGET_PATH ASSEMBLY_NAME PROJECT_NAME PROJECT_PATH)
@@ -89,13 +85,20 @@ function(arcane_add_global_csharp_target target_name)
     endforeach()
   endif()
   message(STATUS "_DOTNET_TARGET_DLL_DEPENDS=${_DOTNET_TARGET_DLL_DEPENDS}")
-  set(_ALL_DEPENDS ${build_proj_path} ${ARGS_DEPENDS} ${ARGS_DOTNET_TARGET_DEPENDS})
+  set(_ALL_DEPENDS ${ARGS_DEPENDS} ${ARGS_DOTNET_TARGET_DEPENDS})
 
   # Ajoute les fichiers à la dépendance de la cible globale
   # Cela est utilisé ensuite dans 'GlobalCSharpCommand.cmake' pour générer la liste de dépendances
   set_property(TARGET arcane_global_csharp_target
     APPEND PROPERTY
     ARCANE_ALL_DEPENDS ${_ALL_DEPENDS}
+  )
+
+  # Ajoute le fichier projet à la dépendance de la cible globale.
+  # Cela sera utilisé ensuite dans 'GlobalCSharpCommand.cmake' pour la restauration nuget.
+  set_property(TARGET arcane_global_csharp_target
+    APPEND PROPERTY
+    ARCANE_CSHARP_PROJECT_DEPENDS "${build_proj_path}"
   )
 
   add_custom_target(${target_name} DEPENDS ${ARGS_DOTNET_TARGET_DEPENDS})

--- a/arcane/cmake/GlobalCSharpTarget.cmake
+++ b/arcane/cmake/GlobalCSharpTarget.cmake
@@ -95,7 +95,7 @@ function(arcane_add_global_csharp_target target_name)
   # Cela est utilisé ensuite dans 'GlobalCSharpCommand.cmake' pour générer la liste de dépendances
   set_property(TARGET arcane_global_csharp_target
     APPEND PROPERTY
-    DEPENDS ${_ALL_DEPENDS}
+    ARCANE_ALL_DEPENDS ${_ALL_DEPENDS}
   )
 
   add_custom_target(${target_name} DEPENDS ${ARGS_DOTNET_TARGET_DEPENDS})


### PR DESCRIPTION
- Always use global C# target
- Re-do nuget package restoration when a project file is modified.