### PR TITLE
Refactor and optimize initialization of 'ConstituentItemVector'

### DIFF
--- a/arcane/src/arcane/core/materials/ComponentItem.h
+++ b/arcane/src/arcane/core/materials/ComponentItem.h
@@ -107,10 +107,16 @@ class ARCANE_CORE_EXPORT ComponentCell
   //! Nombre de sous-éléments
   ARCCORE_HOST_DEVICE Int32 nbSubItem() const { return m_shared_info->_nbSubConstituent(m_constituent_item_index); }
 
-  //! Maille arcane
+  //! Maille globale
   Cell globalCell() const
   {
     return Cell(m_shared_info->_globalItemBase(m_constituent_item_index));
+  }
+
+  //! localId() de la maille globale
+  Int32 globalCellLocalId() const
+  {
+    return m_shared_info->_globalItemLocalId(m_constituent_item_index);
   }
 
   /*!

--- a/arcane/src/arcane/core/materials/ComponentItemInternal.h
+++ b/arcane/src/arcane/core/materials/ComponentItemInternal.h
@@ -186,6 +186,11 @@ class ARCANE_CORE_EXPORT ComponentItemSharedInfo
     ARCCORE_CHECK_RANGE(id.localId(), -1, m_storage_size);
     return impl::ItemBase(m_global_item_local_id_data[id.localId()], m_item_shared_info);
   }
+  ARCCORE_HOST_DEVICE Int32 _globalItemLocalId(ConstituentItemIndex id) const
+  {
+    ARCCORE_CHECK_RANGE(id.localId(), -1, m_storage_size);
+    return m_global_item_local_id_data[id.localId()];
+  }
   ARCCORE_HOST_DEVICE void _setGlobalItem(ConstituentItemIndex id, ItemLocalId global_item_lid)
   {
     ARCCORE_CHECK_RANGE(id.localId(), -1, m_storage_size);

--- a/arcane/src/arcane/core/materials/EnvItemVector.cc
+++ b/arcane/src/arcane/core/materials/EnvItemVector.cc
@@ -13,8 +13,6 @@
 
 #include "arcane/core/materials/EnvItemVector.h"
 
-#include "arcane/utils/FixedArray.h"
-
 #include "arcane/core/materials/MatItemEnumerator.h"
 #include "arcane/core/materials/IMeshMaterialMng.h"
 
@@ -29,9 +27,8 @@ namespace Arcane::Materials
 
 EnvCellVector::
 EnvCellVector(const CellGroup& group,IMeshEnvironment* environment)
-: ComponentItemVector(environment)
+: EnvCellVector(group.view().localIds(), environment)
 {
-  _build(group.view().localIds());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -39,9 +36,8 @@ EnvCellVector(const CellGroup& group,IMeshEnvironment* environment)
 
 EnvCellVector::
 EnvCellVector(CellVectorView view,IMeshEnvironment* environment)
-: ComponentItemVector(environment)
+: EnvCellVector(view.localIds(), environment)
 {
-  _build(view.localIds());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/MatItemVector.cc
+++ b/arcane/src/arcane/core/materials/MatItemVector.cc
@@ -13,8 +13,6 @@
 
 #include "arcane/core/materials/MatItemVector.h"
 
-#include "arcane/utils/FixedArray.h"
-
 #include "arcane/core/materials/MatItemEnumerator.h"
 #include "arcane/core/materials/IMeshMaterialMng.h"
 
@@ -29,9 +27,8 @@ namespace Arcane::Materials
 
 MatCellVector::
 MatCellVector(const CellGroup& group,IMeshMaterial* material)
-: ComponentItemVector(material)
+: MatCellVector(group.view().localIds(), material)
 {
-  _build(group.view().localIds());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -39,9 +36,8 @@ MatCellVector(const CellGroup& group,IMeshMaterial* material)
 
 MatCellVector::
 MatCellVector(CellVectorView view,IMeshMaterial* material)
-: ComponentItemVector(material)
+: MatCellVector(view.localIds(), material)
 {
-  _build(view.localIds());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/internal/ConstituentItemLocalIdList.h
+++ b/arcane/src/arcane/core/materials/internal/ConstituentItemLocalIdList.h
@@ -34,6 +34,9 @@ namespace Arcane::Materials
  */
 class ARCANE_CORE_EXPORT ConstituentItemLocalIdList
 {
+  // Pour accéder en écriture à m_constituent_item_index_list
+  friend class ConstituentItemVectorImpl;
+
  public:
 
   ConstituentItemLocalIdList(ComponentItemSharedInfo* shared_info, const String& debug_name);
@@ -66,18 +69,6 @@ class ARCANE_CORE_EXPORT ConstituentItemLocalIdList
       setConstituentItem(i, view.m_ids[i]);
   }
 
-  /*!
-   * \brief Copie les constituents partitionnés en partie pure et partielle.
-   */
-  void copyPureAndPartial(ConstArrayView<ConstituentItemIndex> ids)
-  {
-    Int32 nb = ids.size();
-
-    resize(nb);
-    for (Int32 i = 0; i < nb; ++i)
-      m_constituent_item_index_list[i] = ids[i];
-  }
-
   ConstArrayView<ConstituentItemIndex> localIds() const
   {
     return m_constituent_item_index_list;
@@ -106,6 +97,8 @@ class ARCANE_CORE_EXPORT ConstituentItemLocalIdList
   }
 
  private:
+
+  SmallSpan<ConstituentItemIndex> _mutableItemIndexList() { return m_constituent_item_index_list.smallSpan(); }
 
   //! Liste des ConstituentItemIndex pour ce constituant.
   UniqueArray<ConstituentItemIndex> m_constituent_item_index_list;

--- a/arcane/src/arcane/core/materials/internal/ConstituentItemLocalIdList.h
+++ b/arcane/src/arcane/core/materials/internal/ConstituentItemLocalIdList.h
@@ -69,17 +69,13 @@ class ARCANE_CORE_EXPORT ConstituentItemLocalIdList
   /*!
    * \brief Copie les constituents partitionnés en partie pure et partielle.
    */
-  void copyPureAndPartial(ConstArrayView<ConstituentItemIndex> pure_ids,
-                          ConstArrayView<ConstituentItemIndex> partial_ids)
+  void copyPureAndPartial(ConstArrayView<ConstituentItemIndex> ids)
   {
-    Int32 nb_pure = pure_ids.size();
-    Int32 nb_partial = partial_ids.size();
+    Int32 nb = ids.size();
 
-    resize(nb_pure + nb_partial);
-    for (Int32 i = 0; i < nb_pure; ++i)
-      setConstituentItem(i, pure_ids[i]);
-    for (Int32 i = 0; i < nb_partial; ++i)
-      setConstituentItem(nb_pure + i, partial_ids[i]);
+    resize(nb);
+    for (Int32 i = 0; i < nb; ++i)
+      m_constituent_item_index_list[i] = ids[i];
   }
 
   ConstArrayView<ConstituentItemIndex> localIds() const

--- a/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
+++ b/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
@@ -127,7 +127,9 @@ _setItems(SmallSpan<const Int32> local_ids)
   // La seconde partie de nb_pure à (nb_pure+nb_impure) contiendra les mailles partielles
   // A noter que (nb_pure + nb_impure) peut être différent de local_ids.size()
   // si certaines mailles de \a local_ids n'ont pas le constituant.
-  UniqueArray<ConstituentItemIndex> item_indexes(total_nb_pure_and_impure);
+  m_constituent_list->resize(total_nb_pure_and_impure);
+
+  SmallSpan<ConstituentItemIndex> item_indexes = m_constituent_list->_mutableItemIndexList();
 
   // TODO: Ne pas remettre à jour systématiquement les
   // 'm_items_local_id' mais ne le faire qu'à la demande
@@ -172,8 +174,6 @@ _setItems(SmallSpan<const Int32> local_ids)
       }
     }
   }
-
-  m_constituent_list->copyPureAndPartial(item_indexes);
 
   ComponentItemSharedInfo* cisi = m_component_shared_info;
 

--- a/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
+++ b/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
@@ -151,6 +151,8 @@ _setItems(SmallSpan<const Int32> local_ids)
           ConstituentItemIndex cii = ec._constituentItemIndex();
           Int32& base_index = (idx.arrayIndex() == 0) ? pure_index : impure_index;
           item_indexes[base_index] = cii;
+          m_matvar_indexes[base_index] = idx;
+          m_items_local_id[base_index] = all_env_cell.globalCellLocalId();
           ++base_index;
         }
       }
@@ -168,19 +170,13 @@ _setItems(SmallSpan<const Int32> local_ids)
             ConstituentItemIndex cii = mc._constituentItemIndex();
             Int32& base_index = (idx.arrayIndex() == 0) ? pure_index : impure_index;
             item_indexes[base_index] = cii;
+            m_matvar_indexes[base_index] = idx;
+            m_items_local_id[base_index] = all_env_cell.globalCellLocalId();
             ++base_index;
           }
         }
       }
     }
-  }
-
-  ComponentItemSharedInfo* cisi = m_component_shared_info;
-
-  for (Int32 i = 0; i < total_nb_pure_and_impure; ++i) {
-    ConstituentItemIndex cii = item_indexes[i];
-    m_matvar_indexes[i] = cisi->_varIndex(cii);
-    m_items_local_id[i] = cisi->_globalItemBase(cii).localId();
   }
 
   // Mise à jour de MeshComponentPartData

--- a/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
+++ b/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
@@ -129,6 +129,13 @@ _setItems(SmallSpan<const Int32> local_ids)
   // si certaines mailles de \a local_ids n'ont pas le constituant.
   UniqueArray<ConstituentItemIndex> item_indexes(total_nb_pure_and_impure);
 
+  // TODO: Ne pas remettre à jour systématiquement les
+  // 'm_items_local_id' mais ne le faire qu'à la demande
+  // car ils ne sont pas utilisés souvent.
+
+  m_matvar_indexes.resize(total_nb_pure_and_impure);
+  m_items_local_id.resize(total_nb_pure_and_impure);
+
   Int32 pure_index = 0;
   Int32 impure_index = nb_pure;
 
@@ -165,30 +172,15 @@ _setItems(SmallSpan<const Int32> local_ids)
       }
     }
   }
-  ConstArrayView<ConstituentItemIndex> globals = item_indexes.subView(0, nb_pure);
-  ConstArrayView<ConstituentItemIndex> multiples = item_indexes.subConstView(nb_pure, nb_impure);
 
-  m_constituent_list->copyPureAndPartial(globals, multiples);
-
-  // TODO: Ne pas remettre à jour systématiquement les
-  // 'm_items_local_id' mais ne le faire qu'à la demande
-  // car ils ne sont pas utilisés souvent.
-
-  m_matvar_indexes.resize(total_nb_pure_and_impure);
-  m_items_local_id.resize(total_nb_pure_and_impure);
+  m_constituent_list->copyPureAndPartial(item_indexes);
 
   ComponentItemSharedInfo* cisi = m_component_shared_info;
 
-  for (Int32 i = 0; i < nb_pure; ++i) {
-    ConstituentItemIndex cii = globals[i];
+  for (Int32 i = 0; i < total_nb_pure_and_impure; ++i) {
+    ConstituentItemIndex cii = item_indexes[i];
     m_matvar_indexes[i] = cisi->_varIndex(cii);
     m_items_local_id[i] = cisi->_globalItemBase(cii).localId();
-  }
-
-  for (Int32 i = 0; i < nb_impure; ++i) {
-    ConstituentItemIndex cii = multiples[i];
-    m_matvar_indexes[nb_pure + i] = cisi->_varIndex(cii);
-    m_items_local_id[nb_pure + i] = cisi->_globalItemBase(cii).localId();
   }
 
   // Mise à jour de MeshComponentPartData


### PR DESCRIPTION
Apply the following optimizations:

- Remove some work arrays.
- Pre-compute the number of pure and impure cells and do only one allocation.
- Do all the update in one loop