### PR TITLE
Add support to use a MemoryPool for CUDA allocators

### DIFF
--- a/arcane/src/arcane/accelerator/core/MemoryTracer.cc
+++ b/arcane/src/arcane/accelerator/core/MemoryTracer.cc
@@ -102,9 +102,6 @@ findMemory(const void* ptr)
 MemoryTracerWrapper::
 MemoryTracerWrapper()
 {
-  // TODO: Utiliser une autre variable d'environnement que CUDA
-  if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_MALLOC_TRACE", true))
-    m_trace_level = v.value();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/internal/MemoryTracer.h
+++ b/arcane/src/arcane/accelerator/core/internal/MemoryTracer.h
@@ -57,6 +57,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT MemoryTracerWrapper
   bool isActive() const { return m_trace_level > 0; }
   void traceDeallocate(const AllocatedMemoryInfo& mem_info, const MemoryAllocationArgs& args);
   void traceAllocate(void* p, size_t new_size, MemoryAllocationArgs args);
+  void setTraceLevel(Int32 v) { m_trace_level = v; }
 
  private:
 


### PR DESCRIPTION
It is not active by default.
It can be activated for `UVM` when setting environment variable `ARCANE_CUDA_MALLOCMANAGED_POOL` to `1`.