### PR TITLE
Use one kernel to copy views after resizing MeshMaterialVariableindexer

### DIFF
--- a/arcane/ceapart/src/arcane/tests/MaterialHeatTest.axl
+++ b/arcane/ceapart/src/arcane/tests/MaterialHeatTest.axl
@@ -22,6 +22,9 @@
     <simple name="nb-additional-variable" type="int32" default="2">
       <description>Number of additional variables to create</description>
     </simple>
+    <simple name="nb-additional-array-variable" type="int32" default="2">
+      <description>Number of additional array variables to create</description>
+    </simple>
 
     <!-- Infos sur les materiaux -->
     <complex name="material" type="Material" minOccurs="1" maxOccurs="unbounded">

--- a/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
+++ b/arcane/ceapart/src/arcane/tests/MaterialHeatTestModule.cc
@@ -286,7 +286,7 @@ buildInit()
     }
   }
 
-  // Créé les éventuelles variables additionnelles.
+  // Créé les éventuelles variables scalaires additionnelles.
   {
     Int32 nb_var_to_add = options()->nbAdditionalVariable();
     info() << "NbVariableToAdd = " << nb_var_to_add;
@@ -295,6 +295,20 @@ buildInit()
       auto* v = new MaterialVariableCellInt32(VariableBuildInfo(mesh, var_name));
       m_additional_variables.add(v);
       v->fill(i + 2);
+    }
+  }
+
+  // Créé les éventuelles variables tableaux additionnelles.
+  {
+    Int32 nb_var_to_add = options()->nbAdditionalArrayVariable();
+    info() << "NbArrayVariableToAdd = " << nb_var_to_add;
+    for (Int32 i = 0; i < nb_var_to_add; ++i) {
+      String var_name = "MaterialAdditionalArrayVar" + String::fromNumber(i);
+      auto* v = new MaterialVariableCellArrayInt32(VariableBuildInfo(mesh, var_name));
+      v->resize(1 + (i% 3));
+      m_additional_variables.add(v);
+      v->globalVariable().fill(i + 5);
+      v->fillPartialValuesWithSuperValues(LEVEL_ALLENVIRONMENT);
     }
   }
 }
@@ -612,7 +626,7 @@ _computeCellsToAdd(const HeatObject& heat_object, MaterialWorkArray& wa)
 
     const Int32 nb_item = all_cells.size();
     wa.resizeNbAdd(nb_item);
-    Accelerator::GenericFilterer filterer(&m_queue);
+    Accelerator::GenericFilterer filterer(m_queue);
     auto in_cell_center = viewIn(m_queue, m_cell_center);
     auto cells_ids = viewIn(m_queue, all_cells.localIds());
 
@@ -680,7 +694,7 @@ _computeCellsToRemove(const HeatObject& heat_object, MaterialWorkArray& wa)
   }
 
   {
-    Accelerator::GenericFilterer filterer(&m_queue);
+    Accelerator::GenericFilterer filterer(m_queue);
     SmallSpan<const Int32> in_remove_view = wa.mat_cells_to_remove.view();
     SmallSpan<Int32> out_remove_view = wa.mat_cells_to_remove.view();
     SmallSpan<const bool> filter_view = wa.mat_cells_remove_filter.to1DSmallSpan();

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -47,6 +47,8 @@ struct ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalOneData
   Int32 m_data_size = 0;
 };
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \brief Arguments des méthodes de copie entre valeurs partielles et globales
  */
@@ -93,6 +95,35 @@ class ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalArgs
   RunQueue m_queue;
   //! Informations de copie si on n'utilise qu'une seule commande
   UniqueArray<CopyBetweenPartialAndGlobalOneData>* m_copy_data = nullptr;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Arguments des méthodes de copie entre valeurs partielles et globales
+ */
+class ARCANE_CORE_EXPORT ResizeVariableIndexerArgs
+{
+ public:
+
+  ResizeVariableIndexerArgs(Int32 var_index, const RunQueue& queue)
+  : m_var_index(var_index)
+  , m_queue(queue)
+  {}
+
+ public:
+
+  void addOneCopyData(Span<std::byte> input, Span<std::byte> output)
+  {
+    m_copy_data.add(input);
+    m_copy_data.add(output);
+  }
+
+ public:
+
+  Int32 m_var_index = -1;
+  RunQueue m_queue;
+  UniqueArray<Span<std::byte>> m_copy_data;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -156,7 +187,7 @@ class ARCANE_CORE_EXPORT IMeshMaterialVariableInternal
   virtual void syncReferences(bool check_resize) = 0;
 
   //! Redimensionne la valeur partielle associée à l'indexer \a index
-  virtual void resizeForIndexer(Int32 index, RunQueue& queue) = 0;
+  virtual void resizeForIndexer(ResizeVariableIndexerArgs& args) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -113,17 +113,24 @@ class ARCANE_CORE_EXPORT ResizeVariableIndexerArgs
 
  public:
 
-  void addOneCopyData(Span<std::byte> input, Span<std::byte> output)
+  void addOneCopyData(Span<const std::byte> input,
+                      Span<std::byte> output,
+                      Int32 data_size) const
   {
-    m_copy_data.add(input);
-    m_copy_data.add(output);
+    if (m_copy_data) {
+      CopyBetweenDataInfo x(input, output, data_size);
+      m_copy_data->add(x);
+    }
   }
+
+  bool isUseOneCommand() const { return m_copy_data; }
 
  public:
 
   Int32 m_var_index = -1;
   RunQueue m_queue;
-  UniqueArray<Span<std::byte>> m_copy_data;
+  //! Informations de copie si on n'utilise qu'une seule commande
+  UniqueArray<CopyBetweenDataInfo>* m_copy_data = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -34,7 +34,7 @@ struct ARCANE_CORE_EXPORT CopyBetweenDataInfo
 {
  public:
 
-  CopyBetweenDataInfo(Span<const std::byte> input, Span<std::byte> output, Int32 data_size)
+  CopyBetweenDataInfo(SmallSpan<const std::byte> input, SmallSpan<std::byte> output, Int32 data_size)
   : m_input(input)
   , m_output(output)
   , m_data_size(data_size)
@@ -42,8 +42,8 @@ struct ARCANE_CORE_EXPORT CopyBetweenDataInfo
 
  public:
 
-  Span<const std::byte> m_input;
-  Span<std::byte> m_output;
+  SmallSpan<const std::byte> m_input;
+  SmallSpan<std::byte> m_output;
   Int32 m_data_size = 0;
 };
 
@@ -72,8 +72,8 @@ class ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalArgs
 
  public:
 
-  void addOneCopyData(Span<const std::byte> input,
-                      Span<std::byte> output,
+  void addOneCopyData(SmallSpan<const std::byte> input,
+                      SmallSpan<std::byte> output,
                       Int32 data_size) const
   {
     if (m_copy_data) {
@@ -113,8 +113,8 @@ class ARCANE_CORE_EXPORT ResizeVariableIndexerArgs
 
  public:
 
-  void addOneCopyData(Span<const std::byte> input,
-                      Span<std::byte> output,
+  void addOneCopyData(SmallSpan<const std::byte> input,
+                      SmallSpan<std::byte> output,
                       Int32 data_size) const
   {
     if (m_copy_data) {

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -28,13 +28,13 @@ class ComponentItemListBuilder;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Informations pour la copie entre valeurs globales et partielles d'une variable
+ * \brief Informations pour la copie entre deux zones mémoire.
  */
-struct ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalOneData
+struct ARCANE_CORE_EXPORT CopyBetweenDataInfo
 {
  public:
 
-  CopyBetweenPartialAndGlobalOneData(Span<const std::byte> input, Span<std::byte> output, Int32 data_size)
+  CopyBetweenDataInfo(Span<const std::byte> input, Span<std::byte> output, Int32 data_size)
   : m_input(input)
   , m_output(output)
   , m_data_size(data_size)
@@ -77,7 +77,7 @@ class ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalArgs
                       Int32 data_size) const
   {
     if (m_copy_data) {
-      CopyBetweenPartialAndGlobalOneData x(input, output, data_size);
+      CopyBetweenDataInfo x(input, output, data_size);
       m_copy_data->add(x);
     }
   }
@@ -94,7 +94,7 @@ class ARCANE_CORE_EXPORT CopyBetweenPartialAndGlobalArgs
   bool m_use_generic_copy = false;
   RunQueue m_queue;
   //! Informations de copie si on n'utilise qu'une seule commande
-  UniqueArray<CopyBetweenPartialAndGlobalOneData>* m_copy_data = nullptr;
+  UniqueArray<CopyBetweenDataInfo>* m_copy_data = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ConstituentModifierWorkInfo.cc
+++ b/arcane/src/arcane/materials/ConstituentModifierWorkInfo.cc
@@ -59,7 +59,7 @@ initialize(Int32 max_local_id, Int32 nb_material, Int32 nb_environment, RunQueue
 
   // Utilise toujours la mémoire du device pour le tableau contenant les données de copie
   if (queue.isAcceleratorPolicy())
-    m_variables_copy_data = NumArray<CopyBetweenPartialAndGlobalOneData, MDDim1>(eMemoryRessource::Device);
+    m_variables_copy_data = NumArray<CopyBetweenDataInfo, MDDim1>(eMemoryRessource::Device);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -758,7 +758,7 @@ _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args)
 
   if (do_copy) {
     bool do_one_command = (m_use_generic_copy_between_pure_and_partial == 2);
-    UniqueArray<CopyBetweenPartialAndGlobalOneData>& copy_data = m_work_info.m_host_variables_copy_data;
+    UniqueArray<CopyBetweenDataInfo>& copy_data = m_work_info.m_host_variables_copy_data;
     copy_data.clear();
     copy_data.reserve(m_material_mng->nbVariable());
 
@@ -777,7 +777,7 @@ _copyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args)
     functor::apply(m_material_mng, &MeshMaterialMng::visitVariables, func2);
     if (do_one_command) {
       // Copie 'copy_data' dans le tableau correspondant pour le device éventuel.
-      MDSpan<CopyBetweenPartialAndGlobalOneData, MDDim1> x(copy_data.data(), MDIndex<1>(copy_data.size()));
+      MDSpan<CopyBetweenDataInfo, MDDim1> x(copy_data.data(), MDIndex<1>(copy_data.size()));
       m_work_info.m_variables_copy_data.copy(x, &queue);
       _applyCopyBetweenPartialsAndGlobals(args2, queue);
     }
@@ -804,8 +804,8 @@ _applyCopyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args,
 
   if (is_global_to_partial)
     std::swap(output_indexes, input_indexes);
-  SmallSpan<const CopyBetweenPartialAndGlobalOneData> host_copy_data(m_work_info.m_host_variables_copy_data);
-  SmallSpan<const CopyBetweenPartialAndGlobalOneData> copy_data(m_work_info.m_variables_copy_data.to1DSmallSpan());
+  SmallSpan<const CopyBetweenDataInfo> host_copy_data(m_work_info.m_host_variables_copy_data);
+  SmallSpan<const CopyBetweenDataInfo> copy_data(m_work_info.m_variables_copy_data.to1DSmallSpan());
   const Int32 nb_value = input_indexes.size();
   if (nb_value != output_indexes.size())
     ARCANE_FATAL("input_indexes ({0}) and output_indexes ({1}) are different", nb_value, output_indexes);

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -870,17 +870,20 @@ _applyCopyVariableViews(RunQueue& queue)
   if (nb_copy == 0)
     return;
 
-  for (Int32 i = 0; i < nb_copy; ++i) {
-    ARCANE_CHECK_ACCESSIBLE_POINTER(queue, host_copy_data[i].m_output.data());
-    ARCANE_CHECK_ACCESSIBLE_POINTER(queue, host_copy_data[i].m_input.data());
-  }
-
   // Suppose que toutes les vues ont les mêmes tailles.
   // C'est le cas car les vues sont composées de 'ArrayView<>' et 'Array2View' et ces
   // deux classes ont la même taille.
   // TODO: il serait préférable de prendre le max des tailles et dans la commande
   // de ne faire la copie que si on ne dépasse pas la taille.
-  Int32 nb_value = host_copy_data[0].m_input.constSmallView().size();
+  Int32 nb_value = host_copy_data[0].m_input.size();
+
+  for (Int32 i = 0; i < nb_copy; ++i) {
+    const CopyBetweenDataInfo& h = host_copy_data[i];
+    ARCANE_CHECK_ACCESSIBLE_POINTER(queue, h.m_output.data());
+    ARCANE_CHECK_ACCESSIBLE_POINTER(queue, h.m_input.data());
+    if (h.m_input.size() != nb_value)
+      ARCANE_FATAL("Invalid nb_value '{0} i={1} expected={2}", h.m_input.size(), nb_value);
+  }
 
   auto command = makeCommand(queue);
   command << RUNCOMMAND_LOOP2(iter, nb_copy, nb_value)

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -709,7 +709,7 @@ _removeItemsInGroup(ItemGroup cells, SmallSpan<const Int32> removed_ids)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Redimensionne l'index \a var_index des variables
+ * \brief Redimensionne l'index \a var_index des variables.
  */
 void IncrementalComponentModifier::
 _resizeVariablesIndexer(Int32 var_index)
@@ -718,7 +718,10 @@ _resizeVariablesIndexer(Int32 var_index)
   RunQueue::ScopedAsync sc(&m_queue);
   Accelerator::ProfileRegion ps(queue, "ResizeVariableIndexer");
   ResizeVariableIndexerArgs resize_args(var_index, queue);
-  bool do_one_command = true;
+  // Regarde si on n'utilise qu'une seule commande pour les copies des vues.
+  // Pour l'instant (novembre 2024) on ne l'utilise par défaut que si
+  // on est sur accélérateur.
+  bool do_one_command = (m_use_generic_copy_between_pure_and_partial == 2);
   UniqueArray<CopyBetweenDataInfo>& copy_data = m_work_info.m_host_variables_copy_data;
   if (do_one_command) {
     copy_data.clear();

--- a/arcane/src/arcane/materials/IncrementalComponentModifier.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier.cc
@@ -714,17 +714,16 @@ _removeItemsInGroup(ItemGroup cells, SmallSpan<const Int32> removed_ids)
 void IncrementalComponentModifier::
 _resizeVariablesIndexer(Int32 var_index)
 {
-  Accelerator::RunQueuePool& queue_pool = m_material_mng->_internalApi()->asyncRunQueuePool();
-  Accelerator::ProfileRegion ps(queue_pool[0],"ResizeVariableIndexer");
-
-  Int32 index = 0;
+  RunQueue& queue = m_material_mng->_internalApi()->runQueue();
+  RunQueue::ScopedAsync sc(&m_queue);
+  Accelerator::ProfileRegion ps(queue, "ResizeVariableIndexer");
+  ResizeVariableIndexerArgs resize_args(var_index, queue);
   auto func1 = [&](IMeshMaterialVariable* mv) {
     auto* mvi = mv->_internalApi();
-    mvi->resizeForIndexer(var_index, queue_pool[index]);
-    ++index;
+    mvi->resizeForIndexer(resize_args);
   };
   functor::apply(m_material_mng, &MeshMaterialMng::visitVariables, func1);
-  queue_pool.barrier();
+  queue.barrier();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -393,8 +393,8 @@ _resizeForIndexer(ResizeVariableIndexerArgs& args)
     this->_setView(index + 1);
   }
   if (args.isUseOneCommand()) {
-    auto dest = asWritableBytes(m_device_views);
-    auto source = asBytes(m_host_views);
+    auto dest = asWritableBytes(m_device_views).smallView();
+    auto source = asBytes(m_host_views).smallView();
     args.addOneCopyData(source,dest,1);
   }
   else
@@ -445,8 +445,8 @@ _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args)
   }
   if (use_generic) {
     Int32 data_type_size = dataTypeSize();
-    Span<const std::byte> input_bytes(Traits::toBytes(input));
-    Span<std::byte> output_bytes(Traits::toBytes(output));
+    SmallSpan<const std::byte> input_bytes(Traits::toBytes(input));
+    SmallSpan<std::byte> output_bytes(Traits::toBytes(output));
     if (args.isUseOneCommand())
       args.addOneCopyData(input_bytes, output_bytes, data_type_size);
     else

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -374,8 +374,10 @@ _isValidAndUsedAndGlobalUsed(PrivatePartType* partial_var)
 
 template <typename Traits> void
 ItemMaterialVariableBase<Traits>::
-_resizeForIndexer(Int32 index, RunQueue& queue)
+_resizeForIndexer(ResizeVariableIndexerArgs& args)
 {
+  Int32 index = args.m_var_index;
+  RunQueue& queue = args.m_queue;
   _setView(0);
   PrivatePartType* partial_var = m_vars[index + 1];
   if (_isValidAndUsedAndGlobalUsed(partial_var)) {
@@ -400,13 +402,15 @@ template <typename Traits> void
 ItemMaterialVariableBase<Traits>::
 _copyHostViewsToViews(RunQueue* queue)
 {
+  auto dest = asWritableBytes(m_device_views);
+  auto source = asBytes(m_host_views);
   if (queue) {
-    Accelerator::MemoryCopyArgs copy_args(asWritableBytes(m_device_views),asBytes(m_host_views));
+    Accelerator::MemoryCopyArgs copy_args(dest,source);
     copy_args.addAsync(true);
     queue->copyMemory(copy_args);
   }
   else
-    MemoryUtils::copy(asWritableBytes(m_device_views),asBytes(m_host_views));
+    MemoryUtils::copy(dest,source);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -392,7 +392,13 @@ _resizeForIndexer(ResizeVariableIndexerArgs& args)
     Traits::resizeWithReserve(partial_var, indexers[index]->maxIndexInMultipleArray(), ratio);
     this->_setView(index + 1);
   }
-  _copyHostViewsToViews(&queue);
+  if (args.isUseOneCommand()) {
+    auto dest = asWritableBytes(m_device_views);
+    auto source = asBytes(m_host_views);
+    args.addOneCopyData(source,dest,1);
+  }
+  else
+    _copyHostViewsToViews(&queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -168,9 +168,9 @@ syncReferences(bool check_resize)
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialVariablePrivate::
-resizeForIndexer(Int32 index, RunQueue& queue)
+resizeForIndexer(ResizeVariableIndexerArgs& args)
 {
-  m_variable->_resizeForIndexer(index, queue);
+  m_variable->_resizeForIndexer(args);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -209,10 +209,10 @@ class MaterialVariableScalarTraits
   ARCANE_MATERIALS_EXPORT static void
   resizeWithReserve(PrivatePartType* var, Int32 new_size, Real reserve_ratio);
   static Integer dimension() { return 0; }
-  static Span<std::byte> toBytes(ArrayView<DataType> view)
+  static SmallSpan<std::byte> toBytes(ArrayView<DataType> view)
   {
-    Span<DataType> s(view);
-    return asWritableBytes(s);
+    SmallSpan<DataType> s(view);
+    return asWritableBytes(s).smallView();
   }
 
 };
@@ -260,10 +260,10 @@ class MaterialVariableArrayTraits
   }
   ARCANE_MATERIALS_EXPORT
   static void resizeWithReserve(PrivatePartType* var, Integer new_size, Real resize_ratio);
-  static Span<std::byte> toBytes(Array2View<DataType> view)
+  static SmallSpan<std::byte> toBytes(Array2View<DataType> view)
   {
-    Span<DataType> s(view.data(),view.totalNbElement());
-    return asWritableBytes(s);
+    SmallSpan<DataType> s(view.data(), view.totalNbElement());
+    return asWritableBytes(s).smallView();
   }
 
   static Integer dimension() { return 0; }

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -52,6 +52,7 @@ class MaterialVariableBuildInfo;
 class MeshMaterialVariablePrivate;
 class MeshMaterialVariableSynchronizerList;
 class CopyBetweenPartialAndGlobalArgs;
+class ResizeVariableIndexerArgs;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -153,7 +154,7 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariable
   virtual void _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
   virtual void _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
   virtual void _syncReferences(bool update_views) = 0;
-  virtual void _resizeForIndexer(Int32 index, RunQueue& queue) = 0;
+  virtual void _resizeForIndexer(ResizeVariableIndexerArgs& args) = 0;
 
  private:
 
@@ -354,7 +355,7 @@ class ItemMaterialVariableBase
   ARCANE_MATERIALS_EXPORT void
   _fillPartialValuesWithSuperValues(MeshComponentList components);
   ARCANE_MATERIALS_EXPORT void _syncReferences(bool check_resize) override;
-  ARCANE_MATERIALS_EXPORT void _resizeForIndexer(Int32 index, RunQueue& queue) override;
+  ARCANE_MATERIALS_EXPORT void _resizeForIndexer(ResizeVariableIndexerArgs& args) override;
   ARCANE_MATERIALS_EXPORT void _copyHostViewsToViews(RunQueue* queue);
 
  public:

--- a/arcane/src/arcane/materials/internal/ConstituentModifierWorkInfo.h
+++ b/arcane/src/arcane/materials/internal/ConstituentModifierWorkInfo.h
@@ -89,10 +89,10 @@ class ARCANE_MATERIALS_EXPORT ConstituentModifierWorkInfo
   ComponentItemListBuilder list_builder;
 
   //! Informations pour les copies entre valeurs partielles et globales.
-  UniqueArray<CopyBetweenPartialAndGlobalOneData> m_host_variables_copy_data;
+  UniqueArray<CopyBetweenDataInfo> m_host_variables_copy_data;
 
   //! Informations pour les copies entre valeurs partielles et globales.
-  NumArray<CopyBetweenPartialAndGlobalOneData, MDDim1> m_variables_copy_data;
+  NumArray<CopyBetweenDataInfo, MDDim1> m_variables_copy_data;
 
  public:
 

--- a/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
+++ b/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
@@ -78,6 +78,7 @@ class ARCANE_MATERIALS_EXPORT IncrementalComponentModifier
                           SmallSpan<const Int32> local_ids);
   void _removeItemsInGroup(ItemGroup cells,SmallSpan<const Int32> removed_ids);
   void _applyCopyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args, RunQueue& queue);
+  void _applyCopyVariableViews(RunQueue& queue);
 
  private:
 

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
@@ -81,7 +81,7 @@ class MeshMaterialVariablePrivate
     return m_refs.view();
   }
   void syncReferences(bool check_resize) override;
-  void resizeForIndexer(Int32 index, RunQueue& queue) override;
+  void resizeForIndexer(ResizeVariableIndexerArgs& args) override;
 
  public:
 


### PR DESCRIPTION
Before this MR, there was one memory copy for each variable. Because the view is small (often less than one 1kB) the overhead for each copy was important.