### PR TITLE
Use 'NumArray' and 'UniqueArray' to keep values and instances of AllCellToAllEnvCell

### DIFF
--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialMngInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialMngInternal.h
@@ -98,7 +98,7 @@ class ARCANE_CORE_EXPORT IMeshMaterialMngInternal
    * Si aucun allocateur n'est spécifié alors la méthode
    * platform::getDefaultDataAllocator() est utilisée
    */
-  virtual void createAllCellToAllEnvCell(IMemoryAllocator* alloc) = 0;
+  virtual void createAllCellToAllEnvCell() = 0;
 
   /*!
    * \briefInstance de ComponentItemSharedInfo pour un constituant

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -18,6 +18,7 @@
 
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/IMemoryAllocator.h"
+#include "arcane/utils/NumArray.h"
 
 #include "arcane/core/IMesh.h"
 #include "arcane/core/materials/MatItem.h"
@@ -66,6 +67,10 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
   friend class MeshMaterialMng;
   friend class AllEnvData;
   friend ArcaneTest::MeshMaterialAcceleratorUnitTest;
+
+ public:
+
+  class Impl;
 
  private:
 
@@ -129,16 +134,8 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
   IMemoryAllocator* m_alloc = nullptr;
   Integer m_size = 0;
   Span<ComponentItemLocalId>* m_allcell_allenvcell = nullptr;
-  ComponentItemLocalId* m_mem_pool = nullptr;
+  NumArray<ComponentItemLocalId, MDDim1> m_mem_pool;
   Int32 m_current_max_nb_env = 0;
-
- private:
-
-  static Int32 _computeMaxNbEnvPerCell(IMeshMaterialMng* material_mng);
-  static void _updateValues(IMeshMaterialMng* material_mng,
-                            ComponentItemLocalId* mem_pool,
-                            Span<ComponentItemLocalId>* allcell_allenvcell,
-                            Int32 max_nb_env);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -104,7 +104,7 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
   //! Méthode d'accès à la table de "connectivité" cell -> all env cells
   ARCCORE_HOST_DEVICE Span<ComponentItemLocalId>* internal() const
   {
-    return m_allcell_allenvcell;
+    return m_allcell_allenvcell_ptr;
   }
 
   /*!
@@ -133,7 +133,8 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
   IMeshMaterialMng* m_material_mng = nullptr;
   IMemoryAllocator* m_alloc = nullptr;
   Integer m_size = 0;
-  Span<ComponentItemLocalId>* m_allcell_allenvcell = nullptr;
+  NumArray<Span<ComponentItemLocalId>, MDDim1> m_allcell_allenvcell;
+  Span<ComponentItemLocalId>* m_allcell_allenvcell_ptr = nullptr;
   NumArray<ComponentItemLocalId, MDDim1> m_mem_pool;
   Int32 m_current_max_nb_env = 0;
 };

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -44,7 +44,7 @@ namespace Arcane::Materials
  * \brief Table de connectivité des 'Cell' vers leur(s) 'AllEnvCell' destinée
  *        à une utilisation sur accélérateur.
  *
- * Classe qui stoque la connectivité de toutes les mailles
+ * Classe qui conserve la connectivité de toutes les mailles
  * \a Cell vers toutes leurs mailles \a AllEnvCell.
  *
  * On crée une instance via la méthode create().
@@ -74,12 +74,11 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
 
  private:
 
-  AllCellToAllEnvCell() = default;
+  explicit AllCellToAllEnvCell(IMeshMaterialMng* mm);
 
  public:
 
   //! Copies interdites
-  AllCellToAllEnvCell(const AllCellToAllEnvCell&) = delete;
   AllCellToAllEnvCell& operator=(const AllCellToAllEnvCell&) = delete;
 
  private:
@@ -96,10 +95,7 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
    * façon systématique.
    * => Gain de perf à évaluer.
    */
-  static AllCellToAllEnvCell* create(IMeshMaterialMng* mm, IMemoryAllocator* alloc);
-
-  //! Fonction de destruction
-  static void destroy(AllCellToAllEnvCell* instance);
+  void initialize(IMeshMaterialMng* mm, IMemoryAllocator* alloc);
 
   //! Méthode d'accès à la table de "connectivité" cell -> all env cells
   ARCCORE_HOST_DEVICE Span<ComponentItemLocalId>* internal() const

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -131,6 +131,14 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
   Span<ComponentItemLocalId>* m_allcell_allenvcell = nullptr;
   ComponentItemLocalId* m_mem_pool = nullptr;
   Int32 m_current_max_nb_env = 0;
+
+ private:
+
+  static Int32 _computeMaxNbEnvPerCell(IMeshMaterialMng* material_mng);
+  static void _updateValues(IMeshMaterialMng* material_mng,
+                            ComponentItemLocalId* mem_pool,
+                            Span<ComponentItemLocalId>* allcell_allenvcell,
+                            Int32 max_nb_env);
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -17,7 +17,6 @@
 #include "arcane/materials/MaterialsGlobal.h"
 
 #include "arcane/utils/PlatformUtils.h"
-#include "arcane/utils/IMemoryAllocator.h"
 #include "arcane/utils/NumArray.h"
 
 #include "arcane/core/IMesh.h"
@@ -95,7 +94,7 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
    * façon systématique.
    * => Gain de perf à évaluer.
    */
-  void initialize(IMeshMaterialMng* mm, IMemoryAllocator* alloc);
+  void initialize();
 
   //! Méthode d'accès à la table de "connectivité" cell -> all env cells
   ARCCORE_HOST_DEVICE Span<ComponentItemLocalId>* internal() const
@@ -127,7 +126,6 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCell
  private:
 
   IMeshMaterialMng* m_material_mng = nullptr;
-  IMemoryAllocator* m_alloc = nullptr;
   Integer m_size = 0;
   NumArray<Span<ComponentItemLocalId>, MDDim1> m_allcell_allenvcell;
   Span<ComponentItemLocalId>* m_allcell_allenvcell_ptr = nullptr;

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -525,7 +525,7 @@ forceRecompute(bool compute_all)
     if (all_cell_to_all_env_cell)
       all_cell_to_all_env_cell->bruteForceUpdate();
     else
-      m_material_mng->_internalApi()->createAllCellToAllEnvCell(platform::getDefaultDataAllocator());
+      m_material_mng->_internalApi()->createAllCellToAllEnvCell();
   }
 }
 

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -21,6 +21,7 @@
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/ValueConvert.h"
 #include "arcane/utils/CheckedConvert.h"
+#include "arcane/utils/MemoryUtils.h"
 
 #include "arcane/core/IMesh.h"
 #include "arcane/core/IItemFamily.h"
@@ -130,6 +131,7 @@ MeshMaterialMng(const MeshHandle& mesh_handle,const String& name)
 , m_internal_api(std::make_unique<InternalApi>(this))
 , m_variable_mng(mesh_handle.variableMng())
 , m_name(name)
+, m_all_cell_to_all_env_cell(MemoryUtils::getDefaultDataAllocator())
 {
   m_all_env_data = std::make_unique<AllEnvData>(this);
   m_exchange_mng = std::make_unique<MeshMaterialExchangeMng>(this);
@@ -180,8 +182,10 @@ MeshMaterialMng::
   m_modifier.reset();
   m_internal_api.reset();
 
-  if (m_allcell_2_allenvcell)
-    AllCellToAllEnvCell::destroy(m_allcell_2_allenvcell);
+  if (m_allcell_2_allenvcell){
+    m_all_cell_to_all_env_cell.clear();
+    m_allcell_2_allenvcell = nullptr;
+  }
 
   // On détruit le Runner à la fin pour être sur qu'il n'y a plus de
   // références dessus dans les autres instances.
@@ -1306,6 +1310,20 @@ _dumpStats()
   }
   for (IMeshMaterial* mat : m_materials) {
     mat->_internalApi()->variableIndexer()->dumpStats();
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MeshMaterialMng::
+createAllCellToAllEnvCell(IMemoryAllocator* alloc)
+{
+  if (!m_allcell_2_allenvcell){
+    m_all_cell_to_all_env_cell.reserve(1);
+    m_all_cell_to_all_env_cell.add(AllCellToAllEnvCell(this));
+    m_allcell_2_allenvcell = m_all_cell_to_all_env_cell.view().ptrAt(0);
+    m_allcell_2_allenvcell->initialize(this, alloc);
   }
 }
 

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -1317,13 +1317,13 @@ _dumpStats()
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialMng::
-createAllCellToAllEnvCell(IMemoryAllocator* alloc)
+createAllCellToAllEnvCell()
 {
   if (!m_allcell_2_allenvcell){
     m_all_cell_to_all_env_cell.reserve(1);
     m_all_cell_to_all_env_cell.add(AllCellToAllEnvCell(this));
     m_allcell_2_allenvcell = m_all_cell_to_all_env_cell.view().ptrAt(0);
-    m_allcell_2_allenvcell->initialize(this, alloc);
+    m_allcell_2_allenvcell->initialize();
   }
 }
 

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -100,9 +100,9 @@ class MeshMaterialMng
     {
       return m_material_mng->getAllCellToAllEnvCell();
     }
-    void createAllCellToAllEnvCell(IMemoryAllocator* alloc) override
+    void createAllCellToAllEnvCell() override
     {
-      return m_material_mng->createAllCellToAllEnvCell(alloc);
+      return m_material_mng->createAllCellToAllEnvCell();
     }
     ConstArrayView<MeshMaterialVariableIndexer*> variablesIndexer() override
     {
@@ -293,7 +293,7 @@ class MeshMaterialMng
   {
     m_is_allcell_2_allenvcell = is_enable;
     if (force_create)
-      createAllCellToAllEnvCell(platform::getDefaultDataAllocator());
+      createAllCellToAllEnvCell();
   }
   bool isCellToAllEnvCellForRunCommand() const override { return m_is_allcell_2_allenvcell; }
 
@@ -311,7 +311,7 @@ class MeshMaterialMng
  private:
 
   AllCellToAllEnvCell* getAllCellToAllEnvCell() const { return m_allcell_2_allenvcell; }
-  void createAllCellToAllEnvCell(IMemoryAllocator* alloc);
+  void createAllCellToAllEnvCell();
 
  private:
 

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -311,11 +311,7 @@ class MeshMaterialMng
  private:
 
   AllCellToAllEnvCell* getAllCellToAllEnvCell() const { return m_allcell_2_allenvcell; }
-  void createAllCellToAllEnvCell(IMemoryAllocator* alloc)
-  {
-    if (!m_allcell_2_allenvcell)
-      m_allcell_2_allenvcell = AllCellToAllEnvCell::create(this, alloc);
-  }
+  void createAllCellToAllEnvCell(IMemoryAllocator* alloc);
 
  private:
 
@@ -374,10 +370,16 @@ class MeshMaterialMng
   String m_data_compressor_service_name;
   MeshMaterialSynchronizer* m_mms = nullptr;
 
+  std::unique_ptr<RunnerInfo> m_runner_info;
+
+  /*!
+   * \brief Contient une instance de AllCellToAllEnvCell.
+   *
+   * On utilise un tableau avec un seul élément pour l'allouer en mémoire unifiée.
+   */
+  UniqueArray<AllCellToAllEnvCell> m_all_cell_to_all_env_cell;
   AllCellToAllEnvCell* m_allcell_2_allenvcell = nullptr;
   bool m_is_allcell_2_allenvcell = false;
-
-  std::unique_ptr<RunnerInfo> m_runner_info;
 
  private:
 

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -737,10 +737,12 @@ _executeTest4(Integer nb_z)
 
   _checkEnvValues1();
 
-    // Some further functions testing, not really usefull here, but it improves cover
-  AllCellToAllEnvCell *useless(nullptr);
-  useless = AllCellToAllEnvCell::create(m_mm_mng, platform::getDefaultDataAllocator());
-  AllCellToAllEnvCell::destroy(useless);
+  // Some further functions testing, not really usefull here, but it improves cover
+  {
+    UniqueArray<AllCellToAllEnvCell> useless;
+    useless.add(AllCellToAllEnvCell(m_mm_mng));
+    useless[0].initialize(m_mm_mng, platform::getDefaultDataAllocator());
+  }
 
   // Call to forceRecompute to test bruteForceUpdate
   m_mm_mng->forceRecompute();

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -741,7 +741,7 @@ _executeTest4(Integer nb_z)
   {
     UniqueArray<AllCellToAllEnvCell> useless;
     useless.add(AllCellToAllEnvCell(m_mm_mng));
-    useless[0].initialize(m_mm_mng, platform::getDefaultDataAllocator());
+    useless[0].initialize();
   }
 
   // Call to forceRecompute to test bruteForceUpdate


### PR DESCRIPTION
Before that, we directly used `IMemoryAllocator` but it prevent usage of memory pool and the automatic allocation on a page boundary for managed memory.
It should also make the code simpler.