### PR TITLE
Compute the number of transformed cells to remove some operations if this number is zero

### DIFF
--- a/arcane/src/arcane/materials/internal/ConstituentConnectivityList.h
+++ b/arcane/src/arcane/materials/internal/ConstituentConnectivityList.h
@@ -88,9 +88,11 @@ class ConstituentConnectivityList
 
   /*!
    * \brief Replit \a cells_do_transform en indiquant is la maille passe de pure à partielle.
+   *
+   * Retourne le nombre de mailles transformées
    */
-  void fillCellsToTransform(SmallSpan<const Int32> cells_local_id, Int16 env_id,
-                            SmallSpan<bool> cells_do_transform, bool is_add, RunQueue& queue);
+  Int32 fillCellsToTransform(SmallSpan<const Int32> cells_local_id, Int16 env_id,
+                             SmallSpan<bool> cells_do_transform, bool is_add, RunQueue& queue);
 
   /*!
    * \brief Replit \a cells_is_partial en indiquant is la maille est partielle pour le milieu \a env_id

--- a/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
+++ b/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
@@ -72,7 +72,7 @@ class ARCANE_MATERIALS_EXPORT IncrementalComponentModifier
 
  public:
 
-  void _computeCellsToTransformForEnvironments(SmallSpan<const Int32> ids);
+  Int32 _computeCellsToTransformForEnvironments(SmallSpan<const Int32> ids);
   void _resetTransformedCells(SmallSpan<const Int32> ids);
   void _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
                           SmallSpan<const Int32> local_ids);
@@ -85,7 +85,7 @@ class ARCANE_MATERIALS_EXPORT IncrementalComponentModifier
                                    SmallSpan<const Int32> ids);
   void _switchCellsForMaterials(const MeshMaterial* modified_mat,
                                 SmallSpan<const Int32> ids);
-  void _computeCellsToTransformForMaterial(const MeshMaterial* mat, SmallSpan<const Int32> ids);
+  Int32 _computeCellsToTransformForMaterial(const MeshMaterial* mat, SmallSpan<const Int32> ids);
   void _removeItemsFromEnvironment(MeshEnvironment* env, MeshMaterial* mat,
                                    SmallSpan<const Int32> local_ids, bool update_env_indexer);
   void _addItemsToEnvironment(MeshEnvironment* env, MeshMaterial* mat,


### PR DESCRIPTION
Also, compute only one time (instead of one time per environment) the number of transformed environment cells for a modification because the computed value does not depend of the current environment.
