### PR TITLE
Refactor 'ItemFamily' to use a pointer of DynamicMeshKindInfos instead of a direct instance.

### DIFF
--- a/arcane/src/arcane/mesh/CartesianFaceUniqueIdBuilder.cc
+++ b/arcane/src/arcane/mesh/CartesianFaceUniqueIdBuilder.cc
@@ -17,6 +17,8 @@
 #include "arcane/core/IParallelMng.h"
 #include "arcane/core/CartesianGridDimension.h"
 
+#include "arcane/mesh/ItemInternalMap.h"
+
 #include <array>
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DynamicMesh.h
+++ b/arcane/src/arcane/mesh/DynamicMesh.h
@@ -103,8 +103,6 @@ class ARCANE_MESH_EXPORT DynamicMesh
  public:
 
   typedef ItemInternal* ItemInternalPtr;
-  typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
-
   typedef List<IItemFamily*> ItemFamilyList;
 
   class InitialAllocator

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -18,16 +18,13 @@
 #include "arcane/utils/String.h"
 #include "arcane/utils/TraceAccessor.h"
 
-#include "arcane/IItemFamily.h"
-#include "arcane/ItemPairGroup.h"
-#include "arcane/ObserverPool.h"
-
-#include "arcane/mesh/DynamicMeshKindInfos.h"
-
-#include "arcane/IItemConnectivity.h"
-#include "arcane/IIncrementalItemConnectivity.h"
-
-#include "arcane/ItemSharedInfo.h"
+#include "arcane/core/IItemFamily.h"
+#include "arcane/core/ItemPairGroup.h"
+#include "arcane/core/ObserverPool.h"
+#include "arcane/core/IItemConnectivity.h"
+#include "arcane/core/IIncrementalItemConnectivity.h"
+#include "arcane/core/ItemSharedInfo.h"
+#include "arcane/core/ItemGroup.h"
 
 #include <map>
 #include <set>
@@ -54,12 +51,11 @@ template <typename T> class ItemScalarProperty;
 
 namespace Arcane::mesh
 {
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
+class ItemInternalMap;
+class DynamicMeshKindInfos;
 class ItemSharedInfoList;
 class ItemConnectivityInfo;
+class ItemConnectivitySelector;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -110,9 +106,10 @@ class ARCANE_MESH_EXPORT ItemFamily
 
   };
   typedef std::map<AdjencyInfo,ItemPairGroup> AdjencyGroupMap;
+
  public:
 
-  typedef DynamicMeshKindInfos::ItemInternalMap ItemInternalMap;
+  using ItemInternalMap = ::Arcane::mesh::ItemInternalMap;
 
  public:
 
@@ -127,7 +124,7 @@ class ARCANE_MESH_EXPORT ItemFamily
 
   String name() const override { return m_name; }
   String fullName() const override { return m_full_name; }
-  eItemKind itemKind() const override { return m_infos.kind(); }
+  eItemKind itemKind() const override;
   Integer nbItem() const override;
   Int32 maxLocalId() const override;
   ItemInternalList itemsInternal() override;
@@ -145,7 +142,7 @@ class ARCANE_MESH_EXPORT ItemFamily
 
  public:
 
-  ItemInternalMap& itemsMap() { return m_infos.itemsMap(); }
+  ItemInternalMap& itemsMap();
 
  public:
 
@@ -185,7 +182,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   ItemVectorView view(Int32ConstArrayView local_ids) override;
   ItemVectorView view() override;
 
-  ItemInternal* findOneItem(Int64 uid) override { return m_infos.findOne(uid) ; }
+  ItemInternal* findOneItem(Int64 uid) override;
 
  public:
 
@@ -219,7 +216,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   void compactItems(bool do_sort) override;
   void clearItems() override;
 
-  const DynamicMeshKindInfos& infos() const { return m_infos; }
+  const DynamicMeshKindInfos& infos() const;
   Int64ArrayView* uniqueIds();
 
   ItemSharedInfo* commonItemSharedInfo() { return m_common_item_shared_info; }
@@ -290,48 +287,16 @@ class ARCANE_MESH_EXPORT ItemFamily
 
  protected:
 
-  void _removeOne(Item item)
-  {
-    // TODO: vérifier en mode check avec les nouvelles connectivités que l'entité supprimée
-    // n'a pas d'objets connectés.
-    m_infos.removeOne(ItemCompatibility::_itemInternal(item));
-  }
-  void _detachOne(Item item)
-  {
-    m_infos.detachOne(ItemCompatibility::_itemInternal(item));
-  }
-  ItemInternalList _itemsInternal()
-  {
-    return m_infos.itemsInternal();
-  }
-  ItemInternal* _itemInternal(Int32 local_id)
-  {
-    return m_infos.itemInternal(local_id);
-  }
-  ItemInternal* _allocOne(Int64 unique_id)
-  {
-    return m_infos.allocOne(unique_id);
-  }
-  ItemInternal* _allocOne(Int64 unique_id,bool& need_alloc)
-  {
-    return m_infos.allocOne(unique_id,need_alloc);
-  }
-  ItemInternal* _findOrAllocOne(Int64 uid,bool& is_alloc)
-  {
-    return m_infos.findOrAllocOne(uid,is_alloc);
-  }
-  void _setHasUniqueIdMap(bool v)
-  {
-    m_infos.setHasUniqueIdMap(v);
-  }
-  void _removeMany(Int32ConstArrayView local_ids)
-  {
-    m_infos.removeMany(local_ids);
-  }
-  void _removeDetachedOne(Item item)
-  {
-    m_infos.removeDetachedOne(ItemCompatibility::_itemInternal(item));
-  }
+  void _removeOne(Item item);
+  void _detachOne(Item item);
+  ItemInternalList _itemsInternal();
+  ItemInternal* _itemInternal(Int32 local_id);
+  ItemInternal* _allocOne(Int64 unique_id);
+  ItemInternal* _allocOne(Int64 unique_id, bool& need_alloc);
+  ItemInternal* _findOrAllocOne(Int64 uid, bool& is_alloc);
+  void _setHasUniqueIdMap(bool v);
+  void _removeMany(Int32ConstArrayView local_ids);
+  void _removeDetachedOne(Item item);
 
   void _detachCells2(Int32ConstArrayView local_ids);
 
@@ -350,7 +315,7 @@ class ARCANE_MESH_EXPORT ItemFamily
 
  private:
 
-  DynamicMeshKindInfos m_infos;
+  std::unique_ptr<DynamicMeshKindInfos> m_infos;
 
  protected:
 

--- a/arcane/src/arcane/mesh/ItemFamilyCompactPolicy.h
+++ b/arcane/src/arcane/mesh/ItemFamilyCompactPolicy.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemFamilyCompactPolicy.h                                   (C) 2000-2016 */
+/* ItemFamilyCompactPolicy.h                                   (C) 2000-2024 */
 /*                                                                           */
 /* Politique de compactage des entités d'une famille.                        */
 /*---------------------------------------------------------------------------*/
@@ -17,15 +17,15 @@
 #include "arcane/utils/TraceAccessor.h"
 #include "arcane/utils/ArrayView.h"
 
-#include "arcane/IItemFamilyCompactPolicy.h"
+#include "arcane/core/IItemFamilyCompactPolicy.h"
 
 #include "arcane/mesh/ItemFamily.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-ARCANE_MESH_BEGIN_NAMESPACE
+namespace Arcane::mesh
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -45,8 +45,11 @@ class ARCANE_MESH_EXPORT ItemFamilyCompactPolicy
 , public IItemFamilyCompactPolicy
 {
  public:
-  ItemFamilyCompactPolicy(ItemFamily* family);
+
+  explicit ItemFamilyCompactPolicy(ItemFamily* family);
+
  public:
+
   void beginCompact(ItemFamilyCompactInfos& compact_infos) override;
   void compactVariablesAndGroups(const ItemFamilyCompactInfos& compact_infos) override;
   void endCompact(ItemFamilyCompactInfos& compact_infos) override;
@@ -56,17 +59,23 @@ class ARCANE_MESH_EXPORT ItemFamilyCompactPolicy
   }
   IItemFamily* family() const override;
   void compactConnectivityData() override;
+
  protected:
-  void _changeItem(Int32* items,Integer nb_item,Int32ConstArrayView old_to_new)
+
+  void _changeItem(Int32* items, Integer nb_item, Int32ConstArrayView old_to_new)
   {
-    for( Integer i=0; i<nb_item; ++i ){
+    for (Integer i = 0; i < nb_item; ++i) {
       Integer item_local_id = items[i];
       items[i] = old_to_new[item_local_id];
     }
   }
+
  protected:
+
   ItemFamily* _family() const { return m_family; }
+
  private:
+
   ItemFamily* m_family;
 };
 
@@ -79,10 +88,15 @@ class StandardItemFamilyCompactPolicy
 : public ItemFamilyCompactPolicy
 {
  public:
+
   StandardItemFamilyCompactPolicy(ItemFamily* family);
+
  public:
+
   void updateInternalReferences(IMeshCompacter* compacter) override;
+
  public:
+
   IItemFamily* m_node_family;
   IItemFamily* m_edge_family;
   IItemFamily* m_face_family;
@@ -92,8 +106,7 @@ class StandardItemFamilyCompactPolicy
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_MESH_END_NAMESPACE
-ARCANE_END_NAMESPACE
+} // namespace Arcane::mesh
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ParticleFamily.cc
+++ b/arcane/src/arcane/mesh/ParticleFamily.cc
@@ -24,8 +24,8 @@
 
 #include "arcane/mesh/ItemsExchangeInfo2.h"
 #include "arcane/mesh/DynamicMesh.h"
-#include "arcane/mesh/IncrementalItemConnectivity.h"
 #include "arcane/mesh/ItemConnectivitySelector.h"
+#include "arcane/mesh/DynamicMeshKindInfos.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/PolyhedralMesh.cc
+++ b/arcane/src/arcane/mesh/PolyhedralMesh.cc
@@ -21,6 +21,7 @@
 #include "arcane/core/MeshBuildInfo.h"
 #include "arcane/core/ServiceFactory.h"
 #include "arcane/mesh/ItemFamily.h"
+#include "arcane/mesh/DynamicMeshKindInfos.h"
 #include "arcane/utils/ITraceMng.h"
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/core/AbstractService.h"


### PR DESCRIPTION
This will allow us to make class `DynamicMeshKindInfos` private to Arcane.