### PR TITLE
Add generic for memory copy from a numpy array to an Arcane Variable.

### DIFF
--- a/arcane/src/arcane/core/InterfaceImpl.cc
+++ b/arcane/src/arcane/core/InterfaceImpl.cc
@@ -51,6 +51,7 @@
 #include "arcane/core/IMeshMng.h"
 #include "arcane/core/IMeshPartitioner.h"
 #include "arcane/core/IGridMeshPartitioner.h"
+#include "arcane/core/IDataStorageFactory.h"
 #include "arcane/core/IDirectExecution.h"
 #include "arcane/core/IDirectSubDomainExecuteFunctor.h"
 #include "arcane/core/ISerializer.h"

--- a/arcane/src/arcane/core/MeshVariableArrayRefT.H
+++ b/arcane/src/arcane/core/MeshVariableArrayRefT.H
@@ -278,7 +278,7 @@ copy(const ItemVariableArrayRefT<DataTypeT>& v,RunQueue* queue)
     copy(v);
     return;
   }
-  impl::copyContigousData(this->m_private_part->data(),v.m_private_part->data(),*queue);
+  impl::copyContiguousData(this->m_private_part->data(), v.m_private_part->data(), *queue);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -292,7 +292,7 @@ fill(const DataTypeT& v,RunQueue* queue)
     fill(v);
     return;
   }
-  impl::fillContigousData(this->m_private_part->data(),v,*queue);
+  impl::fillContiguousData(this->m_private_part->data(), v, *queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshVariableScalarRefT.H
+++ b/arcane/src/arcane/core/MeshVariableScalarRefT.H
@@ -177,7 +177,7 @@ copy(const ItemVariableScalarRefT<DataTypeT>& v,RunQueue* queue)
     copy(v);
     return;
   }
-  impl::copyContigousData(this->m_private_part->data(),v.m_private_part->data(),*queue);
+  impl::copyContiguousData(this->m_private_part->data(), v.m_private_part->data(), *queue);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -191,7 +191,7 @@ fill(const DataTypeT& v, RunQueue* queue)
     fill(v);
     return;
   }
-  impl::fillContigousData<DataTypeT>(this->m_private_part->data(),v,*queue);
+  impl::fillContiguousData<DataTypeT>(this->m_private_part->data(), v, *queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableUtilsInternal.cc
+++ b/arcane/src/arcane/core/VariableUtilsInternal.cc
@@ -14,9 +14,13 @@
 #include "arcane/core/internal/VariableUtilsInternal.h"
 
 #include "arcane/utils/ArrayView.h"
+#include "arcane/utils/MemoryView.h"
 
 #include "arcane/core/IVariable.h"
 #include "arcane/core/IData.h"
+#include "arcane/core/internal/IDataInternal.h"
+
+#include "arcane/accelerator/core/RunQueue.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -46,13 +50,20 @@ fillFloat64Array(IVariable* v, ArrayView<double> values)
 bool VariableUtilsInternal::
 setFromFloat64Array(IVariable* v, ConstArrayView<double> values)
 {
-  IData* var_data = v->data();
-  auto* true_data = dynamic_cast<IArrayDataT<double>*>(var_data);
-  if (!true_data)
+  return setFromMemoryBuffer(v, ConstMemoryView(values));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool VariableUtilsInternal::
+setFromMemoryBuffer(IVariable* v, ConstMemoryView mem_view)
+{
+  INumericDataInternal* num_data = v->data()->_commonInternal()->numericData();
+  if (!num_data)
     return true;
-  // TODO: Vérifier la taille
-  ArrayView<Real> var_values(true_data->view());
-  var_values.copy(values);
+  RunQueue queue;
+  impl::copyContiguousData(num_data, mem_view, queue);
   return false;
 }
 

--- a/arcane/src/arcane/core/internal/IDataInternal.h
+++ b/arcane/src/arcane/core/internal/IDataInternal.h
@@ -242,21 +242,30 @@ namespace Arcane::impl
 /*!
  * \brief Copie de \a source vers \a destination.
  *
+ * La zone mémoire \a source doit déjà avoir la même taille que celle de
+ * la donnée \a destination.
+ */
+extern "C++" ARCANE_CORE_EXPORT void
+copyContiguousData(INumericDataInternal* destination, ConstMemoryView source, RunQueue& queue);
+
+/*!
+ * \brief Copie de \a source vers \a destination.
+ *
  * Les données doivent être de type \a INumericData et la zone mémoire
  * de destination doit déjà avoir été alloué à la bonne taille.
  */
 extern "C++" ARCANE_CORE_EXPORT void
-copyContigousData(IData* destination, IData* source, RunQueue& queue);
+copyContiguousData(IData* destination, IData* source, RunQueue& queue);
 
 extern "C++" ARCANE_CORE_EXPORT void
-fillContigousDataGeneric(IData* data, const void* fill_address,
-                         Int32 datatype_size, RunQueue& queue);
+fillContiguousDataGeneric(IData* data, const void* fill_address,
+                          Int32 datatype_size, RunQueue& queue);
 
 template <typename DataType> inline void
-fillContigousData(IData* data, const DataType& value, RunQueue& queue)
+fillContiguousData(IData* data, const DataType& value, RunQueue& queue)
 {
   constexpr Int32 type_size = static_cast<Int32>(sizeof(DataType));
-  fillContigousDataGeneric(data, &value, type_size, queue);
+  fillContiguousDataGeneric(data, &value, type_size, queue);
 }
 
 } // namespace Arcane::impl

--- a/arcane/src/arcane/core/internal/VariableUtilsInternal.h
+++ b/arcane/src/arcane/core/internal/VariableUtilsInternal.h
@@ -33,7 +33,7 @@ class ARCANE_CORE_EXPORT VariableUtilsInternal
   /*!
    * \brief Remplit \a values avec les valeurs de la variable.
    *
-   * Seules les variables 1D de type \a DT_Real dont convertibles.
+   * Seules les variables 1D de type \a DT_Real sont convertibles.
    *
    * \retval false si tout s'est bien passé.
    * \retval true si rien n'a été effectué.
@@ -43,12 +43,22 @@ class ARCANE_CORE_EXPORT VariableUtilsInternal
   /*!
    * \brief Recopie dans la variable \a v les valeurs \a values.
    *
-   * Seules les variables 1D de type \a DT_Real dont convertibles.
+   * Seules les variables 1D de type \a DT_Real sont convertibles.
    *
    * \retval false si tout s'est bien passé.
    * \retval true si rien n'a été effectué.
    */
   static bool setFromFloat64Array(IVariable* v, ConstArrayView<double> values);
+
+  /*!
+   * \brief Recopie dans la variable \a v les valeurs \a values.
+   *
+   * Seules les variables numériques sont convertibles.
+   *
+   * \retval false si tout s'est bien passé.
+   * \retval true si rien n'a été effectué.
+   */
+  static bool setFromMemoryBuffer(IVariable* v, ConstMemoryView values);
 
   //! Retourne l'API internal de IData associé à la variable \a v
   static IDataInternal* getDataInternal(IVariable* v);

--- a/arcane/tools/wrapper/core/ArcaneSwigCore.i
+++ b/arcane/tools/wrapper/core/ArcaneSwigCore.i
@@ -139,6 +139,31 @@ typedef uint64_t UInt64;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+// Macro pour générer un type POD
+// - CPP_TYPE est le type C++
+// - CSHARP_TYPE est le type C#.
+// Pour que cela fonctionne, il faut que la macro soit utilisée avant que le
+// type ne soit utilisé.
+// Les types 'MutableMemoryView' et 'ConstMemoryView' sont des exemples d'utilisation.
+%define ARCANE_SWIG_GENERATE_POD_TYPE(CPP_TYPE,CSHARP_TYPE)
+%typemap(csinterfaces) CPP_TYPE "";
+%typemap(csbody) CPP_TYPE %{ %}
+%typemap(SWIG_DISPOSING, methodname="Dispose", methodmodifiers="private") CPP_TYPE ""
+%typemap(SWIG_DISPOSE, methodname="Dispose", methodmodifiers="private") CPP_TYPE ""
+%typemap(csclassmodifiers) CPP_TYPE "public struct"
+%typemap(csattributes) CPP_TYPE "[StructLayout(LayoutKind.Sequential)]"
+%typemap(cstype) CPP_TYPE "CSHARP_TYPE"
+%typemap(ctype, out="CPP_TYPE",
+	 directorout="CPP_TYPE",
+	 directorin="CPP_TYPE") CPP_TYPE "CPP_TYPE"
+%typemap(imtype) CPP_TYPE "CSHARP_TYPE"
+%typemap(csin) CPP_TYPE "$csinput"
+%typemap(csout) CPP_TYPE { return $imcall;  }
+%enddef
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 // Gestion des interfaces de Arcane.
 // Ce fichier doit être inclus avant toute classe utilisant des
 // interfaces de Arcane.

--- a/arcane/tools/wrapper/core/MemoryView.i
+++ b/arcane/tools/wrapper/core/MemoryView.i
@@ -1,27 +1,20 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 
-/*---------------------------------------------------------------------------*/
+%define ARCANE_SWIG_GENERATE_MEMORY_VIEW(CPP_TYPE,CSHARP_TYPE)
+ARCANE_SWIG_GENERATE_POD_TYPE(CPP_TYPE,CSHARP_TYPE)
+%typemap(csclassmodifiers) CPP_TYPE "public unsafe struct"
+%typemap(directorin) CPP_TYPE %{ $input = $1; %}
+%typemap(in) CPP_TYPE %{ $1 = $input; %}
+%typemap(out) CPP_TYPE %{ $result = $1; %}
+%typemap(directorout) CPP_TYPE %{ $1 = $input; %}
+%typemap(csdirectorin) CPP_TYPE "$iminput"
+%typemap(csdirectorout) CPP_TYPE "$cscall"
+%enddef
+
+ /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 // typemap pour MutableMemoryView
-%typemap(csinterfaces) Arcane::MutableMemoryView "";
-%typemap(csbody) Arcane::MutableMemoryView %{ %}
-%typemap(SWIG_DISPOSING, methodname="Dispose", methodmodifiers="private") Arcane::MutableMemoryView ""
-%typemap(SWIG_DISPOSE, methodname="Dispose", methodmodifiers="private") Arcane::MutableMemoryView ""
-%typemap(csclassmodifiers) Arcane::MutableMemoryView "public struct"
-%typemap(csattributes) Arcane::MutableMemoryView "[StructLayout(LayoutKind.Sequential)]"
-%typemap(cstype) Arcane::MutableMemoryView %{ Arcane.MutableMemoryView %}
-%typemap(ctype, out="Arcane::MutableMemoryView",
-	 directorout="Arcane::MutableMemoryView",
-	 directorin="Arcane::MutableMemoryView") Arcane::MutableMemoryView "Arcane::MutableMemoryView"
-%typemap(imtype) Arcane::MutableMemoryView %{ Arcane.MutableMemoryView %}
-%typemap(csin) Arcane::MutableMemoryView "$csinput"
-%typemap(csout) Arcane::MutableMemoryView { return $imcall;  }
-%typemap(in) Arcane::MutableMemoryView %{$1 = Arcane::Arcane::MutableMemoryView($input.m_size,$input.m_ptr); %}
-%typemap(directorin) Arcane::MutableMemoryView %{ $input = $1; %}
-%typemap(out) Arcane::MutableMemoryView %{ $result = $1; %}
-%typemap(directorout) Arcane::MutableMemoryView %{ $1 = $input; %}
-%typemap(csdirectorin) Arcane::MutableMemoryView "$iminput"
-%typemap(csdirectorout) Arcane::MutableMemoryView "$cscall"
+ARCANE_SWIG_GENERATE_MEMORY_VIEW(Arcane::MutableMemoryView,Arcane.MutableMemoryView)
 %typemap(cscode) Arcane::MutableMemoryView
 %{
     public IntPtr Pointer { get { return m_ptr; } }
@@ -34,6 +27,34 @@
     Int32 m_datatype_size;
 %}
 
+ /*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// typemap pour ConstMemoryView
+ARCANE_SWIG_GENERATE_MEMORY_VIEW(Arcane::ConstMemoryView,Arcane.ConstMemoryView)
+%typemap(cscode) Arcane::ConstMemoryView
+%{
+  public IntPtr Pointer { get { return m_ptr; } }
+  public Int64 ByteSize { get { return m_size; } }
+  public Int64 NbElement { get { return m_nb_element; } }
+
+  IntPtr m_ptr;
+  Int64 m_size;
+  Int64 m_nb_element;
+  Int32 m_datatype_size;
+
+  static public ConstMemoryView FromView<T>(ConstArrayView<T> buf)
+  where T : unmanaged
+  {
+    ConstMemoryView v = new ConstMemoryView();
+    v.m_ptr = (IntPtr)buf.m_ptr;
+    v.m_nb_element = buf.Size;
+    v.m_datatype_size = sizeof(T);
+    v.m_size = v.m_datatype_size * v.m_nb_element;
+    return v;
+  }
+%}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -42,6 +63,10 @@ namespace Arcane
   class MutableMemoryView
   {
     MutableMemoryView() {}
+  };
+  class ConstMemoryView
+  {
+    ConstMemoryView() {}
   };
 }
 

--- a/arcane/tools/wrapper/python/ArcaneSwigPython.i
+++ b/arcane/tools/wrapper/python/ArcaneSwigPython.i
@@ -10,8 +10,10 @@
 using namespace Arcane;
 %}
 
+ARCANE_STD_EXHANDLER
 %include arcane/core/internal/VariableUtilsInternal.h
 %include arcane/core/internal/IDataInternal.h
+%exception;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/tools/wrapper/python/csharp/PythonSubDomainContext.cs
+++ b/arcane/tools/wrapper/python/csharp/PythonSubDomainContext.cs
@@ -81,7 +81,9 @@ namespace Arcane.Python
       using (var rview_wrapper = new RealArrayView.Wrapper(xvalues))
       {
         RealConstArrayView v = rview_wrapper.ConstView;
-        Arcane.VariableUtilsInternal.SetFromFloat64Array(var_wrapper.m_variable, v);
+        ConstArrayView<double> cv = v;
+        ConstMemoryView mv = ConstMemoryView.FromView(cv);
+        Arcane.VariableUtilsInternal.SetFromMemoryBuffer(var_wrapper.m_variable, mv);
       }
     }
     public IMesh DefaultMesh { get { return m_default_mesh; } }


### PR DESCRIPTION
At the moment it is only available for numpy array of type `float64`.
