### PR TITLE
Add preliminary support for null variable on mesh items

### DIFF
--- a/arcane/src/arcane/core/ArcaneTypes.h
+++ b/arcane/src/arcane/core/ArcaneTypes.h
@@ -524,6 +524,7 @@ class IVariableFactory;
 class VariableTypeInfo;
 class VariableRef;
 class VariableBuildInfo;
+class NullVariableBuildInfo;
 class VariableFactoryRegisterer;
 class VariableInfo;
 typedef VariableRef* (*VariableFactoryVariableRefCreateFunc)(const VariableBuildInfo& vb);

--- a/arcane/src/arcane/core/Array2Variable.cc
+++ b/arcane/src/arcane/core/Array2Variable.cc
@@ -243,7 +243,9 @@ Array2VariableT(const VariableBuildInfo& vb,const VariableInfo& info)
 template<typename T> Array2VariableT<T>* Array2VariableT<T>::
 getReference(const VariableBuildInfo& vb,const VariableInfo& vi)
 {
-  ThatClass* true_ptr = 0;
+  if (vb.isNull())
+    return nullptr;
+  ThatClass* true_ptr = nullptr;
   IVariableMng* vm = vb.variableMng();
   IVariable* var = vm->checkVariable(vi);
   if (var)

--- a/arcane/src/arcane/core/Array2Variable.h
+++ b/arcane/src/arcane/core/Array2Variable.h
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -16,7 +16,7 @@
 
 #include "arcane/utils/Array2.h"
 
-#include "arcane/Variable.h"
+#include "arcane/core/Variable.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -35,11 +35,11 @@ class Array2VariableT
 : public Variable
 {
  public:
-	
-  typedef Array2<T> ValueType;
-  typedef IArray2DataT<T> ValueDataType;
-  typedef Array2VariableT<T> ThatClass;
-  typedef Variable BaseClass;
+
+  using ValueType = Array2<T>;
+  using ValueDataType = IArray2DataT<T>;
+  using ThatClass = Array2VariableT<T>;
+  using BaseClass = Variable;
 
  protected:
 
@@ -92,7 +92,7 @@ class Array2VariableT
 
  private:
 
-  ValueDataType* m_data;
+  ValueDataType* m_data = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshVariableArrayRef.h
+++ b/arcane/src/arcane/core/MeshVariableArrayRef.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshVariableArrayRef.h                                      (C) 2000-2023 */
+/* MeshVariableArrayRef.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Classe gérant une variable vectorielle sur une entité du maillage.        */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshVariableArrayRef.h
+++ b/arcane/src/arcane/core/MeshVariableArrayRef.h
@@ -63,8 +63,8 @@ class ItemVariableArrayRefT
  protected:
   
   //! Positionne la référence de l'instance à la variable \a rhs.
-  ARCANE_CORE_EXPORT void operator=(const ItemVariableArrayRefT<DataType>& rhs);
-  
+  ARCANE_CORE_EXPORT ItemVariableArrayRefT<DataType>& operator=(const ItemVariableArrayRefT<DataType>& rhs);
+
  public:
 
   //! Valeur non modifiable de l'entité \a item

--- a/arcane/src/arcane/core/MeshVariableArrayRefT.H
+++ b/arcane/src/arcane/core/MeshVariableArrayRefT.H
@@ -61,9 +61,11 @@ ItemVariableArrayRefT<DataType>::
 ItemVariableArrayRefT(const VariableBuildInfo& vb,eItemKind ik)
 : PrivateVariableArrayT<DataType>(vb,_internalVariableInfo(vb,ik))
 {
-  this->_internalInit();
-  if (this->m_private_part->isPartial())
-    ARCANE_FATAL("Can not assign a partial variable to a full variable");
+  if (!vb.isNull()) {
+    this->_internalInit();
+    if (this->m_private_part->isPartial())
+      ARCANE_FATAL("Can not assign a partial variable to a full variable");
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -85,19 +87,25 @@ template<class DataType> ItemVariableArrayRefT<DataType>::
 ItemVariableArrayRefT(const ItemVariableArrayRefT<DataType>& rhs)
 : PrivateVariableArrayT<DataType>(rhs)
 {
-  this->updateFromInternal();
+  if (this->m_private_part)
+    this->updateFromInternal();
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<class DataType> void 
+template <class DataType> ItemVariableArrayRefT<DataType>&
 ItemVariableArrayRefT<DataType>::
 operator=(const ItemVariableArrayRefT<DataType>& rhs)
 {
-  BaseClass::operator=(rhs);
-  this->m_private_part = rhs.m_private_part;
-  this->updateFromInternal();
+  if (this != &rhs) {
+    BaseClass::operator=(rhs);
+    if (this->m_private_part) {
+      this->m_private_part = rhs.m_private_part;
+      this->updateFromInternal();
+    }
+  }
+  return (*this);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshVariableArrayRefT.H
+++ b/arcane/src/arcane/core/MeshVariableArrayRefT.H
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshVariableArrayRefT.H                                     (C) 2000-2023 */
+/* MeshVariableArrayRefT.H                                     (C) 2000-2024 */
 /*                                                                           */
 /* Variable vectorielle du maillage.                                         */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshVariableRef.h
+++ b/arcane/src/arcane/core/MeshVariableRef.h
@@ -35,8 +35,8 @@ class ARCANE_CORE_EXPORT MeshVariableRef
  public:
 
   //! Construit une référence liée au module \a module
-  MeshVariableRef(const VariableBuildInfo& vb);
-  virtual ~MeshVariableRef() {}
+  explicit MeshVariableRef(const VariableBuildInfo& vb);
+  ~MeshVariableRef() override = default;
 
  protected:
 

--- a/arcane/src/arcane/core/MeshVariableScalarRefT.H
+++ b/arcane/src/arcane/core/MeshVariableScalarRefT.H
@@ -102,9 +102,11 @@ ItemVariableScalarRefT<DataTypeT>::
 ItemVariableScalarRefT(const VariableBuildInfo& vb,eItemKind ik)
 : PrivateVariableScalarT<DataTypeT>(vb,_internalVariableInfo(vb,ik))
 {
-  this->_internalInit();
-  if (this->m_private_part->isPartial())
-    ARCANE_FATAL("Can not assign a partial variable to a full variable");
+  if (!vb.isNull()) {
+    this->_internalInit();
+    if (this->m_private_part->isPartial())
+      ARCANE_FATAL("Can not assign a partial variable to a full variable");
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/PrivateVariableArrayT.H
+++ b/arcane/src/arcane/core/PrivateVariableArrayT.H
@@ -53,7 +53,8 @@ PrivateVariableArrayT(const PrivateVariableArrayT& rhs)
 : MeshVariableRef(rhs)
 , m_private_part(rhs.m_private_part)
 {
-  updateFromInternal();
+  if (m_private_part)
+    updateFromInternal();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -63,9 +64,12 @@ template<class DataType> void
 PrivateVariableArrayT<DataType>::
 operator=(const PrivateVariableArrayT& rhs)
 {
-  VariableRef::operator=(rhs);
-  m_private_part = rhs.m_private_part;
-  updateFromInternal();
+  if (this != &rhs) {
+    VariableRef::operator=(rhs);
+    m_private_part = rhs.m_private_part;
+    if (m_private_part)
+      updateFromInternal();
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -74,7 +78,8 @@ operator=(const PrivateVariableArrayT& rhs)
 template<class DataType> void
 PrivateVariableArrayT<DataType>::
 updateFromInternal()
-{ 
+{
+  ARCANE_CHECK_POINTER(m_private_part);
   m_view = m_private_part->valueView();
   MeshVariableRef::updateFromInternal();
   _executeUpdateFunctors();
@@ -87,6 +92,7 @@ template<class DataType> void
 PrivateVariableArrayT<DataType>::
 resize(Integer dim2_size)
 {
+  ARCANE_CHECK_POINTER(m_private_part);
   m_private_part->directResize(m_private_part->valueView().dim1Size(),dim2_size);
   updateFromInternal();
 }

--- a/arcane/src/arcane/core/PrivateVariableScalar.h
+++ b/arcane/src/arcane/core/PrivateVariableScalar.h
@@ -82,11 +82,11 @@ class PrivateVariableScalarT
   
  protected:
 
-  PrivatePartType* m_private_part;
-    
+  PrivatePartType* m_private_part = nullptr;
+
   ArrayView<DataType> m_view;
-  
-  IMemoryAccessTrace* m_memory_trace;
+
+  IMemoryAccessTrace* m_memory_trace = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/PrivateVariableScalar.h
+++ b/arcane/src/arcane/core/PrivateVariableScalar.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* PrivateVariableScalar.h                                     (C) 2000-2023 */
+/* PrivateVariableScalar.h                                     (C) 2000-2024 */
 /*                                                                           */
 /* Classe gérant une variable sur une entité du maillage.                    */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/PrivateVariableScalarT.H
+++ b/arcane/src/arcane/core/PrivateVariableScalarT.H
@@ -56,7 +56,8 @@ PrivateVariableScalarT(const PrivateVariableScalarT& rhs)
 , m_private_part(rhs.m_private_part)
 , m_memory_trace(rhs.m_memory_trace)
 {
-  updateFromInternal();
+  if (m_private_part)
+    updateFromInternal();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -65,8 +66,6 @@ PrivateVariableScalarT(const PrivateVariableScalarT& rhs)
 template<class DataType> 
 PrivateVariableScalarT<DataType>::
 PrivateVariableScalarT()
-: m_private_part(nullptr)
-, m_memory_trace(nullptr)
 {
 }
 
@@ -79,7 +78,8 @@ operator=(const PrivateVariableScalarT& rhs)
 {
   VariableRef::operator=(rhs);
   m_private_part = rhs.m_private_part;
-  updateFromInternal();
+  if (m_private_part)
+    updateFromInternal();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -248,7 +248,9 @@ template<typename T> VariableArrayT<T>::
 template<typename T> VariableArrayT<T>* VariableArrayT<T>::
 getReference(const VariableBuildInfo& vb,const VariableInfo& vi)
 {
-  ThatClass* true_ptr = 0;
+  if (vb.isNull())
+    return nullptr;
+  ThatClass* true_ptr = nullptr;
   IVariableMng* vm = vb.variableMng();
   IVariable* var = vm->checkVariable(vi);
   if (var)

--- a/arcane/src/arcane/core/VariableBuildInfo.cc
+++ b/arcane/src/arcane/core/VariableBuildInfo.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableBuildInfo.cc                                        (C) 2000-2023 */
+/* VariableBuildInfo.cc                                        (C) 2000-2024 */
 /*                                                                           */
 /* Informations pour construire une variable.                                */
 /*---------------------------------------------------------------------------*/
@@ -59,7 +59,6 @@ VariableBuildInfo(IModule* m,const String& name,int property)
 VariableBuildInfo::
 VariableBuildInfo(ISubDomain* sd,const String& name,int property)
 : m_sub_domain(sd)
-, m_module(nullptr)
 , m_name(name)
 , m_property(property)
 {
@@ -72,7 +71,6 @@ VariableBuildInfo(ISubDomain* sd,const String& name,int property)
 VariableBuildInfo::
 VariableBuildInfo(IVariableMng* variable_mng,const String& name,int property)
 : m_sub_domain(variable_mng->_internalApi()->internalSubDomain())
-, m_module(nullptr)
 , m_name(name)
 , m_property(property)
 {
@@ -85,7 +83,6 @@ VariableBuildInfo(IVariableMng* variable_mng,const String& name,int property)
 VariableBuildInfo::
 VariableBuildInfo(const MeshHandle& mesh_handle,const String& name,int property)
 : m_sub_domain(_getSubDomainDeprecated(mesh_handle))
-, m_module(nullptr)
 , m_mesh_handle(mesh_handle)
 , m_name(name)
 , m_property(property)
@@ -125,7 +122,6 @@ VariableBuildInfo::
 VariableBuildInfo(const MeshHandle& mesh_handle,const String& name,
                   const String& item_family_name,int property)
 : m_sub_domain(_getSubDomainDeprecated(mesh_handle))
-, m_module(nullptr)
 , m_mesh_handle(mesh_handle)
 , m_name(name)
 , m_item_family_name(item_family_name)
@@ -151,7 +147,6 @@ VariableBuildInfo::
 VariableBuildInfo(ISubDomain* sd,const String& name,const String& mesh_name,
                   const String& item_family_name,int property)
 : m_sub_domain(sd)
-, m_module(nullptr)
 , m_name(name)
 , m_item_family_name(item_family_name)
 , m_mesh_name(mesh_name)
@@ -167,7 +162,6 @@ VariableBuildInfo::
 VariableBuildInfo(IVariableMng* variable_mng,const String& name,const String& mesh_name,
                   const String& item_family_name,int property)
 : m_sub_domain(variable_mng->_internalApi()->internalSubDomain())
-, m_module(nullptr)
 , m_name(name)
 , m_item_family_name(item_family_name)
 , m_mesh_name(mesh_name)
@@ -182,7 +176,6 @@ VariableBuildInfo(IVariableMng* variable_mng,const String& name,const String& me
 VariableBuildInfo::
 VariableBuildInfo(IItemFamily* family,const String& name,int property)
 : m_sub_domain(_getSubDomainDeprecated(family->mesh()->handle()))
-, m_module(nullptr)
 , m_mesh_handle(family->mesh()->handle())
 , m_name(name)
 , m_item_family_name(family->name())
@@ -217,7 +210,6 @@ VariableBuildInfo(const MeshHandle& mesh_handle,const String& name,
                   const String& item_family_name,
                   const String& item_group_name,int property)
 : m_sub_domain(_getSubDomainDeprecated(mesh_handle))
-, m_module(nullptr)
 , m_mesh_handle(mesh_handle)
 , m_name(name)
 , m_item_family_name(item_family_name)
@@ -247,7 +239,6 @@ VariableBuildInfo(ISubDomain* sd,const String& name,
                   const String& item_family_name,
                   const String& item_group_name,int property)
 : m_sub_domain(sd)
-, m_module(nullptr)
 , m_name(name)
 , m_item_family_name(item_family_name)
 , m_item_group_name(item_group_name)
@@ -266,12 +257,21 @@ VariableBuildInfo(IVariableMng* variable_mng,const String& name,
                   const String& item_family_name,
                   const String& item_group_name,int property)
 : m_sub_domain(variable_mng->_internalApi()->internalSubDomain())
-, m_module(nullptr)
 , m_name(name)
 , m_item_family_name(item_family_name)
 , m_item_group_name(item_group_name)
 , m_mesh_name(mesh_name)
 , m_property(property)
+{
+  _init();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+VariableBuildInfo::
+VariableBuildInfo(const NullTag&)
+: m_is_null(true)
 {
   _init();
 }

--- a/arcane/src/arcane/core/VariableBuildInfo.h
+++ b/arcane/src/arcane/core/VariableBuildInfo.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableBuildInfo.h                                         (C) 2000-2022 */
+/* VariableBuildInfo.h                                         (C) 2000-2024 */
 /*                                                                           */
 /* Informations pour construire une variable.                                */
 /*---------------------------------------------------------------------------*/
@@ -15,7 +15,7 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/String.h"
-#include "arcane/MeshHandle.h"
+#include "arcane/core/MeshHandle.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -42,8 +42,18 @@ class IDataFactoryMng;
 class ARCANE_CORE_EXPORT VariableBuildInfo
 {
  public:
+
+  // Pour accéder au constructeur par défaut.
+  friend class NullVariableBuildInfo;
   // TEMPORAIRE Pour accéder à _subDomain(). A supprimer par la suite.
   friend class VariablePrivate;
+
+ private:
+
+  //! Tag pour un VariableBuildInfo nul.
+  struct NullTag
+  {};
+
  public:
 
   /*!
@@ -235,10 +245,17 @@ class ARCANE_CORE_EXPORT VariableBuildInfo
                     const String& item_family_name,
                     const String& item_group_name,int property=0);
 
+ private:
+
+  explicit VariableBuildInfo(const NullTag&);
+
  public:
+
   ARCCORE_DEPRECATED_2020("Do not use this method. Try to get ISubDomain from another way")
   ISubDomain* subDomain() const { return m_sub_domain; }
+
  public:
+
   IVariableMng* variableMng() const;
   IDataFactoryMng* dataFactoryMng() const;
   ITraceMng* traceMng() const;
@@ -250,22 +267,42 @@ class ARCANE_CORE_EXPORT VariableBuildInfo
   const String& itemGroupName() const { return m_item_group_name; }
   const String& meshName() const { return m_mesh_name; }
   int property() const { return m_property; }
+  bool isNull() const { return m_is_null; }
 
  private:
 
-  ISubDomain* m_sub_domain; //!< Gestionnaire de sous-domaine
-  IModule* m_module; //!< Module associé à la variable
+  ISubDomain* m_sub_domain = nullptr; //!< Gestionnaire de sous-domaine
+  IModule* m_module = nullptr; //!< Module associé à la variable
   MeshHandle m_mesh_handle;  //!< Handle sur le maillage
   String m_name; //!< Nom de la variable
   String m_item_family_name; //!< Nom de la famille d'entité
   String m_item_group_name; //!< Nom du groupe d'entité support
   String m_mesh_name; //!< Nom du maillage associé à la variable
-  int m_property; //!< Propriétés de la variable
+  int m_property = 0; //!< Propriétés de la variable
+  bool m_is_null = false;
 
  private:
 
   void _init();
   ISubDomain* _subDomain() const { return m_sub_domain; }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Constructeur pour une variable nulle.
+ *
+ * \warning Cette classe est expérimentale. Ne pas utiliser en dehors
+ * de Arcane.
+ */
+class ARCANE_CORE_EXPORT NullVariableBuildInfo
+: public VariableBuildInfo
+{
+ public:
+
+  NullVariableBuildInfo()
+  : VariableBuildInfo(NullTag{})
+  {}
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableRef.cc
+++ b/arcane/src/arcane/core/VariableRef.cc
@@ -124,14 +124,8 @@ class VariableRef::UpdateNotifyFunctorList
 
 VariableRef::
 VariableRef(const VariableBuildInfo& vbi)
-: m_variable(0)
-, m_module(vbi.module())
-, m_is_registered(false)
+: m_module(vbi.module())
 , m_reference_property(vbi.property())
-, m_previous_reference(0)
-, m_next_reference(0)
-, m_has_trace(false)
-, m_notify_functor_list(0)
 {
   //cout << "VAR NAME=" << vbi.name() << " this="
   //     << this << " module=" << m_module << '\n';
@@ -144,13 +138,7 @@ VariableRef(const VariableBuildInfo& vbi)
 VariableRef::
 VariableRef(IVariable* var)
 : m_variable(var)
-, m_module(0)
-, m_is_registered(false)
 , m_reference_property(var->property())
-, m_previous_reference(0)
-, m_next_reference(0)
-, m_has_trace(false)
-, m_notify_functor_list(0)
 {
   //cout << "VAR NAME=" << vbi.name() << " this="
   //     << this << " module=" << m_module << '\n';
@@ -168,14 +156,6 @@ VariableRef(IVariable* var)
  */
 VariableRef::
 VariableRef()
-: m_variable(0)
-, m_module(0)
-, m_is_registered(false)
-, m_reference_property(0)
-, m_previous_reference(0)
-, m_next_reference(0)
-, m_has_trace(false)
-, m_notify_functor_list(0)
 {
 }
 
@@ -186,12 +166,7 @@ VariableRef::
 VariableRef(const VariableRef& from)
 : m_variable(from.m_variable)
 , m_module(from.m_module)
-, m_is_registered(false)
 , m_reference_property(from.m_reference_property)
-, m_previous_reference(0)
-, m_next_reference(0)
-, m_has_trace(false)
-, m_notify_functor_list(0)
 {
   _setAssignmentStackTrace();
   //cout << "** TODO: check variable copy constructor with linked list\n";
@@ -207,8 +182,10 @@ VariableRef(const VariableRef& from)
 VariableRef& VariableRef::
 operator=(const VariableRef& rhs)
 {
-  if (rhs.m_variable!=m_variable)
-    _internalAssignVariable(rhs);
+  if (this != &rhs) {
+    if (rhs.m_variable != m_variable)
+      _internalAssignVariable(rhs);
+  }
   return (*this);
 }
 

--- a/arcane/src/arcane/core/VariableRef.cc
+++ b/arcane/src/arcane/core/VariableRef.cc
@@ -170,10 +170,11 @@ VariableRef(const VariableRef& from)
 {
   _setAssignmentStackTrace();
   //cout << "** TODO: check variable copy constructor with linked list\n";
-  //NOTE:
+  // NOTE:
   // C'est la variable qui met à jour m_previous_reference et m_next_reference
   // dans registerVariable.
-  registerVariable();
+  if (from.m_variable)
+    registerVariable();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -250,7 +251,7 @@ _internalInit(IVariable* variable)
   m_variable = variable;
   registerVariable();
   updateFromInternal();
-  // Les variables autre que celles sur le maillages sont toujours utilisées
+  // Les variables autres que celles sur le maillage sont toujours utilisées
   // par défaut
   if (variable->itemKind()==IK_Unknown)
     setUsed(true);

--- a/arcane/src/arcane/core/VariableRef.h
+++ b/arcane/src/arcane/core/VariableRef.h
@@ -64,7 +64,7 @@ class ARCANE_CORE_EXPORT VariableRef
   //! Construit une référence sur une variable avec les infos \a vbi
   explicit VariableRef(const VariableBuildInfo& vbi);
   //! Constructeur de copie
-  explicit VariableRef(const VariableRef& from);
+  VariableRef(const VariableRef& from);
   //! Construit une référence sur une variable \a var
   explicit VariableRef(IVariable* var);
   //! Opérateur de recopie
@@ -301,22 +301,22 @@ class ARCANE_CORE_EXPORT VariableRef
  private:
 
   //! Variable associée
-  IVariable* m_variable;
+  IVariable* m_variable = nullptr;
 
   //! Module associé (ou 0 si aucun)
-  IModule* m_module;
+  IModule* m_module = nullptr;
 
   //! \a true si la variable a été enregistrée
-  bool m_is_registered;
+  bool m_is_registered = false;
 
   //! Propriétés de la référence
-  int m_reference_property;
+  int m_reference_property = 0;
 
   //! Référence précédente sur \a m_variable
-  VariableRef* m_previous_reference;
+  VariableRef* m_previous_reference = nullptr;
 
   //! Référence suivante sur \a m_variable
-  VariableRef* m_next_reference;
+  VariableRef* m_next_reference = nullptr;
 
   /*!
    * \brief Pile d'appel lors de l'assignation de la variable.
@@ -329,7 +329,7 @@ class ARCANE_CORE_EXPORT VariableRef
 
   void _executeUpdateFunctors();
 
-  bool m_has_trace;
+  bool m_has_trace = false;
 
  private:
 
@@ -351,7 +351,7 @@ class ARCANE_CORE_EXPORT VariableRef
  private:
 
   static bool m_static_has_trace_creation;
-  UpdateNotifyFunctorList* m_notify_functor_list;
+  UpdateNotifyFunctorList* m_notify_functor_list = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/VariableUnitTest.cc
+++ b/arcane/src/arcane/tests/VariableUnitTest.cc
@@ -265,6 +265,9 @@ _testRefersTo()
 
   ValueChecker vc(A_FUNCINFO);
 
+  VariableCellReal null_var1(NullVariableBuildInfo{});
+  VariableCellArrayReal null_array_var1(NullVariableBuildInfo{});
+
   // Teste refersTo() pour les variables 0D sur les entités du maillage
   {
     VariableCellReal var1(VariableBuildInfo(mesh(),"CellRealTest1"));
@@ -276,6 +279,11 @@ _testRefersTo()
     // Vérifie que ce sont les mêmes variables avec les mêmes valeurs.
     vc.areEqual(var1.variable(),var2.variable(),"Bad refersTo()");
     vc.areEqualArray(var1.asArray().constView(),var2.asArray().constView(),"Bad values");
+
+    VariableCellReal from_null_var2(null_var1);
+    from_null_var2.refersTo(var2);
+    vc.areEqual(from_null_var2.variable(),var2.variable(),"Bad refersTo()");
+    vc.areEqualArray(from_null_var2.asArray().constView(),var2.asArray().constView(),"Bad values");
   }
 
   // Teste refersTo() pour les variables 1D sur les entités du maillage
@@ -294,6 +302,11 @@ _testRefersTo()
     vc.areEqual(var1.variable(),var2.variable(),"Bad refersTo() for Array");
     vc.areEqual(var1.arraySize(),3,"Bad size (2)");
     //vc.areEqualArray(var1.asArray().constView(),var2.asArray().constView(),"Bad values");
+
+    VariableCellArrayReal from_null_array_var2(null_array_var1);
+    from_null_array_var2.refersTo(var2);
+    vc.areEqual(from_null_array_var2.variable(),var2.variable(),"Bad refersTo() for Array");
+    vc.areEqual(from_null_array_var2.arraySize(),3,"Bad size (2)");
 
     // Teste les accesseurs
     {


### PR DESCRIPTION
This is experimental.
It will allow the creation of `VariableRef` without referencing a variable. It may be useful for example if you want to use a `VariableRef` in a field of a class with a default constructor.
 