### PR TITLE
Add missing IT_CellLine2 in arcaneToVtkVellTypes translator

### DIFF
--- a/arcane/src/arcane/std/internal/VtkCellTypes.cc
+++ b/arcane/src/arcane/std/internal/VtkCellTypes.cc
@@ -90,6 +90,8 @@ arcaneToVtkCellType(Int16 arcane_type)
     return VTK_LINE;
   case IT_Line3:
     return VTK_QUADRATIC_EDGE;
+  case IT_CellLine2:
+    return VTK_LINE;
   case IT_Triangle3:
     return VTK_TRIANGLE;
   case IT_Triangle6:


### PR DESCRIPTION
With this fix, it should be better in order to use VtkHdfV2PostProcessor in 1D cases.