### PR TITLE
Cleanup and improve thread-safety of TraceMng

### DIFF
--- a/arccore/src/trace/arccore/trace/TraceMng.cc
+++ b/arccore/src/trace/arccore/trace/TraceMng.cc
@@ -433,8 +433,8 @@ class TraceMng
   bool m_want_trace_timer = false;
   Int32 m_verbosity_level = TraceMessage::DEFAULT_LEVEL;
   Int32 m_stdout_verbosity_level = TraceMessage::DEFAULT_LEVEL;
-  Int32 m_current_class_verbosity_level = TraceMessage::DEFAULT_LEVEL;
-  Int32 m_current_class_flags = Trace::PF_Default;
+  std::atomic<Int32> m_current_class_verbosity_level = TraceMessage::DEFAULT_LEVEL;
+  std::atomic<Int32> m_current_class_flags = Trace::PF_Default;
   ListenerList* m_listeners = nullptr;
   bool m_is_info_activated = true;
   std::map<String,TraceClassConfig*> m_trace_class_config_map;
@@ -480,7 +480,11 @@ class TraceMng
     }
     return &m_default_trace_class_config;
   }
-  const String& _currentTraceClassName() const { return m_current_msg_class.m_name; }
+  String _currentTraceClassName() const
+  {
+    Mutex::ScopedLock sl(m_trace_mutex);
+    return m_current_msg_class.m_name;
+  }
   void _checkFlush();
   void _putStream(std::ostream& ostr,Span<const Byte> buffer);
   void _putTraceMessage(std::ostream& ostr,Trace::eMessageType id,Span<const Byte>);

--- a/arccore/src/trace/arccore/trace/TraceMng.cc
+++ b/arccore/src/trace/arccore/trace/TraceMng.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TraceMng.cc                                                 (C) 2000-2021 */
+/* TraceMng.cc                                                 (C) 2000-2024 */
 /*                                                                           */
 /* Gestionnaire des traces.                                                  */
 /*---------------------------------------------------------------------------*/
@@ -443,7 +443,7 @@ class TraceMng
   TraceClass m_default_trace_class;
   TraceClass m_current_msg_class;
   ReferenceCounter<ITraceStream> m_listing_stream;
-  Integer m_nb_flush;
+  std::atomic<Int64> m_nb_flush;
   String m_error_file_name;
   String m_log_file_name;
   String m_trace_id;


### PR DESCRIPTION
Remove potential race conditions.
This was about flush or printing of messages so it was harmless.