### PR TITLE
Move classes 'ItemBase' and 'MutableItemBase' in public API

### DIFF
--- a/arcane/src/arcane/core/ItemInternal.h
+++ b/arcane/src/arcane/core/ItemInternal.h
@@ -44,11 +44,6 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-namespace Arcane::impl
-{
-class ItemBase;
-}
-
 namespace Arcane::mesh
 {
 class IncrementalItemConnectivityBase;
@@ -95,7 +90,7 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
   // IMPORTANT: Cette structure doit avoir le même agencement mémoire
   // que la structure C# de même nom.
 
-  friend class impl::ItemBase;
+  friend class ItemBase;
   friend class ItemInternal;
   friend class Item;
 
@@ -417,11 +412,6 @@ class ARCANE_CORE_EXPORT ItemInternalConnectivityList
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-namespace impl
-{
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 /*!
  * \brief Classe de base pour les entités du maillage.
  *
@@ -685,15 +675,15 @@ class ARCANE_CORE_EXPORT ItemBase
    * se traduit par un débordement de tableau.
    */
   //@{
-  ItemIndexedListView<DynExtent> nodeList() const { return _connectivity()->nodeList(m_local_id); }
-  ItemIndexedListView<DynExtent> edgeList() const { return _connectivity()->edgeList(m_local_id); }
-  ItemIndexedListView<DynExtent> faceList() const { return _connectivity()->faceList(m_local_id); }
-  ItemIndexedListView<DynExtent> cellList() const { return _connectivity()->cellList(m_local_id); }
+  impl::ItemIndexedListView<DynExtent> nodeList() const { return _connectivity()->nodeList(m_local_id); }
+  impl::ItemIndexedListView<DynExtent> edgeList() const { return _connectivity()->edgeList(m_local_id); }
+  impl::ItemIndexedListView<DynExtent> faceList() const { return _connectivity()->faceList(m_local_id); }
+  impl::ItemIndexedListView<DynExtent> cellList() const { return _connectivity()->cellList(m_local_id); }
 
-  ItemIndexedListView<DynExtent> itemList(Node*) const { return nodeList(); }
-  ItemIndexedListView<DynExtent> itemList(Edge*) const { return edgeList(); }
-  ItemIndexedListView<DynExtent> itemList(Face*) const { return faceList(); }
-  ItemIndexedListView<DynExtent> itemList(Cell*) const { return cellList(); }
+  impl::ItemIndexedListView<DynExtent> itemList(Node*) const { return nodeList(); }
+  impl::ItemIndexedListView<DynExtent> itemList(Edge*) const { return edgeList(); }
+  impl::ItemIndexedListView<DynExtent> itemList(Face*) const { return faceList(); }
+  impl::ItemIndexedListView<DynExtent> itemList(Cell*) const { return cellList(); }
   //@}
 
   ItemBase nodeBase(Int32 index) const { return _connectivity()->nodeBase(m_local_id,index); }
@@ -891,11 +881,6 @@ class ARCANE_CORE_EXPORT MutableItemBase
 
   inline void _setFaceInfos(Int32 mod_flags);
 };
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-} // End namespace impl
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemInternalVectorView.h
+++ b/arcane/src/arcane/core/ItemInternalVectorView.h
@@ -1,23 +1,23 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemInternalVectorView.h                                    (C) 2000-2023 */
+/* ItemInternalVectorView.h                                    (C) 2000-2024 */
 /*                                                                           */
 /* Vue sur un vecteur (tableau indirect) d'entités.                          */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ITEMINTERNALVECTORVIEW_H
-#define ARCANE_ITEMINTERNALVECTORVIEW_H
+#ifndef ARCANE_CORE_ITEMINTERNALVECTORVIEW_H
+#define ARCANE_CORE_ITEMINTERNALVECTORVIEW_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/ArrayView.h"
-#include "arcane/ItemTypes.h"
-#include "arcane/ItemSharedInfo.h"
-#include "arcane/ItemIndexedListView.h"
+#include "arcane/core/ItemTypes.h"
+#include "arcane/core/ItemSharedInfo.h"
+#include "arcane/core/ItemIndexedListView.h"
 
 #include <iterator>
 
@@ -126,7 +126,7 @@ class ARCANE_CORE_EXPORT ItemInternalVectorView
 
   friend class ItemVectorView;
   friend class ItemInternalConnectivityList;
-  friend class impl::ItemBase;
+  friend class ItemBase;
   friend class ItemEnumeratorBase;
   friend class SimdItemEnumeratorBase;
   friend class ItemInternalEnumerator;

--- a/arcane/src/arcane/core/ItemSharedInfo.h
+++ b/arcane/src/arcane/core/ItemSharedInfo.h
@@ -1,23 +1,23 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemSharedInfo.h                                            (C) 2000-2023 */
+/* ItemSharedInfo.h                                            (C) 2000-2024 */
 /*                                                                           */
 /* Informations communes à plusieurs entités.                                */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ITEMSHAREDINFO_H
-#define ARCANE_ITEMSHAREDINFO_H
+#ifndef ARCANE_CORE_ITEMSHAREDINFO_H
+#define ARCANE_CORE_ITEMSHAREDINFO_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ArcaneTypes.h"
-#include "arcane/ItemTypes.h"
-#include "arcane/ItemTypeInfo.h"
-#include "arcane/MeshItemInternalList.h"
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/ItemTypes.h"
+#include "arcane/core/ItemTypeInfo.h"
+#include "arcane/core/MeshItemInternalList.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -53,8 +53,8 @@ class ItemInternalConnectivityList;
  */
 class ARCANE_CORE_EXPORT ItemSharedInfo
 {
-  friend class impl::ItemBase;
-  friend class impl::MutableItemBase;
+  friend class ItemBase;
+  friend class MutableItemBase;
   friend class Item;
   friend class ItemGenericInfoListView;
   friend class ItemInternal;

--- a/arcane/src/arcane/core/ItemTypes.h
+++ b/arcane/src/arcane/core/ItemTypes.h
@@ -59,10 +59,12 @@ class DoF;
 class Item;
 class ItemWithNodes;
 class ItemInternal;
-namespace impl
-{
 class ItemBase;
 class MutableItemBase;
+namespace impl
+{
+using ItemBase = ::Arcane::ItemBase;
+using MutableItemBase = ::Arcane::MutableItemBase;
 template<int Extent = DynExtent> class ItemIndexedListView;
 class ItemLocalIdListContainerView;
 }

--- a/arcane/src/arcane/core/MeshItemInternalList.h
+++ b/arcane/src/arcane/core/MeshItemInternalList.h
@@ -1,21 +1,21 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshItemInternalList.h                                      (C) 2000-2022 */
+/* MeshItemInternalList.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Tableaux d'indirection sur les entités d'un maillage.                     */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_MESHITEMINTERNALLIST_H
-#define ARCANE_MESHITEMINTERNALLIST_H
+#ifndef ARCANE_CORE_MESHITEMINTERNALLIST_H
+#define ARCANE_CORE_MESHITEMINTERNALLIST_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/ArrayView.h"
-#include "arcane/ItemTypes.h"
+#include "arcane/core/ItemTypes.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ class ARCANE_CORE_EXPORT MeshItemInternalList
   friend class mesh::PolyhedralMesh;
 
   friend class ItemInternalConnectivityList;
-  friend class impl::ItemBase;
+  friend class ItemBase;
 
  public:
 

--- a/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
+++ b/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
@@ -31,14 +31,13 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-namespace Arcane::impl
+namespace Arcane
 {
 class ItemBase;
 }
-
 namespace Arcane::Materials::matimpl
 {
-using Arcane::impl::ItemBase;
+using ::Arcane::ItemBase;
 class ConstituentItemBase;
 }
 


### PR DESCRIPTION
These classes are moved from namespace `Arcane::impl` to namespace `Arcane`.
