### PR TITLE
Initialize variables in mesh services after application of additional services

### DIFF
--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
@@ -166,8 +166,6 @@ allocateMeshItems()
 
   m_mesh_builder->allocateMeshItems(m_mesh);
 
-  // TODO: Faire cela après les opérations additionnelles
-  _initializeVariables();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -194,6 +192,8 @@ applyAdditionalOperations()
   IMeshSubdivider* subdivider = options()->subdivider();
   if (subdivider)
     subdivider->subdivideMesh(m_mesh);
+
+  _initializeVariables();
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This way variables are initialized after the application of sub-divider service.
