### PR TITLE
Print more information during constituents update

### DIFF
--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -299,9 +299,9 @@ _switchCellsForMaterials(const MeshMaterial* modified_mat,
 
       Int32 nb_transformed = _computeCellsToTransformForMaterial(mat, ids);
       info(4) << "nb_transformed=" << nb_transformed;
-      if (nb_transformed==0)
+      if (nb_transformed == 0)
         continue;
-      indexer->computeCellsToTransform(m_work_info, m_queue);
+      indexer->transformCells(m_work_info, m_queue, false);
       _resetTransformedCells(ids);
 
       auto pure_local_ids = m_work_info.pure_local_ids.view(is_device);
@@ -377,7 +377,7 @@ _switchCellsForEnvironments(const IMeshEnvironment* modified_env,
             << " env_id=" << env_id
             << " indexer=" << indexer->name() << " nb_item=" << ids.size();
 
-    indexer->computeCellsToTransform(m_work_info, m_queue);
+    indexer->transformCells(m_work_info, m_queue, true);
 
     SmallSpan<const Int32> pure_local_ids = m_work_info.pure_local_ids.view(is_device);
     SmallSpan<const Int32> partial_indexes = m_work_info.partial_indexes.view(is_device);

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariableIndexer.h
@@ -88,7 +88,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
   // Méthodes publiques car utilisées sur accélérateurs
   void endUpdateAdd(const ComponentItemListBuilder& builder, RunQueue& queue);
   void endUpdateRemoveV2(ConstituentModifierWorkInfo& work_info, Integer nb_remove, RunQueue& queue);
-  void computeCellsToTransform(ConstituentModifierWorkInfo& args, RunQueue& queue);
+  void transformCells(ConstituentModifierWorkInfo& args, RunQueue& queue, bool is_from_env);
 
  private:
 
@@ -147,7 +147,8 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariableIndexer
    * Un appel est inutile si la liste des entités modifiées en sortie
    * est vide.
    */
-  Int32 m_nb_useless_transform = 0;
+  Int32 m_nb_useless_add_transform = 0;
+  Int32 m_nb_useless_remove_transform = 0;
 
   //! Indique si on affiche un message lors d'une transformation inutile
   bool m_is_print_useless_transform = false;


### PR DESCRIPTION
- Rename `MeshMaterialVariableIndexer::computeCellsToTransform()`  to `transformCells()`.
- Use a different name for the kernel when going from pure and partial and partial to pure.
- Print the number of useless add, useless remove and if the caller is a material or an environment.
