### PR TITLE
Set the MPI communicator for 'MessagePassingMng' instance of 'SequentialParallelMng'

### DIFF
--- a/arcane/src/arcane/impl/SequentialParallelMng.cc
+++ b/arcane/src/arcane/impl/SequentialParallelMng.cc
@@ -655,6 +655,7 @@ SequentialParallelMng(const SequentialParallelMngBuildInfo& bi)
   if (!m_world_parallel_mng)
     m_world_parallel_mng = this;
   m_stat = Parallel::createDefaultStat();
+  _messagePassingMng()->setCommunicator(m_communicator);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This fix an incoherence between the values returned with `IParallelMng::communicator()` and `IMessagePassingMng::communicator()` for the same instance of `SequentialParallelMng`.