### PR TITLE
Allow usage of 'BinaryFormatter' in C# project

### DIFF
--- a/arcane/tools/Directory.Build.props
+++ b/arcane/tools/Directory.Build.props
@@ -29,5 +29,9 @@
     <RestoreOutputPath>$(BaseIntermediateOutputPath)</RestoreOutputPath>
 
     <LangVersion>8.0</LangVersion>
+
+    <!-- Pour éviter une exception en fin d'exécution avec .Net 8 -->
+    <!-- Le 'BinaryFormatter' est obsolète en '.Net 8' et supprimé en '.Net 9' -->
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
`BinaryFormatter` is deprecated in `.Net 8` but it is still used by `pythonnet`.
