### PR TITLE
Add support to print accelerator memory profiling information anywhere

### DIFF
--- a/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
+++ b/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
@@ -17,6 +17,9 @@
 #include "arcane/utils/IProfilingService.h"
 #include "arcane/utils/IMemoryRessourceMng.h"
 
+#include "arcane/utils/Profiling.h"
+#include "arcane/utils/internal/ProfilingInternal.h"
+
 #include "arcane/core/VariableTypes.h"
 #include "arcane/core/IMesh.h"
 #include "arcane/core/Item.h"
@@ -42,6 +45,7 @@
 #include "arcane/accelerator/core/RunCommand.h"
 #include "arcane/accelerator/core/RunQueue.h"
 #include "arcane/accelerator/core/Runner.h"
+#include "arcane/accelerator/core/internal/RunnerInternal.h"
 #include "arcane/accelerator/VariableViews.h"
 #include "arcane/accelerator/MaterialVariableViews.h"
 #include "arcane/accelerator/RunCommandMaterialEnumerate.h"
@@ -226,7 +230,6 @@ void MaterialHeatTestModule::
 buildInit()
 {
   m_sequential_runner.initialize(Accelerator::eExecutionPolicy::Sequential);
-  //m_queue = makeQueue(m_sequential_runner);
   m_queue = *acceleratorMng()->defaultQueue();
   ProfilingRegistry::setProfilingLevel(2);
 
@@ -374,6 +377,14 @@ compute()
   Int32 iteration = m_global_iteration();
   if (iteration <= 2)
     _changeVariableAllocator();
+
+  if (iteration>=2){
+    Runner runner = *acceleratorMng()->defaultRunner();
+    ostringstream o;
+    runner._internalApi()->printProfilingInfos(o);
+    info() << o.str();
+  }
+
   bool is_end = (iteration >= options()->nbIteration());
   if (is_end)
     subDomain()->timeLoopMng()->stopComputeLoop(true);

--- a/arcane/src/arcane/accelerator/core/Runner.cc
+++ b/arcane/src/arcane/accelerator/core/Runner.cc
@@ -19,6 +19,8 @@
 #include "arcane/utils/ArgumentException.h"
 #include "arcane/utils/MemoryView.h"
 #include "arcane/utils/ValueConvert.h"
+#include "arcane/utils/Profiling.h"
+#include "arcane/utils/internal/ProfilingInternal.h"
 
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
 #include "arcane/accelerator/core/DeviceId.h"
@@ -511,6 +513,29 @@ bool RunnerInternal::
 isProfilingActive()
 {
   return m_runner_impl->runtime()->isProfilingActive();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void RunnerInternal::
+printProfilingInfos(std::ostream& o)
+{
+  bool is_active = isProfilingActive();
+  if (is_active)
+    stopProfiling();
+
+  {
+    // Affiche les statistiques de profiling.
+    using Arcane::impl::AcceleratorStatInfoList;
+    auto f = [&](const AcceleratorStatInfoList& stat_list) {
+      stat_list.print(o);
+    };
+    ProfilingRegistry::visitAcceleratorStat(f);
+  }
+
+  if (is_active)
+    startProfiling();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/internal/RunnerInternal.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunnerInternal.h
@@ -53,6 +53,13 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunnerInternal
   //! Stoppe le profiling pour le runtime associé
   void stopProfiling();
 
+  /*!
+   * \brief Affiche les informations de profiling.
+   *
+   * S'il est actif, le profiling est temporairement arrêté et redémaré.
+   */
+  void printProfilingInfos(std::ostream& o);
+
  private:
 
   impl::RunnerImpl* m_runner_impl = nullptr;

--- a/arcane/src/arcane/impl/ExecutionStatsDumper.cc
+++ b/arcane/src/arcane/impl/ExecutionStatsDumper.cc
@@ -138,7 +138,7 @@ _dumpProfiling(std::ostream& o)
   // qu'il est désactivé. Normalement c'est le cas si on utilise ArcaneMainBatch.
   {
     auto f = [&](const impl::AcceleratorStatInfoList& stat_list) {
-      _dumpOneAcceleratorListStat(o, stat_list);
+      stat_list.print(o);
     };
     ProfilingRegistry::visitAcceleratorStat(f);
   }
@@ -220,22 +220,6 @@ _printGlobalLoopInfos(std::ostream& o, const impl::ForLoopCumulativeStat& cumula
   o << "LoopStat: global_time (ms) = " << x / 1.0e6 << "\n";
   o << "LoopStat: global_nb_loop   = " << std::setw(10) << nb_loop_parallel_for << " time=" << x1 << "\n";
   o << "LoopStat: global_nb_chunk  = " << std::setw(10) << nb_chunk_parallel_for << " time=" << x2 << "\n";
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void ExecutionStatsDumper::
-_dumpOneAcceleratorListStat(std::ostream& o, const impl::AcceleratorStatInfoList& stat_list)
-{
-  const auto& htod = stat_list.memoryTransfer(impl::AcceleratorStatInfoList::eMemoryTransferType::HostToDevice);
-  const auto& dtoh = stat_list.memoryTransfer(impl::AcceleratorStatInfoList::eMemoryTransferType::DeviceToHost);
-  o << "MemoryTransferSTATS: HTOD = " << htod.m_nb_byte << " (" << htod.m_nb_call << ")"
-    << " DTOH = " << dtoh.m_nb_byte << " (" << dtoh.m_nb_call << ")";
-  const auto& cpu_fault = stat_list.memoryPageFault(impl::AcceleratorStatInfoList::eMemoryPageFaultType::Cpu);
-  const auto& gpu_fault = stat_list.memoryPageFault(impl::AcceleratorStatInfoList::eMemoryPageFaultType::Gpu);
-  o << " PageFaultCPU = " << cpu_fault.m_nb_fault << " (" << cpu_fault.m_nb_call << ")"
-    << " PageFaultGPU = " << gpu_fault.m_nb_fault << " (" << gpu_fault.m_nb_call << ")";
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ExecutionStatsDumper.h
+++ b/arcane/src/arcane/impl/ExecutionStatsDumper.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExecutionStatsDumper.h                                      (C) 2000-2023 */
+/* ExecutionStatsDumper.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Ecriture des statistiques d'exécution.                                    */
 /*---------------------------------------------------------------------------*/
@@ -59,7 +59,6 @@ class ExecutionStatsDumper
   void _dumpProfilingJSON(const String& filename);
   void _dumpProfilingJSON(JSONWriter& json_writer);
   void _dumpProfilingTable(ISimpleTableOutput* table);
-  void _dumpOneAcceleratorListStat(std::ostream& o, const impl::AcceleratorStatInfoList& stat_list);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/Profiling.cc
+++ b/arcane/src/arcane/utils/Profiling.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Profiling.cc                                                (C) 2000-2022 */
+/* Profiling.cc                                                (C) 2000-2024 */
 /*                                                                           */
 /* Classes pour gérer le profilage.                                          */
 /*---------------------------------------------------------------------------*/
@@ -272,6 +272,22 @@ merge(const ForLoopOneExecStat& loop_stat_info, const ForLoopTraceInfo& loop_tra
       loop_name = loop_trace_info.traceInfo().name();
   }
   m_p->m_stat_map[loop_name].add(loop_stat_info);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void impl::AcceleratorStatInfoList::
+print(std::ostream& o) const
+{
+  const auto& htod = memoryTransfer(eMemoryTransferType::HostToDevice);
+  const auto& dtoh = memoryTransfer(eMemoryTransferType::DeviceToHost);
+  o << "MemoryTransferSTATS: HTOD = " << htod.m_nb_byte << " (" << htod.m_nb_call << ")"
+    << " DTOH = " << dtoh.m_nb_byte << " (" << dtoh.m_nb_call << ")";
+  const auto& cpu_fault = memoryPageFault(eMemoryPageFaultType::Cpu);
+  const auto& gpu_fault = memoryPageFault(eMemoryPageFaultType::Gpu);
+  o << " PageFaultCPU = " << cpu_fault.m_nb_fault << " (" << cpu_fault.m_nb_call << ")"
+    << " PageFaultGPU = " << gpu_fault.m_nb_fault << " (" << gpu_fault.m_nb_call << ")";
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/ProfilingInternal.h
+++ b/arcane/src/arcane/utils/internal/ProfilingInternal.h
@@ -55,7 +55,7 @@ struct ARCANE_UTILS_EXPORT ForLoopProfilingStat
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-class ForLoopStatInfoListImpl
+class ARCANE_UTILS_EXPORT ForLoopStatInfoListImpl
 {
  public:
 
@@ -67,13 +67,12 @@ class ForLoopStatInfoListImpl
   std::map<String, ForLoopProfilingStat> m_stat_map;
 };
 
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
  * \brief Statistiques cumulées sur le nombre de boucles exécutées.
  */
-class ForLoopCumulativeStat
+class ARCANE_UTILS_EXPORT ForLoopCumulativeStat
 {
  public:
 
@@ -105,7 +104,7 @@ class ForLoopCumulativeStat
  * TODO: regarder comment rendre cela plus générique et permettre à
  * l'implémentation d'ajouter ses évènements
  */
-class AcceleratorStatInfoList
+class ARCANE_UTILS_EXPORT AcceleratorStatInfoList
 {
  public:
 
@@ -174,6 +173,10 @@ class AcceleratorStatInfoList
   {
     return m_managed_memory_page_fault_list[(int)type];
   }
+
+ public:
+
+  void print(std::ostream& ostr) const;
 
  private:
 


### PR DESCRIPTION
It is useful to display memory transfer information between two parts of the code.
This is internal to Arcane at the moment.
