### PR TITLE
Minor improvements in memory pool management

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -63,7 +63,7 @@ void arcaneCheckCudaErrorsNoThrow(const TraceInfo& ti, cudaError_t e)
     return;
   String str = String::format("CUDA Error trace={0} e={1} str={2}", ti, e, cudaGetErrorString(e));
   FatalErrorException ex(ti, str);
-  ex.explain(std::cerr);
+  ex.write(std::cerr);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -106,25 +106,28 @@ class BlockAllocatorWrapper
     const bool do_page = m_do_block_allocate;
     if (!do_page)
       return wanted_capacity;
-    // Alloue un multiple de la taille d'une page
+    // Alloue un multiple de la taille d'un bloc
+    // Pour la mémoire unifiée, la taille de bloc est une page mémoire.
     // Comme les transfers de la mémoire unifiée se font par page,
-    // cela permet de détecter quelles allocations provoquent le transfert
+    // cela permet de détecter quelles allocations provoquent le transfert.
+    // On se débrouille aussi pour limiter les différentes taille
+    // de bloc alloué pour éviter d'avoir trop de blocs de taille
+    // différente pour que l'éventuel MemoryPool ne contienne trop
+    // de valeurs.
     Int64 orig_capacity = wanted_capacity;
     Int64 new_size = orig_capacity * element_size;
     Int64 block_size = m_block_size;
-    if (new_size >= (4 * block_size))
-      block_size *= 4;
-    if (new_size >= (4 * block_size))
-      block_size = 4 * block_size;
-    if (new_size >= (4 * block_size))
-      block_size = 4 * block_size;
-    if (new_size >= (4 * block_size))
-      block_size = 4 * block_size;
+    Int64 nb_iter = 4 + (4096 / block_size);
+    for (Int64 i=0; i<nb_iter; ++i ){
+      if (new_size >= (4 * block_size))
+        block_size *= 4;
+      else
+        break;
+    }
     new_size = _computeNextMultiple(new_size, block_size);
     wanted_capacity = new_size / element_size;
     if (wanted_capacity < orig_capacity)
       wanted_capacity = orig_capacity;
-    //std::cout << "Adjust capacity=" << wanted_capacity << " elem_size=" << element_size << " bs=" << block_size << "\n";
     return wanted_capacity;
   }
 
@@ -176,6 +179,18 @@ class CudaMemoryAllocatorBase
 
  public:
 
+  class ConcreteAllocator
+  {
+   public:
+
+    virtual ~ConcreteAllocator() = default;
+
+   public:
+
+    virtual cudaError_t _allocate(void** ptr, size_t new_size) = 0;
+    virtual cudaError_t _deallocate(void* ptr) = 0;
+  };
+
   class UnderlyingAllocator
   : public IMemoryPoolAllocator
   {
@@ -191,13 +206,13 @@ class CudaMemoryAllocatorBase
     void* allocateMemory(size_t size) override
     {
       void* out = nullptr;
-      ARCANE_CHECK_CUDA(m_base->_allocate(&out, size));
+      ARCANE_CHECK_CUDA(m_base->m_concrete_allocator->_allocate(&out, size));
       m_base->m_block_wrapper.doAllocate(out, size);
       return out;
     }
     void freeMemory(void* ptr, [[maybe_unused]] size_t size) override
     {
-      ARCANE_CHECK_CUDA_NOTHROW(m_base->_deallocate(ptr));
+      ARCANE_CHECK_CUDA_NOTHROW(m_base->m_concrete_allocator->_deallocate(ptr));
     }
 
    public:
@@ -207,8 +222,9 @@ class CudaMemoryAllocatorBase
 
  public:
 
-  CudaMemoryAllocatorBase(const String& allocator_name)
+  CudaMemoryAllocatorBase(const String& allocator_name, ConcreteAllocator* concrete_allocator)
   : AlignedMemoryAllocator3(128)
+  , m_concrete_allocator(concrete_allocator)
   , m_direct_sub_allocator(this)
   , m_memory_pool(&m_direct_sub_allocator, allocator_name)
   , m_sub_allocator(&m_direct_sub_allocator)
@@ -255,13 +271,17 @@ class CudaMemoryAllocatorBase
       std::cout << "Reallocate allocator=" << m_allocator_name
                 << " current_size=" << current_size
                 << " current_capacity=" << current_info.capacity()
-                << " new_capacity=" << new_size;
-      if (array_name.null()) {
-        std::cout << " stack=" << platform::getStackTrace() << "\n";
-        std::cout << "\n";
+                << " new_capacity=" << new_size
+                << " ptr=" << current_info.baseAddress();
+      if (array_name.null() && m_print_level >= 3) {
+        std::cout << " stack=" << platform::getStackTrace();
       }
-      else
-        std::cout << " name=" << array_name << "\n";
+      else {
+        std::cout << " name=" << array_name;
+        if (m_print_level >= 4)
+          std::cout << " stack=" << platform::getStackTrace();
+      }
+      std::cout << "\n";
     }
     if (m_use_memory_pool)
       _removeHint(current_info.baseAddress(), current_size, args);
@@ -292,8 +312,6 @@ class CudaMemoryAllocatorBase
 
  protected:
 
-  virtual cudaError_t _allocate(void** ptr, size_t new_size) = 0;
-  virtual cudaError_t _deallocate(void* ptr) = 0;
   virtual void _applyHint([[maybe_unused]] void* ptr, [[maybe_unused]] size_t new_size,
                           [[maybe_unused]] MemoryAllocationArgs args) {}
   virtual void _removeHint([[maybe_unused]] void* ptr, [[maybe_unused]] size_t new_size,
@@ -302,6 +320,7 @@ class CudaMemoryAllocatorBase
  private:
 
   impl::MemoryTracerWrapper m_tracer;
+  std::unique_ptr<ConcreteAllocator> m_concrete_allocator;
   UnderlyingAllocator m_direct_sub_allocator;
   MemoryPool m_memory_pool;
   IMemoryPoolAllocator* m_sub_allocator = nullptr;
@@ -325,6 +344,14 @@ class CudaMemoryAllocatorBase
     IMemoryPoolAllocator* direct = &m_direct_sub_allocator;
     m_sub_allocator = (is_used) ? mem_pool : direct;
     m_use_memory_pool = is_used;
+    if (is_used){
+      if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_ACCELERATOR_MEMORY_POOL_MAX_BLOCK_SIZE", true)){
+        if (v.value()<0)
+          ARCANE_FATAL("Invalid value '{0}' for memory pool max block size");
+        size_t block_size = static_cast<size_t>(v.value());
+        m_memory_pool.setMaxCachedBlockSize(block_size);
+      }
+    }
   }
 };
 
@@ -342,11 +369,55 @@ class UnifiedMemoryCudaMemoryAllocator
 {
  public:
 
-  UnifiedMemoryCudaMemoryAllocator()
-  : CudaMemoryAllocatorBase("UnifiedMemoryCudaMemory")
+  class Allocator
+  : public ConcreteAllocator
   {
-    if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_USE_ALLOC_ATS", true))
-      m_use_ats = v.value();
+   public:
+
+    Allocator()
+    {
+      if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_USE_ALLOC_ATS", true))
+        m_use_ats = v.value();
+    }
+
+    cudaError_t _deallocate(void* ptr) final
+    {
+      if (m_use_ats) {
+        ::free(ptr);
+        return cudaSuccess;
+      }
+      //std::cout << "CUDA_MANAGED_FREE ptr=" << ptr << "\n";
+      return ::cudaFree(ptr);
+    }
+
+    cudaError_t _allocate(void** ptr, size_t new_size) final
+    {
+      if (m_use_ats) {
+        *ptr = ::aligned_alloc(128, new_size);
+      }
+      else {
+        auto r = ::cudaMallocManaged(ptr, new_size, cudaMemAttachGlobal);
+        //std::cout << "CUDA_MANAGED_MALLOC ptr=" << (*ptr) << " size=" << new_size << "\n";
+        //if (new_size < 4000)
+        //std::cout << "STACK=" << platform::getStackTrace() << "\n";
+
+        if (r != cudaSuccess)
+          return r;
+      }
+
+      return cudaSuccess;
+    }
+
+   public:
+
+    bool m_use_ats = false;
+  };
+
+ public:
+
+  UnifiedMemoryCudaMemoryAllocator()
+  : CudaMemoryAllocatorBase("UnifiedMemoryCudaMemory", new Allocator())
+  {
     if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_MALLOC_TRACE", true))
       _setTraceLevel(v.value());
   }
@@ -377,29 +448,6 @@ class UnifiedMemoryCudaMemoryAllocator
   }
 
  protected:
-
-  cudaError_t _deallocate(void* ptr) final
-  {
-    if (m_use_ats) {
-      ::free(ptr);
-      return cudaSuccess;
-    }
-    return ::cudaFree(ptr);
-  }
-
-  cudaError_t _allocate(void** ptr, size_t new_size) final
-  {
-    if (m_use_ats) {
-      *ptr = ::aligned_alloc(128, new_size);
-    }
-    else {
-      auto r = ::cudaMallocManaged(ptr, new_size, cudaMemAttachGlobal);
-      if (r != cudaSuccess)
-        return r;
-    }
-
-    return cudaSuccess;
-  }
 
   void _applyHint(void* p, size_t new_size, MemoryAllocationArgs args)
   {
@@ -447,8 +495,25 @@ class HostPinnedCudaMemoryAllocator
 {
  public:
 
+  class Allocator
+  : public ConcreteAllocator
+  {
+   public:
+
+    cudaError_t _allocate(void** ptr, size_t new_size) final
+    {
+      return ::cudaMallocHost(ptr, new_size);
+    }
+    cudaError_t _deallocate(void* ptr) final
+    {
+      return ::cudaFreeHost(ptr);
+    }
+  };
+
+ public:
+
   HostPinnedCudaMemoryAllocator()
-  : CudaMemoryAllocatorBase("HostPinnedCudaMemory")
+  : CudaMemoryAllocatorBase("HostPinnedCudaMemory", new Allocator())
   {
   }
 
@@ -462,17 +527,6 @@ class HostPinnedCudaMemoryAllocator
     _setUseMemoryPool(use_memory_pool);
     m_block_wrapper.initialize(128, use_memory_pool);
   }
-
- protected:
-
-  cudaError_t _allocate(void** ptr, size_t new_size) final
-  {
-    return ::cudaMallocHost(ptr, new_size);
-  }
-  cudaError_t _deallocate(void* ptr) final
-  {
-    return ::cudaFreeHost(ptr);
-  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -481,13 +535,51 @@ class HostPinnedCudaMemoryAllocator
 class DeviceCudaMemoryAllocator
 : public CudaMemoryAllocatorBase
 {
+
+  class Allocator
+  : public ConcreteAllocator
+  {
+   public:
+
+    Allocator()
+    {
+      if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_USE_ALLOC_ATS", true))
+        m_use_ats = v.value();
+    }
+
+    cudaError_t _allocate(void** ptr, size_t new_size) final
+    {
+      if (m_use_ats) {
+        // FIXME: it does not work on WIN32
+        *ptr = std::aligned_alloc(128, new_size);
+        if (*ptr)
+          return cudaSuccess;
+        return cudaErrorMemoryAllocation;
+      }
+      cudaError_t r = ::cudaMalloc(ptr, new_size);
+      //std::cout << "ALLOCATE_DEVICE ptr=" << (*ptr) << " size=" << new_size << " r=" << (int)r << "\n";
+      return r;
+    }
+    cudaError_t _deallocate(void* ptr) final
+    {
+      if (m_use_ats) {
+        std::free(ptr);
+        return cudaSuccess;
+      }
+      //std::cout << "FREE_DEVICE ptr=" << ptr << "\n";
+      return ::cudaFree(ptr);
+    }
+
+   private:
+
+    bool m_use_ats = false;
+  };
+
  public:
 
   DeviceCudaMemoryAllocator()
-  : CudaMemoryAllocatorBase("DeviceCudaMemoryAllocator")
+  : CudaMemoryAllocatorBase("DeviceCudaMemoryAllocator", new Allocator())
   {
-    if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_CUDA_USE_ALLOC_ATS", true))
-      m_use_ats = v.value();
   }
 
  public:
@@ -500,32 +592,6 @@ class DeviceCudaMemoryAllocator
     _setUseMemoryPool(use_memory_pool);
     m_block_wrapper.initialize(128, use_memory_pool);
   }
-
- protected:
-
-  cudaError_t _allocate(void** ptr, size_t new_size) final
-  {
-    if (m_use_ats) {
-      // FIXME: it does not work on WIN32
-      *ptr = std::aligned_alloc(128, new_size);
-      if (*ptr)
-        return cudaSuccess;
-      return cudaErrorMemoryAllocation;
-    }
-    return ::cudaMalloc(ptr, new_size);
-  }
-  cudaError_t _deallocate(void* ptr) final
-  {
-    if (m_use_ats) {
-      std::free(ptr);
-      return cudaSuccess;
-    }
-    return ::cudaFree(ptr);
-  }
-
- private:
-
-  bool m_use_ats = false;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryPool.cc
+++ b/arcane/src/arcane/utils/MemoryPool.cc
@@ -201,6 +201,7 @@ class MemoryPool::Impl
   void freeMemory(void* ptr, size_t size);
   void dumpStats(std::ostream& ostr);
   void dumpFreeMap(std::ostream& ostr);
+  void setMaxCachedBlockSize(size_t v);
 
  public:
 
@@ -291,7 +292,8 @@ _addAllocated(void* ptr, size_t size)
 void MemoryPool::Impl::
 dumpStats(std::ostream& ostr)
 {
-  ostr << "Stats '" << m_name << "' TotalAllocated=" << m_total_allocated
+  ostr << "Stats '" << m_name << "' max_block=" << m_max_memory_size_to_pool
+       << " TotalAllocated=" << m_total_allocated
        << " TotalFree=" << m_total_free
        << " nb_allocated=" << m_allocated_map.size()
        << " nb_free=" << m_free_map.size()
@@ -307,6 +309,17 @@ void MemoryPool::Impl::
 dumpFreeMap(std::ostream& ostr)
 {
   m_free_map.dump(ostr);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MemoryPool::Impl::
+setMaxCachedBlockSize(size_t v)
+{
+  if (m_allocated_map.size() != 0 || m_free_map.size() != 0)
+    ARCANE_FATAL("Can not change maximum cached block size on non empty pool");
+  m_max_memory_size_to_pool = v;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -335,6 +348,11 @@ dumpFreeMap(std::ostream& ostr)
 String MemoryPool::name() const
 {
   return m_p->m_name;
+}
+void MemoryPool::
+setMaxCachedBlockSize(size_t v)
+{
+  m_p->setMaxCachedBlockSize(v);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryPool.cc
+++ b/arcane/src/arcane/utils/MemoryPool.cc
@@ -213,6 +213,7 @@ class MemoryPool::Impl
   std::atomic<size_t> m_total_allocated = 0;
   std::atomic<size_t> m_total_free = 0;
   std::atomic<Int32> m_nb_cached = 0;
+  std::atomic<Int32> m_nb_no_cached = 0;
   size_t m_max_memory_size_to_pool = 1024 * 64 * 4 * 4;
   String m_name;
 
@@ -245,8 +246,10 @@ MemoryPool::
 void* MemoryPool::Impl::
 allocateMemory(size_t size)
 {
-  if (m_max_memory_size_to_pool != 0 && size > m_max_memory_size_to_pool)
+  if (m_max_memory_size_to_pool != 0 && size > m_max_memory_size_to_pool) {
+    ++m_nb_no_cached;
     return m_allocator->allocateMemory(size);
+  }
 
   void* ptr = m_free_map.getPointer(size);
   if (ptr) {
@@ -298,6 +301,7 @@ dumpStats(std::ostream& ostr)
        << " nb_allocated=" << m_allocated_map.size()
        << " nb_free=" << m_free_map.size()
        << " nb_cached=" << m_nb_cached
+       << " nb_no_cached=" << m_nb_no_cached
        << " nb_error=" << m_allocated_map.nbError()
        << "\n";
 }

--- a/arcane/src/arcane/utils/internal/MemoryPool.h
+++ b/arcane/src/arcane/utils/internal/MemoryPool.h
@@ -75,6 +75,15 @@ class ARCANE_UTILS_EXPORT MemoryPool
   void dumpFreeMap(std::ostream& ostr);
   String name() const;
 
+  /*!
+   * \brief Positionne la taille en octet à partir de laquelle
+   * on ne conserve pas un bloc dans le cache.
+   *
+   * Cette méthode ne peut être appelé que s'il n'y a aucun bloc dans le
+   * cache.
+   */
+  void setMaxCachedBlockSize(size_t v);
+
  private:
 
   std::shared_ptr<Impl> m_p;

--- a/arcane/src/arcane/utils/internal/MemoryPool.h
+++ b/arcane/src/arcane/utils/internal/MemoryPool.h
@@ -56,6 +56,9 @@ class ARCANE_UTILS_EXPORT IMemoryPoolAllocator
  * \brief Classe pour gérer une liste de zone allouées.
  *
  * Cette classe utilise une sémantique par référence.
+ *
+ * L'allocateur passé en argument du constructeur doit rester valide
+ * durant toute la vie de l'instance.
  */
 class ARCANE_UTILS_EXPORT MemoryPool
 : public IMemoryPoolAllocator
@@ -83,6 +86,9 @@ class ARCANE_UTILS_EXPORT MemoryPool
    * cache.
    */
   void setMaxCachedBlockSize(size_t v);
+
+  //! Libère la mémoire dans le cache
+  void freeCachedMemory();
 
  private:
 

--- a/arcane/src/arcane/utils/tests/TestMemoryPool.cc
+++ b/arcane/src/arcane/utils/tests/TestMemoryPool.cc
@@ -47,6 +47,11 @@ TEST(MemoryPool, Misc)
 
   void* a4 = memory_pool.allocateMemory(max_block_size * 2);
   memory_pool.freeMemory(a4, max_block_size * 2);
+
+  std::cout << "End Of Test\n";
+  memory_pool.dumpStats(std::cout);
+  memory_pool.dumpFreeMap(std::cout);
+  memory_pool.freeCachedMemory();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/TestMemoryPool.cc
+++ b/arcane/src/arcane/utils/tests/TestMemoryPool.cc
@@ -32,7 +32,9 @@ class MyMemoryPoolAllocator
 TEST(MemoryPool, Misc)
 {
   MyMemoryPoolAllocator my_allocator;
-  MemoryPool memory_pool(&my_allocator,"MyMemoryPool");
+  MemoryPool memory_pool(&my_allocator, "MyMemoryPool");
+  size_t max_block_size = 1024 * 8;
+  memory_pool.setMaxCachedBlockSize(1024 * 8);
 
   void* a1 = memory_pool.allocateMemory(25);
   void* a2 = memory_pool.allocateMemory(47);
@@ -42,6 +44,9 @@ TEST(MemoryPool, Misc)
   memory_pool.dumpStats(std::cout);
   memory_pool.dumpFreeMap(std::cout);
   memory_pool.freeMemory(a3, 25);
+
+  void* a4 = memory_pool.allocateMemory(max_block_size * 2);
+  memory_pool.freeMemory(a4, max_block_size * 2);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Minor additions in `MemoryPool`:

- Add support to change the max size of a cached block
- Add a method to free the memory in the cache

Refactor CUDA allocators to use these functionalities.