### PR TITLE
Add support to check coherence of synchronization

### DIFF
--- a/arcane/src/arcane/impl/internal/VariableSynchronizer.h
+++ b/arcane/src/arcane/impl/internal/VariableSynchronizer.h
@@ -76,11 +76,11 @@ class ARCANE_IMPL_EXPORT VariableSynchronizer
   void synchronize(IVariable* var) override;
 
   void synchronize(IVariable* var, Int32ConstArrayView local_ids) override;
-  
+
   void synchronize(VariableCollection vars) override;
 
   void synchronize(VariableCollection vars, Int32ConstArrayView local_ids) override;
-  
+
   Int32ConstArrayView communicatingRanks() override;
 
   Int32ConstArrayView sharedItems(Int32 index) override;
@@ -116,7 +116,8 @@ class ARCANE_IMPL_EXPORT VariableSynchronizer
   Ref<DataSynchronizeInfo> m_partial_sync_info;
   Ref<SyncMessage> m_partial_message;
   UniqueArray<Int32> m_partial_local_ids;
-  
+  bool m_is_check_coherence = false;
+
  private:
 
   void _synchronize(IVariable* var, SyncMessage* message);

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -418,7 +418,7 @@ arcane_add_test_parallel(parallel2_synchronize_compare testParallel-synchronize1
 arcane_add_test_parallel(parallel2_synchronize_legacymulti testParallel-synchronize1.arc 4 -We,ARCANE_USE_LEGACY_MULTISYNCHRONIZE,1)
 arcane_add_test_parallel(parallel2_synchronize_v1 testParallel-synchronize1.arc 4 -We,ARCANE_SYNCHRONIZE_VERSION,1)
 arcane_add_test_parallel(parallel2_synchronize_v2 testParallel-synchronize1.arc 4 -We,ARCANE_SYNCHRONIZE_VERSION,2)
-arcane_add_test_parallel(parallel2_synchronize_v3 testParallel-synchronize1.arc 4 -We,ARCANE_SYNCHRONIZE_VERSION,3)
+arcane_add_test_parallel(parallel2_synchronize_v3 testParallel-synchronize1.arc 4 -We,ARCANE_SYNCHRONIZE_VERSION,3 -We,ARCANE_CHECK_SYNCHRONIZE_COHERENCE,1)
 arcane_add_test_parallel(parallel2_synchronize_v4 testParallel-synchronize1.arc 4 -We,ARCANE_SYNCHRONIZE_VERSION,4 -We,ARCANE_SYNCHRONIZE_NB_SEQUENCE,3)
 arcane_add_test_parallel(parallel2_synchronize_v4_b1024 testParallel-synchronize1.arc 4 -We,ARCANE_SYNCHRONIZE_VERSION,4 -We,ARCANE_SYNCHRONIZE_BLOCK_SIZE,1024)
 arcane_add_test_parallel(parallel2_synchronize testParallel-synchronize2.arc 8)


### PR DESCRIPTION
This add support to check if all the sub-domains are synchronizing the same variable.
This is enabled if environment variable `ARCANE_CHECK_SYNCHRONIZE_COHERENCE` is set to `1`.
