### PR TITLE
Add support to compile CUDA files with Clang compiler

### DIFF
--- a/arcane/src/arcane/accelerator/MaterialVariableViews.h
+++ b/arcane/src/arcane/accelerator/MaterialVariableViews.h
@@ -93,7 +93,7 @@ class MatItemVariableScalarInViewT
 
   ARCCORE_HOST_DEVICE const DataType& value0(PureMatVarIndex idx) const
   {
-    return this->m_value0[idx.valueIndex()];
+    return this->m_value[0][idx.valueIndex()];
   }
 
  private:

--- a/arcane/src/arcane/accelerator/cuda/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/cuda/CMakeLists.txt
@@ -25,17 +25,29 @@ if (ARCANE_CUDA_DEVICE_DEBUG)
   set(_CUDA_DEBUG_FLAGS "--device-debug")
 endif()
 
-target_compile_options(arcane_cuda_compile_flags INTERFACE
-  "$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>"
-  "$<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>"
-  "$<$<COMPILE_LANGUAGE:CUDA>:-g>"
-  "$<$<COMPILE_LANGUAGE:CUDA>:-Werror>"
-  "$<$<COMPILE_LANGUAGE:CUDA>:cross-execution-space-call>"
-)
+if (CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
+  # Lorsqu'on compile avec clang, il ne faut pas générer certaines informations
+  # de debug car cela provoque une erreur de compilation
+  # (voir https://github.com/llvm/llvm-project/issues/58491)
+  # Cela sera peut-être corrigé avec la version 19 de clang
+  target_compile_options(arcane_cuda_compile_flags INTERFACE
+    "$<$<COMPILE_LANGUAGE:CUDA>:-Xarch_device>"
+    "$<$<COMPILE_LANGUAGE:CUDA>:-g0>"
+  )
+else()
+  # Compilateur CUDA classique (NVCC ou NVHPC)
+  target_compile_options(arcane_cuda_compile_flags INTERFACE
+    "$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>"
+    "$<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>"
+    "$<$<COMPILE_LANGUAGE:CUDA>:-g>"
+    "$<$<COMPILE_LANGUAGE:CUDA>:-Werror>"
+    "$<$<COMPILE_LANGUAGE:CUDA>:cross-execution-space-call>"
+  )
 
-target_compile_options(arcane_cuda_build_compile_flags INTERFACE
-  "$<$<COMPILE_LANGUAGE:CUDA>:${_CUDA_DEBUG_FLAGS}>"
-)
+  target_compile_options(arcane_cuda_build_compile_flags INTERFACE
+    "$<$<COMPILE_LANGUAGE:CUDA>:${_CUDA_DEBUG_FLAGS}>"
+  )
+endif()
 
 install(TARGETS arcane_cuda_compile_flags EXPORT ArcaneTargets)
 install(TARGETS arcane_cuda_build_compile_flags EXPORT ArcaneTargets)

--- a/arcane/src/arcane/utils/ForLoopRanges.h
+++ b/arcane/src/arcane/utils/ForLoopRanges.h
@@ -257,7 +257,7 @@ inline void
 arcaneSequentialFor(LoopBoundType<1, IndexType> bounds, const Lambda& func, ReducerArgs... reducer_args)
 {
   for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
-    func(ArrayBoundsIndex<1>(i0), reducer_args...);
+    func(MDIndex<1>(i0), reducer_args...);
   impl::HostReducerHelper::applyReducerArgs(reducer_args...);
 }
 
@@ -267,7 +267,7 @@ arcaneSequentialFor(LoopBoundType<2, IndexType> bounds, const Lambda& func)
 {
   for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
     for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
-      func(ArrayBoundsIndex<2>(i0, i1));
+      func(MDIndex<2>(i0, i1));
 }
 
 //! Applique le fonctor \a func sur une boucle 3D.
@@ -277,7 +277,7 @@ arcaneSequentialFor(LoopBoundType<3, IndexType> bounds, const Lambda& func)
   for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
     for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
       for (Int32 i2 = bounds.template lowerBound<2>(); i2 < bounds.template upperBound<2>(); ++i2)
-        func(ArrayIndex<3>(i0, i1, i2));
+        func(MDIndex<3>(i0, i1, i2));
 }
 
 //! Applique le fonctor \a func sur une boucle 4D.
@@ -288,7 +288,7 @@ arcaneSequentialFor(LoopBoundType<4, IndexType> bounds, const Lambda& func)
     for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
       for (Int32 i2 = bounds.template lowerBound<2>(); i2 < bounds.template upperBound<2>(); ++i2)
         for (Int32 i3 = bounds.template lowerBound<3>(); i3 < bounds.template upperBound<3>(); ++i3)
-          func(ArrayIndex<4>(i0, i1, i2, i3));
+          func(MDIndex<4>(i0, i1, i2, i3));
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This enable CUDA compilation with Clang. Set `CMAKE_CUDA_COMPILER` to a version of Clang supporting NVPTX assembler to use it.
