### PR TITLE
Fix graph connectivity lifetime problem

### DIFF
--- a/arcane/src/arcane/mesh/DoFFamily.cc
+++ b/arcane/src/arcane/mesh/DoFFamily.cc
@@ -221,11 +221,10 @@ _allocDoFGhost(const Int64 uid, const Int32 owner)
 }
 
 ItemInternal* DoFFamily::
-_findOrAllocDoF(const Int64 uid,[[maybe_unused]] bool is_alloc)
+_findOrAllocDoF(const Int64 uid,bool& is_alloc)
 {
-  bool need_alloc; // given by alloc
-  ItemInternal* item_internal = ItemFamily::_findOrAllocOne(uid,need_alloc);
-  if (!need_alloc) {
+  ItemInternal* item_internal = ItemFamily::_findOrAllocOne(uid,is_alloc);
+  if (!is_alloc) {
     item_internal->setUniqueId(uid);
   }
   else {

--- a/arcane/src/arcane/mesh/DoFFamily.cc
+++ b/arcane/src/arcane/mesh/DoFFamily.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DoFFamily.cc                                                (C) 2000-2023 */
+/* DoFFamily.cc                                                (C) 2000-2024 */
 /*                                                                           */
 /* Famille de degre de liberte                                               */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DoFFamily.h
+++ b/arcane/src/arcane/mesh/DoFFamily.h
@@ -155,7 +155,7 @@ class ARCANE_MESH_EXPORT DoFFamily
   void preAllocate(Integer nb_item);
   ItemInternal* _allocDoF(const Int64 uid);
   ItemInternal* _allocDoFGhost(const Int64 uid, const Int32 owner);
-  ItemInternal* _findOrAllocDoF(const Int64 uid, bool is_alloc);
+  ItemInternal* _findOrAllocDoF(const Int64 uid, bool& is_alloc);
 
   ItemSharedInfoWithType* m_shared_info;
 

--- a/arcane/src/arcane/mesh/DoFFamily.h
+++ b/arcane/src/arcane/mesh/DoFFamily.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DoFFamily.h                                                 (C) 2000-2022 */
+/* DoFFamily.h                                                 (C) 2000-2024 */
 /*                                                                           */
 /* Famille de degres de liberte (DoF)                                        */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/GraphDoFs.cc
+++ b/arcane/src/arcane/mesh/GraphDoFs.cc
@@ -37,8 +37,6 @@ GraphIncrementalConnectivity(GraphDoFs* graph)
 , m_link_connectivity(graph->m_links_incremental_connectivity)
 , m_dualitem_connectivities(graph->m_incremental_connectivities)
 , m_dualnode_to_connectivity_index(graph->m_dual_node_to_connectivity_index)
-, m_dualnode_connectivity_accessor(m_dualnode_connectivity->connectivityAccessor())
-, m_link_connectivity_accessor(m_link_connectivity->connectivityAccessor())
 {
 }
 

--- a/arcane/src/arcane/mesh/GraphDoFs.cc
+++ b/arcane/src/arcane/mesh/GraphDoFs.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* GraphDoFs.cc                                                (C) 2000-2021 */
+/* GraphDoFs.cc                                                (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 
@@ -717,22 +717,16 @@ updateAfterMeshChanged()
 void GraphDoFs::
 printDualNodes() const
 {
-  auto graph_connectivity = GraphIncrementalConnectivity(dualNodeFamily(),
-                                                         linkFamily(),
-                                                         m_dualnodes_incremental_connectivity,
-                                                         m_links_incremental_connectivity,
-                                                         m_incremental_connectivities,
-                                                         m_dual_node_to_connectivity_index);
   ENUMERATE_DOF (idualnode, dualNodeFamily()->allItems()) {
     info() << "DualNode : lid = " << idualnode->localId();
     info() << "           uid = " << idualnode->uniqueId();
     info() << "         owner = " << idualnode->owner();
-    auto dual_item = graph_connectivity.dualItem(*idualnode);
+    auto dual_item = m_graph_connectivity->dualItem(*idualnode);
     info() << "           DualItem : lid = " << dual_item.localId();
     info() << "                      uid = " << dual_item.uniqueId();
     info() << "                     kind = " << dual_item.kind();
     info() << "                    owner = " << dual_item.owner();
-    auto links = graph_connectivity.links(*idualnode);
+    auto links = m_graph_connectivity->links(*idualnode);
     for (auto const& link : links) {
       info() << "           Connected link : lid = " << link.localId();
       info() << "                            uid = " << link.uniqueId();
@@ -747,23 +741,16 @@ printDualNodes() const
 void GraphDoFs::
 printLinks() const
 {
-  ConnectivityItemVector dual_nodes(m_links_incremental_connectivity);
-  auto graph_connectivity = GraphIncrementalConnectivity(dualNodeFamily(),
-                                                         linkFamily(),
-                                                         m_dualnodes_incremental_connectivity,
-                                                         m_links_incremental_connectivity,
-                                                         m_incremental_connectivities,
-                                                         m_dual_node_to_connectivity_index);
   ENUMERATE_DOF (ilink, linkFamily()->allItems()) {
     info() << "Link       :         LID = " << ilink.localId();
     info() << "                     UID = " << ilink->uniqueId();
     info() << "                   OWNER = " << ilink->owner();
-    ENUMERATE_DOF (idual_node, dual_nodes.connectedItems(ilink)) {
+    ENUMERATE_DOF (idual_node, m_graph_connectivity->dualNodes(*ilink)) {
       info() << "     Dof :       index = " << idual_node.index();
       info() << "     Dof :         LID = " << idual_node->localId();
       info() << "                   UID = " << idual_node->uniqueId();
       info() << "                 OWNER = " << idual_node->owner();
-      auto dual_item = graph_connectivity.dualItem(*idual_node);
+      auto dual_item = m_graph_connectivity->dualItem(*idual_node);
       info() << "         dual item UID = " << dual_item.uniqueId();
       info() << "                  KIND = " << dual_item.kind();
       info() << "                 OWNER = " << dual_item.owner();

--- a/arcane/src/arcane/mesh/GraphDoFs.h
+++ b/arcane/src/arcane/mesh/GraphDoFs.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* GraphDoFs.h                                                 (C) 2000-2023 */
+/* GraphDoFs.h                                                 (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCANE_MESH_GRAPHDOFS_H
@@ -106,16 +106,7 @@ class ARCANE_MESH_EXPORT GraphIncrementalConnectivity
   , m_link_connectivity(link_connectivity)
   , m_dualitem_connectivities(dualitem_connectivities)
   , m_dualnode_to_connectivity_index(dualnode_to_connectivity)
-  , m_dualnode_connectivity_accessor(dualnode_connectivity->connectivityAccessor())
-  , m_link_connectivity_accessor(link_connectivity->connectivityAccessor())
-  {
-    m_dualitem_connectivity_accessors.resize(m_dualitem_connectivities.size());
-    for (Integer i = 0; i < m_dualitem_connectivities.size(); ++i) {
-      if (m_dualitem_connectivities[i]) {
-        m_dualitem_connectivity_accessors[i] = m_dualitem_connectivities[i]->connectivityAccessor();
-      }
-    }
-  }
+  {}
 
   GraphIncrementalConnectivity(GraphIncrementalConnectivity const& rhs)
   : m_dualnode_family(rhs.m_dualnode_family)
@@ -124,16 +115,7 @@ class ARCANE_MESH_EXPORT GraphIncrementalConnectivity
   , m_link_connectivity(rhs.m_link_connectivity)
   , m_dualitem_connectivities(rhs.m_dualitem_connectivities)
   , m_dualnode_to_connectivity_index(rhs.m_dualnode_to_connectivity_index)
-  , m_dualnode_connectivity_accessor(m_dualnode_connectivity->connectivityAccessor())
-  , m_link_connectivity_accessor(m_link_connectivity->connectivityAccessor())
-  {
-    m_dualitem_connectivity_accessors.resize(m_dualitem_connectivities.size());
-    for (Integer i = 0; i < m_dualitem_connectivities.size(); ++i) {
-      if (m_dualitem_connectivities[i]) {
-        m_dualitem_connectivity_accessors[i] = m_dualitem_connectivities[i]->connectivityAccessor();
-      }
-    }
-  }
+  {}
 
   GraphIncrementalConnectivity(GraphDoFs* graph);
 
@@ -141,17 +123,18 @@ class ARCANE_MESH_EXPORT GraphIncrementalConnectivity
 
   inline Item dualItem(const DoF& dualNode) const
   {
-    return m_dualitem_connectivity_accessors[m_dualnode_to_connectivity_index[dualNode]](ItemLocalId(dualNode))[0];
+    auto dualitem_connectivity_accessor = m_dualitem_connectivities[m_dualnode_to_connectivity_index[dualNode]]->connectivityAccessor();
+    return dualitem_connectivity_accessor(ItemLocalId(dualNode))[0];
   }
 
   inline DoFVectorView links(const DoF& dualNode) const
   {
-    return m_dualnode_connectivity_accessor(ItemLocalId(dualNode));
+    return m_dualnode_connectivity->connectivityAccessor()(ItemLocalId(dualNode));
   }
 
   inline DoFVectorView dualNodes(const DoF& link) const
   {
-    return m_link_connectivity_accessor(ItemLocalId(link));
+    return m_link_connectivity->connectivityAccessor()(ItemLocalId(link));
   }
 
  private:
@@ -162,11 +145,6 @@ class ARCANE_MESH_EXPORT GraphIncrementalConnectivity
   Arcane::mesh::IncrementalItemConnectivity* m_link_connectivity = nullptr;
   UniqueArray<Arcane::mesh::IncrementalItemConnectivity*> const& m_dualitem_connectivities;
   ItemScalarProperty<Integer> const& m_dualnode_to_connectivity_index;
-
-  Arcane::mesh::IndexedItemConnectivityAccessor m_dualnode_connectivity_accessor;
-  Arcane::mesh::IndexedItemConnectivityAccessor m_link_connectivity_accessor;
-
-  UniqueArray<Arcane::mesh::IndexedItemConnectivityAccessor> m_dualitem_connectivity_accessors;
 };
 
 class ARCANE_MESH_EXPORT GraphDoFs


### PR DESCRIPTION
Links, dual nodes and dual items connectivity accessors are stored in GraphIncrementalConnectivity.

- This object is stored in the graph and has the same lifetime. 
- When the connectivities change, the accessors are invalidated
- It is not enough to update the stored GraphIncrementalConnectivity in `Graph::EndUpdate()`

Fix : the accessors are re-built at each call to connectivity methods (`links()`, `dualNodes()`, `DualItem`)
To check : if is a performance issue.