### PR TITLE
Deprecate 'NumArray::span()' and 'NumArray::constSpan()'

### DIFF
--- a/arcane/src/arcane/accelerator/NumArrayViews.h
+++ b/arcane/src/arcane/accelerator/NumArrayViews.h
@@ -153,7 +153,7 @@ template <typename DataType, typename Extents, typename LayoutPolicy> auto
 viewOut(const ViewBuildInfo& command, NumArray<DataType, Extents, LayoutPolicy>& var)
 {
   using Accessor = DataViewSetter<DataType>;
-  return NumArrayView<Accessor, Extents, LayoutPolicy>(command, var.span());
+  return NumArrayView<Accessor, Extents, LayoutPolicy>(command, var.mdspan());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -166,7 +166,7 @@ template <typename DataType, typename Extents, typename LayoutPolicy> auto
 viewInOut(const ViewBuildInfo& command, NumArray<DataType, Extents, LayoutPolicy>& v)
 {
   using Accessor = DataViewGetterSetter<DataType>;
-  return NumArrayView<Accessor, Extents, LayoutPolicy>(command, v.span());
+  return NumArrayView<Accessor, Extents, LayoutPolicy>(command, v.mdspan());
 }
 
 /*----------------------------------------------1-----------------------------*/
@@ -178,7 +178,7 @@ template <typename DataType, typename Extents, typename LayoutType> auto
 viewIn(const ViewBuildInfo& command, const NumArray<DataType, Extents, LayoutType>& v)
 {
   using Accessor = DataViewGetter<DataType>;
-  return NumArrayView<Accessor, Extents, LayoutType>(command, v.constSpan());
+  return NumArrayView<Accessor, Extents, LayoutType>(command, v.constMDSpan());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/cuda/runtime/Test.cu
+++ b/arcane/src/arcane/accelerator/cuda/runtime/Test.cu
@@ -411,9 +411,9 @@ int arcaneTestCudaNumArray()
 
     dim3 dimGrid(threadsPerBlock, 1, 1), dimBlock(blocksPerGrid, 1, 1);
 
-    MDSpan<const double,MDDim1> d_a_span = d_a.constSpan();
-    MDSpan<const double,MDDim1> d_b_span = d_b.constSpan();
-    MDSpan<double,MDDim1> d_out_view = d_out.span();
+    MDSpan<const double,MDDim1> d_a_span = d_a.constMDSpan();
+    MDSpan<const double,MDDim1> d_b_span = d_b.constMDSpan();
+    MDSpan<double,MDDim1> d_out_view = d_out.mdspan();
 
     void *kernelArgs[] = {
       (void*)&d_a_span,
@@ -432,9 +432,9 @@ int arcaneTestCudaNumArray()
   // Lance une lambda
   {
     _initArrays(d_a,d_b,d_out,3);
-    MDSpan<const double,MDDim1> d_a_span = d_a.constSpan();
-    MDSpan<const double,MDDim1> d_b_span = d_b.constSpan();
-    MDSpan<double,MDDim1> d_out_span = d_out.span();
+    MDSpan<const double,MDDim1> d_a_span = d_a.constMDSpan();
+    MDSpan<const double,MDDim1> d_b_span = d_b.constMDSpan();
+    MDSpan<double,MDDim1> d_out_span = d_out.mdspan();
     auto func = [=] ARCCORE_HOST_DEVICE (int i)
                 {
                   d_out_span(i) = d_a_span(i) + d_b_span(i);
@@ -473,9 +473,9 @@ int arcaneTestCudaNumArray()
       d_b3(i,2) = b + 2.0;
     }
 
-    MDSpan<const Real,MDDim2> d_a3_span = d_a3.constSpan();
-    MDSpan<const Real,MDDim2> d_b3_span = d_b3.constSpan();
-    MDSpan<double,MDDim1> d_out_span = d_out.span();
+    MDSpan<const Real,MDDim2> d_a3_span = d_a3.constMDSpan();
+    MDSpan<const Real,MDDim2> d_b3_span = d_b3.constMDSpan();
+    MDSpan<double,MDDim1> d_out_span = d_out.mdspan();
     auto func2 = [=] ARCCORE_HOST_DEVICE (int i) {
                    Real3 xa(d_a3_span(i,0),d_a3_span(i,1),d_a3_span(i,2));
                    Real3 xb(d_b3_span(i,0),d_b3_span(i,1),d_b3_span(i,2));

--- a/arcane/src/arcane/core/datatype/RealArray2Variant.h
+++ b/arcane/src/arcane/core/datatype/RealArray2Variant.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RealArray2Variant.h                                         (C) 2000-2023 */
+/* RealArray2Variant.h                                         (C) 2000-2024 */
 /*                                                                           */
 /* Variant pouvant contenir les types ConstArray2View, Real2x2 et Real3x3.   */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/datatype/RealArray2Variant.h
+++ b/arcane/src/arcane/core/datatype/RealArray2Variant.h
@@ -62,7 +62,7 @@ class RealArray2Variant
 #if defined(ARCANE_HAS_ACCELERATOR_API)
   template<typename LayoutType>
   RealArray2Variant(const NumArray<Real,MDDim2,LayoutType>& v)
-  : RealArray2Variant(v.span())
+  : RealArray2Variant(v.mdspan())
   {}
   template<typename LayoutType>
   RealArray2Variant(MDSpan<Real,MDDim2,LayoutType> v)

--- a/arcane/src/arcane/core/datatype/RealArrayVariant.h
+++ b/arcane/src/arcane/core/datatype/RealArrayVariant.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RealArrayVariant.h                                          (C) 2000-2023 */
+/* RealArrayVariant.h                                          (C) 2000-2024 */
 /*                                                                           */
 /* Variant pouvant contenir les types ConstArrayView, Real2 et Real3.        */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/datatype/RealArrayVariant.h
+++ b/arcane/src/arcane/core/datatype/RealArrayVariant.h
@@ -52,7 +52,7 @@ class RealArrayVariant
 #if defined(ARCANE_HAS_ACCELERATOR_API)
   template<typename LayoutType>
   RealArrayVariant(const NumArray<Real,MDDim1,LayoutType>& v)
-  : RealArrayVariant(v.span())
+  : RealArrayVariant(v.mdspan())
   {}
   template<typename LayoutType>
   RealArrayVariant(MDSpan<Real,MDDim1,LayoutType> v)

--- a/arcane/src/arcane/impl/NumArrayData.cc
+++ b/arcane/src/arcane/impl/NumArrayData.cc
@@ -129,8 +129,8 @@ class NumArrayDataT
   eDataType dataType() const override { return DataTypeTraitsT<DataType>::type(); }
   void serialize(ISerializer* sbuf, IDataOperation* operation) override;
   void serialize(ISerializer* sbuf, Int32ConstArrayView ids, IDataOperation* operation) override;
-  MDSpan<DataType,ExtentType> view() override { return m_value.span(); }
-  MDSpan<const DataType,ExtentType> view() const override { return m_value.span(); }
+  MDSpan<DataType,ExtentType> view() override { return m_value.mdspan(); }
+  MDSpan<const DataType,ExtentType> view() const override { return m_value.mdspan(); }
   void resize(Integer new_size) override;
   IData* clone() override { return _cloneTrue(); }
   IData* cloneEmpty() override { return _cloneTrueEmpty(); };

--- a/arcane/src/arcane/impl/NumArrayData.cc
+++ b/arcane/src/arcane/impl/NumArrayData.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* NumArrayData.cc                                             (C) 2000-2023 */
+/* NumArrayData.cc                                             (C) 2000-2024 */
 /*                                                                           */
 /* Donnée de type 'NumArray'.                                                */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/accelerator/AcceleratorReduceUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/AcceleratorReduceUnitTest.cc
@@ -251,7 +251,7 @@ _executeTestReduceDirect(Int32 nb_iteration, const NumArray<DataType, MDDim1>& t
   // Utilisation des kernels spécifiques
   for (int z = 0; z < nb_iteration; ++z) {
     ax::GenericReducer<DataType> reducer(m_queue);
-    reducer.applySum(t1.to1DSmallSpan(), A_FUNCINFO);
+    reducer.applySum(t1, A_FUNCINFO);
     DataType reduced_sum = reducer.reducedValue();
     if (z == 0)
       info() << "REDUCED_SUM (direct)=" << reduced_sum;
@@ -260,7 +260,7 @@ _executeTestReduceDirect(Int32 nb_iteration, const NumArray<DataType, MDDim1>& t
 
   for (int z = 0; z < nb_iteration; ++z) {
     ax::GenericReducer<DataType> reducer(m_queue);
-    reducer.applyMin(t1.to1DSmallSpan(), A_FUNCINFO);
+    reducer.applyMin(t1, A_FUNCINFO);
     DataType reduced_min = reducer.reducedValue();
     if (z == 0)
       info() << "REDUCED_MIN (direct)=" << reduced_min;
@@ -270,7 +270,7 @@ _executeTestReduceDirect(Int32 nb_iteration, const NumArray<DataType, MDDim1>& t
 
   for (int z = 0; z < nb_iteration; ++z) {
     ax::GenericReducer<DataType> reducer(m_queue);
-    reducer.applyMax(t1.to1DSmallSpan(), A_FUNCINFO);
+    reducer.applyMax(t1, A_FUNCINFO);
     DataType reduced_max = reducer.reducedValue();
     if (z == 0)
       info() << "REDUCED_MAX (direct)=" << reduced_max;

--- a/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
+++ b/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
@@ -902,7 +902,7 @@ doExit(RealArrayView reduced_values)
   NumArray3Type host_nstate(eMemoryRessource::Host);
   host_nstate.copy(nstate);
 
-  auto ns = host_nstate.constSpan();
+  auto ns = host_nstate.constMDSpan();
 
   for (ll = 0; ll < NUM_VARS; ll++)
     sum_v[ll] = 0.0;

--- a/arcane/src/arcane/tests/accelerator/MiniWeatherArraySequential.cc
+++ b/arcane/src/arcane/tests/accelerator/MiniWeatherArraySequential.cc
@@ -288,9 +288,9 @@ void MiniWeatherArraySequential::
 semi_discrete_step(NumArray<double,MDDim3>& nstate_init, NumArray<double,MDDim3>& nstate_forcing, NumArray<double,MDDim3>& nstate_out,
                    double dt, int dir, NumArray<double,MDDim3>& flux, NumArray<double,MDDim3>& tend)
 {
-  auto state_init = nstate_init.constSpan();
-  auto state_out = nstate_out.span();
-  auto in_tend = tend.constSpan();
+  auto state_init = nstate_init.constMDSpan();
+  auto state_out = nstate_out.mdspan();
+  auto in_tend = tend.constMDSpan();
 
   int i, k, ll;
   if (dir == DIR_X) {
@@ -327,14 +327,14 @@ semi_discrete_step(NumArray<double,MDDim3>& nstate_init, NumArray<double,MDDim3>
 void MiniWeatherArraySequential::
 compute_tendencies_x(NumArray<double,MDDim3>& nstate, NumArray<double,MDDim3>& flux, NumArray<double,MDDim3>& tend)
 {
-  auto state = nstate.constSpan();
+  auto state = nstate.constMDSpan();
 
   int i, k, ll, s;
   double r, u, w, t, p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
   //Compute the hyperviscosity coeficient
   hv_coef = -hv_beta * dx / (16 * dt);
   //Compute fluxes in the x-direction for each cell
-  auto out_flux = flux.span();
+  auto out_flux = flux.mdspan();
   for (k = 0; k < nz; k++){
     for (i = 0; i < nx + 1; i++){
       //Use fourth-order interpolation from four cell averages to compute the value at the interface in question
@@ -363,8 +363,8 @@ compute_tendencies_x(NumArray<double,MDDim3>& nstate, NumArray<double,MDDim3>& f
     }
   }
 
-  auto in_flux = flux.constSpan();
-  auto out_tend = tend.span();
+  auto in_flux = flux.constMDSpan();
+  auto out_tend = tend.mdspan();
   // Use the fluxes to compute tendencies for each cell
   for (ll = 0; ll < NUM_VARS; ll++) {
     for (k = 0; k < nz; k++) {
@@ -385,12 +385,12 @@ compute_tendencies_x(NumArray<double,MDDim3>& nstate, NumArray<double,MDDim3>& f
 void MiniWeatherArraySequential::
 compute_tendencies_z(NumArray<double,MDDim3>& nstate, NumArray<double,MDDim3>& flux, NumArray<double,MDDim3>& tend)
 {
-  auto state = nstate.constSpan();
+  auto state = nstate.constMDSpan();
   double r, u, w, t, p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
   //Compute the hyperviscosity coeficient
   hv_coef = -hv_beta * dx / (16 * dt);
   //Compute fluxes in the x-direction for each cell
-  auto out_flux = flux.span();
+  auto out_flux = flux.mdspan();
   for (int k = 0; k < nz + 1; k++){
     for (int i = 0; i < nx; i++){
       //Use fourth-order interpolation from four cell averages to compute the value at the interface in question
@@ -420,8 +420,8 @@ compute_tendencies_z(NumArray<double,MDDim3>& nstate, NumArray<double,MDDim3>& f
   }
 
   // Use the fluxes to compute tendencies for each cell
-  auto in_flux = flux.constSpan();
-  auto out_tend = tend.span();
+  auto in_flux = flux.constMDSpan();
+  auto out_tend = tend.mdspan();
   for (int ll = 0; ll < NUM_VARS; ll++){
     for (int k = 0; k < nz; k++){
       for (int i = 0; i < nx; i++){
@@ -440,8 +440,8 @@ compute_tendencies_z(NumArray<double,MDDim3>& nstate, NumArray<double,MDDim3>& f
 void MiniWeatherArraySequential::
 set_halo_values_x(NumArray<double,MDDim3>& nstate)
 {
-  auto state_in = nstate.constSpan();
-  auto state_out = nstate.span();
+  auto state_in = nstate.constMDSpan();
+  auto state_out = nstate.mdspan();
 
   for (int ll = 0; ll < NUM_VARS; ll++){
     for ( int k = 0; k < nz; k++){
@@ -473,8 +473,8 @@ set_halo_values_x(NumArray<double,MDDim3>& nstate)
 void MiniWeatherArraySequential::
 set_halo_values_z(NumArray<double,MDDim3>& nstate)
 {
-  auto state_in = nstate.constSpan();
-  auto state_out = nstate.span();
+  auto state_in = nstate.constMDSpan();
+  auto state_out = nstate.mdspan();
   for (int ll = 0; ll < NUM_VARS; ll++){
     for (int i = 0; i < nx + 2 * hs; i++){
       if (ll == ID_WMOM){
@@ -550,7 +550,7 @@ init()
   info() << "dx,dz: " << dx << " " << dz;
   info() << "dt: " << dt;
 
-  auto state = nstate.span();
+  auto state = nstate.mdspan();
 
   //////////////////////////////////////////////////////////////////////////
   // Initialize the cell-averaged fluid state via Gauss-Legendre quadrature
@@ -585,8 +585,8 @@ init()
   }
 
   // Compute the hydrostatic background state over vertical cell averages
-  auto out_hy_dens_cell = hy_dens_cell.span();
-  auto out_hy_dens_theta_cell = hy_dens_theta_cell.span();
+  auto out_hy_dens_cell = hy_dens_cell.mdspan();
+  auto out_hy_dens_theta_cell = hy_dens_theta_cell.mdspan();
   for (k = 0; k < nz + 2 * hs; k++){
     double dens_cell = 0.0;
     double dens_theta_cell = 0.0;
@@ -603,9 +603,9 @@ init()
     out_hy_dens_theta_cell(k) = dens_theta_cell;
   }
 
-  auto out_hy_dens_int = hy_dens_int.span();
-  auto out_hy_dens_theta_int = hy_dens_theta_int.span();
-  auto out_hy_pressure_int = hy_pressure_int.span();
+  auto out_hy_dens_int = hy_dens_int.mdspan();
+  auto out_hy_dens_theta_int = hy_dens_theta_int.mdspan();
+  auto out_hy_pressure_int = hy_pressure_int.mdspan();
   // Compute the hydrostatic background state at vertical cell interfaces
   for (k = 0; k < nz + 1; k++) {
     z = (k_beg + k) * dz;
@@ -678,7 +678,7 @@ doExit(RealArrayView reduced_values)
   int k, i, ll;
   double sum_v[NUM_VARS];
 
-  auto ns = nstate.constSpan();
+  auto ns = nstate.constMDSpan();
 
   for (ll = 0; ll < NUM_VARS; ll++)
     sum_v[ll] = 0.0;

--- a/arcane/src/arcane/tests/accelerator/MiniWeatherArraySequential.cc
+++ b/arcane/src/arcane/tests/accelerator/MiniWeatherArraySequential.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------

--- a/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
@@ -312,7 +312,7 @@ _executeTest1(eMemoryRessource mem_kind)
     t3.resize(n1);
 
     {
-      [[maybe_unused]] auto span_value = t1.span();
+      [[maybe_unused]] auto span_value = t1.mdspan();
       using ValueType1 = NumArray<double, MDDim1>::value_type;
       using ValueType2 = decltype(span_value)::value_type;
       bool is_same_type = std::is_same_v<ValueType1, ValueType2>;
@@ -349,8 +349,8 @@ _executeTest1(eMemoryRessource mem_kind)
     }
     {
       auto command = makeCommand(queue);
-      auto in_t1 = t1.constSpan();
-      MDSpan<double, MDDim1> out_t2 = t2.span();
+      auto in_t1 = t1.constMDSpan();
+      MDSpan<double, MDDim1> out_t2 = t2.mdspan();
 
       command << RUNCOMMAND_LOOP1(iter, n1)
       {
@@ -820,10 +820,10 @@ _arcaneNumArraySamples()
 
   {
     Arcane::NumArray<Arcane::Int32, Arcane::MDDim2> aaa(5, 4);
-    Arcane::MDSpan<Arcane::Int32, Arcane::MDDim1> bbb(aaa.span().slice(0));
+    Arcane::MDSpan<Arcane::Int32, Arcane::MDDim1> bbb(aaa.mdspan().slice(0));
 
-    Arcane::MDSpan<Arcane::Real, Arcane::MDDim3> a3_span(a3.span());
-    Arcane::MDSpan<Arcane::Real, Arcane::MDDim1> a2_span1(a2.span().slice(0));
+    Arcane::MDSpan<Arcane::Real, Arcane::MDDim3> a3_span(a3.mdspan());
+    Arcane::MDSpan<Arcane::Real, Arcane::MDDim1> a2_span1(a2.mdspan().slice(0));
     for (Arcane::Int32 i = 0; i < a3.extent0(); ++i) {
       Arcane::MDSpan<Arcane::Real, Arcane::MDDim2> span_array2 = a3_span.slice(i);
       std::cout << " MDDim2 slice i=" << i << " X=" << span_array2.extent0()

--- a/arcane/src/arcane/tests/accelerator/SimpleHydroAcceleratorService.cc
+++ b/arcane/src/arcane/tests/accelerator/SimpleHydroAcceleratorService.cc
@@ -650,9 +650,10 @@ updateDensity()
   auto command = makeCommand(m_default_queue);
   ax::ReducerMax2<double> density_ratio_maximum(command);
   density_ratio_maximum.setValue(0.0);
-  auto in_cell_mass = ax::viewIn(command,m_cell_mass);
-  auto in_volume = ax::viewIn(command,m_volume);
-  auto in_out_density = ax::viewInOut(command,m_density);
+
+  auto in_cell_mass = viewIn(command,m_cell_mass);
+  auto in_volume = viewIn(command,m_volume);
+  auto in_out_density = viewInOut(command,m_density);
 
   command << RUNCOMMAND_ENUMERATE(Cell,cid,allCells(),density_ratio_maximum)
   {

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -391,7 +391,7 @@ class NumArray
    */
   void copy(const ThatClass& rhs, RunQueue* queue)
   {
-    _resizeAndCopy(rhs.constSpan(), rhs.memoryRessource(), queue);
+    _resizeAndCopy(rhs.constMDSpan(), rhs.memoryRessource(), queue);
   }
 
  public:
@@ -487,24 +487,48 @@ class NumArray
 
  public:
 
+  //! Vue multi-dimension sur l'instance
+  ARCANE_DEPRECATED_REASON("Y2024: Use mdspan() instead")
   MDSpanType span() { return m_span; }
+
+  //! Vue constante multi-dimension sur l'instance
+  ARCANE_DEPRECATED_REASON("Y2024: Use mdspan() instead")
   ConstMDSpanType span() const { return m_span.constMDSpan(); }
+
+  //! Vue constante multi-dimension sur l'instance
+  ARCANE_DEPRECATED_REASON("Y2024: Use constMDSpan() instead")
   ConstMDSpanType constSpan() const { return m_span.constMDSpan(); }
 
+  //! Vue multi-dimension sur l'instance
   MDSpanType mdspan() { return m_span; }
+
+  //! Vue constante multi-dimension sur l'instance
   ConstMDSpanType mdspan() const { return m_span.constMDSpan(); }
+
+  //! Vue constante multi-dimension sur l'instance
   ConstMDSpanType constMDSpan() const { return m_span.constMDSpan(); }
 
+  //! Vue 1D constante sur l'instance
   Span<const DataType> to1DSpan() const { return m_span.to1DSpan(); }
+
+  //! Vue 1D sur l'instance
   Span<DataType> to1DSpan() { return m_span.to1DSpan(); }
 
-  constexpr operator MDSpanType() { return this->span(); }
-  constexpr operator ConstMDSpanType() const { return this->constSpan(); }
+  //! Conversion vers une vue multi-dimension sur l'instance
+  constexpr operator MDSpanType() { return this->mdspan(); }
+  //! Conversion vers une vue constante multi-dimension sur l'instance
+  constexpr operator ConstMDSpanType() const { return this->constMDSpan(); }
+
+  //! Conversion vers une vue 1D sur l'instance (uniquement si rank == 1)
   constexpr operator SmallSpan<DataType>() requires(Extents::rank() == 1) { return this->to1DSpan().smallView(); }
+  //! Conversion vers une vue constante 1D sur l'instance (uniquement si rank == 1)
   constexpr operator SmallSpan<const DataType>() const requires(Extents::rank() == 1) { return this->to1DSpan().constSmallView(); }
 
+  //! Vue 1D sur l'instance (uniquement si rank == 1)
   constexpr SmallSpan<DataType> to1DSmallSpan() requires(Extents::rank() == 1) { return m_span.to1DSmallSpan(); }
+  //! Vue constante 1D sur l'instance (uniquement si rank == 1)
   constexpr SmallSpan<const DataType> to1DSmallSpan() const requires(Extents::rank() == 1) { return m_span.to1DSmallSpan(); }
+  //! Vue constante 1D sur l'instance (uniquement si rank == 1)
   constexpr SmallSpan<const DataType> to1DConstSmallSpan() const requires(Extents::rank() == 1) { return m_span.to1DConstSmallSpan(); }
 
  public:

--- a/arcane/src/arcane/utils/tests/TestNumArray.cc
+++ b/arcane/src/arcane/utils/tests/TestNumArray.cc
@@ -84,7 +84,7 @@ TEST(NumArray, Basic)
     MDSpan<Real, MDDim2> span_array2(array2.mdspan());
     std::cout << "Array2: extents=" << array2.extent0() << "," << array2.extent1() << "\n";
     for (Int32 i = 0; i < array2.extent0(); ++i) {
-      MDSpan<Real, MDDim1> span_array1 = array2.span().slice(i);
+      MDSpan<Real, MDDim1> span_array1 = array2.mdspan().slice(i);
       ASSERT_EQ(span_array1.extent0(), span_array2.extent1());
       std::cout << " MDDim1 slice i=" << i << " X=" << span_array2.extent0() << "\n";
       for (Int32 x = 0, xn = span_array1.extent0(); x < xn; ++x) {
@@ -269,7 +269,7 @@ TEST(NumArray3, Copy)
   v.fill(3.2);
   NumArray<Real, MDDim3> v2(nb_x * 2, nb_y / 2, nb_z * 3);
 
-  v.copy(v2.span());
+  v.copy(v2.mdspan());
 
   {
     NumArray<int, MDDim1> vi0(4, { 1, 3, 5, 7 });


### PR DESCRIPTION
These methods return a `MDSpan` and are renamed `mdspan()` and `constMDSpan()`.
