### PR TITLE
Add method to directly set all connected items to an item

### DIFF
--- a/arcane/src/arcane/core/IIncrementalItemConnectivity.h
+++ b/arcane/src/arcane/core/IIncrementalItemConnectivity.h
@@ -135,6 +135,22 @@ class ARCANE_CORE_EXPORT IIncrementalItemConnectivity
   //! Ajoute l'entité de localId() \a target_local_id à la connectivité de \a source_item
   virtual void addConnectedItem(ItemLocalId source_item, ItemLocalId target_local_id) = 0;
 
+  /*!
+   * \brief Alloue et positionne les entités connectées à \a source_item.
+   *
+   * S'il y avait des déjà des entités connectées à \a source_item, elles sont supprimées.
+   * \a target_local_ids contient la liste des numéros locaux des entités à ajouter.
+   * Cette méthode est équivalente à appeler le code suivant mais permet des optimisations sur la
+   * gestion mémoire:
+   * \code
+   * IIncrementalItemConnectivity* c = ...;
+   * c->removeConnectedItems(source_item);
+   * for( Int32 x : target_local_ids )
+   *   c->addConnectedItem(source_item,ItemLocalId{x});
+   * \endcode
+   */
+  virtual void setConnectedItems(ItemLocalId source_item, Int32ConstArrayView target_local_ids);
+
   //! Supprime l'entité de localId() \a target_local_id à la connectivité de \a source_item
   virtual void removeConnectedItem(ItemLocalId source_item, ItemLocalId target_local_id) = 0;
 

--- a/arcane/src/arcane/core/InterfaceImpl.cc
+++ b/arcane/src/arcane/core/InterfaceImpl.cc
@@ -239,6 +239,17 @@ _internalNotifySourceItemsAdded(Int32ConstArrayView local_ids)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+void IIncrementalItemConnectivity::
+setConnectedItems(ItemLocalId source_item, Int32ConstArrayView target_local_ids)
+{
+  removeConnectedItems(source_item);
+  for (Int32 x : target_local_ids)
+    addConnectedItem(source_item, ItemLocalId{ x });
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 void IPostProcessorWriter::
 setMesh([[maybe_unused]] IMesh* mesh)
 {

--- a/arcane/src/arcane/core/MeshUtils.h
+++ b/arcane/src/arcane/core/MeshUtils.h
@@ -427,7 +427,7 @@ fillUniqueIds(ItemVectorView items,Array<Int64>& uids);
  * La connectivité aura pour nom \a connectivity_name.
  */
 extern "C++" ARCANE_CORE_EXPORT Ref<IIndexedIncrementalItemConnectivity>
-createNodeNodeViaEdgeConnectivity(IMesh* mesh, const String& connectivity_name);
+computeNodeNodeViaEdgeConnectivity(IMesh* mesh, const String& connectivity_name);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/MeshUtils2.cc
+++ b/arcane/src/arcane/core/MeshUtils2.cc
@@ -36,7 +36,7 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 
 Ref<IIndexedIncrementalItemConnectivity> MeshUtils::
-createNodeNodeViaEdgeConnectivity(IMesh* mesh, const String& connectivity_name)
+computeNodeNodeViaEdgeConnectivity(IMesh* mesh, const String& connectivity_name)
 {
   IItemFamily* node_family = mesh->nodeFamily();
   auto connectivity_mng = mesh->indexedConnectivityMng();

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.cc
@@ -625,6 +625,17 @@ addConnectedItems(ItemLocalId source_item,Integer nb_item)
 /*---------------------------------------------------------------------------*/
 
 void IncrementalItemConnectivity::
+setConnectedItems(ItemLocalId source_item, Int32ConstArrayView target_local_ids)
+{
+  removeConnectedItems(source_item);
+  addConnectedItems(source_item, target_local_ids.size());
+  replaceConnectedItems(source_item, target_local_ids);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void IncrementalItemConnectivity::
 removeConnectedItems(ItemLocalId source_item)
 {
   Int32 lid = source_item.localId();
@@ -665,22 +676,25 @@ void IncrementalItemConnectivity::
 replaceConnectedItems(ItemLocalId source_item,Int32ConstArrayView target_local_ids)
 {
   Int32 lid = source_item.localId();
-  Integer n = target_local_ids.size();
-  ARCANE_CHECK_AT(n,m_connectivity_nb_item[lid]);
-  for( Integer i=0; i<n; ++i )
-    m_connectivity_list[ m_connectivity_index[lid] + i ] = target_local_ids[i];
+  Int32 n = target_local_ids.size();
+  if (n > 0) {
+    ARCANE_CHECK_AT(n - 1, m_connectivity_nb_item[lid]);
+    const Int32 pos = m_connectivity_index[lid];
+    for (Integer i = 0; i < n; ++i)
+      m_connectivity_list[pos + i] = target_local_ids[i];
+  }
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 bool IncrementalItemConnectivity::
-hasConnectedItem(Arcane::ItemLocalId source_item,
-                 Arcane::ItemLocalId target_local_id) const
+hasConnectedItem(ItemLocalId source_item, ItemLocalId target_local_id) const
 {
   bool has_connection = false;
   auto connected_items = _connectedItemsLocalId(source_item);
-  if (std::find(connected_items.begin(),connected_items.end(),target_local_id) != connected_items.end()) has_connection = true;
+  if (std::find(connected_items.begin(), connected_items.end(), target_local_id) != connected_items.end())
+    has_connection = true;
   return has_connection;
 }
 

--- a/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
+++ b/arcane/src/arcane/mesh/IncrementalItemConnectivity.h
@@ -209,6 +209,7 @@ class ARCANE_MESH_EXPORT IncrementalItemConnectivity
  public:
 
   void addConnectedItems(ItemLocalId source_item,Integer nb_item);
+  void setConnectedItems(ItemLocalId source_item, Int32ConstArrayView target_local_ids) override;
   void removeConnectedItems(ItemLocalId source_item) override;
   void addConnectedItem(ItemLocalId source_item,ItemLocalId target_local_id) override;
   void removeConnectedItem(ItemLocalId source_item,ItemLocalId target_local_id) override;

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -305,8 +305,11 @@ executeTest()
   _testCoherency();
   _testFindOneItem();
   _testEvents();
-  if (options()->createEdges())
+  if (options()->createEdges()) {
+    // Appelle 2 fois la méthode pour vérifier que le recalcul est correct.
     _testNodeNodeViaEdgeConnectivity();
+    _testNodeNodeViaEdgeConnectivity();
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1694,7 +1697,8 @@ _testEvents()
 void MeshUnitTest::
 _testNodeNodeViaEdgeConnectivity()
 {
-  auto x = Arcane::MeshUtils::createNodeNodeViaEdgeConnectivity(mesh(), "NodeNodeViaEdge");
+  info() << "Test: _testNodeNodeViaEdgeConnectivity";
+  auto x = Arcane::MeshUtils::computeNodeNodeViaEdgeConnectivity(mesh(), "NodeNodeViaEdge");
   IndexedNodeNodeConnectivityView nn_cv = x->view();
 
   // Tableau contenant la liste triée des nœuds connectés à un nœud.


### PR DESCRIPTION
This is a small optimization to prevent memory hole in the connectivity list when we add many connected items without pre-allocation.