### PR TITLE
Fix bad size and capacity when calling IMemoryAllocator::deallocate() for non POD type during reallocation

### DIFF
--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -126,10 +126,10 @@ _allocate(Int64 new_capacity, Int64 sizeof_true_type, RunQueue* queue)
   _checkAllocator();
   MemoryAllocationArgs alloc_args = _getAllocationArgs(queue);
   IMemoryAllocator* a = _allocator();
-  size_t s_new_capacity = static_cast<size_t>(new_capacity);
-  s_new_capacity = a->adjustedCapacity(alloc_args, s_new_capacity, sizeof_true_type);
-  size_t s_sizeof_true_type = (size_t)sizeof_true_type;
-  size_t elem_size = s_new_capacity * s_sizeof_true_type;
+  //size_t s_new_capacity = static_cast<size_t>(new_capacity);
+  new_capacity = a->adjustedCapacity(alloc_args, new_capacity, sizeof_true_type);
+  //size_t s_sizeof_true_type = (size_t)sizeof_true_type;
+  Int64 elem_size = new_capacity * sizeof_true_type;
   MemoryPointer p = a->allocate(alloc_args, elem_size).baseAddress();
 #ifdef ARCCORE_DEBUG_ARRAY
   std::cout << "ArrayImplBase::ALLOCATE: elemsize=" << elem_size
@@ -144,7 +144,7 @@ _allocate(Int64 new_capacity, Int64 sizeof_true_type, RunQueue* queue)
     throw BadAllocException(ostr.str());
   }
 
-  this->capacity = (Int64)s_new_capacity;
+  this->capacity = new_capacity;
 
   return p;
 }
@@ -162,7 +162,6 @@ _reallocate(Int64 new_capacity, Int64 sizeof_true_type, MemoryPointer current,Ru
   const Int64 current_size = this->size * sizeof_true_type;
   new_capacity = a->adjustedCapacity(alloc_args, new_capacity, sizeof_true_type);
   size_t elem_size = new_capacity * sizeof_true_type;
-
   MemoryPointer p = nullptr;
   {
     AllocatedMemoryInfo current_info(current, current_size, current_allocated_size);
@@ -206,12 +205,9 @@ _reallocate(Int64 new_capacity, Int64 sizeof_true_type, MemoryPointer current,Ru
 /*---------------------------------------------------------------------------*/
 
 void ArrayMetaData::
-_deallocate(MemoryPointer current, Int64 sizeof_true_type,RunQueue* queue) noexcept
+_deallocate(const AllocatedMemoryInfo& mem_info, RunQueue* queue) noexcept
 {
   if (_allocator()) {
-    Int64 current_size = this->size * sizeof_true_type;
-    Int64 current_capacity = this->capacity * sizeof_true_type;
-    AllocatedMemoryInfo mem_info(current, current_size, current_capacity);
     MemoryAllocationArgs alloc_args = _getAllocationArgs(queue);
     _allocator()->deallocate(alloc_args, mem_info);
   }

--- a/arccore/src/collections/arccore/collections/Array.cc
+++ b/arccore/src/collections/arccore/collections/Array.cc
@@ -126,9 +126,7 @@ _allocate(Int64 new_capacity, Int64 sizeof_true_type, RunQueue* queue)
   _checkAllocator();
   MemoryAllocationArgs alloc_args = _getAllocationArgs(queue);
   IMemoryAllocator* a = _allocator();
-  //size_t s_new_capacity = static_cast<size_t>(new_capacity);
   new_capacity = a->adjustedCapacity(alloc_args, new_capacity, sizeof_true_type);
-  //size_t s_sizeof_true_type = (size_t)sizeof_true_type;
   Int64 elem_size = new_capacity * sizeof_true_type;
   MemoryPointer p = a->allocate(alloc_args, elem_size).baseAddress();
 #ifdef ARCCORE_DEBUG_ARRAY
@@ -153,18 +151,16 @@ _allocate(Int64 new_capacity, Int64 sizeof_true_type, RunQueue* queue)
 /*---------------------------------------------------------------------------*/
 
 ArrayMetaData::MemoryPointer ArrayMetaData::
-_reallocate(Int64 new_capacity, Int64 sizeof_true_type, MemoryPointer current,RunQueue* queue)
+_reallocate(const AllocatedMemoryInfo& current_info, Int64 new_capacity, Int64 sizeof_true_type, RunQueue* queue)
 {
   _checkAllocator();
+  MemoryPointer current = current_info.baseAddress();
   MemoryAllocationArgs alloc_args = _getAllocationArgs(queue);
   IMemoryAllocator* a = _allocator();
-  const Int64 current_allocated_size = capacity * sizeof_true_type;
-  const Int64 current_size = this->size * sizeof_true_type;
   new_capacity = a->adjustedCapacity(alloc_args, new_capacity, sizeof_true_type);
   size_t elem_size = new_capacity * sizeof_true_type;
   MemoryPointer p = nullptr;
   {
-    AllocatedMemoryInfo current_info(current, current_size, current_allocated_size);
     const bool use_realloc = a->hasRealloc(alloc_args);
     // Lorsqu'on voudra implémenter un realloc avec alignement, il faut passer
     // par use_realloc = false car sous Linux il n'existe pas de méthode realloc

--- a/arccore/src/collections/arccore/collections/Array.h
+++ b/arccore/src/collections/arccore/collections/Array.h
@@ -99,7 +99,7 @@ class ARCCORE_COLLECTIONS_EXPORT ArrayMetaData
  protected:
 
   MemoryPointer _allocate(Int64 nb, Int64 sizeof_true_type, RunQueue* queue);
-  MemoryPointer _reallocate(Int64 nb, Int64 sizeof_true_type, MemoryPointer current, RunQueue* queue);
+  MemoryPointer _reallocate(const AllocatedMemoryInfo& mem_info, Int64 new_capacity, Int64 sizeof_true_type, RunQueue* queue);
   void _deallocate(const AllocatedMemoryInfo& mem_info, RunQueue* queue) ARCCORE_NOEXCEPT;
   void _setMemoryLocationHint(eMemoryLocationHint new_hint, void* ptr, Int64 sizeof_true_type);
   void _copyFromMemory(MemoryPointer destination, ConstMemoryPointer source, Int64 sizeof_true_type, RunQueue* queue);
@@ -365,9 +365,9 @@ class AbstractArray
    * \sa _initFromAllocator(MemoryAllocationOptions o,Int64 acapacity);
    */
   // TODO A supprimer. Utiliser la surcharge avec MemoryAllocationOptions à la place.
-  void _initFromAllocator(IMemoryAllocator* a,Int64 acapacity)
+  void _initFromAllocator(IMemoryAllocator* a, Int64 acapacity)
   {
-    _initFromAllocator(MemoryAllocationOptions(a),acapacity);
+    _initFromAllocator(MemoryAllocationOptions(a), acapacity);
   }
 
   /*!
@@ -379,7 +379,7 @@ class AbstractArray
    * Cette méthode ne doit être appelée que dans un constructeur de la classe dérivée
    * et uniquement par les classes utilisant une sémantique à la UniqueArray.
    */
-  void _initFromAllocator(MemoryAllocationOptions o,Int64 acapacity)
+  void _initFromAllocator(MemoryAllocationOptions o, Int64 acapacity)
   {
     _directFirstAllocateWithAllocator(acapacity,o);
   }
@@ -435,24 +435,25 @@ class AbstractArray
   bool contains(ConstReferenceType v) const
   {
     const T* ptr = m_ptr;
-    for( Int64 i=0, n=m_md->size; i<n; ++i ){
+    for (Int64 i = 0, n = m_md->size; i < n; ++i) {
       if (ptr[i]==v)
         return true;
     }
     return false;
   }
+
  public:
 
   //! Elément d'indice \a i
   ConstReferenceType operator[](Int64 i) const
   {
-    ARCCORE_CHECK_AT(i,m_md->size);
+    ARCCORE_CHECK_AT(i, m_md->size);
     return m_ptr[i];
   }
   //! Elément d'indice \a i
   ConstReferenceType operator()(Int64 i) const
   {
-    ARCCORE_CHECK_AT(i,m_md->size);
+    ARCCORE_CHECK_AT(i, m_md->size);
     return m_ptr[i];
   }
 
@@ -632,12 +633,12 @@ class AbstractArray
 
   void _allocateMP(Int64 new_capacity, RunQueue* queue)
   {
-    _setMP(reinterpret_cast<TrueImpl*>(m_md->_allocate(new_capacity, sizeof(T), queue)));
+    _setMPCast(m_md->_allocate(new_capacity, typeSize(), queue));
   }
 
-  void _directReAllocate(Int64 new_capacity,RunQueue* queue)
+  void _directReAllocate(Int64 new_capacity, RunQueue* queue)
   {
-    _setMP(reinterpret_cast<TrueImpl*>(m_md->_reallocate(new_capacity,sizeof(T),m_ptr, queue)));
+    _setMPCast(m_md->_reallocate(_currentMemoryInfo(), new_capacity, typeSize(), queue));
   }
 
  public:
@@ -905,7 +906,7 @@ class AbstractArray
     _setToSharedNull();
   }
 
-  constexpr Integer _clampSizeOffet(Int64 offset,Int32 asize) const
+  constexpr Integer _clampSizeOffet(Int64 offset, Int32 asize) const
   {
     Int64 max_size = m_md->size - offset;
     if (asize>max_size)
@@ -951,7 +952,7 @@ class AbstractArray
 
   bool _isSharedNull()
   {
-    return m_ptr==nullptr;
+    return m_ptr == nullptr;
   }
 
  private:
@@ -961,6 +962,10 @@ class AbstractArray
     m_ptr = nullptr;
     m_meta_data = ArrayMetaData();
     m_md = &m_meta_data;
+  }
+  void _setMPCast(void* p)
+  {
+    _setMP(reinterpret_cast<TrueImpl*>(p));
   }
 };
 
@@ -1004,6 +1009,7 @@ class Array
   using typename BaseClassType::const_reference;
   using typename BaseClassType::size_type;
   using typename BaseClassType::difference_type;
+
  protected:
 
   Array() {}


### PR DESCRIPTION
In the specific case of reallocation on non-POD type, the size and capacity values passed in argument during the de-allocation were wrong. It was the size/capacity for the reallocation.
Theses values were used only for debugging information so it should not have any impact on existing code.
