### PR TITLE
In VtkLegacy reader, do not destroy variables loaded during in the file

### DIFF
--- a/arcane/src/arcane/core/internal/IVariableMngInternal.h
+++ b/arcane/src/arcane/core/internal/IVariableMngInternal.h
@@ -123,6 +123,15 @@ class ARCANE_CORE_EXPORT IVariableMngInternal
    */
   virtual void initializeVariables(bool is_continue) = 0;
 
+  /*!
+   * \brief Ajoute la variable à la liste des variables qui sont conservées
+   * jusqu'à la fin de l'exécution.
+   *
+   * La variable sera détruite par l'appel à l'opérateur operator delete()
+   * lors de l'appel à IVariableMng::removeAllVariables().
+   */
+  virtual void addAutoDestroyVariable(VariableRef* var) =0;
+
  public:
 
   //! Fonction interne temporaire pour récupérer le sous-domaine.

--- a/arcane/src/arcane/impl/internal/VariableMng.h
+++ b/arcane/src/arcane/impl/internal/VariableMng.h
@@ -137,6 +137,7 @@ class VariableMng
     ISubDomain* internalSubDomain() const override { return m_variable_mng->_internalSubDomain(); }
     IAcceleratorMng* acceleratorMng() const override { return m_variable_mng->m_accelerator_mng.get(); }
     void setAcceleratorMng(Ref<IAcceleratorMng> v) override { m_variable_mng->m_accelerator_mng = v; }
+    void addAutoDestroyVariable(VariableRef* var) override { m_variable_mng->m_auto_create_variables.add(var); }
 
    private:
 


### PR DESCRIPTION
These variables are now kept until the end of the execution.
Before, they were destroyed when the reader service was destroyed. The only way to access them was to already know the list of these variables and explicitly declare a variable with the same name in a module.
