### PR TITLE
Minor cleanup in CUDA runtime

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/runtime/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(ARCANE_SOURCES
   CudaAcceleratorRuntime.cc
+  internal/Cupti.h
   )
 
 arcane_find_package(CUDAToolkit REQUIRED)

--- a/arcane/src/arcane/accelerator/cuda/runtime/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CMakeLists.txt
@@ -19,20 +19,16 @@ target_link_libraries(arcane_accelerator_cuda_runtime PUBLIC
   arcane_accelerator arcane_cuda_compile_flags CUDA::cudart CUDA::cuda_driver
   )
 
-# Note: à partir de CMake 3.25 'nvToolsExt' devient 'nvtx3'
-#
-# NB: Avec CMake 3.25.2 le remplacement de 'nvToolsExt' par 'nvtx3' produit des erreurs de link :
-# /usr/bin/ld : ../../../../../../../../lib/libarcane_accelerator_cuda_runtime.so : référence indéfinie vers « nvtxRangePop »
-# /usr/bin/ld : ../../../../../../../../lib/libarcane_accelerator_cuda_runtime.so : référence indéfinie vers « nvtxRangePushA »
-#
-#if (TARGET CUDA::nvtx3)
-#  target_compile_definitions(arcane_accelerator_cuda_runtime PRIVATE ARCANE_HAS_CUDA_NVTOOLSEXT)
-#  target_link_libraries(arcane_accelerator_cuda_runtime PRIVATE CUDA::nvtx3)
-if (TARGET CUDA::nvToolsExt)
-  message(STATUS "CUDA: 'nvToolsExt' is available")
+# ----------------------------------------------------------------------------
+
+if (TARGET CUDA::nvtx3)
+  message(STATUS "CUDA: 'nvtx3' is available")
   target_compile_definitions(arcane_accelerator_cuda_runtime PRIVATE ARCANE_HAS_CUDA_NVTOOLSEXT)
-  target_link_libraries(arcane_accelerator_cuda_runtime PRIVATE CUDA::nvToolsExt)
+  target_link_libraries(arcane_accelerator_cuda_runtime PRIVATE CUDA::nvtx3)
 endif()
+
+# ----------------------------------------------------------------------------
+
 if (TARGET CUDA::cupti)
   message(STATUS "CUDA: 'cupti' is available")
   target_sources(arcane_accelerator_cuda_runtime PRIVATE Cupti.cc)

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -43,7 +43,7 @@
 #include <cuda.h>
 
 #ifdef ARCANE_HAS_CUDA_NVTOOLSEXT
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 #endif
 
 using namespace Arccore;
@@ -157,7 +157,7 @@ class CudaRunQueueStream
   void prefetchMemory(const MemoryPrefetchArgs& args) override
   {
     auto src = args.source().bytes();
-    if (src.size()==0)
+    if (src.size() == 0)
       return;
     DeviceId d = args.deviceId();
     int device = cudaCpuDeviceId;
@@ -483,8 +483,8 @@ class CudaMemoryCopier
             MutableMemoryView to, [[maybe_unused]] eMemoryRessource to_mem,
             const RunQueue* queue) override
   {
-    if (queue){
-      queue->copyMemory(MemoryCopyArgs(to.bytes(),from.bytes()).addAsync(queue->isAsync()));
+    if (queue) {
+      queue->copyMemory(MemoryCopyArgs(to.bytes(), from.bytes()).addAsync(queue->isAsync()));
       return;
     }
     // 'cudaMemcpyDefault' sait automatiquement ce qu'il faut faire en tenant

--- a/arcane/src/arcane/accelerator/cuda/runtime/internal/Cupti.h
+++ b/arcane/src/arcane/accelerator/cuda/runtime/internal/Cupti.h
@@ -1,0 +1,79 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* Cupti.h                                                     (C) 2000-2024 */
+/*                                                                           */
+/* Intégration de CUPTI.                                                     */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_ACCELERATOR_CUDA_RUNTIME_INTERNAL_CUPTI_H
+#define ARCANE_ACCELERATOR_CUDA_RUNTIME_INTERNAL_CUPTI_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/FixedArray.h"
+
+#include "arcane/accelerator/cuda/CudaAccelerator.h"
+
+#ifdef ARCANE_HAS_CUDA_CUPTI
+#include <cuda.h>
+#include <cupti.h>
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator::Cuda
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Classe singleton pour gérer CUPTI.
+ */
+class CuptiInfo
+{
+ public:
+
+  void init(Int32 level, bool do_print)
+  {
+    m_profiling_level = level;
+    m_do_print = do_print;
+  }
+  bool isActive() const { return m_is_active; }
+
+ public:
+
+#ifdef ARCANE_HAS_CUDA_CUPTI
+  void start();
+  void stop();
+  void flush();
+#else
+  void start() {}
+  void stop() {}
+  void flush() {}
+#endif
+
+ private:
+
+#ifdef ARCANE_HAS_CUDA_CUPTI
+  FixedArray<CUpti_ActivityUnifiedMemoryCounterConfig, 4> config;
+  CUpti_ActivityPCSamplingConfig configPC;
+#endif
+  bool m_is_active = false;
+  bool m_do_print = true;
+  int m_profiling_level = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::Cuda
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
- Improve 'CUPTI' wrapper and fix compilation error if CUPTI is not available.
- Use target `CUDA::nvtx3` for NVIDIA tools extensions instead of `CUDA::nvToolsExt` because it is deprecated starting with CMake 3.25.
