### PR TITLE
Add compatibility with libxml2 2.13.0+

### DIFF
--- a/arcane/src/arcane/core/DomLibXml2V2.cc
+++ b/arcane/src/arcane/core/DomLibXml2V2.cc
@@ -365,11 +365,12 @@ class LibXml2_MemoryReader
   {
     const char* encoding = nullptr;
     int options = parser.options();
-    const char* buf_base = (const char*)m_buffer.data();
+    const char* buf_base = reinterpret_cast<const char*>(m_buffer.data());
     // TODO: regarder s'il n'y a pas une version 64 bits de lecture
     // qui fonctionne aussi sur les anciennes versions de LibXml2
     // (pour le support RHEL6)
     int buf_size = CheckedConvert::toInt32(m_buffer.size());
+    while (buf_size > 0 && static_cast<char>(m_buffer[--buf_size]) == '\0');
     const String& name = parser.fileName();
     ::xmlParserCtxtPtr ctxt = ::xmlNewParserCtxt();
     ::xmlDocPtr doc = ::xmlCtxtReadMemory(ctxt,buf_base,buf_size,

--- a/arcane/src/arcane/core/DomLibXml2V2.cc
+++ b/arcane/src/arcane/core/DomLibXml2V2.cc
@@ -370,7 +370,9 @@ class LibXml2_MemoryReader
     // qui fonctionne aussi sur les anciennes versions de LibXml2
     // (pour le support RHEL6)
     int buf_size = CheckedConvert::toInt32(m_buffer.size());
-    while (buf_size > 0 && static_cast<char>(m_buffer[--buf_size]) == '\0');
+    while (buf_size > 0 && static_cast<char>(m_buffer[buf_size - 1]) == '\0') {
+      buf_size--;
+    }
     const String& name = parser.fileName();
     ::xmlParserCtxtPtr ctxt = ::xmlNewParserCtxt();
     ::xmlDocPtr doc = ::xmlCtxtReadMemory(ctxt,buf_base,buf_size,

--- a/arcane/src/arcane/impl/IOMng.cc
+++ b/arcane/src/arcane/impl/IOMng.cc
@@ -186,8 +186,8 @@ IXmlDocumentHolder* IOMng::
 parseXmlString(const String& str, const String& name)
 {
   dom::DOMImplementation domimp;
-  UCharConstArrayView utf16_buf(str.utf16());
-  ByteConstSpan buffer(reinterpret_cast<const std::byte*>(utf16_buf.data()),utf16_buf.size() * 2);
+  ByteConstArrayView utf8_buf(str.utf8());
+  ByteConstSpan buffer(reinterpret_cast<const std::byte*>(utf8_buf.data()), utf8_buf.size());
   // Lecture du fichier contenant les informations internes.
   return domimp._load(buffer, name, m_trace_mng);
 }

--- a/arcane/src/arcane/impl/IOMng.cc
+++ b/arcane/src/arcane/impl/IOMng.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IOMng.cc                                                    (C) 2000-2015 */
+/* IOMng.cc                                                    (C) 2000-2024 */
 /*                                                                           */
 /* Gestionnaire des entrées-sorties.                                         */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The buffer sent to xmlCtxtReadMemory() must not contain a null byte (they have updated [their doc](https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-parser.html#xmlCtxtReadMemory)).