### PR TITLE
Add statistics about useless constituent transform computation

### DIFF
--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -409,7 +409,7 @@ foreach(test_index 1 2 3 4)
   endforeach()
 endforeach()
 if (ARCANE_HAS_ACCELERATOR_API)
-  arcane_add_test_sequential(material_heat2_opt15_2small testMaterialHeat-2-small-opt15.arc "-We,ARCANE_DEBUG_MATERIAL_MODIFIER,2")
+  arcane_add_test_sequential(material_heat2_opt15_2small testMaterialHeat-2-small-opt15.arc "-We,ARCANE_DEBUG_MATERIAL_MODIFIER,2" "-We,ARCANE_PRINT_USELESS_TRANSFORMATION,1")
   arcane_add_test_sequential(material_heat2_accelerator
     "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc"
     "-We,ARCANE_MATERIALMNG_ADDITIONAL_CAPACITY_RATIO,0.5"

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -290,7 +290,7 @@ _switchCellsForMaterials(const MeshMaterial* modified_mat,
       info(4) << "nb_transformed=" << nb_transformed;
       if (nb_transformed==0)
         continue;
-      indexer->transformCellsV2(m_work_info, m_queue);
+      indexer->computeCellsToTransform(m_work_info, m_queue);
       _resetTransformedCells(ids);
 
       auto pure_local_ids = m_work_info.pure_local_ids.view(is_device);
@@ -366,7 +366,7 @@ _switchCellsForEnvironments(const IMeshEnvironment* modified_env,
             << " env_id=" << env_id
             << " indexer=" << indexer->name() << " nb_item=" << ids.size();
 
-    indexer->transformCellsV2(m_work_info, m_queue);
+    indexer->computeCellsToTransform(m_work_info, m_queue);
 
     SmallSpan<const Int32> pure_local_ids = m_work_info.pure_local_ids.view(is_device);
     SmallSpan<const Int32> partial_indexes = m_work_info.partial_indexes.view(is_device);

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -150,9 +150,7 @@ MeshMaterialMng::
 ~MeshMaterialMng()
 {
   //std::cout << "DESTROY MESH MATERIAL MNG this=" << this << '\n';
-  IEnumeratorTracer* tracer = IEnumeratorTracer::singleton();
-  if (tracer)
-    tracer->dumpStats();
+  _dumpStats();
 
   delete m_mms;
   delete m_variable_factory_mng;
@@ -170,20 +168,16 @@ MeshMaterialMng::
     delete e;
   m_true_environments.clear();
 
-  for( IMeshBlock* b : m_true_blocks )
+  for (IMeshBlock* b : m_true_blocks)
     delete b;
 
-  for( MeshMaterialInfo* mmi : m_materials_info )
+  for (MeshMaterialInfo* mmi : m_materials_info)
     delete mmi;
 
-  for( MeshMaterialVariableIndexer* mvi : m_variables_indexer_to_destroy )
+  for (MeshMaterialVariableIndexer* mvi : m_variables_indexer_to_destroy)
     delete mvi;
 
-  if (m_modifier){
-    m_modifier->dumpStats();
-    m_modifier.reset();
-  }
-
+  m_modifier.reset();
   m_internal_api.reset();
 
   if (m_allcell_2_allenvcell)
@@ -1288,6 +1282,31 @@ componentItemSharedInfo(Int32 level) const
     ARCANE_FATAL("Bad internal type of component");
 
   return shared_info;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MeshMaterialMng::
+_dumpStats()
+{
+  IEnumeratorTracer* tracer = IEnumeratorTracer::singleton();
+  if (tracer)
+    tracer->dumpStats();
+
+  if (m_modifier)
+    m_modifier->dumpStats();
+
+  for (IMeshEnvironment* env : m_environments) {
+    // N'affiche pas les statistiques si le milieu n'a qu'un seul matériau
+    // car il utilise le même indexeur que la matériau et les statistiques
+    // pour ce dernier seront affichées lors du parcours des matériaux.
+    if (env->nbMaterial() > 1)
+      env->_internalApi()->variableIndexer()->dumpStats();
+  }
+  for (IMeshMaterial* mat : m_materials) {
+    mat->_internalApi()->variableIndexer()->dumpStats();
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
@@ -314,21 +314,9 @@ _changeLocalIdsV2(MeshMaterialVariableIndexer* var_indexer, Int32ConstArrayView 
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialVariableIndexer::
-transformCellsV2(ConstituentModifierWorkInfo& work_info, RunQueue& queue)
+computeCellsToTransform(ConstituentModifierWorkInfo& work_info, RunQueue& queue)
 {
-  _switchBetweenPureAndPartial(work_info, queue, work_info.isAdd());
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Échange des mailles entre pures et partielles.
- */
-void MeshMaterialVariableIndexer::
-_switchBetweenPureAndPartial(ConstituentModifierWorkInfo& work_info,
-                             RunQueue& queue,
-                             bool is_pure_to_partial)
-{
+  bool is_pure_to_partial = work_info.isAdd();
   bool is_device = isAcceleratorPolicy(queue.executionPolicy());
 
   Integer nb = nbItem();

--- a/arcane/src/arcane/materials/internal/MeshMaterial.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterial.h
@@ -57,7 +57,7 @@ class MeshMaterial
    public:
     InternalApi(MeshMaterial* mat) : m_material(mat){}
    public:
-    MeshMaterialVariableIndexer* variableIndexer() const override\
+    MeshMaterialVariableIndexer* variableIndexer() const override
     {
       return m_material->variableIndexer();
     }

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -409,6 +409,7 @@ class MeshMaterialMng
   {
     return m_all_cells_env_only_synchronizer.get();
   }
+  void _dumpStats();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
@@ -107,7 +107,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
 
  private:
 
-  void transformCellsV2(ConstituentModifierWorkInfo& args, RunQueue& queue);
+  void computeCellsToTransform(ConstituentModifierWorkInfo& args, RunQueue& queue);
 
  private:
 
@@ -153,17 +153,11 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
   //! Indique si on affiche un message lors d'une transformation inutile
   bool m_is_print_useless_transform = false;
 
-private:
+ private:
 
   static void _changeLocalIdsV2(MeshMaterialVariableIndexer* var_indexer,
                                 Int32ConstArrayView old_to_new_ids);
   void _init();
-
- public:
-
-  void _switchBetweenPureAndPartial(ConstituentModifierWorkInfo& work_info,
-                                    RunQueue& queue,
-                                    bool is_pure_to_partial);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
@@ -88,6 +88,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
   // Méthodes publiques car utilisées sur accélérateurs
   void endUpdateAdd(const ComponentItemListBuilder& builder, RunQueue& queue);
   void endUpdateRemoveV2(ConstituentModifierWorkInfo& work_info, Integer nb_remove, RunQueue& queue);
+  void computeCellsToTransform(ConstituentModifierWorkInfo& args, RunQueue& queue);
 
  private:
 
@@ -106,8 +107,6 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
   //@}
 
  private:
-
-  void computeCellsToTransform(ConstituentModifierWorkInfo& args, RunQueue& queue);
 
  private:
 

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
@@ -81,6 +81,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
   void checkValid();
   //! Vrai si cet indexeur est celui d'un milieu.
   bool isEnvironment() const { return m_is_environment; }
+  void dumpStats() const;
 
  public:
 
@@ -90,7 +91,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
 
  private:
 
-  //! Fonctions publiques mais réservées aux classes de Arcane.
+  //! Fonctions privées mais accessibles aux classes 'friend'.
   //@{
   void endUpdate(const ComponentItemListBuilderOld& builder);
   Array<MatVarIndex>& matvarIndexesArray() { return m_matvar_indexes; }
@@ -122,7 +123,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
   //! Liste des mailles de cet indexer
   CellGroup m_cells;
 
-  //! Liste des indexes pour les variables matériaux.
+  //! Liste des indexs pour les variables matériaux.
   UniqueArray<MatVarIndex> m_matvar_indexes;
 
   /*!
@@ -138,7 +139,21 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
   //! Vrai si l'indexeur est associé à un milieu.
   bool m_is_environment = false;
 
- private:
+  //! Nombre d'appels aux méthodes de transformation
+  Int32 m_nb_transform_called = 0;
+
+  /*!
+   * \brief  Nombre d'appels inutiles aux méthodes de transformation.
+   *
+   * Un appel est inutile si la liste des entités modifiées en sortie
+   * est vide.
+   */
+  Int32 m_nb_useless_transform = 0;
+
+  //! Indique si on affiche un message lors d'une transformation inutile
+  bool m_is_print_useless_transform = false;
+
+private:
 
   static void _changeLocalIdsV2(MeshMaterialVariableIndexer* var_indexer,
                                 Int32ConstArrayView old_to_new_ids);


### PR DESCRIPTION
Keep the number of calls to `MeshMaterialVariableIndexer::computeCellsToTransform()` which are useless because the number of cells computed is zero.
We can remove these calls with a smart computation of added/removed cells.