### PR TITLE
Use a negative number instead of MPI_UNDEFINED in 'ParallelMngUtils::createSubParallelMngRef()'

### DIFF
--- a/arcane/src/arcane/core/ParallelMngUtils.h
+++ b/arcane/src/arcane/core/ParallelMngUtils.h
@@ -70,7 +70,12 @@ createTopologyRef(IParallelMng* pm);
  * Cette opération est collective et est équivalent à MPI_Comm_split.
  *
  * Les rangs dont \a color vaut la même valeur seront dans le même communicateur.
- * \a key indique le rang de cette instance dans le nouveau communicateur.
+ * \a key permet d'ordonner les rangs dans le sous-communicateur créé. S'il vaut
+ * pm->commRank() alors les rangs dans le sous-communicateur auront le même ordre
+ * que dans \a pm.
+ *
+ * * Si \a color est négatif, alors le rang actuel ne sera associé à aucun
+ * communicateur et la valeur retournée sera nulle.
  */
 extern "C++" ARCANE_CORE_EXPORT Ref<IParallelMng>
 createSubParallelMngRef(IParallelMng* pm, Int32 color, Int32 key);

--- a/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
+++ b/arcane/src/arcane/parallel/mpi/MpiParallelMng.cc
@@ -486,8 +486,8 @@ build()
   if (m_mpi_lock)
     m_trace->info() << "Using mpi with locks.";
 
-  // Pour l'instant (avril 2020) on laisse l'implémentation historique le
-  // temps de valider l'ancienne.
+  // Utilise par défaut (janvier 2024) la nouvelle implémentation de la sérialisation,
+  // mais on laisse l'ancienne accessible au cas où.
   if (platform::getEnvironmentVariable("ARCANE_SYNCHRONIZE_LIST_VERSION") == "1") {
     m_use_serialize_list_v2 = false;
     m_trace->info() << "Using MPI SerializeList version 1";
@@ -835,6 +835,8 @@ _createSubParallelMng(MPI_Comm sub_communicator)
 Ref<IParallelMng> MpiParallelMng::
 _createSubParallelMngRef(Int32 color, Int32 key)
 {
+  if (color < 0)
+    color = MPI_UNDEFINED;
   MPI_Comm sub_communicator = MPI_COMM_NULL;
   MPI_Comm_split(m_communicator, color, key, &sub_communicator);
   IParallelMng* sub_pm = _createSubParallelMng(sub_communicator);

--- a/arcane/src/arcane/std/MetisWrapper.cc
+++ b/arcane/src/arcane/std/MetisWrapper.cc
@@ -84,7 +84,7 @@ _callMetisWith2Processors(const Int32 ncon, const bool need_part,
 
   metis_gather.gatherGraph(need_part, half_vtxdist, ncon, my_graph, metis_graph);
 
-  color = MPI_UNDEFINED;
+  color = -1;
   if (my_rank == comm_0_io_rank || my_rank == comm_1_io_rank) {
     color = 1;
   }


### PR DESCRIPTION
The value of `MPI_UNDEFINED` is dependent of the MPI implementation but `IParallelMng` may be used without MPI available.