### PR TITLE
Use one kernel when initializing new ConstituentItem from global values

### DIFF
--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -184,8 +184,11 @@ class ARCANE_CORE_EXPORT IMeshMaterialVariableInternal
   //! \internal
   virtual void copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
 
-  //! \internal
-  virtual void initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
+  //! Initialize les valeurs des nouveaux constituants avec la valeur zéro
+  virtual void initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
+
+  //! Initialize les valeurs des nouveaux constituants avec les valeurs des mailles pures
+  virtual void initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
 
   //! Liste des 'VariableRef' associées à cette variable.
   virtual ConstArrayView<VariableRef*> variableReferenceList() const =0;

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialVariableInternal.h
@@ -187,9 +187,6 @@ class ARCANE_CORE_EXPORT IMeshMaterialVariableInternal
   //! Initialize les valeurs des nouveaux constituants avec la valeur zéro
   virtual void initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
 
-  //! Initialize les valeurs des nouveaux constituants avec les valeurs des mailles pures
-  virtual void initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
-
   //! Liste des 'VariableRef' associées à cette variable.
   virtual ConstArrayView<VariableRef*> variableReferenceList() const =0;
 

--- a/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
@@ -327,8 +327,13 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
       Accelerator::ProfileRegion ps(m_queue, "InitializeNewItems", 0xFFFF00);
       RunQueue::ScopedAsync sc(&m_queue);
       IMeshMaterialMng* mm = m_material_mng;
+      bool init_with_zero = mm->isDataInitialisationWithZero();
+
       auto func = [&](IMeshMaterialVariable* mv) {
-        mv->_internalApi()->initializeNewItems(list_builder, m_queue);
+        if (init_with_zero)
+          mv->_internalApi()->initializeNewItemsWithZero(list_builder, m_queue);
+        else
+          mv->_internalApi()->initializeNewItemsWithPureValues(list_builder, m_queue);
       };
       functor::apply(mm, &IMeshMaterialMng::visitVariables, func);
       m_queue.barrier();

--- a/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
+++ b/arcane/src/arcane/materials/IncrementalComponentModifier_Accelerator.cc
@@ -251,15 +251,15 @@ _computeCellsToTransformForEnvironments(SmallSpan<const Int32> ids)
 /*---------------------------------------------------------------------------*/
 
 void IncrementalComponentModifier::
-_addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
-                   SmallSpan<const Int32> local_ids)
+_computeItemsToAdd(ComponentItemListBuilder& list_builder, SmallSpan<const Int32> local_ids)
 {
-  // TODO Conserver l'instance au cours de toutes modifications
-  ComponentItemListBuilder& list_builder = m_work_info.list_builder;
-  list_builder.setIndexer(var_indexer);
+  SmallSpan<const bool> cells_is_partial = m_work_info.m_cells_is_partial;
 
-  const Int32 n = local_ids.size();
-  list_builder.preAllocate(n);
+  Accelerator::GenericFilterer filterer(m_queue);
+
+  MeshMaterialVariableIndexer* var_indexer = list_builder.indexer();
+
+  const Int32 nb_id = local_ids.size();
 
   SmallSpan<Int32> pure_indexes = list_builder.pureIndexes();
   SmallSpan<Int32> partial_indexes = list_builder.partialIndexes();
@@ -267,10 +267,6 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
   Int32 nb_pure_added = 0;
   Int32 nb_partial_added = 0;
   Int32 index_in_partial = var_indexer->maxIndexInMultipleArray();
-
-  SmallSpan<const bool> cells_is_partial = m_work_info.m_cells_is_partial;
-
-  Accelerator::GenericFilterer filterer(m_queue);
 
   // TODO: pour l'instant on remplit en deux fois mais il serait
   // possible de le faire en une seule fois en utilisation l'algorithme de Partition.
@@ -286,7 +282,7 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
       Int32 local_id = local_ids[input_index];
       pure_indexes[output_index] = local_id;
     };
-    filterer.applyWithIndex(n, select_lambda, setter_lambda, A_FUNCINFO);
+    filterer.applyWithIndex(nb_id, select_lambda, setter_lambda, A_FUNCINFO);
     nb_pure_added = filterer.nbOutputElement();
   }
   // Remplit la liste des mailles partielles
@@ -299,46 +295,11 @@ _addItemsToIndexer(MeshMaterialVariableIndexer* var_indexer,
       partial_indexes[output_index] = index_in_partial + output_index;
       partial_local_ids[output_index] = local_id;
     };
-    filterer.applyWithIndex(n, select_lambda, setter_lambda, A_FUNCINFO);
+    filterer.applyWithIndex(nb_id, select_lambda, setter_lambda, A_FUNCINFO);
     nb_partial_added = filterer.nbOutputElement();
   }
 
   list_builder.resize(nb_pure_added, nb_partial_added);
-
-  if (traceMng()->verbosityLevel() >= 5)
-    info() << "ADD_MATITEM_TO_INDEXER component=" << var_indexer->name()
-           << " nb_pure=" << list_builder.pureIndexes().size()
-           << " nb_partial=" << list_builder.partialIndexes().size()
-           << "\n pure=(" << list_builder.pureIndexes() << ")"
-           << "\n partial=(" << list_builder.partialIndexes() << ")";
-
-  // TODO: lors de cet appel, on connait le max de \a index_in_partial donc
-  // on peut éviter de faire une réduction pour le recalculer.
-
-  var_indexer->endUpdateAdd(list_builder, m_queue);
-
-  // Maintenant que les nouveaux MatVar sont créés, il faut les
-  // initialiser avec les bonnes valeurs.
-  {
-    _resizeVariablesIndexer(var_indexer->index());
-    // TODO: Comme tout est indépendant par variable, on pourrait
-    // éventuellement utiliser plusieurs files.
-    if (m_do_init_new_items) {
-      Accelerator::ProfileRegion ps(m_queue, "InitializeNewItems", 0xFFFF00);
-      RunQueue::ScopedAsync sc(&m_queue);
-      IMeshMaterialMng* mm = m_material_mng;
-      bool init_with_zero = mm->isDataInitialisationWithZero();
-
-      auto func = [&](IMeshMaterialVariable* mv) {
-        if (init_with_zero)
-          mv->_internalApi()->initializeNewItemsWithZero(list_builder, m_queue);
-        else
-          mv->_internalApi()->initializeNewItemsWithPureValues(list_builder, m_queue);
-      };
-      functor::apply(mm, &IMeshMaterialMng::visitVariables, func);
-      m_queue.barrier();
-    }
-  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -492,29 +492,6 @@ _initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQue
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template <typename Traits> void
-ItemMaterialVariableBase<Traits>::
-_initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue)
-{
-  MeshMaterialVariableIndexer* indexer = list_builder.indexer();
-  Int32 var_index = indexer->index();
-  PrivatePartType* partial_var = m_vars[var_index + 1];
-  if (!_isValidAndUsedAndGlobalUsed(partial_var))
-    return;
-
-  SmallSpan<const Int32> partial_indexes = list_builder.partialIndexes();
-  SmallSpan<const Int32> partial_local_ids = list_builder.partialLocalIds();
-
-  ContainerSpanType partial_view = m_host_views[var_index + 1];
-  ContainerSpanType pure_view = m_host_views[0];
-
-  ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_indexes.data());
-  Traits::copyTo(pure_view,partial_local_ids,partial_view,partial_indexes,queue);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 template<typename Traits> void
 ItemMaterialVariableBase<Traits>::
 fillPartialValuesWithGlobalValues()

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -503,23 +503,13 @@ _initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, 
     return;
 
   SmallSpan<const Int32> partial_indexes = list_builder.partialIndexes();
-
-  Int32 nb_partial = partial_indexes.size();
+  SmallSpan<const Int32> partial_local_ids = list_builder.partialLocalIds();
 
   ContainerSpanType partial_view = m_host_views[var_index + 1];
   ContainerSpanType pure_view = m_host_views[0];
 
   ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_indexes.data());
-
-  auto command = makeCommand(queue);
-  SmallSpan<const Int32> partial_local_ids = list_builder.partialLocalIds();
-  ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_local_ids.data());
-  command << RUNCOMMAND_LOOP1(iter, nb_partial)
-  {
-    auto [i] = iter();
-    Int32 index = partial_indexes[i];
-    Traits::setValue(partial_view[index], pure_view[partial_local_ids[i]]);
-  };
+  Traits::copyTo(pure_view,partial_local_ids,partial_view,partial_indexes,queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
+++ b/arcane/src/arcane/materials/ItemMaterialVariableBaseT.H
@@ -461,9 +461,9 @@ _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename Traits> void
+template <typename Traits> void
 ItemMaterialVariableBase<Traits>::
-_initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue)
+_initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue)
 {
   MeshMaterialVariableIndexer* indexer = list_builder.indexer();
   Integer var_index = indexer->index();
@@ -471,42 +471,55 @@ _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queu
   if (!_isValidAndUsedAndGlobalUsed(partial_var))
     return;
 
-  bool init_with_zero = m_p->materialMng()->isDataInitialisationWithZero();
-
   SmallSpan<const Int32> partial_indexes = list_builder.partialIndexes();
 
   Integer nb_partial = partial_indexes.size();
 
-  // TODO: regarder s'il faut initialiser les mailles pure avec zéro.
-  // En effet, normalement il n'y a pas de maille pure si on ajoute un matériau
-  // (sauf lors de l'init).
-  DataType zero = DataType();
+  ContainerSpanType partial_view = m_host_views[var_index + 1];
 
+  ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_indexes.data());
+
+  DataType zero = DataType();
   auto command = makeCommand(queue);
+  command << RUNCOMMAND_LOOP1(iter, nb_partial)
+  {
+    auto [i] = iter();
+    Int32 index = partial_indexes[i];
+    Traits::setValue(partial_view[index], zero);
+  };
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template <typename Traits> void
+ItemMaterialVariableBase<Traits>::
+_initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue)
+{
+  MeshMaterialVariableIndexer* indexer = list_builder.indexer();
+  Int32 var_index = indexer->index();
+  PrivatePartType* partial_var = m_vars[var_index + 1];
+  if (!_isValidAndUsedAndGlobalUsed(partial_var))
+    return;
+
+  SmallSpan<const Int32> partial_indexes = list_builder.partialIndexes();
+
+  Int32 nb_partial = partial_indexes.size();
 
   ContainerSpanType partial_view = m_host_views[var_index + 1];
   ContainerSpanType pure_view = m_host_views[0];
 
   ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_indexes.data());
 
-  if (init_with_zero) {
-    command << RUNCOMMAND_LOOP1(iter, nb_partial)
-    {
-      auto [i] = iter();
-      Int32 index = partial_indexes[i];
-      Traits::setValue(partial_view[index], zero);
-    };
-  }
-  else {
-    SmallSpan<const Int32> partial_local_ids = list_builder.partialLocalIds();
-    ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_local_ids.data());
-    command << RUNCOMMAND_LOOP1(iter, nb_partial)
-    {
-      auto [i] = iter();
-      Int32 index = partial_indexes[i];
-      Traits::setValue(partial_view[index], pure_view[partial_local_ids[i]]);
-    };
-  }
+  auto command = makeCommand(queue);
+  SmallSpan<const Int32> partial_local_ids = list_builder.partialLocalIds();
+  ARCANE_CHECK_ACCESSIBLE_POINTER(queue, partial_local_ids.data());
+  command << RUNCOMMAND_LOOP1(iter, nb_partial)
+  {
+    auto [i] = iter();
+    Int32 index = partial_indexes[i];
+    Traits::setValue(partial_view[index], pure_view[partial_local_ids[i]]);
+  };
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -150,9 +150,18 @@ copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args)
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialVariablePrivate::
-initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue)
+initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue)
 {
-  m_variable->_initializeNewItems(list_builder, queue);
+  m_variable->_initializeNewItemsWithZero(list_builder, queue);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MeshMaterialVariablePrivate::
+initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue)
+{
+  m_variable->_initializeNewItemsWithPureValues(list_builder, queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -159,15 +159,6 @@ initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueu
 /*---------------------------------------------------------------------------*/
 
 void MeshMaterialVariablePrivate::
-initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue)
-{
-  m_variable->_initializeNewItemsWithPureValues(list_builder, queue);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void MeshMaterialVariablePrivate::
 syncReferences(bool check_resize)
 {
   m_variable->_syncReferences(check_resize);

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -153,7 +153,6 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariable
                             Int32ConstArrayView ids,bool allow_null_id) =0;
   virtual void _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
   virtual void _initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
-  virtual void _initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
   virtual void _syncReferences(bool update_views) = 0;
   virtual void _resizeForIndexer(ResizeVariableIndexerArgs& args) = 0;
 
@@ -325,8 +324,6 @@ class ItemMaterialVariableBase
   void _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
   ARCANE_MATERIALS_EXPORT
   void _initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
-  ARCANE_MATERIALS_EXPORT
-  void _initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
 
   ARCANE_MATERIALS_EXPORT void fillPartialValuesWithGlobalValues() override;
   ARCANE_MATERIALS_EXPORT void

--- a/arcane/src/arcane/materials/MeshMaterialVariable.h
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.h
@@ -152,7 +152,8 @@ class ARCANE_MATERIALS_EXPORT MeshMaterialVariable
   virtual void _restoreData(IMeshComponent* component,IData* data,Integer data_index,
                             Int32ConstArrayView ids,bool allow_null_id) =0;
   virtual void _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) = 0;
-  virtual void _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
+  virtual void _initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
+  virtual void _initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) = 0;
   virtual void _syncReferences(bool update_views) = 0;
   virtual void _resizeForIndexer(ResizeVariableIndexerArgs& args) = 0;
 
@@ -323,7 +324,9 @@ class ItemMaterialVariableBase
   ARCANE_MATERIALS_EXPORT
   void _copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
   ARCANE_MATERIALS_EXPORT
-  void _initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
+  void _initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
+  ARCANE_MATERIALS_EXPORT
+  void _initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
 
   ARCANE_MATERIALS_EXPORT void fillPartialValuesWithGlobalValues() override;
   ARCANE_MATERIALS_EXPORT void

--- a/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
+++ b/arcane/src/arcane/materials/internal/IncrementalComponentModifier.h
@@ -79,6 +79,7 @@ class ARCANE_MATERIALS_EXPORT IncrementalComponentModifier
   void _removeItemsInGroup(ItemGroup cells,SmallSpan<const Int32> removed_ids);
   void _applyCopyBetweenPartialsAndGlobals(const CopyBetweenPartialAndGlobalArgs& args, RunQueue& queue);
   void _applyCopyVariableViews(RunQueue& queue);
+  void _computeItemsToAdd(ComponentItemListBuilder& list_builder, SmallSpan<const Int32> local_ids);
 
  private:
 

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
@@ -74,7 +74,8 @@ class MeshMaterialVariablePrivate
 
   void copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
 
-  void initializeNewItems(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
+  void initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
+  void initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
 
   ConstArrayView<VariableRef*> variableReferenceList() const override
   {

--- a/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialVariablePrivate.h
@@ -75,7 +75,6 @@ class MeshMaterialVariablePrivate
   void copyBetweenPartialAndGlobal(const CopyBetweenPartialAndGlobalArgs& args) override;
 
   void initializeNewItemsWithZero(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
-  void initializeNewItemsWithPureValues(const ComponentItemListBuilder& list_builder, RunQueue& queue) override;
 
   ConstArrayView<VariableRef*> variableReferenceList() const override
   {


### PR DESCRIPTION
Before this MR there was one kernel per variable. Because the work is very small the overhead of multiple kernel launches was significant.
