### PR TITLE
Add support in VtkHdf format for MPI-IO writing in several blocks

### DIFF
--- a/arcane/src/arcane/std/VtkHdfV2PostProcessor.axl
+++ b/arcane/src/arcane/std/VtkHdfV2PostProcessor.axl
@@ -19,6 +19,16 @@
         pas le cas alors l'écriture ne sera pas collective.
     </description>
    </simple>
+
+    <simple name="max-write-size" type="int64" default="0">
+      <userclass>User</userclass>
+      <description>
+        Taille maximale en octet d'un bloc pour une écriture collective.
+        Si la taille maximale dépasse cette valeur, l'écriture est scindée en
+        plusieurs écritures. Cela n'est actif que pour les écritures avec MPI-IO.
+      </description>
+    </simple>
+
   </options>
 
 </service>

--- a/arcane/src/arcane/std/VtkHdfV2PostProcessor.cc
+++ b/arcane/src/arcane/std/VtkHdfV2PostProcessor.cc
@@ -228,6 +228,7 @@ class VtkHdfV2DataWriter
 
   void setTimes(RealConstArrayView times) { m_times = times; }
   void setDirectoryName(const String& dir_name) { m_directory_name = dir_name; }
+  void setMaxWriteSize(Int64 v) { m_max_write_size = v; }
 
  private:
 
@@ -1217,10 +1218,13 @@ class VtkHdfV2PostProcessor
   void notifyBeginWrite() override
   {
     bool use_collective_io = true;
+    Int64 max_write_size = 0;
     if (options()) {
       use_collective_io = options()->useCollectiveWrite();
+      max_write_size = options()->maxWriteSize();
     }
     auto w = std::make_unique<VtkHdfV2DataWriter>(mesh(), groups(), use_collective_io);
+    w->setMaxWriteSize(max_write_size);
     w->setTimes(times());
     Directory dir(baseDirectoryName());
     w->setDirectoryName(dir.file("vtkhdfv2"));

--- a/arcane/tests/testHydro-1-vtkhdfv2-backward.arc
+++ b/arcane/tests/testHydro-1-vtkhdfv2-backward.arc
@@ -21,7 +21,9 @@
 
  <arcane-post-processing>
    <output-period>2</output-period>
-   <format name="VtkHdfV2PostProcessor" />
+   <format name="VtkHdfV2PostProcessor" >
+     <max-write-size>15000</max-write-size>
+   </format>
    <output>
     <variable>CellMass</variable>
     <variable>CellVolume</variable>

--- a/arcane/tests/testHydro-1-vtkhdfv2.arc
+++ b/arcane/tests/testHydro-1-vtkhdfv2.arc
@@ -33,7 +33,9 @@
 
  <arcane-post-processing>
    <output-period>5</output-period>
-   <format name="VtkHdfV2PostProcessor" />
+   <format name="VtkHdfV2PostProcessor">
+     <max-write-size>15000</max-write-size>
+   </format>
    <output>
     <variable>CellMass</variable>
     <variable>CellVolume</variable>


### PR DESCRIPTION
This may be needed when writing large dataset whose total size exceeds 4Go.