### PR TITLE
Add support to use 'std::unordered_map` for implementation of 'ItemInternalMap'

### DIFF
--- a/arcane/src/arcane/mesh/DynamicMeshKindInfos.h
+++ b/arcane/src/arcane/mesh/DynamicMeshKindInfos.h
@@ -187,12 +187,12 @@ class ARCANE_MESH_EXPORT DynamicMeshKindInfos
     if (!m_has_unique_id_map)
       _badUniqueIdMap();
 #endif
-    ItemInternalMapData* item_data = m_items_map._lookupAdd(uid, 0, is_alloc);
+    ItemInternalMap::LookupData item_data = m_items_map._lookupAdd(uid, 0, is_alloc);
     if (is_alloc){
       bool need_alloc;
-      item_data->setValue(_allocOne(need_alloc));
+      item_data.setValue(_allocOne(need_alloc));
     }
-    return item_data->value();
+    return item_data.value();
   }
 
   //! Recherche l'entité de numéro unique \a uid

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -629,7 +629,7 @@ _endUpdate(bool need_check_remove)
 
   _resizeVariables(false);
   info(4) << "ItemFamily:endUpdate(): " << fullName()
-          << " hashmapsize=" << itemsMap().buckets().size()
+          << " hashmapsize=" << itemsMap().nbBucket()
           << " nb_group=" << m_item_groups.count();
 
   _updateGroups(need_check_remove);

--- a/arcane/src/arcane/mesh/ItemInternalMap.cc
+++ b/arcane/src/arcane/mesh/ItemInternalMap.cc
@@ -13,9 +13,9 @@
 
 #include "arcane/mesh/ItemInternalMap.h"
 
-#include "arcane/utils/ArrayView.h"
 #include "arcane/utils/Iterator.h"
 #include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/NotSupportedException.h"
 
 #include "arcane/core/Item.h"
 
@@ -46,23 +46,40 @@ ItemInternalMap()
 void ItemInternalMap::
 notifyUniqueIdsChanged()
 {
-  if (arcaneIsCheck()){
+  if (arcaneIsCheck()) {
     // Vérifie qu'on n'a pas deux fois la même clé.
     std::unordered_set<Int64> uids;
     this->eachItem([&](Item item) {
       Int64 uid = item.uniqueId().asInt64();
-      if (uids.find(uid)!=uids.end())
-        ARCANE_FATAL("Duplicated uniqueId '{0}'",uid);
+      if (uids.find(uid) != uids.end())
+        ARCANE_FATAL("Duplicated uniqueId '{0}'", uid);
       uids.insert(uid);
     });
   }
 
-  ENUMERATE_ITEM_INTERNAL_MAP_DATA2(nbid, m_impl)
-  {
-    nbid->setKey(nbid->value()->uniqueId().asInt64());
+  if constexpr (UseNewImpl) {
+    Int64 nb_item = m_new_impl.size();
+    UniqueArray<ItemInternal*> items(nb_item);
+    Int64 index = 0;
+    for (auto& x : m_new_impl) {
+      items[index] = x.second;
+      ++index;
+    }
+    m_new_impl.clear();
+    for (index = 0; index < nb_item; ++index) {
+      ItemInternal* item = items[index];
+      m_new_impl.insert(std::make_pair(item->uniqueId(), item));
+    }
+  }
+  else {
+    ENUMERATE_ITEM_INTERNAL_MAP_DATA2 (nbid, m_impl) {
+      nbid->setKey(nbid->value()->uniqueId().asInt64());
+    }
+
+    m_impl.rehash();
   }
 
-  m_impl.rehash();
+  checkValid();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -72,12 +89,73 @@ void ItemInternalMap::
 _changeLocalIds(ArrayView<ItemInternal*> items_internal,
                 ConstArrayView<Int32> old_to_new_local_ids)
 {
-  ENUMERATE_ITEM_INTERNAL_MAP_DATA2(nbid, m_impl)
-  {
-    ItemInternal* item = nbid->value();
-    Int32 current_local_id = item->localId();
-    nbid->setValue(items_internal[old_to_new_local_ids[current_local_id]]);
+  checkValid();
+
+  if constexpr (UseNewImpl) {
+    for (auto& iter : m_new_impl) {
+      ItemInternal* old_ii = iter.second;
+      Int32 current_local_id = old_ii->localId();
+      ItemInternal* new_ii = items_internal[old_to_new_local_ids[current_local_id]];
+      iter.second = new_ii;
+    }
   }
+  else {
+    ENUMERATE_ITEM_INTERNAL_MAP_DATA2 (nbid, m_impl) {
+      ItemInternal* old_ii = nbid->value();
+      Int32 current_local_id = old_ii->localId();
+      ItemInternal* new_ii = items_internal[old_to_new_local_ids[current_local_id]];
+      nbid->setValue(new_ii);
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemInternalMap::
+checkValid() const
+{
+  if (!arcaneIsCheck())
+    return;
+
+  if constexpr (UseNewImpl) {
+    for (auto& x : m_new_impl) {
+      if (x.first != x.second->uniqueId())
+        ARCANE_FATAL("Incoherent uid key={0} item_internal={1}", x.first, x.second->uniqueId());
+    }
+  }
+  else {
+    ENUMERATE_ITEM_INTERNAL_MAP_DATA2(nbid, m_impl)
+    {
+      if (nbid->key() != nbid->value()->uniqueId())
+        ARCANE_FATAL("Incoherent uid key={0} item_internal={1}", nbid->key(), nbid->value()->uniqueId());
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemInternalMap::
+_throwNotFound(Int64 key) const
+{
+  ARCANE_FATAL("ERROR: can not find key={0}", key);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemInternalMap::
+_throwNotSupported(const char* func_name) const
+{
+  ARCANE_THROW(NotSupportedException, func_name);
+}
+
+void ItemInternalMap::
+_checkValid(Int64 uid, ItemInternal* v) const
+{
+  if (v->uniqueId() != uid)
+    ARCANE_FATAL("Bad found uniqueId found={0} expected={1}", v->uniqueId(), uid);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemInternalMap.h
+++ b/arcane/src/arcane/mesh/ItemInternalMap.h
@@ -321,7 +321,7 @@ class ItemInternalMap
   ConstArrayView<BaseData*> buckets() const
   {
     if constexpr (UseNewImpl) {
-      _throwNotSupported("lookup");
+      _throwNotSupported("buckets");
     }
     else
       return m_impl.buckets();
@@ -331,7 +331,7 @@ class ItemInternalMap
   BaseData* lookupAdd(Int64 id, ItemInternal* value, bool& is_add)
   {
     if constexpr (UseNewImpl) {
-      _throwNotSupported("lookup");
+      _throwNotSupported("lookupAdd(id,value,is_add)");
     }
     else
       return m_impl.lookupAdd(id, value, is_add);
@@ -341,7 +341,7 @@ class ItemInternalMap
   BaseData* lookupAdd(Int64 uid)
   {
     if constexpr (UseNewImpl) {
-      _throwNotSupported("lookup");
+      _throwNotSupported("lookupAdd(uid)");
     }
     else
       return m_impl.lookupAdd(uid);
@@ -351,7 +351,7 @@ class ItemInternalMap
   ItemInternal* lookupValue(Int64 uid) const
   {
     if constexpr (UseNewImpl) {
-      _throwNotSupported("lookup");
+      _throwNotSupported("lookupValue");
     }
     else
       return m_impl.lookupValue(uid);
@@ -361,7 +361,7 @@ class ItemInternalMap
   ItemInternal* operator[](Int64 uid) const
   {
     if constexpr (UseNewImpl) {
-      _throwNotSupported("lookup");
+      _throwNotSupported("operator[]");
     }
     else
       return m_impl.lookupValue(uid);


### PR DESCRIPTION
This is not active at the moment.
It may only be used if no code use deprecated methods of `ItemInternalMap`.