### PR TITLE
Do not explicitly transform cells for mono-mat environment

### DIFF
--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -361,6 +361,10 @@ _switchCellsForEnvironments(const IMeshEnvironment* modified_env,
     // Ne traite pas le milieu en cours de modification.
     if (env == modified_env)
       continue;
+    // Si je suis mono matériau, la mise à jour de l'indexeur a été faite par le matériau
+    if (env->isMonoMaterial())
+      continue;
+
     const Int32 env_id = env->id();
 
     if (!is_environments_modified[env_id])


### PR DESCRIPTION
The transformation is done when we tread the corresponding material. Calling it again for environment is a no-op because they share the same `MeshMaterialVariableIndexer`.