### PR TITLE
Remove some useless computation of material transformation when removing consituants

### DIFF
--- a/arcane/ceapart/tests/CMakeLists.txt
+++ b/arcane/ceapart/tests/CMakeLists.txt
@@ -410,6 +410,7 @@ foreach(test_index 1 2 3 4)
 endforeach()
 if (ARCANE_HAS_ACCELERATOR_API)
   arcane_add_test_sequential(material_heat2_opt15_2small testMaterialHeat-2-small-opt15.arc "-We,ARCANE_DEBUG_MATERIAL_MODIFIER,2" "-We,ARCANE_PRINT_USELESS_TRANSFORMATION,1")
+  arcane_add_test_sequential(material_heat2_opt15_2small_force_transform testMaterialHeat-2-small-opt15.arc "-We,ARCANE_MATERIAL_FORCE_TRANSFORM,1")
   arcane_add_test_sequential(material_heat2_accelerator
     "${ARCANE_TEST_PATH}/testMaterialHeat-2-opt15.arc"
     "-We,ARCANE_MATERIALMNG_ADDITIONAL_CAPACITY_RATIO,0.5"

--- a/arcane/src/arcane/materials/internal/ConstituentConnectivityList.h
+++ b/arcane/src/arcane/materials/internal/ConstituentConnectivityList.h
@@ -137,7 +137,7 @@ class ConstituentConnectivityList
   //! Indice du milieu auquel appartient un matériau
   DualUniqueArray<Int16> m_environment_for_materials;
   bool m_is_active = false;
-  bool m_is_force_recompute_all_constituants = false;
+  bool m_is_force_transform_all_constituants = false;
 
  public:
 


### PR DESCRIPTION
When there is only one environment in a cell, we add to compute material transformation only if the material is the only remaining material after the modification.