### PR TITLE
Add utility method to create custom node-node via edge connectivity

### DIFF
--- a/arcane/src/arcane/core/MeshUtils.h
+++ b/arcane/src/arcane/core/MeshUtils.h
@@ -421,6 +421,17 @@ fillUniqueIds(ItemVectorView items,Array<Int64>& uids);
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+/*!
+ * \brief Créé ou recréé une connectivité noeuds-noeuds via les arêtes.
+ *
+ * La connectivité aura pour nom \a connectivity_name.
+ */
+extern "C++" ARCANE_CORE_EXPORT Ref<IIndexedIncrementalItemConnectivity>
+createNodeNodeViaEdgeConnectivity(IMesh* mesh, const String& connectivity_name);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // namespace Arcane::MeshUtils
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshUtils2.cc
+++ b/arcane/src/arcane/core/MeshUtils2.cc
@@ -1,0 +1,87 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* MeshUtils2.cc                                               (C) 2000-2024 */
+/*                                                                           */
+/* Fonctions utilitaires diverses sur le maillage.                           */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/core/MeshUtils.h"
+
+#include "arcane/core/IMesh.h"
+#include "arcane/core/IItemFamily.h"
+#include "arcane/core/Item.h"
+#include "arcane/core/ItemEnumerator.h"
+#include "arcane/core/ItemGroup.h"
+#include "arcane/core/IIndexedIncrementalItemConnectivityMng.h"
+#include "arcane/core/IIndexedIncrementalItemConnectivity.h"
+#include "arcane/core/IIncrementalItemConnectivity.h"
+
+#include <set>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+Ref<IIndexedIncrementalItemConnectivity> MeshUtils::
+createNodeNodeViaEdgeConnectivity(IMesh* mesh, const String& connectivity_name)
+{
+  IItemFamily* node_family = mesh->nodeFamily();
+  auto connectivity_mng = mesh->indexedConnectivityMng();
+  auto connectivity_ref = connectivity_mng->findOrCreateConnectivity(node_family,node_family,connectivity_name);
+  IIncrementalItemConnectivity* cx = connectivity_ref->connectivity();
+
+  // Ensemble des nœuds connectés à un nœud
+  // On utilise un 'std::set' car on veut trier par localId() croissant
+  // pour avoir toujours le même ordre.
+  std::set<Int32> node_set;
+
+  // Pour créer la connectivité, parcours l'ensemble des mailles connectées
+  // nœud et ensuite l'ensemble des arêtes de cette maille.
+  // Si un des deux nœuds de l'arête est mon nœud, l'ajoute
+  // à la connectivité.
+
+  ENUMERATE_ (Node, inode, node_family->allItems()) {
+    Node node = *inode;
+    NodeLocalId node_lid(node.localId());
+    node_set.clear();
+    for (Cell cell : node.cells()) {
+      const ItemTypeInfo* t = cell.typeInfo();
+      for( Int32 i=0, n=t->nbLocalEdge(); i<n; ++i ) {
+        ItemTypeInfo::LocalEdge e = t->localEdge(i);
+        NodeLocalId node0_lid = cell.nodeId(e.beginNode());
+        NodeLocalId node1_lid = cell.nodeId(e.endNode());
+        if (node0_lid == node_lid)
+          node_set.insert(node1_lid);
+        if (node1_lid == node_lid)
+          node_set.insert(node0_lid);
+      }
+    }
+    // Au cas où la connectivité existe déjà, supprime les entités
+    // connectées à ce nœud.
+    cx->removeConnectedItems(node_lid);
+    for( auto x : node_set) {
+      cx->addConnectedItem(node_lid,ItemLocalId{x});
+    }
+  }
+
+  return connectivity_ref;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/srcs.cmake
+++ b/arcane/src/arcane/core/srcs.cmake
@@ -512,6 +512,7 @@ set(ARCANE_ORIGINAL_SOURCES
   MeshToMeshTransposer.cc
   MeshToMeshTransposer.h
   MeshUtils.cc
+  MeshUtils2.cc
   MeshUtils.h
   MeshVariable.h
   MeshVariableArrayRef.h

--- a/arcane/src/arcane/tests/MeshUnitTest.axl
+++ b/arcane/src/arcane/tests/MeshUnitTest.axl
@@ -8,7 +8,7 @@
 <service name="MeshUnitTest" version="1.0" type="caseoption" parent-name="Arcane::BasicUnitTest" namespace-name="ArcaneTest">
  <interface name="Arcane::IUnitTest" inherited="false" />
 
-	<variables>
+ <variables>
     <variable
       field-name="cell_flag"
       name="MeshUnitTest_CellFlags"
@@ -124,6 +124,12 @@ Teste la désallocation du maillage
    <description>
      Indique si on tri les faces et les arêtes connectées aux noeuds
    </description>
+  </simple>
+
+  <simple name = "create-edges" type = "bool" default = "false">
+    <description>
+      Indique si en 3D on créé les arêtes.
+    </description>
   </simple>
 
  </options>

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -7,23 +7,17 @@
 /*---------------------------------------------------------------------------*/
 /* MeshUnitTest.cc                                             (C) 2000-2024 */
 /*                                                                           */
-/* Service du test du maillage.                                              */
+/* Service de test du maillage.                                              */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/Array.h"
 #include "arcane/utils/StringBuilder.h"
-#include "arcane/utils/ScopedPtr.h"
 #include "arcane/utils/List.h"
 #include "arcane/utils/ArithmeticException.h"
 #include "arcane/utils/ValueChecker.h"
 #include "arcane/utils/TestLogger.h"
 
 #include "arcane/core/BasicUnitTest.h"
-
-#include "arcane/tests/ArcaneTestGlobal.h"
-#include "arcane/tests/MeshUnitTest_axl.h"
-
 #include "arcane/core/AbstractItemOperationByBasicType.h"
 #include "arcane/core/IMeshWriter.h"
 #include "arcane/core/IParallelMng.h"
@@ -47,45 +41,35 @@
 #include "arcane/core/IIndexedIncrementalItemConnectivityMng.h"
 #include "arcane/core/IIndexedIncrementalItemConnectivity.h"
 #include "arcane/core/IIncrementalItemConnectivity.h"
-
 #include "arcane/core/ServiceFinder2.h"
 #include "arcane/core/SerializeBuffer.h"
 #include "arcane/core/IMeshPartitioner.h"
 #include "arcane/core/IMainFactory.h"
-#include "arcane/core/IMeshModifier.h"
 #include "arcane/core/Properties.h"
-#include "arcane/core/Timer.h"
-
-#include "arcane/core/ItemArrayEnumerator.h"
 #include "arcane/core/ItemPairGroup.h"
 #include "arcane/core/ItemPairEnumerator.h"
 #include "arcane/core/ItemPairGroupBuilder.h"
-
 #include "arcane/core/IPostProcessorWriter.h"
-
 #include "arcane/core/ItemVectorView.h"
 #include "arcane/core/ItemVector.h"
-
 #include "arcane/core/GeometricUtilities.h"
-
-#include "arcane/core/MeshVisitor.h"
-
 #include "arcane/core/IMeshReader.h"
 #include "arcane/core/IXmlDocumentHolder.h"
 #include "arcane/core/IIOMng.h"
 #include "arcane/core/MeshReaderMng.h"
 #include "arcane/core/UnstructuredMeshConnectivity.h"
-#include "arcane/core/MeshVisitor.h"
 #include "arcane/core/MeshKind.h"
 #include "arcane/core/MeshEvents.h"
+#include "arcane/core/BlockIndexList.h"
+#include "arcane/core/Connectivity.h"
 
-#include <set>
+#include "arcane/tests/MeshUnitTest_axl.h"
 
 #ifdef ARCANE_HAS_POLYHEDRAL_MESH_TOOLS
 #include "neo/Mesh.h"
 #endif
 
-#include "arcane/core/BlockIndexList.h"
+#include <set>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -165,11 +149,10 @@ class MeshUnitTest
  public:
 
   explicit MeshUnitTest(const ServiceBuildInfo& cb);
-  ~MeshUnitTest();
 
  public:
 
-  void initializeTest() override;
+  void buildInitializeTest() override;
   void executeTest() override;
 
  private:
@@ -213,6 +196,7 @@ class MeshUnitTest
   void _testCoherency();
   void _testFindOneItem();
   void _testEvents();
+  void _testNodeNodeViaEdgeConnectivity();
 };
 
 /*---------------------------------------------------------------------------*/
@@ -232,9 +216,13 @@ MeshUnitTest(const ServiceBuildInfo& mb)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-MeshUnitTest::
-~MeshUnitTest()
+void MeshUnitTest::
+buildInitializeTest()
 {
+  if (options()->createEdges()) {
+    Connectivity c(mesh()->connectivity());
+    c.enableConnectivity(Connectivity::CT_HasEdge);
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -244,7 +232,7 @@ void MeshUnitTest::
 executeTest()
 {
   bool do_sort_faces_and_edges = options()->testSortNodeFacesAndEdges();
-  if (do_sort_faces_and_edges){
+  if (do_sort_faces_and_edges) {
     mesh()->nodeFamily()->properties()->setBool("sort-connected-faces-edges",true);
     mesh()->modifier()->endUpdate();
   }
@@ -317,18 +305,9 @@ executeTest()
   _testCoherency();
   _testFindOneItem();
   _testEvents();
+  if (options()->createEdges())
+    _testNodeNodeViaEdgeConnectivity();
 }
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void MeshUnitTest::
-initializeTest()
-{
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -1018,7 +997,7 @@ _testVisitors()
   // Vérifie que le nombre de passage dans le visiteur est égal au nombre
   // de groupes de la famille.
   info() << "TEST Visit CellFamily";
-  meshvisitor::visitGroups(item_family,func);
+  MeshUtils::visitGroups(item_family, func);
   vc.areEqual(nb_group,item_family->groups().count(),"Bad number of group for cell family");
   info() << "Nb group=" << nb_group;
 
@@ -1028,7 +1007,7 @@ _testVisitors()
   for( IItemFamilyCollection::Enumerator ifamily(mesh()->itemFamilies()); ++ifamily; ){
     nb_expected_group += (*ifamily)->groups().count();
   }
-  meshvisitor::visitGroups(mesh(),func);
+  MeshUtils::visitGroups(mesh(), func);
   vc.areEqual(nb_group,nb_expected_group,"Bad number of group for mesh");
   info() << "Nb group=" << nb_group;
 
@@ -1045,7 +1024,7 @@ _testVisitors()
       else
         info() << "group not sorted name=" << g.name();
     };
-    meshvisitor::visitGroups(mesh(),check_sorted_func);
+    MeshUtils::visitGroups(mesh(), check_sorted_func);
     info() << "Nb group=" << nb_group << " nb_sorted=" << nb_sorted_group;
   }
 }
@@ -1343,8 +1322,8 @@ _testAdditionnalConnectivity()
   info() << A_FUNCINFO;
   ValueChecker vc(A_FUNCINFO);
 
-  // Créé une connectivité maille->face contenant pour chaque mailles la liste
-  // des faces n'étant pas à la frontière: il s'agit donc des faces qui ont
+  // Créé une connectivité maille <-> face contenant pour chaque maille la liste
+  // des faces n'étant pas à la frontière : il s'agit donc des faces qui ont
   // deux mailles connectées.
   IItemFamily* cell_family = mesh()->cellFamily();
   IItemFamily* face_family = mesh()->faceFamily();
@@ -1619,7 +1598,7 @@ _testGroupsAsBlocks()
     bli.fillArray(computed_values);
     vc.areEqualArray(computed_values.constView(),group.view().localIds(),group.name());
   };
-  meshvisitor::visitGroups(mesh(),xx);
+  MeshUtils::visitGroups(mesh(), xx);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1707,6 +1686,46 @@ _testEvents()
     ARCANE_FATAL("Event BeginPrepareDump has not been called");
   if (!has_call_end_prepare_dump)
     ARCANE_FATAL("Event EndPrepareDump has not been called");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MeshUnitTest::
+_testNodeNodeViaEdgeConnectivity()
+{
+  auto x = Arcane::MeshUtils::createNodeNodeViaEdgeConnectivity(mesh(), "NodeNodeViaEdge");
+  IndexedNodeNodeConnectivityView nn_cv = x->view();
+
+  // Tableau contenant la liste triée des nœuds connectés à un nœud.
+  UniqueArray<Int32> ref_cx_nodes;
+
+  ENUMERATE_ (Node, inode, allNodes()) {
+    Node node = *inode;
+    Int32 nb_edge = node.nbEdge();
+    Int32 nb_connectivity_node = nn_cv.nbNode(node);
+    if (nb_edge != nb_connectivity_node)
+      ARCANE_FATAL("Bad number of connected node uid={0} nb_edge={1} nb_connected={2}",
+                   node.uniqueId(), nb_edge, nb_connectivity_node);
+    ref_cx_nodes.resize(nb_edge);
+    for (Int32 i = 0; i < nb_edge; ++i) {
+      Edge edge = node.edge(i);
+      Int32 connected_node_lid = (edge.node(0) == node) ? edge.node(1).localId() : edge.node(0).localId();
+      ref_cx_nodes[i] = connected_node_lid;
+    }
+    std::sort(ref_cx_nodes.begin(), ref_cx_nodes.end());
+    // Les nœuds de la connectivité 'nn_cv' sont bien triés par indice croissant des nœuds,
+    // mais ce n'est pas forcément le cas de node.edges() car ces derniers sont triés par
+    // uniqueId() des arêtes. On passe par un tableau temporaire qu'on trie pour tester les
+    // valeurs.
+    for (Int32 i = 0; i < nb_edge; ++i) {
+      Int32 ref_cx_node_lid = ref_cx_nodes[i];
+      Int32 cx_node_lid = nn_cv.nodeId(node, i);
+      if (ref_cx_node_lid != cx_node_lid)
+        ARCANE_FATAL("Bad connected node uid={0} index={1} ref={2} current={3}",
+                     node.uniqueId(), i, ref_cx_node_lid, cx_node_lid);
+    }
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/tests/testMesh-2.arc
+++ b/arcane/tests/testMesh-2.arc
@@ -13,6 +13,7 @@
  <module-test-unitaire>
   <test name="MeshUnitTest">
     <maillage-additionnel>sod.vtk</maillage-additionnel>
+    <create-edges>true</create-edges>
   </test>
  </module-test-unitaire>
 


### PR DESCRIPTION
This may be used if we want to know list of nodes connected to a node via edge elements without the need to create edges in the mesh.