### PR TITLE
Add command 'set debuginfod enabled off' when launching gdb

### DIFF
--- a/arcane/src/arcane/utils/PlatformUtils.cc
+++ b/arcane/src/arcane/utils/PlatformUtils.cc
@@ -571,7 +571,7 @@ getGDBStack()
   //sprintf (cmd, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt'", (long)getpid ());
   //sprintf (cmd, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt' --batch", (long)getpid ());
   long pid = (long)getpid();
-  snprintf(cmd, cmd_size, "gdb --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt full' --batch", pid);
+  snprintf(cmd, cmd_size, "gdb --ex 'set debuginfod enabled off' --ex 'attach %ld' --ex 'info threads' --ex 'thread apply all bt full' --batch", pid);
   result = _getDebuggerStack(cmd);
 #endif
   return result;


### PR DESCRIPTION
This is to prevent downloading of debug symbols from internet which may cause timeout when used in CI.