### PR TITLE
Use 'MessageRank::anySourceRank()' instead of default MessageRank to specifiy any source

### DIFF
--- a/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.h
+++ b/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* HybridMessageQueue.h                                        (C) 2000-2022 */
+/* HybridMessageQueue.h                                        (C) 2000-2024 */
 /*                                                                           */
 /* File de messages pour une implémentation hybride MPI/Mémoire partagée.    */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.h
+++ b/arcane/src/arcane/parallel/mpithread/HybridMessageQueue.h
@@ -221,6 +221,7 @@ class HybridMessageQueue
   Int32 m_local_nb_rank;
   RankTagBuilder m_rank_tag_builder;
   Int32 m_debug_level = 0;
+  bool m_is_allow_null_rank_for_any_source = true;
 
  private:
 

--- a/arcane/src/arcane/parallel/thread/SharedMemoryMessageQueue.h
+++ b/arcane/src/arcane/parallel/thread/SharedMemoryMessageQueue.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SharedMemoryMessageQueue.h                                  (C) 2000-2019 */
+/* SharedMemoryMessageQueue.h                                  (C) 2000-2024 */
 /*                                                                           */
 /* Implémentation d'une file de messages en mémoire partagée.                */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/parallel/thread/SharedMemoryMessageQueue.h
+++ b/arcane/src/arcane/parallel/thread/SharedMemoryMessageQueue.h
@@ -76,7 +76,7 @@ class ARCANE_THREAD_EXPORT SharedMemoryMessageQueue
 
  private:
 
-  Int32 m_nb_thread;
+  Int32 m_nb_thread = 0;
   UniqueArray<SubQueue*> m_sub_queues;
   std::atomic<Int64> m_atomic_request_id;
 

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -374,7 +374,7 @@ arcane_add_test_parallel(standalone_subdomain2 dummy.arc 4 "-A,StandaloneSubDoma
 
 # Macro pour tester le message_passing
 macro(add_test_message_passing test_name)
-  set(_OPTS -We,MESSAGE_PASSING_TEST,${test_name} -arcane_opt direct_test ParallelMngTest null)
+  set(_OPTS -We,MESSAGE_PASSING_TEST,${test_name} -We,ARCCORE_ALLOW_NULL_RANK_FOR_MPI_ANY_SOURCE,1 -arcane_opt direct_test ParallelMngTest null)
   set(_TEST_NAME parallelmng_${test_name})
   add_test(${_TEST_NAME}_seq ${ARCANE_TEST_DRIVER} launch ${_OPTS})
   if(TARGET arcane_mpi)

--- a/arcane/src/arcane/tests/ParallelMngDataTypeTest.cc
+++ b/arcane/src/arcane/tests/ParallelMngDataTypeTest.cc
@@ -909,7 +909,7 @@ _testMessageProbe(Int32 rank_to_receive,Integer nb_message,
     for( Integer orig=0; orig<comm_size; ++orig ){
       if (orig!=rank_to_receive)
         for( Integer z=0; z<nb_message; ++z ){
-          MessageRank source_rank( (use_any_source) ? A_NULL_RANK : orig );
+          MessageRank source_rank( (use_any_source) ? MessageRank::anySourceRank() : MessageRank(orig) );
           all_msg_info.add({source_rank, Parallel::NonBlocking});
         }
     }
@@ -1011,7 +1011,7 @@ _testMessageLegacyProbe(Int32 rank_to_receive,Int32 nb_message,
     for( Integer orig=0; orig<comm_size; ++orig ){
       if (orig!=rank_to_receive)
         for( Integer z=0; z<nb_message; ++z ){
-          MessageRank source_rank( (use_any_source) ? A_NULL_RANK : orig );
+          MessageRank source_rank( (use_any_source) ? MessageRank::anySourceRank() : MessageRank(orig) );
           all_msg_info.add({source_rank, Parallel::NonBlocking});
         }
     }

--- a/arcane/src/arcane/tests/ParallelMngDataTypeTest.cc
+++ b/arcane/src/arcane/tests/ParallelMngDataTypeTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelMngDataTypeTest.cc                                  (C) 2000-2023 */
+/* ParallelMngDataTypeTest.cc                                  (C) 2000-2024 */
 /*                                                                           */
 /* Test des opérations de base du parallèlisme.                              */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The usage of default `MessageRank` to specifiy any source is deprecated. The environment variable `ARCCORE_ALLOW_NULL_RANK_FOR_MPI_ANY_SOURCE` may be used to disable the deprecated behavior.
