### PR TITLE
Always include 'cassert' when compiling with CUDA

### DIFF
--- a/arccore/src/base/arccore/base/ArccoreGlobal.h
+++ b/arccore/src/base/arccore/base/ArccoreGlobal.h
@@ -130,11 +130,9 @@ typedef ARCCORE_TYPE_INT64 Int64;
 #  endif
 #  if defined(__CUDA_ARCH__)
 #    define ARCCORE_DEVICE_TARGET_CUDA
-#    if defined(__HIPSYCL__)
 // Nécessaire pour assert() par exemple dans arccoreCheckAt()
 // TODO: regarder si cela est aussi nécessaire pour AMD HIP.
 #include <cassert>
-#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
This is needed if we do not use NVCC  nor NVHPC