### PR TITLE
[arcane, accelerator] Use `malloc` for allocating nvidia GPU memory

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/cuda/CMakeLists.txt
@@ -2,6 +2,8 @@
 # ----------------------------------------------------------------------------
 # Backend Arcane pour CUDA
 
+option(ARCANE_CUDA_ALLOC_ATS "Force using ATS memory for nvidia" OFF)
+
 set(ARCANE_SOURCES
   CudaAccelerator.cc
   CudaAccelerator.h
@@ -61,6 +63,10 @@ arcane_add_library(arcane_accelerator_cuda
 target_link_libraries(arcane_accelerator_cuda PUBLIC
   arcane_core arcane_cuda_compile_flags $<BUILD_INTERFACE:arcane_cuda_build_compile_flags> CUDA::cudart
 )
+
+if (ARCANE_CUDA_ALLOC_ATS)
+  target_compile_definitions(arcane_accelerator_cuda PRIVATE ARCANE_CUDA_ALLOC_ATS)
+endif()
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------

--- a/arcane/src/arcane/accelerator/cuda/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/cuda/CMakeLists.txt
@@ -2,8 +2,6 @@
 # ----------------------------------------------------------------------------
 # Backend Arcane pour CUDA
 
-option(ARCANE_CUDA_ALLOC_ATS "Force using ATS memory for nvidia" OFF)
-
 set(ARCANE_SOURCES
   CudaAccelerator.cc
   CudaAccelerator.h
@@ -63,10 +61,6 @@ arcane_add_library(arcane_accelerator_cuda
 target_link_libraries(arcane_accelerator_cuda PUBLIC
   arcane_core arcane_cuda_compile_flags $<BUILD_INTERFACE:arcane_cuda_build_compile_flags> CUDA::cudart
 )
-
-if (ARCANE_CUDA_ALLOC_ATS)
-  target_compile_definitions(arcane_accelerator_cuda PRIVATE ARCANE_CUDA_ALLOC_ATS)
-endif()
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------

--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -1,4 +1,4 @@
-﻿﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
 // Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
@@ -190,8 +190,10 @@ class UnifiedMemoryCudaMemoryAllocator
 {
  public:
 
-  ~UnifiedMemoryCudaMemoryAllocator()
+  UnifiedMemoryCudaMemoryAllocator()
   {
+    if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_USE_ALLOC_ATS", true))
+      m_use_ats = v.value();
   }
 
   void initialize()
@@ -222,25 +224,26 @@ class UnifiedMemoryCudaMemoryAllocator
   {
     m_wrapper.doDeallocate(mem_info, args);
     void* ptr = mem_info.baseAddress();
-#ifdef ARCANE_CUDA_ALLOC_ATS
-    ::free(ptr);
-    return cudaSuccess;
-#else
+    if (m_use_ats) {
+      ::free(ptr);
+      return cudaSuccess;
+    }
     return ::cudaFree(ptr);
-#endif
   }
 
   cudaError_t _allocate(void** ptr, size_t new_size, MemoryAllocationArgs args) override
   {
-#ifdef ARCANE_CUDA_ALLOC_ATS
-    *ptr = ::aligned_alloc(128, new_size);
-    auto p = *ptr;
-#else
-    auto r = ::cudaMallocManaged(ptr, new_size, cudaMemAttachGlobal);
-    void* p = *ptr;
-    if (r != cudaSuccess)
-      return r;
-#endif
+    void* p = nullptr;
+    if (m_use_ats) {
+      *ptr = ::aligned_alloc(128, new_size);
+      p = *ptr;
+    }
+    else {
+      auto r = ::cudaMallocManaged(ptr, new_size, cudaMemAttachGlobal);
+      p = *ptr;
+      if (r != cudaSuccess)
+        return r;
+    }
 
     m_wrapper.doAllocate(p, new_size, args);
 
@@ -276,6 +279,7 @@ class UnifiedMemoryCudaMemoryAllocator
  private:
 
   CommonUnifiedMemoryAllocatorWrapper m_wrapper;
+  bool m_use_ats = false;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -302,29 +306,40 @@ class HostPinnedCudaMemoryAllocator
 class DeviceCudaMemoryAllocator
 : public CudaMemoryAllocatorBase
 {
+ public:
+
+  DeviceCudaMemoryAllocator()
+  {
+    if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_USE_ALLOC_ATS", true))
+      m_use_ats = v.value();
+  }
+
  protected:
 
   cudaError_t _allocate(void** ptr, size_t new_size, MemoryAllocationArgs) override
   {
-#ifdef ARCANE_CUDA_ALLOC_ATS
-    *ptr = ::aligned_alloc(128, new_size);
-    if (*ptr != nullptr)
-      return cudaSuccess;
-    else
-      return cudaErrorMemoryAllocation;
-#else
+    if (m_use_ats) {
+      // FIXME: it does not work on WIN32
+      *ptr = std::aligned_alloc(128, new_size);
+      if (*ptr != nullptr)
+        return cudaSuccess;
+      else
+        return cudaErrorMemoryAllocation;
+    }
     return ::cudaMalloc(ptr, new_size);
-#endif
   }
   cudaError_t _deallocate(AllocatedMemoryInfo mem_info, MemoryAllocationArgs) override
   {
-#ifdef ARCANE_CUDA_ALLOC_ATS
-    free(mem_info.baseAddress());
-    return cudaSuccess;
-#else
+    if (m_use_ats) {
+      std::free(mem_info.baseAddress());
+      return cudaSuccess;
+    }
     return ::cudaFree(mem_info.baseAddress());
-#endif
   }
+
+ private:
+
+  bool m_use_ats = false;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -233,7 +233,7 @@ class UnifiedMemoryCudaMemoryAllocator
   cudaError_t _allocate(void** ptr, size_t new_size, MemoryAllocationArgs args) override
   {
 #ifdef ARCANE_CUDA_ALLOC_ATS
-    *ptr = ::malloc(new_size);
+    *ptr = ::aligned_alloc(128, new_size);
     auto p = *ptr;
 #else
     auto r = ::cudaMallocManaged(ptr, new_size, cudaMemAttachGlobal);
@@ -307,7 +307,7 @@ class DeviceCudaMemoryAllocator
   cudaError_t _allocate(void** ptr, size_t new_size, MemoryAllocationArgs) override
   {
 #ifdef ARCANE_CUDA_ALLOC_ATS
-    *ptr = malloc(new_size);
+    *ptr = ::aligned_alloc(128, new_size);
     if (*ptr != nullptr)
       return cudaSuccess;
     else


### PR DESCRIPTION
To exploit ATS on Nvidia Grace-Hopper or HMM-enabled computers.

This PR adds a new `ARCANE_CUDA_ALLOC_ATS` cmake option, that is disabled by default.

We kept all the prefetch machinery, but most of it should be removed as there is no any more data "migration."
We do not use `cudaMemAdvise_v2` to choose memory placement, letting the system do it. If page migration is not enabled, it can lead to performance penalties as the data location is chosen through a first-touch policy. 