### PR TITLE
Add support to split a 'IParallelMng' with a color 

### DIFF
--- a/arcane/src/arcane/core/ParallelMngDispatcher.cc
+++ b/arcane/src/arcane/core/ParallelMngDispatcher.cc
@@ -19,7 +19,6 @@
 #include "arcane/utils/HPReal.h"
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/ScopedPtr.h"
-#include "arcane/utils/Ref.h"
 #include "arcane/utils/ITraceMng.h"
 #include "arcane/utils/ValueConvert.h"
 
@@ -196,7 +195,11 @@ class ParallelMngDispatcher::SerializeDispatcher
 : public MP::ISerializeDispatcher
 {
  public:
-  SerializeDispatcher(IParallelMng* pm) : m_parallel_mng(pm){}
+
+  explicit SerializeDispatcher(IParallelMng* pm)
+  : m_parallel_mng(pm)
+  {}
+
  public:
   Ref<ISerializeMessageList> createSerializeMessageListRef() override
   {
@@ -258,6 +261,10 @@ class ParallelMngDispatcher::Impl
     }
     else
       m_queue.reset();
+  }
+  Ref<IParallelMng> createSubParallelMngRef(Int32 color, Int32 key) override
+  {
+    return m_parallel_mng->_createSubParallelMngRef(color, key);
   }
 
  private:
@@ -537,6 +544,15 @@ Ref<IParallelMng> ParallelMngDispatcher::
 createSubParallelMngRef(Int32ConstArrayView kept_ranks)
 {
   return makeRef(_createSubParallelMng(kept_ranks));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+Ref<IParallelMng> ParallelMngDispatcher::
+_createSubParallelMngRef([[maybe_unused]] Int32 color, [[maybe_unused]] Int32 key)
+{
+  ARCANE_THROW(NotImplementedException, "Create sub-parallelmng with split semantic");
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ParallelMngDispatcher.h
+++ b/arcane/src/arcane/core/ParallelMngDispatcher.h
@@ -284,6 +284,7 @@ class ARCANE_CORE_EXPORT ParallelMngDispatcher
   virtual ISerializeMessageList* _createSerializeMessageList() =0;
   virtual IParallelMng* _createSubParallelMng(Int32ConstArrayView kept_ranks) =0;
   virtual bool _isAcceleratorAware() const { return false; }
+  virtual Ref<IParallelMng> _createSubParallelMngRef(Int32 color, Int32 key);
 
  protected:
 

--- a/arcane/src/arcane/core/ParallelMngUtils.cc
+++ b/arcane/src/arcane/core/ParallelMngUtils.cc
@@ -1,20 +1,21 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelMngUtils.cc                                         (C) 2000-2021 */
+/* ParallelMngUtils.cc                                         (C) 2000-2024 */
 /*                                                                           */
 /* Fonctions utilitaires associées aux 'IParallelMng'.                       */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ParallelMngUtils.h"
+#include "arcane/core/ParallelMngUtils.h"
 
-#include "arcane/IParallelMng.h"
-#include "arcane/IParallelMngUtilsFactory.h"
+#include "arcane/core/IParallelMng.h"
+#include "arcane/core/IParallelMngUtilsFactory.h"
+#include "arcane/core/internal/IParallelMngInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -58,19 +59,19 @@ class ParallelMngUtilsAccessor
   }
 
   static Ref<IVariableSynchronizer>
-  createSynchronizer(IParallelMng* pm,IItemFamily* family)
+  createSynchronizer(IParallelMng* pm, IItemFamily* family)
   {
     ARCANE_CHECK_POINTER(pm);
     auto f = pm->_internalUtilsFactory();
-    return f->createSynchronizer(pm,family);
+    return f->createSynchronizer(pm, family);
   }
 
   static Ref<IVariableSynchronizer>
-  createSynchronizer(IParallelMng* pm,const ItemGroup& group)
+  createSynchronizer(IParallelMng* pm, const ItemGroup& group)
   {
     ARCANE_CHECK_POINTER(pm);
     auto f = pm->_internalUtilsFactory();
-    return f->createSynchronizer(pm,group);
+    return f->createSynchronizer(pm, group);
   }
 
   static Ref<IParallelTopology>
@@ -79,6 +80,12 @@ class ParallelMngUtilsAccessor
     ARCANE_CHECK_POINTER(pm);
     auto f = pm->_internalUtilsFactory();
     return f->createTopology(pm);
+  }
+  static Ref<IParallelMng>
+  createSubParallelMngRef(IParallelMng* pm, Int32 color, Int32 key)
+  {
+    ARCANE_CHECK_POINTER(pm);
+    return pm->_internalApi()->createSubParallelMngRef(color, key);
   }
 };
 
@@ -130,6 +137,12 @@ Ref<IParallelTopology>
 createTopologyRef(IParallelMng* pm)
 {
   return ParallelMngUtilsAccessor::createTopology(pm);
+}
+
+Ref<IParallelMng>
+createSubParallelMngRef(IParallelMng* pm, Int32 color, Int32 key)
+{
+  return ParallelMngUtilsAccessor::createSubParallelMngRef(pm, color, key);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ParallelMngUtils.h
+++ b/arcane/src/arcane/core/ParallelMngUtils.h
@@ -1,35 +1,29 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelMngUtils.h                                          (C) 2000-2021 */
+/* ParallelMngUtils.h                                          (C) 2000-2024 */
 /*                                                                           */
 /* Fonctions utilitaires associées aux 'IParallelMng'.                       */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_PARALLELMNGUTILS_H
-#define ARCANE_PARALLELMNGUTILS_H
+#ifndef ARCANE_CORE_PARALLELMNGUTILS_H
+#define ARCANE_CORE_PARALLELMNGUTILS_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/UtilsTypes.h"
 
-#include "arcane/Parallel.h"
-
-namespace Arcane
-{
-class IItemFamily;
-class ItemGroup;
-}
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/Parallel.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
  * \brief Fonctions utilitaires associées à IParallelMng.
  */
-
 namespace Arcane::ParallelMngUtils
 {
 /*!
@@ -52,14 +46,14 @@ createExchangerRef(IParallelMng* pm);
  * variables sur le groupe de la famille \a family
  */
 extern "C++" ARCANE_CORE_EXPORT Ref<IVariableSynchronizer>
-createSynchronizerRef(IParallelMng* pm,IItemFamily* family);
+createSynchronizerRef(IParallelMng* pm, IItemFamily* family);
 
 /*!
  * \brief Retourne une interface pour synchroniser des
  * variables sur le groupe \a group.
  */
 extern "C++" ARCANE_CORE_EXPORT Ref<IVariableSynchronizer>
-createSynchronizerRef(IParallelMng* pm,const ItemGroup& group);
+createSynchronizerRef(IParallelMng* pm, const ItemGroup& group);
 
 /*!
  * \brief Créé une instance contenant les infos sur la topologie des rangs de ce gestionnnaire.
@@ -68,6 +62,18 @@ createSynchronizerRef(IParallelMng* pm,const ItemGroup& group);
  */
 extern "C++" ARCANE_CORE_EXPORT Ref<IParallelTopology>
 createTopologyRef(IParallelMng* pm);
+
+/*!
+ * \brief Créé un nouveau gestionnaire de parallélisme pour un sous-ensemble
+ * des rangs.
+ *
+ * Cette opération est collective et est équivalent à MPI_Comm_split.
+ *
+ * Les rangs dont \a color vaut la même valeur seront dans le même communicateur.
+ * \a key indique le rang de cette instance dans le nouveau communicateur.
+ */
+extern "C++" ARCANE_CORE_EXPORT Ref<IParallelMng>
+createSubParallelMngRef(IParallelMng* pm, Int32 color, Int32 key);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/IParallelMngInternal.h
+++ b/arcane/src/arcane/core/internal/IParallelMngInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IParallelMngInternal.h                                      (C) 2000-2023 */
+/* IParallelMngInternal.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Partie interne à Arcane de IParallelMng.                                  */
 /*---------------------------------------------------------------------------*/
@@ -49,6 +49,9 @@ class ARCANE_CORE_EXPORT IParallelMngInternal
    * dans les appels MPI ce qui permet d'éviter d'éventuelles recopies.
    */
   virtual bool isAcceleratorAware() const = 0;
+
+  //! Créé un sous IParallelMng de manière similaire à MPI_Comm_split.
+  virtual Ref<IParallelMng> createSubParallelMngRef(Int32 color, Int32 key) = 0;
 
  public:
 

--- a/arcane/src/arcane/parallel/mpi/MpiParallelMng.h
+++ b/arcane/src/arcane/parallel/mpi/MpiParallelMng.h
@@ -155,6 +155,7 @@ class ARCANE_MPI_EXPORT MpiParallelMng
   ISerializeMessageList* _createSerializeMessageList() override;
   IParallelMng* _createSubParallelMng(Int32ConstArrayView kept_ranks) override;
   bool _isAcceleratorAware() const override;
+  Ref<IParallelMng> _createSubParallelMngRef(Int32 color, Int32 key) override;
 
  public:
 
@@ -199,6 +200,7 @@ class ARCANE_MPI_EXPORT MpiParallelMng
 
   void _checkFinishedSubRequests();
   UniqueArray<Integer> _waitSomeRequests(ArrayView<Request> requests, bool is_non_blocking);
+  IParallelMng* _createSubParallelMng(MPI_Comm sub_communicator);
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This is similar to the way `MPI_Comm_split` works.
At the moment it is only implemented for message passing with MPI.