### PR TITLE
Make deprecated the version 1 of CartesianMeshCoarsening

### DIFF
--- a/arcane/src/arcane/cartesianmesh/CartesianMeshCoarsening.h
+++ b/arcane/src/arcane/cartesianmesh/CartesianMeshCoarsening.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CartesianMeshCoarsening.h                                   (C) 2000-2023 */
+/* CartesianMeshCoarsening.h                                   (C) 2000-2024 */
 /*                                                                           */
 /* Déraffinement d'un maillage cartésien.                                    */
 /*---------------------------------------------------------------------------*/
@@ -35,7 +35,8 @@ namespace Arcane
  *
  * \brief Déraffine un maillage cartésien par 2.
  *
- * \warning Cette méthode est expérimentale.
+ * \deprecated Cette classe est obsolète. Il faut utiliser la version 2
+ * de l'implémentation (CartesianMeshCoarsening2).
  *
  * Cette classe permet de déraffiner un maillage cartésien. Les instances
  * de cette classe sont créées via ICartesianMesh::createCartesianMeshCoarsening().
@@ -84,6 +85,7 @@ class ARCANE_CARTESIANMESH_EXPORT CartesianMeshCoarsening
 
  private:
 
+  ARCANE_DEPRECATED_REASON("Y2024: Use Arcane::CartesianMeshUtils::createCartesianMeshCoarsening2() instead")
   explicit CartesianMeshCoarsening(ICartesianMesh* m);
 
  public:

--- a/arcane/src/arcane/cartesianmesh/ICartesianMesh.h
+++ b/arcane/src/arcane/cartesianmesh/ICartesianMesh.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ICartesianMesh.h                                            (C) 2000-2023 */
+/* ICartesianMesh.h                                            (C) 2000-2024 */
 /*                                                                           */
 /* Interface d'un maillage cartésien.                                        */
 /*---------------------------------------------------------------------------*/
@@ -172,8 +172,9 @@ class ARCANE_CARTESIANMESH_EXPORT ICartesianMesh
 
   /*!
    * \brief Créé une instance pour gérer le déraffinement du maillage.
-   * \warning Experimental method !
+   * \deprecated Utiliser Arcane::CartesianMeshUtils::createCartesianMeshCoarsening2() à la place.
    */
+  ARCANE_DEPRECATED_REASON("Y2024: Use Arcane::CartesianMeshUtils::createCartesianMeshCoarsening2() instead")
   virtual Ref<CartesianMeshCoarsening> createCartesianMeshCoarsening() = 0;
 
  public:


### PR DESCRIPTION
Only the version 2 should be used.
