### PR TITLE
Remove usage of 'ItemInternalMap::Data' and 'ItemInternal*' in 'ItemInternalMap'

### DIFF
--- a/arcane/src/arcane/core/ItemInternal.h
+++ b/arcane/src/arcane/core/ItemInternal.h
@@ -399,7 +399,7 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
 
  private:
 
-  // NOTE: à terme, il faudra fusionné cette classe avec ItemConnectivityContainerView
+  // NOTE : à terme, il faudra fusionner cette classe avec ItemConnectivityContainerView
   //! Conteneur des vues pour les informations de connectivité d'une famille
   struct Container
   {
@@ -498,8 +498,12 @@ class ARCANE_CORE_EXPORT ItemBase
  public:
 
   ItemBase() : m_shared_info(ItemSharedInfo::nullItemSharedInfoPointer) {}
-  ItemBase(ItemBase* x) : m_local_id(x->m_local_id), m_shared_info(x->m_shared_info) {}
   ItemBase(ItemBaseBuildInfo x) : m_local_id(x.m_local_id), m_shared_info(x.m_shared_info) {}
+
+ public:
+
+  // TODO: A supprimer à terme
+  inline ItemBase(ItemInternal* x);
 
  public:
 
@@ -829,8 +833,15 @@ class ARCANE_CORE_EXPORT MutableItemBase
  public:
 
   MutableItemBase() = default;
-  MutableItemBase(ItemBase* x) : ItemBase(x) {}
   MutableItemBase(ItemBaseBuildInfo x) : ItemBase(x) {}
+  explicit MutableItemBase(const ItemBase& x)
+  : ItemBase(x)
+  {}
+
+ public:
+
+  // TODO: A supprimer à terme
+  inline MutableItemBase(ItemInternal* x);
 
  public:
 
@@ -1138,6 +1149,23 @@ class ARCANE_CORE_EXPORT ItemInternal
   ItemInternal* _internalHChild(Int32 index) const { return _connectivity()->_hChildV2(m_local_id,index); }
   ItemInternal* _parent(Integer index) const { return m_shared_info->_parentV2(m_local_id,index); }
 };
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+impl::ItemBase::
+ItemBase(ItemInternal* x)
+: m_local_id(x->m_local_id)
+, m_shared_info(x->m_shared_info)
+{}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+impl::MutableItemBase::
+MutableItemBase(ItemInternal* x)
+: ItemBase(x)
+{}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DoFFamily.cc
+++ b/arcane/src/arcane/mesh/DoFFamily.cc
@@ -7,16 +7,16 @@
 /*---------------------------------------------------------------------------*/
 /* DoFFamily.cc                                                (C) 2000-2024 */
 /*                                                                           */
-/* Famille de degre de liberte                                               */
+/* Famille de degré de liberté                                               */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
 #include "arcane/mesh/DoFFamily.h"
 
-#include "arcane/ISubDomain.h"
-#include "arcane/IMesh.h"
-#include "arcane/ItemTypeMng.h"
-#include "arcane/ItemTypeInfo.h"
-#include "arcane/IExtraGhostItemsBuilder.h"
+#include "arcane/core/IMesh.h"
+#include "arcane/core/ItemTypeMng.h"
+#include "arcane/core/ItemTypeInfo.h"
+#include "arcane/core/IExtraGhostItemsBuilder.h"
 
 #include "arcane/mesh/ExtraGhostItemsManager.h"
 
@@ -152,12 +152,7 @@ void
 DoFFamily::
 _printInfos(Integer nb_added)
 {
-  Integer nb_in_map = 0;
-  for( auto i : itemsMap().buckets() ){
-    for( ItemInternalMap::Data* nbid = i; nbid; nbid = nbid->next() ){
-      ++nb_in_map;
-    }
-  }
+  Integer nb_in_map = itemsMap().count();
 
   info() << "DoFFamily: added=" << nb_added
          << " nb_internal=" << infos().m_internals.size()

--- a/arcane/src/arcane/mesh/DynamicMeshIncrementalBuilder.h
+++ b/arcane/src/arcane/mesh/DynamicMeshIncrementalBuilder.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DynamicMeshIncrementalBuilder.h                             (C) 2000-2021 */
+/* DynamicMeshIncrementalBuilder.h                             (C) 2000-2024 */
 /*                                                                           */
 /* Construction d'un maillage de manière incrémentale.                       */
 /*---------------------------------------------------------------------------*/
@@ -14,20 +14,18 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include <list>
-
-#include "arcane/mesh/FullItemInfo.h"
-
 #include "arcane/utils/HashTableMap.h"
 #include "arcane/utils/TraceAccessor.h"
 
-#include "arcane/IItemFamilyNetwork.h"
-
-#include "arcane/ArcaneTypes.h"
-#include "arcane/ItemInternal.h"
+#include "arcane/core/IItemFamilyNetwork.h"
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/ItemInternal.h"
 
 #include "arcane/mesh/DynamicMeshKindInfos.h"
 #include "arcane/mesh/ItemData.h"
+#include "arcane/mesh/FullItemInfo.h"
+
+#include <list>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -59,14 +57,8 @@ class DynamicMeshIncrementalBuilder
 {
  public:
 
-  //! Type la table de hashage uniqueId()->ItemInternal*
-  typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
-  typedef ItemInternalMap::Data ItemInternalMapData;
-  
- public:
-
   //! Construit une instance pour le maillage \a mesh
-  DynamicMeshIncrementalBuilder(DynamicMesh* mesh);
+  explicit DynamicMeshIncrementalBuilder(DynamicMesh* mesh);
   ~DynamicMeshIncrementalBuilder();
 
  public:

--- a/arcane/src/arcane/mesh/DynamicMeshKindInfos.h
+++ b/arcane/src/arcane/mesh/DynamicMeshKindInfos.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DynamicMeshKindInfos.h                                      (C) 2000-2022 */
+/* DynamicMeshKindInfos.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Infos de maillage pour un genre d'entité donnée.                          */
 /*---------------------------------------------------------------------------*/
@@ -19,9 +19,9 @@
 #include "arcane/utils/HashTableMap.h"
 #include "arcane/utils/TraceAccessor.h"
 
-#include "arcane/ItemGroup.h"
-#include "arcane/ItemInternal.h"
-#include "arcane/VariableTypedef.h"
+#include "arcane/core/ItemGroup.h"
+#include "arcane/core/ItemInternal.h"
+#include "arcane/core/VariableTypedef.h"
 
 #include "arcane/mesh/ItemInternalMap.h"
 
@@ -53,8 +53,12 @@ class ARCANE_MESH_EXPORT DynamicMeshKindInfos
 {
  public:
 
+  // TODO: a supprimer
   typedef Arcane::mesh::ItemInternalMap ItemInternalMap;
-  typedef ItemInternalMap::Data ItemInternalMapData;
+
+ private:
+
+  using ItemInternalMapData = ItemInternalMap::BaseData;
 
  public:
 
@@ -190,18 +194,15 @@ class ARCANE_MESH_EXPORT DynamicMeshKindInfos
     }
     return item_data->value();
   }
-  
-  //! Recherche l'entit de numro unique \a unique_id et 
+
+  //! Recherche l'entité de numéro unique \a uid
   ItemInternal* findOne(Int64 uid)
   {
 #ifdef ARCANE_CHECK
     if (!m_has_unique_id_map)
       _badUniqueIdMap();
 #endif
-    ItemInternalMapData* item_data = m_items_map.lookup(uid);
-    if(item_data)
-      return item_data->value();
-    return nullptr;
+    return m_items_map.tryFindItemInternal(uid);
   }
 
   //! Vérifie si les structures internes de l'instance sont valides

--- a/arcane/src/arcane/mesh/EdgeUniqueIdBuilder.cc
+++ b/arcane/src/arcane/mesh/EdgeUniqueIdBuilder.cc
@@ -474,15 +474,14 @@ _computeEdgesUniqueIdsParallel3()
       for (Int64 z=0; z<nb_item; ++z ){
         Int64 old_uid = received_infos[(z*3)];
         Int64 new_uid = received_infos[(z*3)+1];
-        Int32 new_owner = (Int32)received_infos[(z*3)+2];
+        Int32 new_owner = static_cast<Int32>(received_infos[(z * 3) + 2]);
         //info() << "EDGE old_uid=" << old_uid << " new_uid=" << new_uid;
-        ItemInternalMapData* edge_data = edges_map.lookup(old_uid);
-        if (!edge_data)
+        impl::MutableItemBase iedge(edges_map.tryFind(old_uid));
+        if (iedge.null())
           ARCANE_FATAL("Can not find own edge uid={0}",old_uid);
-        ItemInternal* iedge = edge_data->value();
+        iedge.setUniqueId(new_uid);
+        iedge.setOwner(new_owner, my_rank);
         Edge edge{iedge};
-        iedge->setUniqueId(new_uid);
-        iedge->setOwner(new_owner,my_rank);
         if (is_verbose)
           info() << "SetEdgeOwner uid=" << new_uid << " owner=" << new_owner
                  << " n0,n1=" << edge.node(0).uniqueId() << "," << edge.node(1).uniqueId()
@@ -494,7 +493,6 @@ _computeEdgesUniqueIdsParallel3()
   traceMng()->flush();
   pm->barrier();
   info() << "END OF TEST NEW EDGE COMPUTE";
-  return;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/EdgeUniqueIdBuilder.h
+++ b/arcane/src/arcane/mesh/EdgeUniqueIdBuilder.h
@@ -7,7 +7,7 @@
 /*---------------------------------------------------------------------------*/
 /* EdgeUniqueIdBuilder.h                                       (C) 2000-2024 */
 /*                                                                           */
-/* Construction des indentifiants uniques des edges.                         */
+/* Construction des identifiants uniques des edges.                          */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCANE_MESH_EDGEUNIQUEIDBUILDER_H
 #define ARCANE_MESH_EDGEUNIQUEIDBUILDER_H
@@ -44,9 +44,6 @@ class EdgeUniqueIdBuilder
 : public TraceAccessor
 {
  public:
-
-  typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
-  typedef ItemInternalMap::Data ItemInternalMapData;
 
   typedef HashTableMapT<Int32,SharedArray<Int64> > BoundaryInfosMap;
   typedef HashTableMapEnumeratorT<Int32,SharedArray<Int64> > BoundaryInfosMapEnumerator;

--- a/arcane/src/arcane/mesh/FaceUniqueIdBuilder.cc
+++ b/arcane/src/arcane/mesh/FaceUniqueIdBuilder.cc
@@ -354,12 +354,12 @@ _computeFacesUniqueIdsParallelV1()
           ++recv_faces_infos_index;
           Integer cell_face_index = CheckedConvert::toInteger(recv_faces_infos[recv_faces_infos_index]);
           ++recv_faces_infos_index;
-          
-          ItemInternalMapData* data = nodes_map.lookup(faces_nodes_uid[0]);
+
+          Node node = nodes_map.tryFind(faces_nodes_uid[0]);
           // Si la face n'existe pas dans mon sous-domaine, elle ne m'intéresse pas
-          if (!data)
+          if (node.null())
             continue;
-          Face face = ItemTools::findFaceInNode2(data->value(),face_type,faces_nodes_uid);
+          Face face = ItemTools::findFaceInNode2(node, face_type, faces_nodes_uid);
           if (face.null())
             continue;
           ++nb_recv_sub_domain_boundary_face;
@@ -879,11 +879,11 @@ _computeFacesUniqueIdsParallelV2()
         Int64 old_uid = received_infos[(z*3)];
         Int64 new_uid = received_infos[(z*3)+1];
         Int32 new_owner = (Int32)received_infos[(z*3)+2];
-        ItemInternalMapData* face_data = faces_map.lookup(old_uid);
-        if (!face_data)
-          fatal() << "Can not find own face uid=" << old_uid;
-        face_data->value()->setUniqueId(new_uid);
-        face_data->value()->setOwner(new_owner,my_rank);
+        impl::MutableItemBase face(faces_map.tryFind(old_uid));
+        if (face.null())
+          ARCANE_FATAL("Can not find own face uid={0}", old_uid);
+        face.setUniqueId(new_uid);
+        face.setOwner(new_owner, my_rank);
       }
     }
   }

--- a/arcane/src/arcane/mesh/FaceUniqueIdBuilder.h
+++ b/arcane/src/arcane/mesh/FaceUniqueIdBuilder.h
@@ -39,9 +39,6 @@ class FaceUniqueIdBuilder
 {
  public:
 
-  using ItemInternalMap = DynamicMeshKindInfos::ItemInternalMap;
-  using ItemInternalMapData = ItemInternalMap::Data;
-
   using BoundaryInfosMap = HashTableMapT<Int32, SharedArray<Int64>>;
   using BoundaryInfosMapEnumerator = HashTableMapEnumeratorT<Int32, SharedArray<Int64>>;
 

--- a/arcane/src/arcane/mesh/FaceUniqueIdBuilder2.cc
+++ b/arcane/src/arcane/mesh/FaceUniqueIdBuilder2.cc
@@ -85,11 +85,6 @@ class FaceUniqueIdBuilder2
 
  public:
 
-  using ItemInternalMap = DynamicMeshKindInfos::ItemInternalMap;
-  using ItemInternalMapData = ItemInternalMap::Data;
-
- public:
-
   //! Construit une instance pour le maillage \a mesh
   explicit FaceUniqueIdBuilder2(DynamicMesh* mesh);
 
@@ -992,11 +987,10 @@ _resendCellsAndComputeFacesUniqueId(ConstArrayView<AnyFaceInfo> all_csi)
         Int32 full_local_index = rci.m_face_local_index_and_owner_rank;
         Int32 face_local_index = full_local_index / nb_rank;
         Int32 owner_rank = full_local_index % nb_rank;
-        
-        ItemInternalMapData* cell_data = cells_map.lookup(cell_uid);
-        if (!cell_data)
+
+        Cell cell = cells_map.tryFind(cell_uid);
+        if (cell.null())
           ARCANE_FATAL("Can not find cell data for '{0}'",cell_uid);
-        Cell cell(cell_data->value());
         Face face = cell.face(face_local_index);
         Int64 face_uid = all_first_face_uid[rank] + rci.m_index_in_rank_list;
         face.mutableItemBase().setUniqueId(face_uid);

--- a/arcane/src/arcane/mesh/GhostLayerBuilder.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder.cc
@@ -433,9 +433,9 @@ _addOneGhostLayerV2()
         z += nb_rank;
         for( Integer z2=0; z2<nb_cell; ++z2 ){
           Int64 cell_uid = received_infos[z+z2];
-          ItemInternalMap::Data* dcell = cells_map.lookup(cell_uid);
-          if (dcell)
-            cells.add(dcell->value()->localId());
+          impl::ItemBase dcell = cells_map.tryFind(cell_uid);
+          if (!dcell.null())
+            cells.add(dcell.localId());
         }
         for( Integer z2=0,zs=ranks.size(); z2<zs; ++z2 ){
           SubDomainItemMap::Data* d = cells_to_send.lookupAdd(ranks[z2]);
@@ -524,7 +524,7 @@ addGhostChildFromParent()
   cells_map.eachItem([&](Item cell) {
     ARCANE_ASSERT((cell.owner() != -1), (""));
     if (cell.itemBase().level() == 0 && cell.owner() != sid) {
-      ARCANE_ASSERT((cell->owner() != -1),(""));
+      ARCANE_ASSERT((cell.owner() != -1), (""));
       Int64Array& v = boundary_infos_to_send.lookupAdd(cell.owner())->value();
       v.add(sid);
       v.add(cell.uniqueId());

--- a/arcane/src/arcane/mesh/GhostLayerBuilder.h
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* GhostLayerBuilder.h                                         (C) 2000-2021 */
+/* GhostLayerBuilder.h                                         (C) 2000-2024 */
 /*                                                                           */
 /* Construction des couches fantômes.                                        */
 /*---------------------------------------------------------------------------*/
@@ -41,7 +41,6 @@ class GhostLayerBuilder
  public:
 
   typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
-  typedef ItemInternalMap::Data ItemInternalMapData;
 
   typedef HashTableMapT<Int32,SharedArray<Int64> > BoundaryInfosMap;
   typedef HashTableMapEnumeratorT<Int32,SharedArray<Int64> > BoundaryInfosMapEnumerator;
@@ -49,7 +48,7 @@ class GhostLayerBuilder
  public:
 
   //! Construit une instance pour le maillage \a mesh
-  GhostLayerBuilder(DynamicMeshIncrementalBuilder* mesh_builder);
+  explicit GhostLayerBuilder(DynamicMeshIncrementalBuilder* mesh_builder);
   virtual ~GhostLayerBuilder();
 
  public:

--- a/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
@@ -747,16 +747,16 @@ _addGhostLayer(Integer current_layer,Int32ConstArrayView node_layer)
         if (is_verbose)
           info() << " CELL=" << cell_uid << " owner=" << cell_owner;
         if (cell_owner==my_rank){
-          ItemInternalMap::Data* dcell = cells_map.lookup(cell_uid);
-          if (!dcell)
-            throw FatalErrorException(A_FUNCINFO,"Internal error: cell not in our mesh");
+          impl::ItemBase dcell = cells_map.tryFind(cell_uid);
+          if (dcell.null())
+            ARCANE_FATAL("Internal error: cell uid={0} is not in our mesh", cell_uid);
           if (do_only_minimal_uid){
             // Ajoute toutes les mailles autour de mon noeud
             for( CellLocalId c : current_node.cellIds() )
               my_cells.add(c);
           }
           else
-            my_cells.add(dcell->value()->localId());
+            my_cells.add(dcell.localId());
         }
         else{
           if (ranks_done.find(cell_owner)==ranks_done.end()){

--- a/arcane/src/arcane/mesh/MapCoordToUid.h
+++ b/arcane/src/arcane/mesh/MapCoordToUid.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MapCoordToUid.cc                                            (C) 2000-2017 */
+/* MapCoordToUid.cc                                            (C) 2000-2024 */
 /*                                                                           */
 /* Recherche d'entités à partir de ses coordonnées.                          */
 /*---------------------------------------------------------------------------*/
@@ -19,11 +19,11 @@
 #include "arcane/utils/Real3.h"
 #include "arcane/utils/Math.h"
 
+#include "arcane/core/SharedVariable.h"
+#include "arcane/core/MathUtils.h"
+
 #include "arcane/mesh/MeshGlobal.h"
 #include "arcane/mesh/DynamicMeshKindInfos.h"
-#include "arcane/SharedVariable.h"
-
-#include "arcane/MathUtils.h"
 
 #include <map>
 #include <unordered_map>
@@ -33,12 +33,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_MESH_BEGIN_NAMESPACE
+namespace Arcane::mesh
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -49,23 +45,21 @@ ARCANE_MESH_BEGIN_NAMESPACE
    */
 class MapCoordToUid
 {
+ public:
 
-public:
-  typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
-  typedef ItemInternalMap::Data ItemInternalMapData;
-
-  typedef std::unordered_multimap<Int32, std::pair<const Real3,Int64> > map_type;
-//  typedef std::unordered_multimap<Int64, std::pair<const Real3,Int64> > map_type; // This (needed !) correction introduces a bug in a IFPEN application...investigation in progress (Scarab Arc356@IFPEN)
+  typedef std::unordered_multimap<Int32, std::pair<const Real3, Int64>> map_type;
+  //  typedef std::unordered_multimap<Int64, std::pair<const Real3,Int64> > map_type; // This (needed !) correction introduces a bug in a IFPEN application...investigation in progress (Scarab Arc356@IFPEN)
   typedef std::unordered_set<Int64> set_type;
   static const Real TOLERANCE;
 
   class Box
   {
-  public :
-    Box() ;
-    virtual ~Box(){}
-    void init(IMesh* mesh) ;
-    void init2(IMesh* mesh) ;
+   public:
+
+    Box();
+    virtual ~Box() {}
+    void init(IMesh* mesh);
+    void init2(IMesh* mesh);
     Real3 m_lower_bound;
     Real3 m_upper_bound;
     Real3 m_size;
@@ -74,36 +68,38 @@ public:
 #ifdef ACTIVATE_PERF_COUNTER
   struct PerfCounter
   {
-      typedef enum {
-        Clear,
-        Fill,
-        Fill2,
-        Insert,
-        Find,
-        Key,
-        NbCounters
-      }  eType ;
+    typedef enum
+    {
+      Clear,
+      Fill,
+      Fill2,
+      Insert,
+      Find,
+      Key,
+      NbCounters
+    } eType;
 
-      static const std::string m_names[NbCounters] ;
-  } ;
+    static const std::string m_names[NbCounters];
+  };
 #endif
-  MapCoordToUid(IMesh* mesh) ;
+  MapCoordToUid(IMesh* mesh);
 
-  void setBox(Box* box) {
-    m_box=box ;
+  void setBox(Box* box)
+  {
+    m_box = box;
   }
 
   void clear() { m_map.clear(); }
-  void _clear() ;
+  void _clear();
 
-  void updateNodeData(ArrayView<ItemInternal*> coarsen_cells) ;
-  void updateFaceData(ArrayView<ItemInternal*> coarsen_cells) ;
+  void updateNodeData(ArrayView<ItemInternal*> coarsen_cells);
+  void updateFaceData(ArrayView<ItemInternal*> coarsen_cells);
 
-  void clearNodeData(ArrayView<ItemInternal*> coarsen_cells) ;
-  void clearFaceData(ArrayView<ItemInternal*> coarsen_cells) ;
+  void clearNodeData(ArrayView<ItemInternal*> coarsen_cells);
+  void clearFaceData(ArrayView<ItemInternal*> coarsen_cells);
 
-  Int64 insert(const Real3,const Int64, const Real tol = TOLERANCE);
-  void erase(const Real3,const Real tol = TOLERANCE);
+  Int64 insert(const Real3, const Int64, const Real tol = TOLERANCE);
+  void erase(const Real3, const Real tol = TOLERANCE);
 
   bool empty() const { return m_map.empty(); }
 
@@ -112,13 +108,15 @@ public:
   bool areClose(Real3 const& p1, Real3 const& p2, Real tol)
   {
     return Arcane::math::abs(p1.x - p2.x) +
-           Arcane::math::abs(p1.y - p2.y) +
-           Arcane::math::abs(p1.z - p2.z) <= tol ;
+    Arcane::math::abs(p1.y - p2.y) +
+    Arcane::math::abs(p1.z - p2.z) <=
+    tol;
   }
 
 #ifdef ACTIVATE_PERF_COUNTER
-  PerfCounterMng<PerfCounter>& getPerfCounter() {
-    return m_perf_counter ;
+  PerfCounterMng<PerfCounter>& getPerfCounter()
+  {
+    return m_perf_counter;
   }
 #endif
  protected:
@@ -132,7 +130,7 @@ public:
   Box* m_box;
   VariableNodeReal3& m_nodes_coords;
 #ifdef ACTIVATE_PERF_COUNTER
-  PerfCounterMng<PerfCounter> m_perf_counter ;
+  PerfCounterMng<PerfCounter> m_perf_counter;
 #endif
 };
 
@@ -142,22 +140,25 @@ public:
 class NodeMapCoordToUid
 : public MapCoordToUid
 {
- public :
+ public:
+
   typedef MapCoordToUid BaseType;
-  NodeMapCoordToUid(IMesh* mesh) : MapCoordToUid(mesh) {}
+  NodeMapCoordToUid(IMesh* mesh)
+  : MapCoordToUid(mesh)
+  {}
   void init();
   void check();
 
-  bool insert(const Real3 center,const Int64 uid, const Real tol = TOLERANCE)
+  bool insert(const Real3 center, const Int64 uid, const Real tol = TOLERANCE)
   {
-    return BaseType::insert(center,uid,tol) != uid;
+    return BaseType::insert(center, uid, tol) != uid;
   }
 
   void init2();
   void check2();
 
-  void clearData(ArrayView<ItemInternal*> coarsen_cells) ;
-  void updateData(ArrayView<ItemInternal*> refine_cells) ;
+  void clearData(ArrayView<ItemInternal*> coarsen_cells);
+  void updateData(ArrayView<ItemInternal*> refine_cells);
 
   inline bool isItemToSuppress(Node node, const Int64 parent_uid) const;
 
@@ -172,11 +173,12 @@ class NodeMapCoordToUid
 
 class FaceMapCoordToUid : public MapCoordToUid
 {
-public :
-  typedef MapCoordToUid BaseType ;
+ public:
+
+  typedef MapCoordToUid BaseType;
   FaceMapCoordToUid(IMesh* mesh)
   : MapCoordToUid(mesh)
-  , m_face_center(VariableBuildInfo(mesh,"AMRFaceCenter"))
+  , m_face_center(VariableBuildInfo(mesh, "AMRFaceCenter"))
   {}
   void init();
   void check();
@@ -184,51 +186,49 @@ public :
   void init2();
   void check2();
 
-  bool insert(const Real3& center,const Int64& uid, const Real tol = TOLERANCE)
+  bool insert(const Real3& center, const Int64& uid, const Real tol = TOLERANCE)
   {
-    Int64 old_uid = BaseType::insert(center,uid,tol) ;
-    if(uid!=old_uid)
-    {
-      m_new_uids.insert(uid) ;
-      return true ;
+    Int64 old_uid = BaseType::insert(center, uid, tol);
+    if (uid != old_uid) {
+      m_new_uids.insert(uid);
+      return true;
     }
-    return false ;
+    return false;
   }
 
-  void clearNewUids() {
-    m_new_uids.clear() ;
+  void clearNewUids()
+  {
+    m_new_uids.clear();
   }
 
-  bool isNewUid(Int64 uid) {
-    return m_new_uids.find(uid) != m_new_uids.end() ;
+  bool isNewUid(Int64 uid)
+  {
+    return m_new_uids.find(uid) != m_new_uids.end();
   }
 
-  void clearData(ArrayView<ItemInternal*> coarsen_cells) ;
-  void updateData(ArrayView<ItemInternal*> refine_cells) ;
+  void clearData(ArrayView<ItemInternal*> coarsen_cells);
+  void updateData(ArrayView<ItemInternal*> refine_cells);
 
-  void initFaceCenter() ;
-  void updateFaceCenter(ArrayView<ItemInternal*> refine_cells) ;
+  void initFaceCenter();
+  void updateFaceCenter(ArrayView<ItemInternal*> refine_cells);
 
-protected :
+ protected:
+
   void fill();
   void fill2();
 
   Real3 faceCenter(Face face) const;
   bool isItemToSuppress(Face face) const;
- private :
 
-  VariableFaceReal3 m_face_center ;
-  set_type m_new_uids ;
+ private:
+
+  VariableFaceReal3 m_face_center;
+  set_type m_new_uids;
 };
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_MESH_END_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_END_NAMESPACE
+} // namespace Arcane::mesh
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/MeshRefinement.h
+++ b/arcane/src/arcane/mesh/MeshRefinement.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshRefinement.h                                            (C) 2000-2023 */
+/* MeshRefinement.h                                            (C) 2000-2024 */
 /*                                                                           */
 /* Gestion de l'adaptation de maillages non-structurés par raffinement       */
 /*---------------------------------------------------------------------------*/
@@ -17,10 +17,12 @@
 #include "arcane/utils/TraceAccessor.h"
 #include "arcane/utils/PerfCounterMng.h"
 #include "arcane/utils/AMRCallBackMng.h"
+
+#include "arcane/core/ItemRefinementPattern.h"
+
 #include "arcane/mesh/MeshGlobal.h"
 #include "arcane/mesh/MapCoordToUid.h"
 #include "arcane/mesh/DynamicMeshKindInfos.h"
-#include "arcane/ItemRefinementPattern.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -53,12 +55,6 @@ class ParallelAMRConsistency;
 class MeshRefinement
 :  public TraceAccessor
 {
-public:
-  //! Type la table de hashage uniqueId()->ItemInternal*
-  typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
-  typedef ItemInternalMap::Data ItemInternalMapData;
-
-
 public:
 #ifdef ACTIVATE_PERF_COUNTER
   struct PerfCounter

--- a/arcane/src/arcane/mesh/OneMeshItemAdder.cc
+++ b/arcane/src/arcane/mesh/OneMeshItemAdder.cc
@@ -13,17 +13,16 @@
 
 #include "arcane/mesh/OneMeshItemAdder.h"
 
+#include "arcane/utils/NotSupportedException.h"
+
+#include "arcane/core/MeshUtils.h"
+#include "arcane/core/MeshToMeshTransposer.h"
+#include "arcane/core/IParallelMng.h"
+#include "arcane/core/ItemPrinter.h"
+
 #include "arcane/mesh/DynamicMesh.h"
 #include "arcane/mesh/DynamicMeshIncrementalBuilder.h"
 #include "arcane/mesh/ItemTools.h"
-
-#include "arcane/MeshUtils.h"
-#include "arcane/MeshToMeshTransposer.h"
-#include "arcane/IParallelMng.h"
-#include "arcane/ItemPrinter.h"
-
-#include "arcane/utils/NotSupportedException.h"
-
 #include "arcane/mesh/ConnectivityNewWithDependenciesTypes.h"
 #include "arcane/mesh/GraphDoFs.h"
 
@@ -222,7 +221,7 @@ template<>
 Face OneMeshItemAdder::
 _findInternalFace(Integer i_face, const CellInfoProxy& cell_info, bool& is_add)
 {
-  DynamicMeshIncrementalBuilder::ItemInternalMap& nodes_map = m_mesh->nodesMap();
+  ItemInternalMap& nodes_map = m_mesh->nodesMap();
   ItemTypeInfo* cell_type_info = cell_info.typeInfo();
   const ItemTypeInfo::LocalFace& lf = cell_type_info->localFace(i_face);
   ItemInternal* nbi = nodes_map.lookupValue(m_work_face_sorted_nodes[0]);
@@ -272,7 +271,7 @@ _findInternalEdge(Integer i_edge, const CellInfoProxy& cell_info, Int64 first_no
 {
   ARCANE_UNUSED(i_edge);
 
-  DynamicMeshIncrementalBuilder::ItemInternalMap& nodes_map = m_mesh->nodesMap();
+  ItemInternalMap& nodes_map = m_mesh->nodesMap();
   ItemInternal* nbi = nodes_map.lookupValue(first_node);
   Edge edge_internal = ItemTools::findEdgeInNode2(nbi,first_node,second_node);
   if (edge_internal.null()){
@@ -609,8 +608,8 @@ _addOneCell(const CellInfo& cell_info)
   }
 
   //! Type la table de hashage uniqueId()->ItemInternal*
-  DynamicMeshIncrementalBuilder::ItemInternalMap& nodes_map = m_node_family.itemsMap();
-  
+  ItemInternalMap& nodes_map = m_node_family.itemsMap();
+
   _addNodesToCell(inew_cell,cell_info);
   
   if (m_mesh_builder->hasEdge()) {

--- a/arcane/src/arcane/mesh/ParallelAMRConsistency.h
+++ b/arcane/src/arcane/mesh/ParallelAMRConsistency.h
@@ -1,18 +1,18 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
-/*
- * ParallelAMRConsistency.h
- *
- *  Created on: Dec 22, 2010
- *      Author: mesriy
- */
-
-#ifndef PARALLELAMRCONSISTENCY_H_
-#define PARALLELAMRCONSISTENCY_H_
+/*---------------------------------------------------------------------------*/
+/* ParallelAMRConsistency.h                                    (C) 2000-2024 */
+/*                                                                           */
+/* Gestion de la consistance de l'AMR en parallèle.                          */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_MESH_PARALLELAMRCONSISTENCY_H
+#define ARCANE_MESH_PARALLELAMRCONSISTENCY_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/String.h"
 #include "arcane/utils/HashTableMap.h"
@@ -229,11 +229,8 @@ class FaceInfo2
 class ParallelAMRConsistency
 : public TraceAccessor
 {
-public:
-  //! Type la table de hashage uniqueId()->ItemInternal*
-  typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
-  typedef ItemInternalMap::Data ItemInternalMapData;
-public:
+ public:
+
   typedef HashTableMapT<ItemUniqueId, NodeInfo> NodeInfoList;
   typedef HashTableMapT<ItemUniqueId, FaceInfo> FaceInfoMap;
   typedef HashTableMapT<ItemUniqueId, FaceInfo2> FaceInfoMap2;


### PR DESCRIPTION
The use of these types in `ItemInternalMap` is deprecated.
Add methods `ItemInternalMap::tryFind()`, `ItemInternalMap::tryFindLocalId()` to get associated `Item` for a given unique id.