### PR TITLE
Set minimum Python and NumPy version for KDI

### DIFF
--- a/arcane/src/arcane/std/CMakeLists.txt
+++ b/arcane/src/arcane/std/CMakeLists.txt
@@ -5,9 +5,44 @@ set(PKGS ${PRIVATE_PKGS} ${PUBLIC_PKGS})
 foreach(package ${PKGS})
   arcane_find_package(${package})
 endforeach()
-find_package (Python COMPONENTS Development)
 
-set(ADDITIONAL_TARGETS)
+# ----------------------------------------------------------------------------
+# Pour l'instant n'active pas KDI car il n'y a pas d'installation disponibles
+set(ARCANE_HAS_KDI FALSE)
+
+# Nécessite CMake 3.26 pour la détection de l'API stable de Python
+# NOTE: aout 2024. Cependant il semble que cette API stable ne soit pas
+# toujours bien détectée (la cible CMake associée ne contient rien)
+# On utilise donc la cible Python classique temporairement
+
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)
+  message(STATUS "Checking support for KDI Python")
+  set(Python_USE_STATIC_LIBS FALSE)
+  find_package (Python 3.10 COMPONENTS Development Development.SABIModule NumPy)
+  if (Python_FOUND AND Python_Development.SABIModule_FOUND AND Python_NumPy_FOUND)
+    set(ARCANE_HAS_KDI_PYTHON TRUE)
+    message(STATUS "Python version = ${Python_VERSION}")
+    message(STATUS "Python libs = ${Python_LIBRARIES} rtlibs=${Python_RUNTIME_LIBRARY_DIRS}")
+    message(STATUS "Python SABI libs = ${Python_SABI_LIBRARY} ${Python_SABI_LIBRARIES} ${Python_RUNTIME_SABI_LIBRARY_DIRS} ${Python_SABI_LIBRARY_DIRS}")
+    message(STATUS "Python NumPy version = ${Python_NumPy_VERSION}")
+    message(STATUS "Python NumPy include_dirs = ${Python_NumPy_INCLUDE_DIRS}")
+    if (Python_NumPy_VERSION VERSION_LESS 1.23)
+      message(STATUS "Disabling Python_NumPy because version is too old (minimum=1.23)")
+      set (ARCANE_HAS_KDI_PYTHON FALSE)
+    endif()
+  else()
+    set (ARCANE_HAS_KDI_PYTHON FALSE)
+  endif()
+endif()
+
+if (NOT ARCANE_HAS_KDI_PYTHON)
+  set (ARCANE_HAS_KDI FALSE)
+endif()
+
+message(STATUS "Is KDI available? = ${ARCANE_HAS_KDI}")
+set(ARCANE_HAS_KDI ${ARCANE_HAS_KDI} CACHE BOOL "Is KDI available" FORCE)
+
+# ----------------------------------------------------------------------------
 
 # Pour MEDFile, il faut HDF5 mais le find_package fait planter CMake (avec MED 4.0.0)
 # si HDF5 n'est pas trouvé. On ne fait donc le find_package que si HDF5
@@ -117,10 +152,7 @@ if(vtkIOXML_FOUND)
   list(APPEND PRIVATE_PKGS vtkIOXML)
 endif()
 
-# Pour l'instant n'active pas KDI car il n'y a pas d'installation disponibles
-set(ARCANE_HAS_KDI FALSE CACHE BOOL "Is KDI available" FORCE)
-
-if (Python_FOUND AND ARCANE_HAS_KDI)
+if (ARCANE_HAS_KDI_PYTHON)
   list(APPEND ARCANE_SOURCES
     KdiPostProcessor.cc
     internal/Kdi.h
@@ -142,7 +174,11 @@ if(${ARCANE_HAS_MALLOC_HOOKS})
   target_compile_definitions(arcane_std PRIVATE ARCANE_USE_MALLOC_HOOK)
 endif()
 
-target_link_libraries(arcane_std PUBLIC $<TARGET_NAME_IF_EXISTS:Python::Python> $<TARGET_NAME_IF_EXISTS:Arccore::arccore_message_passing_mpi>)
+if (ARCANE_HAS_KDI_PYTHON)
+  target_link_libraries(arcane_std PUBLIC Python::Python Python::NumPy)
+endif()
+
+target_link_libraries(arcane_std PUBLIC $<TARGET_NAME_IF_EXISTS:Arccore::arccore_message_passing_mpi>)
 target_link_libraries(arcane_std PUBLIC $<TARGET_NAME_IF_EXISTS:Arcane::arcane_hdf5>)
 target_link_libraries(arcane_std PUBLIC ${ARCANE_BASE_LIBRARIES})
 

--- a/arcane/src/arcane/std/internal/Kdi.h
+++ b/arcane/src/arcane/std/internal/Kdi.h
@@ -7,15 +7,16 @@
 /*---------------------------------------------------------------------------*/
 /* Kdi.h                                                       (C) 2000-2024 */
 /*                                                                           */
-/* Pos-traitement avec l'outil KDI.                                          */
+/* Post-traitement avec l'outil KDI.                                         */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCANE_STD_INTERNAL_KDI_H
 #define ARCANE_STD_INTERNAL_KDI_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#define Py_LIMITED_API 0x03100000
 #define PY_SSIZE_T_CLEAN
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_23_API_VERSION
 #include <Python.h>
 
 #include <numpy/arrayobject.h>


### PR DESCRIPTION
The minimum required version for Python is 3.10 and for NumPy is 1.23.
