### PR TITLE
Add method in 'MessagePassingMng' to set the communicator

### DIFF
--- a/arccore/src/message_passing/arccore/message_passing/MessagePassingMng.cc
+++ b/arccore/src/message_passing/arccore/message_passing/MessagePassingMng.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -12,7 +12,6 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arccore/message_passing/MessagePassingMng.h"
-#include "arccore/message_passing/Communicator.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -49,6 +48,18 @@ IDispatchers* MessagePassingMng::
 dispatchers()
 {
   return m_dispatchers;
+}
+
+Communicator MessagePassingMng::
+communicator() const
+{
+  return m_communicator;
+}
+
+void MessagePassingMng::
+setCommunicator(Communicator c)
+{
+  m_communicator = c;
 }
 
 ITimeMetricCollector* MessagePassingMng::

--- a/arccore/src/message_passing/arccore/message_passing/MessagePassingMng.h
+++ b/arccore/src/message_passing/arccore/message_passing/MessagePassingMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MessagePassingMng.h                                         (C) 2000-2022 */
+/* MessagePassingMng.h                                         (C) 2000-2024 */
 /*                                                                           */
 /* Gestionnaire des échanges de messages.                                    */
 /*---------------------------------------------------------------------------*/
@@ -17,6 +17,7 @@
 #include "arccore/base/ReferenceCounterImpl.h"
 
 #include "arccore/message_passing/IMessagePassingMng.h"
+#include "arccore/message_passing/Communicator.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -50,7 +51,12 @@ class ARCCORE_MESSAGEPASSING_EXPORT MessagePassingMng
   Int32 commSize() const override { return m_comm_size; }
   IDispatchers* dispatchers() override;
   ITimeMetricCollector* timeMetricCollector() const override;
+  Communicator communicator() const override;
+
+ public:
+
   void setTimeMetricCollector(ITimeMetricCollector* c);
+  void setCommunicator(Communicator c);
 
  private:
 
@@ -58,6 +64,7 @@ class ARCCORE_MESSAGEPASSING_EXPORT MessagePassingMng
   Int32 m_comm_size;
   IDispatchers* m_dispatchers = nullptr;
   ITimeMetricCollector* m_time_metric_collector = nullptr;
+  Communicator m_communicator;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiMessagePassingMng.cc
+++ b/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiMessagePassingMng.cc
@@ -26,25 +26,9 @@ namespace Arccore::MessagePassing::Mpi
 MpiMessagePassingMng::
 MpiMessagePassingMng(const BuildInfo& bi)
 : MessagePassingMng(bi.commRank(),bi.commSize(),bi.dispatchers())
-, m_communicator(bi.communicator())
+, m_mpi_communicator(bi.communicator())
 {
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-MpiMessagePassingMng::
-~MpiMessagePassingMng()
-{
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-Communicator MpiMessagePassingMng::
-communicator() const
-{
-  return Communicator(m_communicator);
+  setCommunicator(Communicator{m_mpi_communicator});
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiMessagePassingMng.h
+++ b/arccore/src/message_passing_mpi/arccore/message_passing_mpi/MpiMessagePassingMng.h
@@ -62,27 +62,22 @@ class ARCCORE_MESSAGEPASSINGMPI_EXPORT MpiMessagePassingMng
  public:
 
   explicit MpiMessagePassingMng(const BuildInfo& bi);
-  ~MpiMessagePassingMng() override;
 
  public:
 
-  Communicator communicator() const override;
-  const MPI_Comm* getMPIComm() const
-  {
-    return &m_communicator;
-  }
+  const MPI_Comm* getMPIComm() const { return &m_mpi_communicator; }
 
  private:
 
-  MPI_Comm m_communicator;
+  MPI_Comm m_mpi_communicator;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace Arccore::MessagePassing::Mpi
+} // namespace Arccore::MessagePassing::Mpi
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
+#endif


### PR DESCRIPTION
At the moment, only a derived class (i.e. `MpiMessagePassingMng`) is able to do that. 