### PR TITLE
Refactor memory allocation for internal view of MeshMaterialVariable

### DIFF
--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -609,18 +609,18 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
   // Maintenant que les nouveaux MatVar sont créés, il faut les
   // initialiser avec les bonnes valeurs.
   {
+    _resizeVariablesIndexer(var_indexer->index());
     // TODO: Comme tout est indépendant par variable, on pourrait
     // éventuellement utiliser plusieurs files.
-    RunQueue::ScopedAsync sc(&m_queue);
-    IMeshMaterialMng* mm = m_material_mng;
-    bool do_init = m_do_init_new_items;
-    auto func = [&](IMeshMaterialVariable* mv) {
-      mv->_internalApi()->resizeForIndexer(var_indexer->index(), m_queue);
-      if (do_init)
+    if (m_do_init_new_items) {
+      RunQueue::ScopedAsync sc(&m_queue);
+      IMeshMaterialMng* mm = m_material_mng;
+      auto func = [&](IMeshMaterialVariable* mv) {
         mv->_internalApi()->initializeNewItems(list_builder, m_queue);
-    };
-    functor::apply(mm, &IMeshMaterialMng::visitVariables, func);
-    m_queue.barrier();
+      };
+      functor::apply(mm, &IMeshMaterialMng::visitVariables, func);
+      m_queue.barrier();
+    }
   }
 }
 
@@ -702,6 +702,25 @@ _removeItemsInGroup(ItemGroup cells, SmallSpan<const Int32> removed_ids)
   }
 }
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Redimensionne l'index \a var_index des variables
+ */
+void IncrementalComponentModifier::
+_resizeVariablesIndexer(Int32 var_index)
+{
+  Accelerator::RunQueuePool& queue_pool = m_material_mng->_internalApi()->asyncRunQueuePool();
+
+  Int32 index = 0;
+  auto func1 = [&](IMeshMaterialVariable* mv) {
+    auto* mvi = mv->_internalApi();
+    mvi->resizeForIndexer(var_index, queue_pool[index]);
+    ++index;
+  };
+  functor::apply(m_material_mng, &MeshMaterialMng::visitVariables, func1);
+    queue_pool.barrier();
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -730,14 +749,7 @@ _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args)
 
   // Redimensionne les variables si nécessaire
   if (is_add_operation) {
-    Int32 index = 0;
-    auto func1 = [&](IMeshMaterialVariable* mv) {
-      auto* mvi = mv->_internalApi();
-      mvi->resizeForIndexer(args.m_var_index, queue_pool[index]);
-      ++index;
-    };
-    functor::apply(m_material_mng, &MeshMaterialMng::visitVariables, func1);
-    queue_pool.barrier();
+    _resizeVariablesIndexer(args.m_var_index);
   }
 
   if (do_copy) {

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -42,6 +42,22 @@
 namespace Arcane::Materials
 {
 
+namespace
+{
+
+// Allocateur utilisé pour les vues
+// On utilise la mémoire de l'accélérateur si l'exécution se fait sur accélérateur
+MemoryAllocationOptions
+_getViewAllocator(IMeshMaterialMng* mm)
+{
+  eMemoryRessource r = eMemoryRessource::Host;
+  if (mm->_internalApi()->runQueue().isAcceleratorPolicy())
+    r = eMemoryRessource::Device;
+  return MemoryUtils::getAllocationOptions(r);
+}
+
+}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -53,7 +69,7 @@ ItemMaterialVariableBase(const MaterialVariableBuildInfo& v,
 : MeshMaterialVariable(v,mvs)
 , m_global_variable(global_var)
 , m_global_variable_ref(global_var_ref)
-, m_views(MemoryUtils::getDeviceOrHostAllocator())
+, m_views(_getViewAllocator(m_p->materialMng()))
 , m_host_views(MemoryUtils::getAllocationOptions(eMemoryRessource::HostPinned))
 {
   m_views.setDebugName(String("ItemMaterialVariableViews") + v.name());

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -69,10 +69,10 @@ ItemMaterialVariableBase(const MaterialVariableBuildInfo& v,
 : MeshMaterialVariable(v,mvs)
 , m_global_variable(global_var)
 , m_global_variable_ref(global_var_ref)
-, m_views(_getViewAllocator(m_p->materialMng()))
+, m_device_views(_getViewAllocator(m_p->materialMng()))
 , m_host_views(MemoryUtils::getAllocationOptions(eMemoryRessource::HostPinned))
 {
-  m_views.setDebugName(String("ItemMaterialVariableViews") + v.name());
+  m_device_views.setDebugName(String("ItemMaterialVariableViews") + v.name());
 }
 
 
@@ -113,7 +113,7 @@ _init(ArrayView<PrivatePartType*> vars)
     ARCANE_FATAL("Internal error: _init() already called");
   m_vars.addRange(vars);
   Integer nb_var = m_vars.size();
-  m_views.resizeNoInit(nb_var);
+  m_device_views.resizeNoInit(nb_var);
   m_host_views.resize(nb_var);
   m_views_as_bytes.resize(nb_var);
   // Il faut maintenir une référence sur les variables qu'on possède pour
@@ -400,14 +400,13 @@ template <typename Traits> void
 ItemMaterialVariableBase<Traits>::
 _copyHostViewsToViews(RunQueue* queue)
 {
-  const bool use_queue = true;
-  if (queue && use_queue){
-    Accelerator::MemoryCopyArgs copy_args(asWritableBytes(m_views),asBytes(m_host_views));
+  if (queue) {
+    Accelerator::MemoryCopyArgs copy_args(asWritableBytes(m_device_views),asBytes(m_host_views));
     copy_args.addAsync(true);
     queue->copyMemory(copy_args);
   }
   else
-    MemoryUtils::copy(asWritableBytes(m_views),asBytes(m_host_views));
+    MemoryUtils::copy(asWritableBytes(m_device_views),asBytes(m_host_views));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -474,7 +473,7 @@ _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queu
   DataType zero = DataType();
 
   auto command = makeCommand(queue);
-  SmallSpan<ContainerViewType> views = m_views.smallSpan();
+  SmallSpan<ContainerViewType> views = m_device_views.smallSpan();
 
   ARCANE_CHECK_ACCESSIBLE_POINTER(queue, views.data());
   ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_matvar.data());

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -53,7 +53,8 @@ ItemMaterialVariableBase(const MaterialVariableBuildInfo& v,
 : MeshMaterialVariable(v,mvs)
 , m_global_variable(global_var)
 , m_global_variable_ref(global_var_ref)
-, m_views(MemoryUtils::getAllocatorForMostlyReadOnlyData())
+, m_views(MemoryUtils::getDefaultDataAllocator())
+, m_host_views(MemoryUtils::getAllocationOptions(eMemoryRessource::HostPinned))
 {
   m_views.setDebugName(String("ItemMaterialVariableViews") + v.name());
 }

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -53,7 +53,7 @@ ItemMaterialVariableBase(const MaterialVariableBuildInfo& v,
 : MeshMaterialVariable(v,mvs)
 , m_global_variable(global_var)
 , m_global_variable_ref(global_var_ref)
-, m_views(MemoryUtils::getDefaultDataAllocator())
+, m_views(MemoryUtils::getDeviceOrHostAllocator())
 , m_host_views(MemoryUtils::getAllocationOptions(eMemoryRessource::HostPinned))
 {
   m_views.setDebugName(String("ItemMaterialVariableViews") + v.name());
@@ -97,7 +97,7 @@ _init(ArrayView<PrivatePartType*> vars)
     ARCANE_FATAL("Internal error: _init() already called");
   m_vars.addRange(vars);
   Integer nb_var = m_vars.size();
-  m_views.resize(nb_var);
+  m_views.resizeNoInit(nb_var);
   m_host_views.resize(nb_var);
   m_views_as_bytes.resize(nb_var);
   // Il faut maintenir une référence sur les variables qu'on possède pour

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -327,19 +327,19 @@ class ItemMaterialVariableBase
 
  public:
 
-  void setValue(MatVarIndex mvi,SubInputViewType v)
+  void setValue(MatVarIndex mvi, SubInputViewType v)
   {
-    Traits::setValue(m_views[mvi.arrayIndex()][mvi.valueIndex()],v);
+    Traits::setValue(m_host_views[mvi.arrayIndex()][mvi.valueIndex()],v);
   }
 
-  void setFillValue(MatVarIndex mvi,const DataType& v)
+  void setFillValue(MatVarIndex mvi, const DataType& v)
   {
-    Traits::setValue(m_views[mvi.arrayIndex()][mvi.valueIndex()],v);
+    Traits::setValue(m_host_views[mvi.arrayIndex()][mvi.valueIndex()],v);
   }
 
   SubConstViewType value(MatVarIndex mvi) const
   {
-    return m_views[mvi.arrayIndex()][mvi.valueIndex()];
+    return m_host_views[mvi.arrayIndex()][mvi.valueIndex()];
   }
 
  protected:
@@ -434,17 +434,17 @@ class ItemMaterialVariableScalar
 
  public:
 
-  ArrayView<DataType>* views() { return this->m_views.data(); }
+  ArrayView<DataType>* views() { return this->m_host_views.data(); }
 
  protected:
 
-  ArrayView<ArrayView<DataType>> _containerView() { return this->m_views; }
+  ArrayView<ArrayView<DataType>> _containerView() { return this->m_host_views; }
 
  public:
   
   DataType operator[](MatVarIndex mvi) const
   {
-    return this->m_views[mvi.arrayIndex()][mvi.valueIndex()];
+    return this->m_host_views[mvi.arrayIndex()][mvi.valueIndex()];
   }
 
   using BaseClass::setValue;
@@ -487,7 +487,7 @@ class ItemMaterialVariableScalar
   using BaseClass::m_global_variable;
   using BaseClass::m_global_variable_ref;
   using BaseClass::m_vars;
-  using BaseClass::m_views;
+  using BaseClass::m_host_views;
 
  private:
 
@@ -605,7 +605,7 @@ class ItemMaterialVariableArray
  public:
 
   ARCANE_DEPRECATED_REASON("Y2022: Do not use internal storage accessor")
-  Array2View<DataType>* views() { return m_views.data(); }
+  Array2View<DataType>* views() { return m_host_views.data(); }
 
  public:
 
@@ -635,7 +635,7 @@ class ItemMaterialVariableArray
 
   ConstArrayView<DataType> operator[](MatVarIndex mvi) const
   {
-    return m_views[mvi.arrayIndex()][mvi.valueIndex()];
+    return m_host_views[mvi.arrayIndex()][mvi.valueIndex()];
   }
 
   using BaseClass::setValue;
@@ -644,14 +644,14 @@ class ItemMaterialVariableArray
  protected:
 
   using BaseClass::m_p;
-  ArrayView<Array2View<DataType>> _containerView() { return m_views; }
+  ArrayView<Array2View<DataType>> _containerView() { return m_host_views; }
 
  private:
 
   using BaseClass::m_global_variable;
   using BaseClass::m_global_variable_ref;
   using BaseClass::m_vars;
-  using BaseClass::m_views;
+  using BaseClass::m_host_views;
 
   void _copyToBufferLegacy(SmallSpan<const MatVarIndex> matvar_indexes,
                            Span<std::byte> bytes) const;

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -366,7 +366,8 @@ class ItemMaterialVariableBase
   VariableRef* m_global_variable_ref = nullptr;
   //! Variables pour les différents matériaux.
   UniqueArray<PrivatePartType*> m_vars;
-  UniqueArray<ContainerViewType> m_views;
+  //! Liste des vues visibles uniquement depuis l'accélérateur
+  UniqueArray<ContainerViewType> m_device_views;
   //! Liste des vues visibles uniquement depuis l'ĥote
   UniqueArray<ContainerViewType> m_host_views;
 

--- a/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
+++ b/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
@@ -91,6 +91,7 @@ class ARCANE_MATERIALS_EXPORT IncrementalComponentModifier
   void _addItemsToEnvironment(MeshEnvironment* env, MeshMaterial* mat,
                               SmallSpan<const Int32> local_ids, bool update_env_indexer);
   void _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args);
+  void _resizeVariablesIndexer(Int32 var_index);
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Use device memory for views used on device (instead of UVM) and host pinned memory for views used on host (instead of standard memory).

This will speed-up copy between host and device and allow batch copy between host and device for these views