### PR TITLE
Remove some usage of 'ItemInternal' in C# wrapper

### DIFF
--- a/arcane/src/arcane/core/ItemIndexArrayView.h
+++ b/arcane/src/arcane/core/ItemIndexArrayView.h
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemIndexArrayView.h                                        (C) 2000-2023 */
+/* ItemIndexArrayView.h                                        (C) 2000-2024 */
 /*                                                                           */
 /* Vue sur un tableau d'index (localIds()) d'entités.                        */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ITEMINDEXARRAYVIEW_H
-#define ARCANE_ITEMINDEXARRAYVIEW_H
+#ifndef ARCANE_CORE_ITEMINDEXARRAYVIEW_H
+#define ARCANE_CORE_ITEMINDEXARRAYVIEW_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -38,6 +38,8 @@ namespace Arcane
  */
 class ARCANE_CORE_EXPORT ItemIndexArrayView
 {
+  // NOTE: Cette classe est mappée en C# et si on change sa structure il
+  // faut mettre à jour la version C# correspondante.
   friend ItemVectorView;
   friend ItemGroup;
   template <int Extent> friend class ItemConnectedListView;

--- a/arcane/src/arcane/core/ItemLocalIdListContainerView.h
+++ b/arcane/src/arcane/core/ItemLocalIdListContainerView.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemLocalIdListContainerView.h                              (C) 2000-2023 */
+/* ItemLocalIdListContainerView.h                              (C) 2000-2024 */
 /*                                                                           */
 /* Vue sur le conteneur d'une liste de ItemLocalId.                          */
 /*---------------------------------------------------------------------------*/
@@ -37,6 +37,8 @@ namespace Arcane::impl
  */
 class ARCANE_CORE_EXPORT ItemLocalIdListContainerView
 {
+  // NOTE: Cette classe est mappée en C# et si on change sa structure il
+  // faut mettre à jour la version C# correspondante.
   template <typename ItemType> friend class ::Arcane::ItemLocalIdListViewT;
   template <int Extent> friend class ::Arcane::impl::ItemIndexedListView;
   friend ItemVectorView;

--- a/arcane/src/arcane/core/ItemVectorView.cc
+++ b/arcane/src/arcane/core/ItemVectorView.cc
@@ -76,6 +76,46 @@ fillLocalIds(Array<Int32>& ids) const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+// Note: ces structures doivent avoir le même layout que la
+// version qui est dans NumericWrapper.h
+
+// Cette classe sert de type de retour pour wrapper la class ConstArrayView
+template<typename DataType> class ConstArrayViewPOD_T
+{
+ public:
+  Integer m_size;
+  const DataType* m_ptr;
+};
+
+class ItemIndexArrayViewPOD
+{
+ public:
+  ConstArrayViewPOD_T<Int32> m_local_ids;
+  Int32 m_flags;
+};
+
+class ItemVectorViewPOD
+{
+ public:
+  ItemIndexArrayViewPOD m_local_ids;
+  ItemSharedInfo* m_shared_info;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemVectorView::
+_internalSwigSet(ItemVectorViewPOD* vpod)
+{
+  vpod->m_local_ids.m_local_ids.m_size = localIds().size();
+  vpod->m_local_ids.m_local_ids.m_ptr = localIds().unguardedBasePointer();
+  vpod->m_local_ids.m_flags = indexes().flags();
+  vpod->m_shared_info = m_shared_info;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // End namespace Arcane
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemVectorView.cc
+++ b/arcane/src/arcane/core/ItemVectorView.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemVectorView.cc                                           (C) 2000-2023 */
+/* ItemVectorView.cc                                           (C) 2000-2024 */
 /*                                                                           */
 /* Vue sur une liste pour obtenir des informations sur les entités.          */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemVectorView.h
+++ b/arcane/src/arcane/core/ItemVectorView.h
@@ -1,29 +1,31 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemVectorView.h                                            (C) 2000-2023 */
+/* ItemVectorView.h                                            (C) 2000-2024 */
 /*                                                                           */
 /* Vue sur un vecteur (tableau indirect) d'entités.                          */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ITEMVECTORVIEW_H
-#define ARCANE_ITEMVECTORVIEW_H
+#ifndef ARCANE_CORE_ITEMVECTORVIEW_H
+#define ARCANE_CORE_ITEMVECTORVIEW_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ItemInternalVectorView.h"
-#include "arcane/ItemIndexArrayView.h"
-#include "arcane/ItemInfoListView.h"
-#include "arcane/ItemConnectedListView.h"
+#include "arcane/core/ItemInternalVectorView.h"
+#include "arcane/core/ItemIndexArrayView.h"
+#include "arcane/core/ItemInfoListView.h"
+#include "arcane/core/ItemConnectedListView.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 namespace Arcane
 {
+// Pour le wrapper C#
+class ItemVectorViewPOD;
 namespace mesh
 {
 class IndexedItemConnectivityAccessor;
@@ -223,6 +225,9 @@ class ItemVectorViewConstIteratorT
  */
 class ARCANE_CORE_EXPORT ItemVectorView
 {
+  // NOTE: Cette classe est mappée en C# et si on change sa structure il
+  // faut mettre à jour la version C# correspondante.
+
   friend ItemVector;
   friend ItemEnumeratorBase;
   friend mesh::IndexedItemConnectivityAccessor;
@@ -383,6 +388,11 @@ class ARCANE_CORE_EXPORT ItemVectorView
     m_shared_info = (size() > 0 && !items.empty()) ? ItemInternalCompatibility::_getSharedInfo(items[0]) : ItemSharedInfo::nullInstance();
   }
   void _init2(IItemFamily* family);
+
+ public:
+
+  // Pour SWIG pour positionner les valeurs l'instance POD
+  void _internalSwigSet(ItemVectorViewPOD* vpod);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/MeshModification.cs
+++ b/arcane/src/arcane/tests/MeshModification.cs
@@ -76,7 +76,7 @@ public class MeshModificationService
   public MeshModificationService(ServiceBuildInfo sbi) : base(sbi)
   {
     Console.WriteLine("CREATE MeshModificationServiceInstance");
-   
+
     m_trace_accessor = new TraceAccessor(sbi.SubDomain().TraceMng());
   }
   public override void InitializeTest()
@@ -134,18 +134,18 @@ public class MeshModificationService
     ItemVectorView cell_view = all_cells.View();
     int n = cell_view.Size;
     for( int i=0; i<n; ++i ){
-      Console.WriteLine("CELL_VIEW i={0} id={1}",i,cell_view.LocalIds[i]);
+      Console.WriteLine("CELL_VIEW i={0} id={1}",i,cell_view.Indexes[i]);
     }
     foreach(Item ie in cell_view){
-      Console.WriteLine("CELL_VIEW2 ie={0}",ie.LocalId);      
+      Console.WriteLine("CELL_VIEW2 ie={0}",ie.LocalId);
     }
     ItemGroup all_items = all_cells;
     foreach(Item ie in all_items){
       Console.WriteLine("CELL_VIEW3 ie={0}",ie.LocalId);
     }
-      
+
     //Int32Array to_destroy_array = new Int32Array();
-    //Int32Array.Wrapper to_destroy_array = 
+    //Int32Array.Wrapper to_destroy_array =
     Int32Array to_destroy_array = new Int32Array();
     Int32 modulo_to_remove = Options.RemoveFraction.Value();
     foreach(Cell c in all_cells){
@@ -180,7 +180,7 @@ public class MeshModificationService
     Int64 max_node_uid = _SearchMaxUniqueId(mesh.AllNodes());
     Int64 max_cell_uid = _SearchMaxUniqueId(mesh.AllCells());
     Trace.Info("MAX UID NODE={0} CELL={1}",max_node_uid,max_cell_uid);
-    
+
     CellGroup all_cells = Mesh().AllCells();
     int index = 0;
     Integer nb_cell_to_add = 0;
@@ -195,7 +195,7 @@ public class MeshModificationService
       ++index;
       if ((index % 3) == 0){
         cells_to_detach.Add(c.LocalId);
-        
+
         to_add_cells.Add(8); // Pour une pyramide
         //to_add_cells.Add(max_cell_uid + index); // Pour le uid
         to_add_cells.Add(c.UniqueId + max_cell_uid); // Pour le uid, reutilise celui de la maille supprimée
@@ -223,7 +223,7 @@ public class MeshModificationService
         ++nb_cell_to_add;
       }
     }
-    
+
     IMeshModifier modifier = mesh.Modifier();
     Integer nb_node_added = nodes_to_add.Length;
     Int32Array new_nodes_local_id = new Int32Array(nb_node_added);
@@ -248,7 +248,7 @@ public class MeshModificationService
       Console.Write(uid_view[i]);
     }
     Console.WriteLine(".");
-    
+
     // Avant d'ajouter les nouvelles mailles, il faut détacher les anciennes
     modifier.DetachCells(cells_to_detach.ConstView);
     modifier.AddCells(nb_cell_to_add,to_add_cells.ConstView);
@@ -257,7 +257,7 @@ public class MeshModificationService
     // Pour l'instant indispensable. Il faudra le supprimer par la suite
     //nodes_coords.Dispose();
   }
-  
+
   void _CheckGC()
   {
     CellGroup all_cells = Mesh().AllCells();
@@ -272,7 +272,7 @@ public class MeshModificationService
     }
     Trace.Info("TOTAL={0}",total);
   }
-  
+
   Int64 _SearchMaxUniqueId(ItemGroup group)
   {
     Int64 max_uid = 0;

--- a/arcane/src/arcane/tests/PerfectGasEOS.cs
+++ b/arcane/src/arcane/tests/PerfectGasEOS.cs
@@ -16,7 +16,7 @@ public class PerfectGasEOSService
   : base(sbi)
   {
   }
-  
+
   public virtual void initEOS(CellGroup group)
   {
     // Initialise l'énergie et la vitesse du son
@@ -45,7 +45,7 @@ public class PerfectGasEOSService
 
   public virtual void applyEOS2(CellGroup group)
   {
-    Int32ConstArrayView local_ids = group.View().LocalIds;
+    ItemIndexArrayView local_ids = group.View().Indexes;
     int nb_cell = local_ids.Length;
     for( int i=0; i<nb_cell; ++i ){
       Int32 icell = local_ids[i];

--- a/arcane/tools/wrapper/NumericWrapper.h
+++ b/arcane/tools/wrapper/NumericWrapper.h
@@ -219,11 +219,13 @@ namespace Arcane
   };
 
   // Cette classe sert de type de retour pour wrapper la classe 'ItemVectorView'
+  // Note: cette structure doit avoir le même layout que la
+  // version qui est dans NumericWrapper.h
   class ItemVectorViewPOD
   {
    public:
-    ArrayViewPOD_T<ItemInternal*> m_items;
     ItemIndexArrayViewPOD m_local_ids;
+    ItemSharedInfo* m_shared_info;
   };
 }
 

--- a/arcane/tools/wrapper/core/CMakeLists.txt
+++ b/arcane/tools/wrapper/core/CMakeLists.txt
@@ -39,6 +39,8 @@ set(ARCANE_SWIG_CORE_CSHARP_FILES
   ItemInternal
   Item
   ItemLocalIdListContainerView
+  ItemIndexArrayView
+  ItemVectorViewT
   Math
   CaseOptionServiceContainer
   CaseOptionEnumT

--- a/arcane/tools/wrapper/core/CMakeLists.txt
+++ b/arcane/tools/wrapper/core/CMakeLists.txt
@@ -38,6 +38,7 @@ set(ARCANE_SWIG_CORE_CSHARP_FILES
   EntryPoint
   ItemInternal
   Item
+  ItemLocalIdListContainerView
   Math
   CaseOptionServiceContainer
   CaseOptionEnumT

--- a/arcane/tools/wrapper/core/ItemGroup.i
+++ b/arcane/tools/wrapper/core/ItemGroup.i
@@ -35,39 +35,23 @@
   internal ItemInternalArrayView m_items;
   internal ItemIndexArrayView m_local_ids;
 
-  public ItemVectorView(ItemInternalArrayView items,Int32ConstArrayView local_ids)
-  {
-    m_items = items;
-    m_local_ids = new ItemIndexArrayView(local_ids);
-  }
-
   public ItemVectorView(ItemInternalArrayView items,ItemIndexArrayView indexes)
   {
     m_items = items;
     m_local_ids = indexes;
   }
 
-  public Integer Size { get { return m_local_ids.Length; } }
+  public Int32 Size { get { return m_local_ids.Length; } }
 
-  public Item this[Integer index]
-  {
-    get { return m_items[m_local_ids[index]]; }
-  }
+  public Item this[Int32 index] { get { return m_items[m_local_ids[index]]; } }
 
-  public Int32ConstArrayView LocalIds
-  {
-    get { return m_local_ids.LocalIds; }
-  }
+  [Obsolete("Use Indexes property instead")]
+  public Int32ConstArrayView LocalIds { get { return m_local_ids.LocalIds; } }
 
-  public ItemIndexArrayView Indexes
-  {
-    get { return m_local_ids; }
-  }
+  public ItemIndexArrayView Indexes { get { return m_local_ids; } }
 
-  public ItemInternalArrayView Items
-  {
-    get { return m_items; }
-  }
+  [Obsolete("This method is internal to Arcane. Use Indexes or operator[] instead.")]
+  public ItemInternalArrayView Items { get { return m_items; } }
 
   public ItemEnumerator GetEnumerator()
   {
@@ -78,6 +62,10 @@
   {
     return new ItemVectorView(m_items,m_local_ids.SubViewInterval(interval,nb_interval));
   }
+
+  // TODO: pour compatibilité avec l'existant. A supprimer
+  internal Int32ConstArrayView _LocalIds { get { return m_local_ids.LocalIds; } }
+  internal ItemInternalArrayView _Items { get { return m_items; } }
 %}
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/tools/wrapper/core/ItemGroup.i
+++ b/arcane/tools/wrapper/core/ItemGroup.i
@@ -9,7 +9,7 @@
 %typemap(csbody) Arcane::ItemVectorView %{ %}
 %typemap(SWIG_DISPOSING, methodname="Dispose", methodmodifiers="private") Arcane::ItemVectorView ""
 %typemap(SWIG_DISPOSE, methodname="Dispose", methodmodifiers="private") Arcane::ItemVectorView ""
-%typemap(csclassmodifiers) Arcane::ItemVectorView "public struct"
+%typemap(csclassmodifiers) Arcane::ItemVectorView "public unsafe struct"
 %typemap(csattributes) Arcane::ItemVectorView "[StructLayout(LayoutKind.Sequential)]"
 %typemap(cstype) Arcane::ItemVectorView "Arcane.ItemVectorView"
 %typemap(imtype) Arcane::ItemVectorView "Arcane.ItemVectorView"
@@ -22,50 +22,59 @@
 %typemap(out) Arcane::ItemVectorView
 %{
    Arcane::ItemVectorView result_ref = ($1);
-   $result . m_local_ids.m_local_ids.m_size = result_ref.localIds().size();
-   $result . m_local_ids.m_local_ids.m_ptr = result_ref.localIds().unguardedBasePointer();
-   $result . m_local_ids.m_flags = result_ref.indexes().flags();
-   Arcane::ItemInternalArrayView av = result_ref.items();
-   $result . m_items.m_size = av.size();
-   $result . m_items.m_ptr = const_cast<Arcane::ItemInternal**>(av.unguardedBasePointer());
+   result_ref._internalSwigSet( & $result);
 %}
+
 %typemap(in) Arcane::ItemVectorView %{$1 = $input; %}
 %typemap(cscode) Arcane::ItemVectorView
 %{
-  internal ItemInternalArrayView m_items;
   internal ItemIndexArrayView m_local_ids;
+  internal ItemSharedInfo* m_shared_info;
 
+  public ItemVectorView()
+  {
+    m_shared_info = ItemSharedInfo.Zero;
+    m_local_ids = new ItemIndexArrayView();
+  }
+
+  internal ItemVectorView(ItemSharedInfo* shared_info,ItemIndexArrayView indexes)
+  {
+    m_local_ids = indexes;
+    m_shared_info = shared_info;
+  }
+
+  [Obsolete("Use another constructor")]
   public ItemVectorView(ItemInternalArrayView items,ItemIndexArrayView indexes)
   {
-    m_items = items;
     m_local_ids = indexes;
+    bool is_valid = (m_local_ids.Size>0 && items.Size>0);
+    m_shared_info = (is_valid) ? items.m_ptr[0]->m_shared_info : ItemSharedInfo.Zero;
   }
 
   public Int32 Size { get { return m_local_ids.Length; } }
 
-  public Item this[Int32 index] { get { return m_items[m_local_ids[index]]; } }
-
-  [Obsolete("Use Indexes property instead")]
-  public Int32ConstArrayView LocalIds { get { return m_local_ids.LocalIds; } }
+  public Item this[Int32 index] { get { return new Item(new ItemBase(m_shared_info,m_local_ids[index])); } }
 
   public ItemIndexArrayView Indexes { get { return m_local_ids; } }
 
-  [Obsolete("This method is internal to Arcane. Use Indexes or operator[] instead.")]
-  public ItemInternalArrayView Items { get { return m_items; } }
-
   public ItemEnumerator GetEnumerator()
   {
-    unsafe{return new ItemEnumerator(m_items.m_ptr,m_local_ids.m_local_ids._UnguardedBasePointer(),m_local_ids.Length);}
+    unsafe{return new ItemEnumerator(m_shared_info->m_items_internal.m_ptr,m_local_ids.m_local_ids._InternalData(),m_local_ids.Length);}
   }
 
   public ItemVectorView SubViewInterval(Integer interval,Integer nb_interval)
   {
-    return new ItemVectorView(m_items,m_local_ids.SubViewInterval(interval,nb_interval));
+    return new ItemVectorView(m_shared_info,m_local_ids.SubViewInterval(interval,nb_interval));
   }
+
+  [Obsolete("Use Indexes property instead")]
+  public Int32ConstArrayView LocalIds { get { return m_local_ids.LocalIds; } }
+  [Obsolete("This method is internal to Arcane. Use Indexes or operator[] instead.")]
+  public ItemInternalArrayView Items { get { return _Items; } }
 
   // TODO: pour compatibilité avec l'existant. A supprimer
   internal Int32ConstArrayView _LocalIds { get { return m_local_ids.LocalIds; } }
-  internal ItemInternalArrayView _Items { get { return m_items; } }
+  internal ItemInternalArrayView _Items { get { return new ItemInternalArrayView(m_shared_info->m_items_internal); } }
 %}
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/tools/wrapper/core/csharp/CaseFunction.cs
+++ b/arcane/tools/wrapper/core/csharp/CaseFunction.cs
@@ -29,8 +29,7 @@ namespace Arcane
         class_type = a.GetType(class_name,true);
       }
       catch(Exception ex){
-        throw new ApplicationException($"Can not load class {class_name} for assembly {a}");
-        return;
+        throw new ApplicationException($"Can not load class {class_name} for assembly {a} ex={ex} stack={ex.StackTrace}");
       }
       LoadCaseFunction(case_mng,class_type);
     }
@@ -69,7 +68,7 @@ namespace Arcane
       //ICaseMng cm = sd.CaseMng();
       BindingFlags flags = BindingFlags.Public|BindingFlags.InvokeMethod|BindingFlags.Instance|BindingFlags.DeclaredOnly;
       MethodInfo[] methods = class_type.GetMethods(flags);
-      
+
       foreach(MethodInfo method in methods){
         string func_name = method.Name;
         Trace.Info(String.Format("FOUND METHOD name={0}",func_name));
@@ -187,7 +186,7 @@ namespace Arcane
     public IRealRealToReal3MathFunctor m_rr_to_r3;
     public IRealReal3ToRealMathFunctor m_rr3_to_r;
     public IRealReal3ToReal3MathFunctor m_rr3_to_r3;
-    
+
     UserStandardCaseFunction(IRealRealToRealMathFunctor r,CaseFunctionBuildInfo cfbi) : base(cfbi)
     {
       m_rr_to_r = r;

--- a/arcane/tools/wrapper/core/csharp/Item.cs
+++ b/arcane/tools/wrapper/core/csharp/Item.cs
@@ -13,7 +13,7 @@ using Integer = System.Int32;
 #endif
 
 namespace Arcane
-{  
+{
   //-----------------------------------------------------------------------------
 
   public unsafe interface IItem
@@ -127,12 +127,6 @@ namespace Arcane
   {
     private ItemBase m_item_base;
 
-    [Obsolete("This method is internal to Arcane. Use constructor with ItemBase() instead.")]
-    public Cell(ItemInternal* ii)
-    {
-      m_item_base = new ItemBase(ii);
-    }
-
     [Obsolete("This method is internal to Arcane. Use ItemBase() instead.")]
     public ItemInternal* Internal
     {
@@ -140,7 +134,7 @@ namespace Arcane
       set { m_item_base = new ItemBase(value); }
     }
 
-    // TODO: a supprimer. Utiliser constructeur avec 'ItemBase' à la place
+    [Obsolete("Use Cell(ItemBase) instead.")]
     public Cell(Item ii)
     {
       m_item_base = ii.ItemBase;
@@ -216,12 +210,6 @@ namespace Arcane
   {
     private ItemBase m_item_base;
 
-    [Obsolete("This method is internal to Arcane. Use constructor with ItemBase() instead.")]
-    public Face(ItemInternal* ii)
-    {
-      m_item_base = new ItemBase(ii);
-    }
-
     [Obsolete("This method is internal to Arcane. Use ItemBase() instead.")]
     public ItemInternal* Internal
     {
@@ -239,8 +227,8 @@ namespace Arcane
       set { m_item_base = value; }
     }
 
-    // TODO: a supprimer. Utiliser constructeur avec 'ItemBase' à la place
-    public Face(Item ii)
+    [Obsolete("Use Face(ItemBase) instead")]
+     public Face(Item ii)
     {
       m_item_base = ii.ItemBase;
     }
@@ -314,12 +302,6 @@ namespace Arcane
   {
     private ItemBase m_item_base;
 
-    [Obsolete("This method is internal to Arcane. Use constructor with ItemBase() instead.")]
-    public Edge(ItemInternal* ii)
-    {
-      m_item_base = new ItemBase(ii);
-    }
-
     [Obsolete("This method is internal to Arcane. Use ItemBase() instead.")]
     public ItemInternal* Internal
     {
@@ -363,16 +345,10 @@ namespace Arcane
   {
     ItemBase m_item_base;
 
-    // TODO: a supprimer. Utiliser constructeur avec 'ItemBase' à la place
+    [Obsolete("Use Node(ItemBase) instead.")]
     public Node(Item ii)
     {
       m_item_base = ii.ItemBase;
-    }
-
-    [Obsolete("This method is internal to Arcane. Use constructor with ItemBase() instead.")]
-    public Node(ItemInternal* ii)
-    {
-      m_item_base = new ItemBase(ii);
     }
 
     [Obsolete("This method is internal to Arcane. Use ItemBase() instead.")]
@@ -442,14 +418,6 @@ namespace Arcane
 
     public Integer Index { get { return m_index; } }
 
-    [Obsolete("This method is internal to Arcane")]
-    public IndexedItem(ItemInternal* ii,Integer index)
-    {
-      m_item = new _ItemKind();
-      m_item.Internal = ii;
-      m_index = index;
-    }
-
     public IndexedItem(ItemBase ii,Integer index)
     {
       m_item = new _ItemKind();
@@ -484,14 +452,6 @@ namespace Arcane
     public Node Item { get { return m_item; } }
 
     public Integer Index { get { return m_index; } }
-
-    [Obsolete("This method is internal to Arcane")]
-    public IndexedNode(ItemInternal* ii,Integer index)
-    {
-      m_item = new Node();
-      m_item.Internal = ii;
-      m_index = index;
-    }
 
     public IndexedNode(ItemBase ii,Integer index)
     {

--- a/arcane/tools/wrapper/core/csharp/ItemEnumerator.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemEnumerator.cs
@@ -218,113 +218,6 @@ namespace Arcane
   /*---------------------------------------------------------------------------*/
 
   [StructLayout(LayoutKind.Sequential)]
-  public unsafe struct ItemIndexArrayView
-  {
-    internal Int32ConstArrayView m_local_ids;
-    internal Int32 m_flags;
-
-    public ItemIndexArrayView(Int32ConstArrayView local_ids)
-    {
-      m_local_ids = local_ids;
-      m_flags = 0;
-    }
-
-    public ItemIndexArrayView(Int32ConstArrayView local_ids,Int32 flags)
-    {
-      m_local_ids = local_ids;
-      m_flags = flags;
-    }
-
-    public Integer Size { get { return m_local_ids.Length; } }
-    public Integer Length { get { return m_local_ids.Length; } }
-
-    public Int32 this[Integer index]
-    {
-      get
-      {
-        return m_local_ids[index];
-      }
-    }
-
-    public Int32ConstArrayView LocalIds
-    {
-      get { return m_local_ids; }
-    }
-
-    public ItemIndexArrayView SubViewInterval(Integer interval,Integer nb_interval)
-    {
-      return new ItemIndexArrayView(m_local_ids.SubViewInterval(interval,nb_interval));
-    }
-  }
-
-  /*---------------------------------------------------------------------------*/
-  /*---------------------------------------------------------------------------*/
-
-  [StructLayout(LayoutKind.Sequential)]
-  public unsafe struct ItemVectorView<_ItemKind>
-    where _ItemKind : IItem, new()
-  {
-    internal ItemInternalArrayView m_items;
-    internal ItemIndexArrayView m_local_ids;
-
-    public ItemVectorView(ItemInternalArrayView items,Int32ConstArrayView local_ids)
-    {
-      m_items = items;
-      m_local_ids = new ItemIndexArrayView(local_ids);
-    }
-    public ItemVectorView(ItemInternalArrayView items,ItemIndexArrayView indexes)
-    {
-      m_items = items;
-      m_local_ids = indexes;
-    }
-    public ItemVectorView(ItemVectorView gen_view)
-    {
-      m_items = gen_view.Items;
-      m_local_ids = gen_view.Indexes;
-    }
-
-    public Integer Size { get { return m_local_ids.Length; } }
-
-    public _ItemKind this[Integer index]
-    {
-      get
-      {
-        _ItemKind item = new _ItemKind();
-        item.ItemBase = m_items[m_local_ids[index]].ItemBase;
-        return item;
-      }
-    }
-
-    public Int32ConstArrayView LocalIds
-    {
-      get { return m_local_ids.LocalIds; }
-    }
-
-    public ItemIndexArrayView Indexes
-    {
-      get { return m_local_ids; }
-    }
-
-    public ItemInternalArrayView Items
-    {
-      get { return m_items; }
-    }
-
-    public IndexedItemEnumerator<_ItemKind> GetEnumerator()
-    {
-      return new IndexedItemEnumerator<_ItemKind>(m_items.m_ptr,m_local_ids.m_local_ids._InternalData(),m_local_ids.Length);
-    }
-
-    public ItemVectorView<_ItemKind> SubViewInterval(Integer interval,Integer nb_interval)
-    {
-      return new ItemVectorView<_ItemKind>(m_items,m_local_ids.SubViewInterval(interval,nb_interval));
-    }
-  }
-  
-  /*---------------------------------------------------------------------------*/
-  /*---------------------------------------------------------------------------*/
-
-  [StructLayout(LayoutKind.Sequential)]
   public unsafe struct NodeList
   {
     ItemInternal** m_items;
@@ -343,7 +236,7 @@ namespace Arcane
       return new IndexedNodeEnumerator(m_items,m_local_ids,m_end);
     }
   }
-  
+
   /*---------------------------------------------------------------------------*/
   /*---------------------------------------------------------------------------*/
 
@@ -382,7 +275,7 @@ namespace Arcane
   : IEnumerator< ItemPairList<_ItemKind1,_ItemKind2> >
     where _ItemKind1 : IItem, new()
     where _ItemKind2 : IItem, new()
-  {  
+  {
     Integer m_current;
     Integer m_end;
     IntegerConstArrayView m_indexes;
@@ -420,7 +313,7 @@ namespace Arcane
     {
       get { return Current; }
     }
-    
+
     public void Reset()
     {
       m_current = -1;
@@ -448,7 +341,7 @@ namespace Arcane
   {
     Item m_first;
     Item m_second;
-  
+
     public ItemPair(Item first,Item second)
     {
       m_first = first;
@@ -468,7 +361,7 @@ namespace Arcane
   {
     _ItemKind1 m_first;
     _ItemKind2 m_second;
-    
+
     public ItemPair(_ItemKind1 first,_ItemKind2 second)
     {
       m_first = first;

--- a/arcane/tools/wrapper/core/csharp/ItemIndexArrayView.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemIndexArrayView.cs
@@ -1,0 +1,47 @@
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Arcane
+{
+  /*---------------------------------------------------------------------------*/
+  /*---------------------------------------------------------------------------*/
+
+  // IMPORTANT: vérifier que cette structure est identique à celle du C++
+  [StructLayout(LayoutKind.Sequential)]
+  public unsafe struct ItemIndexArrayView
+  {
+    internal Int32ConstArrayView m_local_ids;
+    internal Int32 m_flags;
+
+    // TODO: Rendre obsolète
+    public ItemIndexArrayView(Int32ConstArrayView local_ids)
+    {
+      m_local_ids = local_ids;
+      m_flags = 0;
+    }
+
+    public ItemIndexArrayView(Int32ConstArrayView local_ids,Int32 flags)
+    {
+      m_local_ids = local_ids;
+      m_flags = flags;
+    }
+
+    public Int32 Size { get { return m_local_ids.Length; } }
+    public Int32 Length { get { return m_local_ids.Length; } }
+
+    public Int32 this[Int32 index] { get { return m_local_ids[index]; } }
+
+    public Int32ConstArrayView LocalIds { get { return m_local_ids; } }
+
+    public ItemIndexArrayView SubViewInterval(Int32 interval,Int32 nb_interval)
+    {
+      return new ItemIndexArrayView(m_local_ids.SubViewInterval(interval,nb_interval));
+    }
+  }
+}

--- a/arcane/tools/wrapper/core/csharp/ItemInternal.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemInternal.cs
@@ -386,6 +386,11 @@ namespace Arcane
     private Integer m_size;
     internal ItemInternal** m_ptr;
 
+    internal ItemInternalArrayView(ItemInternalList vlist)
+    {
+      m_size = vlist.m_size;
+      m_ptr = vlist.m_ptr;
+    }
     public Item this[Integer index]
     {
       get{

--- a/arcane/tools/wrapper/core/csharp/ItemLocalIdListContainerView.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemLocalIdListContainerView.cs
@@ -1,0 +1,23 @@
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Arcane
+{
+  /*---------------------------------------------------------------------------*/
+  /*---------------------------------------------------------------------------*/
+
+  // IMPORTANT: vérifier que cette structure est identique à celle du C++
+  [StructLayout(LayoutKind.Sequential)]
+  public unsafe struct ItemLocalIdListContainerView
+  {
+    Int32* m_local_ids;
+    Int32 m_local_id_offset;
+    Int32 m_size;
+  }
+}

--- a/arcane/tools/wrapper/core/csharp/ItemVectorViewT.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemVectorViewT.cs
@@ -36,7 +36,7 @@ namespace Arcane
     }
     public ItemVectorView(ItemVectorView gen_view)
     {
-      m_items = gen_view.Items;
+      m_items = gen_view._Items;
       m_local_ids = gen_view.Indexes;
     }
 
@@ -52,20 +52,7 @@ namespace Arcane
       }
     }
 
-    public Int32ConstArrayView LocalIds
-    {
-      get { return m_local_ids.LocalIds; }
-    }
-
-    public ItemIndexArrayView Indexes
-    {
-      get { return m_local_ids; }
-    }
-
-    public ItemInternalArrayView Items
-    {
-      get { return m_items; }
-    }
+    public ItemIndexArrayView Indexes { get { return m_local_ids; } }
 
     public IndexedItemEnumerator<_ItemKind> GetEnumerator()
     {
@@ -76,5 +63,15 @@ namespace Arcane
     {
       return new ItemVectorView<_ItemKind>(m_items,m_local_ids.SubViewInterval(interval,nb_interval));
     }
+
+    [Obsolete("Use Indexes property instead")]
+    public Int32ConstArrayView LocalIds { get { return m_local_ids.LocalIds; } }
+
+    [Obsolete("This method is internal to Arcane. Use ItemBase() instead.")]
+    public ItemInternalArrayView Items { get { return m_items; } }
+
+    // TODO: pour compatibilité avec l'existant. A supprimer
+    internal Int32ConstArrayView _LocalIds { get { return m_local_ids.LocalIds; } }
+    internal ItemInternalArrayView _Items { get { return m_items; } }
   }
 }

--- a/arcane/tools/wrapper/core/csharp/ItemVectorViewT.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemVectorViewT.cs
@@ -26,18 +26,34 @@ namespace Arcane
   public unsafe struct ItemVectorView<_ItemKind>
     where _ItemKind : IItem, new()
   {
-    internal ItemInternalArrayView m_items;
+    //internal ItemInternalArrayView m_items;
     internal ItemIndexArrayView m_local_ids;
+    internal ItemSharedInfo* m_shared_info;
 
-    public ItemVectorView(ItemInternalArrayView items,ItemIndexArrayView indexes)
+    public ItemVectorView()
     {
-      m_items = items;
-      m_local_ids = indexes;
+      m_shared_info = ItemSharedInfo.Zero;
+      m_local_ids = new ItemIndexArrayView();
     }
     public ItemVectorView(ItemVectorView gen_view)
     {
-      m_items = gen_view._Items;
+      //m_items = gen_view._Items;
       m_local_ids = gen_view.Indexes;
+      m_shared_info = gen_view.m_shared_info;
+    }
+
+    [Obsolete("Use another constructor")]
+    public ItemVectorView(ItemInternalArrayView items, ItemIndexArrayView indexes)
+    {
+      //m_items = items;
+      m_local_ids = indexes;
+      bool is_valid = (m_local_ids.Size > 0 && items.Size > 0);
+      m_shared_info = (is_valid) ? items.m_ptr[0]->m_shared_info : ItemSharedInfo.Zero;
+    }
+    internal ItemVectorView(ItemSharedInfo* shared_info, ItemIndexArrayView indexes)
+    {
+      m_local_ids = indexes;
+      m_shared_info = shared_info;
     }
 
     public Integer Size { get { return m_local_ids.Length; } }
@@ -47,7 +63,7 @@ namespace Arcane
       get
       {
         _ItemKind item = new _ItemKind();
-        item.ItemBase = m_items[m_local_ids[index]].ItemBase;
+        item.ItemBase = new ItemBase(m_shared_info, m_local_ids[index]);
         return item;
       }
     }
@@ -56,22 +72,21 @@ namespace Arcane
 
     public IndexedItemEnumerator<_ItemKind> GetEnumerator()
     {
-      return new IndexedItemEnumerator<_ItemKind>(m_items.m_ptr,m_local_ids.m_local_ids._InternalData(),m_local_ids.Length);
+      return new IndexedItemEnumerator<_ItemKind>(m_shared_info->m_items_internal.m_ptr, m_local_ids.m_local_ids._InternalData(), m_local_ids.Length);
     }
 
-    public ItemVectorView<_ItemKind> SubViewInterval(Integer interval,Integer nb_interval)
+    public ItemVectorView<_ItemKind> SubViewInterval(Int32 interval, Int32 nb_interval)
     {
-      return new ItemVectorView<_ItemKind>(m_items,m_local_ids.SubViewInterval(interval,nb_interval));
+      return new ItemVectorView<_ItemKind>(m_shared_info, m_local_ids.SubViewInterval(interval, nb_interval));
     }
 
     [Obsolete("Use Indexes property instead")]
     public Int32ConstArrayView LocalIds { get { return m_local_ids.LocalIds; } }
 
     [Obsolete("This method is internal to Arcane. Use ItemBase() instead.")]
-    public ItemInternalArrayView Items { get { return m_items; } }
+    public ItemInternalArrayView Items { get { return new ItemInternalArrayView(m_shared_info->m_items_internal); } }
 
     // TODO: pour compatibilité avec l'existant. A supprimer
     internal Int32ConstArrayView _LocalIds { get { return m_local_ids.LocalIds; } }
-    internal ItemInternalArrayView _Items { get { return m_items; } }
   }
 }

--- a/arcane/tools/wrapper/core/csharp/ItemVectorViewT.cs
+++ b/arcane/tools/wrapper/core/csharp/ItemVectorViewT.cs
@@ -1,0 +1,80 @@
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+#if ARCANE_64BIT
+using Integer = System.Int64;
+using IntegerConstArrayView = Arcane.Int64ConstArrayView;
+using IntegerArrayView = Arcane.Int64ArrayView;
+#else
+using Integer = System.Int32;
+using IntegerConstArrayView = Arcane.Int32ConstArrayView;
+using IntegerArrayView = Arcane.Int32ArrayView;
+#endif
+
+namespace Arcane
+{
+  /*---------------------------------------------------------------------------*/
+  /*---------------------------------------------------------------------------*/
+
+  [StructLayout(LayoutKind.Sequential)]
+  public unsafe struct ItemVectorView<_ItemKind>
+    where _ItemKind : IItem, new()
+  {
+    internal ItemInternalArrayView m_items;
+    internal ItemIndexArrayView m_local_ids;
+
+    public ItemVectorView(ItemInternalArrayView items,ItemIndexArrayView indexes)
+    {
+      m_items = items;
+      m_local_ids = indexes;
+    }
+    public ItemVectorView(ItemVectorView gen_view)
+    {
+      m_items = gen_view.Items;
+      m_local_ids = gen_view.Indexes;
+    }
+
+    public Integer Size { get { return m_local_ids.Length; } }
+
+    public _ItemKind this[Integer index]
+    {
+      get
+      {
+        _ItemKind item = new _ItemKind();
+        item.ItemBase = m_items[m_local_ids[index]].ItemBase;
+        return item;
+      }
+    }
+
+    public Int32ConstArrayView LocalIds
+    {
+      get { return m_local_ids.LocalIds; }
+    }
+
+    public ItemIndexArrayView Indexes
+    {
+      get { return m_local_ids; }
+    }
+
+    public ItemInternalArrayView Items
+    {
+      get { return m_items; }
+    }
+
+    public IndexedItemEnumerator<_ItemKind> GetEnumerator()
+    {
+      return new IndexedItemEnumerator<_ItemKind>(m_items.m_ptr,m_local_ids.m_local_ids._InternalData(),m_local_ids.Length);
+    }
+
+    public ItemVectorView<_ItemKind> SubViewInterval(Integer interval,Integer nb_interval)
+    {
+      return new ItemVectorView<_ItemKind>(m_items,m_local_ids.SubViewInterval(interval,nb_interval));
+    }
+  }
+}

--- a/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
+++ b/arcane/tools/wrapper/materials/csharp/ComponentItemInternal.cs
@@ -25,7 +25,7 @@ namespace Arcane.Materials
     internal Cell GlobalCell(Int32 constituent_local_id)
     {
       Int32 global_local_id = m_global_item_local_id_data[constituent_local_id];
-      return new Cell(m_item_shared_info->m_items_internal[global_local_id]);
+      return new Cell(new ItemBase(m_item_shared_info->m_items_internal[global_local_id]));
     }
     internal MatVarIndex VarIndex(Int32 constituent_local_id)
     {


### PR DESCRIPTION
Usage of the deprecated class `ItemInternal` is replaced by use of `ItemSharedInfo`.
