### PR TITLE
Add method to get stack trace from GDB

### DIFF
--- a/arcane/src/arcane/std/LibUnwindStackTraceService.cc
+++ b/arcane/src/arcane/std/LibUnwindStackTraceService.cc
@@ -214,8 +214,6 @@ _getGDBStack()
 {
   void *array [256];
   char **names;
-  const size_t cmd_size = 4096;
-  char cmd [cmd_size+1];
   int i, size;
 
   fprintf (stderr, "\nNative stacktrace:\n\n");
@@ -227,26 +225,7 @@ _getGDBStack()
   }
 
   fflush (stderr);
-
-  //sprintf (cmd, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt'", (long)getpid ());
-  //sprintf (cmd, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt' --batch", (long)getpid ());
-  char filename[4096];
-  long pid = (long)getpid();
-  sprintf(filename,"errlog.%ld",pid);
-  snprintf (cmd,cmd_size,"gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt full' --batch",pid);
-  int ret_value = system(cmd);
-
-  long unsigned int file_length = 0;
-  if (ret_value==0)
-    file_length = platform::getFileLength(filename);
-  if (file_length==0)
-    return String();
-
-  std::ifstream ifile;
-  ifile.open(filename,std::ios::binary);
-  ByteUniqueArray bytes(arcaneCheckArraySize(file_length));
-  ifile.read((char*)bytes.data(),file_length);
-  return String(bytes);
+  return platform::getGDBStack();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/PlatformUtils.cc
+++ b/arcane/src/arcane/utils/PlatformUtils.cc
@@ -544,6 +544,38 @@ getPageSize()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+extern "C++" ARCANE_UTILS_EXPORT String platform::
+getGDBStack()
+{
+  String result;
+#if defined(ARCANE_OS_LINUX)
+  const size_t cmd_size = 4096;
+  char cmd[cmd_size + 1];
+  //sprintf (cmd, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt'", (long)getpid ());
+  //sprintf (cmd, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt' --batch", (long)getpid ());
+  char filename[4096];
+  long pid = (long)getpid();
+  sprintf(filename, "errlog.%ld", pid);
+  snprintf(cmd, cmd_size, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt full' --batch", pid);
+  int ret_value = system(cmd);
+
+  long unsigned int file_length = 0;
+  if (ret_value == 0)
+    file_length = platform::getFileLength(filename);
+  if (file_length != 0) {
+    std::ifstream ifile;
+    ifile.open(filename, std::ios::binary);
+    ByteUniqueArray bytes(file_length);
+    ifile.read((char*)bytes.data(), file_length);
+    result = String(bytes);
+  }
+#endif
+  return result;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 namespace
 {
 void (*global_garbage_collector_delegate)() = nullptr;

--- a/arcane/src/arcane/utils/PlatformUtils.h
+++ b/arcane/src/arcane/utils/PlatformUtils.h
@@ -394,6 +394,21 @@ getPageSize();
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Récupère la pile d'appel via gdb.
+ *
+ * Cette méthode ne fonctionne que sous Linux et si GDB est installé. Dans
+ * les autres cas c'est la chaîne nulle qui est retournée.
+ *
+ * Cette méthode appelle la commande std::system() pour lancer gbd qui doit
+ * se trouver dans le PATH. Comme gdb charge ensuite les symboles de debug
+ * la commande peut être assez longue à s'exécuter.
+ */
+extern "C++" ARCANE_UTILS_EXPORT String
+getGDBStack();
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 // Définition du pragma pour indiquer l'indépendance des itérations
 

--- a/arcane/src/arcane/utils/tests/TestPlatform.cc
+++ b/arcane/src/arcane/utils/tests/TestPlatform.cc
@@ -9,6 +9,7 @@
 
 #include "arcane/utils/HashTableMap.h"
 #include "arcane/utils/PlatformUtils.h"
+#include "arcane/utils/String.h"
 
 #include <iostream>
 
@@ -22,6 +23,15 @@ TEST(TestPlatform, Misc)
   Int64 page_size = platform::getPageSize();
   std::cout << "PageSize=" << page_size << "\n";
   ASSERT_TRUE(page_size>0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestPlatform, GDBStack)
+{
+  String str = platform::getGDBStack();
+  std::cout << "Stack=" << str << "\n";
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This method was available only from `LibUnwindStackTraceService`. Now is is moved in `platform::getGDBStack()` and may be called anywhere even if `libunwind` is not available.
