### PR TITLE
Remove usage of 'MatVarIndex' in 'ComponentItemListBuilder'

### DIFF
--- a/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
@@ -263,6 +263,8 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
 
   SmallSpan<MatVarIndex> pure_matvar_indexes = list_builder.pureMatVarIndexes();
   SmallSpan<MatVarIndex> partial_matvar_indexes = list_builder.partialMatVarIndexes();
+  SmallSpan<Int32> pure_indexes = list_builder.pureIndexes();
+  SmallSpan<Int32> partial_indexes = list_builder.partialIndexes();
   SmallSpan<Int32> partial_local_ids = list_builder.partialLocalIds();
   Int32 nb_pure_added = 0;
   Int32 nb_partial_added = 0;
@@ -286,6 +288,7 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
     };
     auto setter_lambda = [=] ARCCORE_HOST_DEVICE(Int32 input_index, Int32 output_index) {
       Int32 local_id = local_ids[input_index];
+      pure_indexes[output_index] = local_id;
       pure_matvar_indexes[output_index] = MatVarIndex(0, local_id);
     };
     filterer.applyWithIndex(n, select_lambda, setter_lambda, A_FUNCINFO);
@@ -298,6 +301,7 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
     };
     auto setter_lambda = [=] ARCCORE_HOST_DEVICE(Int32 input_index, Int32 output_index) {
       Int32 local_id = local_ids[input_index];
+      partial_indexes[output_index] = index_in_partial + output_index;
       partial_matvar_indexes[output_index] = MatVarIndex(component_index, index_in_partial + output_index);
       partial_local_ids[output_index] = local_id;
     };

--- a/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
@@ -261,16 +261,12 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
   const Int32 n = local_ids.size();
   list_builder.preAllocate(n);
 
-  SmallSpan<MatVarIndex> pure_matvar_indexes = list_builder.pureMatVarIndexes();
-  SmallSpan<MatVarIndex> partial_matvar_indexes = list_builder.partialMatVarIndexes();
   SmallSpan<Int32> pure_indexes = list_builder.pureIndexes();
   SmallSpan<Int32> partial_indexes = list_builder.partialIndexes();
   SmallSpan<Int32> partial_local_ids = list_builder.partialLocalIds();
   Int32 nb_pure_added = 0;
   Int32 nb_partial_added = 0;
   Int32 index_in_partial = var_indexer->maxIndexInMultipleArray();
-
-  const Int32 component_index = var_indexer->index() + 1;
 
   SmallSpan<const bool> cells_is_partial = m_work_info.m_cells_is_partial;
 
@@ -289,7 +285,6 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
     auto setter_lambda = [=] ARCCORE_HOST_DEVICE(Int32 input_index, Int32 output_index) {
       Int32 local_id = local_ids[input_index];
       pure_indexes[output_index] = local_id;
-      pure_matvar_indexes[output_index] = MatVarIndex(0, local_id);
     };
     filterer.applyWithIndex(n, select_lambda, setter_lambda, A_FUNCINFO);
     nb_pure_added = filterer.nbOutputElement();
@@ -302,7 +297,6 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
     auto setter_lambda = [=] ARCCORE_HOST_DEVICE(Int32 input_index, Int32 output_index) {
       Int32 local_id = local_ids[input_index];
       partial_indexes[output_index] = index_in_partial + output_index;
-      partial_matvar_indexes[output_index] = MatVarIndex(component_index, index_in_partial + output_index);
       partial_local_ids[output_index] = local_id;
     };
     filterer.applyWithIndex(n, select_lambda, setter_lambda, A_FUNCINFO);
@@ -313,10 +307,10 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
 
   if (traceMng()->verbosityLevel() >= 5)
     info() << "ADD_MATITEM_TO_INDEXER component=" << var_indexer->name()
-           << " nb_pure=" << list_builder.pureMatVarIndexes().size()
-           << " nb_partial=" << list_builder.partialMatVarIndexes().size()
-           << "\n pure=(" << list_builder.pureMatVarIndexes() << ")"
-           << "\n partial=(" << list_builder.partialMatVarIndexes() << ")";
+           << " nb_pure=" << list_builder.pureIndexes().size()
+           << " nb_partial=" << list_builder.partialIndexes().size()
+           << "\n pure=(" << list_builder.pureIndexes() << ")"
+           << "\n partial=(" << list_builder.partialIndexes() << ")";
 
   // TODO: lors de cet appel, on connait le max de \a index_in_partial donc
   // on peut éviter de faire une réduction pour le recalculer.

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -483,12 +483,10 @@ _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queu
   DataType zero = DataType();
 
   auto command = makeCommand(queue);
-  SmallSpan<ContainerViewType> views = m_device_views.smallSpan();
 
   ContainerSpanType partial_view = m_host_views[var_index + 1];
   ContainerSpanType pure_view = m_host_views[0];
 
-  ARCANE_CHECK_ACCESSIBLE_POINTER(queue, views.data());
   ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_indexes.data());
 
   if (init_with_zero) {

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -473,9 +473,9 @@ _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queu
 
   bool init_with_zero = m_p->materialMng()->isDataInitialisationWithZero();
 
-  SmallSpan<const MatVarIndex> partial_matvar = list_builder.partialMatVarIndexes();
+  SmallSpan<const Int32> partial_indexes = list_builder.partialIndexes();
 
-  Integer nb_partial = partial_matvar.size();
+  Integer nb_partial = partial_indexes.size();
 
   // TODO: regarder s'il faut initialiser les mailles pure avec zéro.
   // En effet, normalement il n'y a pas de maille pure si on ajoute un matériau
@@ -489,14 +489,14 @@ _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queu
   ContainerSpanType pure_view = m_host_views[0];
 
   ARCANE_CHECK_ACCESSIBLE_POINTER(queue, views.data());
-  ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_matvar.data());
+  ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_indexes.data());
 
   if (init_with_zero) {
     command << RUNCOMMAND_LOOP1(iter, nb_partial)
     {
       auto [i] = iter();
-      MatVarIndex mvi = partial_matvar[i];
-      Traits::setValue(partial_view[mvi.valueIndex()], zero);
+      Int32 index = partial_indexes[i];
+      Traits::setValue(partial_view[index], zero);
     };
   }
   else {
@@ -505,8 +505,8 @@ _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queu
     command << RUNCOMMAND_LOOP1(iter, nb_partial)
     {
       auto [i] = iter();
-      MatVarIndex mvi = partial_matvar[i];
-      Traits::setValue(partial_view[mvi.valueIndex()], pure_view[partial_local_ids[i]]);
+      Int32 index = partial_indexes[i];
+      Traits::setValue(partial_view[index], pure_view[partial_local_ids[i]]);
     };
   }
 }

--- a/arcane/src/arcane/materials/internal/ComponentItemListBuilder.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemListBuilder.h
@@ -46,6 +46,8 @@ class ARCANE_MATERIALS_EXPORT ComponentItemListBuilder
     m_pure_matvar_indexes.resize(nb_item);
     m_partial_matvar_indexes.resize(nb_item);
     m_partial_local_ids.resize(nb_item);
+    m_pure_indexes.resize(nb_item);
+    m_partial_indexes.resize(nb_item);
   }
 
   void resize(Int32 nb_pure, Int32 nb_partial)
@@ -53,16 +55,22 @@ class ARCANE_MATERIALS_EXPORT ComponentItemListBuilder
     m_pure_matvar_indexes.resize(nb_pure);
     m_partial_matvar_indexes.resize(nb_partial);
     m_partial_local_ids.resize(nb_partial);
+    m_pure_indexes.resize(nb_pure);
+    m_partial_indexes.resize(nb_partial);
   }
 
  public:
 
   SmallSpan<MatVarIndex> pureMatVarIndexes() { return m_pure_matvar_indexes; }
   SmallSpan<MatVarIndex> partialMatVarIndexes() { return m_partial_matvar_indexes; }
+  SmallSpan<Int32> pureIndexes() { return m_pure_indexes; }
+  SmallSpan<Int32> partialIndexes() { return m_partial_indexes; }
   SmallSpan<Int32> partialLocalIds() { return m_partial_local_ids; }
 
   SmallSpan<const MatVarIndex> pureMatVarIndexes() const { return m_pure_matvar_indexes; }
   SmallSpan<const MatVarIndex> partialMatVarIndexes() const { return m_partial_matvar_indexes; }
+  SmallSpan<const Int32> pureIndexes() const { return m_pure_indexes; }
+  SmallSpan<const Int32> partialIndexes() const { return m_partial_indexes; }
   SmallSpan<const Int32> partialLocalIds() const { return m_partial_local_ids; }
 
   MeshMaterialVariableIndexer* indexer() const { return m_indexer; }
@@ -73,6 +81,8 @@ class ARCANE_MATERIALS_EXPORT ComponentItemListBuilder
   NumArray<MatVarIndex, MDDim1> m_pure_matvar_indexes;
   NumArray<MatVarIndex, MDDim1> m_partial_matvar_indexes;
   NumArray<Int32, MDDim1> m_partial_local_ids;
+  NumArray<Int32, MDDim1> m_pure_indexes;
+  NumArray<Int32, MDDim1> m_partial_indexes;
 
   MeshMaterialVariableIndexer* m_indexer = nullptr;
 };

--- a/arcane/src/arcane/materials/internal/ComponentItemListBuilder.h
+++ b/arcane/src/arcane/materials/internal/ComponentItemListBuilder.h
@@ -43,8 +43,6 @@ class ARCANE_MATERIALS_EXPORT ComponentItemListBuilder
 
   void preAllocate(Int32 nb_item)
   {
-    m_pure_matvar_indexes.resize(nb_item);
-    m_partial_matvar_indexes.resize(nb_item);
     m_partial_local_ids.resize(nb_item);
     m_pure_indexes.resize(nb_item);
     m_partial_indexes.resize(nb_item);
@@ -52,8 +50,6 @@ class ARCANE_MATERIALS_EXPORT ComponentItemListBuilder
 
   void resize(Int32 nb_pure, Int32 nb_partial)
   {
-    m_pure_matvar_indexes.resize(nb_pure);
-    m_partial_matvar_indexes.resize(nb_partial);
     m_partial_local_ids.resize(nb_partial);
     m_pure_indexes.resize(nb_pure);
     m_partial_indexes.resize(nb_partial);
@@ -61,14 +57,10 @@ class ARCANE_MATERIALS_EXPORT ComponentItemListBuilder
 
  public:
 
-  SmallSpan<MatVarIndex> pureMatVarIndexes() { return m_pure_matvar_indexes; }
-  SmallSpan<MatVarIndex> partialMatVarIndexes() { return m_partial_matvar_indexes; }
   SmallSpan<Int32> pureIndexes() { return m_pure_indexes; }
   SmallSpan<Int32> partialIndexes() { return m_partial_indexes; }
   SmallSpan<Int32> partialLocalIds() { return m_partial_local_ids; }
 
-  SmallSpan<const MatVarIndex> pureMatVarIndexes() const { return m_pure_matvar_indexes; }
-  SmallSpan<const MatVarIndex> partialMatVarIndexes() const { return m_partial_matvar_indexes; }
   SmallSpan<const Int32> pureIndexes() const { return m_pure_indexes; }
   SmallSpan<const Int32> partialIndexes() const { return m_partial_indexes; }
   SmallSpan<const Int32> partialLocalIds() const { return m_partial_local_ids; }
@@ -78,8 +70,6 @@ class ARCANE_MATERIALS_EXPORT ComponentItemListBuilder
 
  private:
 
-  NumArray<MatVarIndex, MDDim1> m_pure_matvar_indexes;
-  NumArray<MatVarIndex, MDDim1> m_partial_matvar_indexes;
   NumArray<Int32, MDDim1> m_partial_local_ids;
   NumArray<Int32, MDDim1> m_pure_indexes;
   NumArray<Int32, MDDim1> m_partial_indexes;


### PR DESCRIPTION
This is no longer needed. Only the indexes in the pure or impure lists are needed.