### PR TITLE
Allow rethrow a signal inside handler

### DIFF
--- a/arcane/src/arcane/tests/UtilsUnitTest.cc
+++ b/arcane/src/arcane/tests/UtilsUnitTest.cc
@@ -707,18 +707,29 @@ _testFloatingException()
       ARCANE_FATAL("Can not enable FPE");
     // Test si on récupère bien une ArithmeticException.
     bool is_ok = false;
+    bool is_ok2 = false;
     try{
       platform::raiseFloatingException();
     }
     catch(const ArithmeticException& ex){
       info() << "'ArithmeticException' catched\n";
       is_ok = true;
+      // Regarde si le FPE peut être relancé à l'intérieur.
+      try{
+        platform::raiseFloatingException();
+      }
+      catch(const ArithmeticException& ex){
+        info() << "'ArithmeticException' catched (nested)\n";
+        is_ok2 = true;
+      }
     }
     catch(...){
       info() << "Unknown exception catched\n";
     }
     if (!is_ok)
       ARCANE_FATAL("No 'ArithmeticException' catched");
+    if (!is_ok2)
+      ARCANE_FATAL("No nested 'ArithmeticException' catched");
   }
 }
 

--- a/arcane/src/arcane/tests/UtilsUnitTest.cc
+++ b/arcane/src/arcane/tests/UtilsUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* UtilsUnitTest.cc                                            (C) 2000-2023 */
+/* UtilsUnitTest.cc                                            (C) 2000-2024 */
 /*                                                                           */
 /* Test des fonctions utilitaires de Arcane.                                 */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/Misc.cc
+++ b/arcane/src/arcane/utils/Misc.cc
@@ -407,7 +407,7 @@ arcaneRedirectSignals(fSignalFunc sig_func)
 
 #ifdef USE_SIGACTION
   struct sigaction sa;
-  sa.sa_flags = SA_SIGINFO;
+  sa.sa_flags = SA_SIGINFO | SA_NODEFER;
   sigemptyset(&sa.sa_mask);
   sa.sa_sigaction = _MiscSigactionFunc;
 
@@ -456,11 +456,8 @@ arcaneCallDefaultSignal(int val)
     break;
   }
 
-  //cerr << "** SIGVAL " << func << ' ' << SIG_DFL << ' '
-  //<< SIG_IGN << ' ' << global_already_in_signal << '\n';
-
-  //if (val==SIGSEGV || val==SIGBUS)
-  //::abort();
+  // cerr << "** SIGVAL " << val << ' ' << SIG_DFL
+  // << ' ' << SIG_IGN << " is_in_signal?=" << global_already_in_signal << '\n';
 
   // En cas de nouveau signal alors qu'on est déja dans un handler, ou
   // s'il s'agit d'un signal d'erreur memoire (SIGBUS ou SIGSEGV), on fait un abort.

--- a/arcane/src/arcane/utils/Misc.cc
+++ b/arcane/src/arcane/utils/Misc.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Misc.cc                                                     (C) 2000-2023 */
+/* Misc.cc                                                     (C) 2000-2024 */
 /*                                                                           */
 /* Diverses fonctions                                                        */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This was the default behavior when we used `signal` instead of `sigaction`.

