### PR TITLE
Implement active cell api in polyhedral mesh

### DIFF
--- a/arcane/src/arcane/mesh/PolyhedralMesh.cc
+++ b/arcane/src/arcane/mesh/PolyhedralMesh.cc
@@ -1327,6 +1327,76 @@ removeItems(Int32ConstArrayView local_ids, eItemKind ik, const String& family_na
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+CellGroup mesh::PolyhedralMesh::
+allActiveCells()
+{
+  return allCells().activeCellGroup();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+CellGroup mesh::PolyhedralMesh::ownActiveCells()
+{
+  return allCells().ownActiveCellGroup();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+CellGroup mesh::PolyhedralMesh::
+allLevelCells(const Integer& level)
+{
+  return allCells().levelCellGroup(level);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+CellGroup mesh::PolyhedralMesh::
+ownLevelCells(const Integer& level)
+{
+  return allCells().ownLevelCellGroup(level);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+FaceGroup mesh::PolyhedralMesh::
+allActiveFaces()
+{
+  return allCells().activeFaceGroup();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+FaceGroup mesh::PolyhedralMesh::
+ownActiveFaces()
+{
+  return allCells().ownActiveFaceGroup();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+FaceGroup mesh::PolyhedralMesh::
+innerActiveFaces()
+{
+  return allCells().innerActiveFaceGroup();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+FaceGroup mesh::PolyhedralMesh::outerActiveFaces()
+{
+  return allCells().outerActiveFaceGroup();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 
 } // End namespace Arcane
 

--- a/arcane/src/arcane/mesh/PolyhedralMesh.h
+++ b/arcane/src/arcane/mesh/PolyhedralMesh.h
@@ -253,6 +253,16 @@ class PolyhedralMesh
   // For now, use _internalAPI()->polyhedralMeshModifier instead of IMeshModifier not implemented yet
   IMeshModifier* modifier() override {return nullptr;}
 
+  // AMR is not activated with Polyhedral mesh. All items are thus active.
+  CellGroup allActiveCells() override;
+  CellGroup ownActiveCells() override;
+  CellGroup allLevelCells(const Integer& level) override;
+  CellGroup ownLevelCells(const Integer& level) override;
+  FaceGroup allActiveFaces() override;
+  FaceGroup ownActiveFaces() override;
+  FaceGroup innerActiveFaces() override;
+  FaceGroup outerActiveFaces() override;
+
  private:
 
   void addItems(Int64ConstArrayView unique_ids, Int32ArrayView local_ids, eItemKind ik, const String& family_name);

--- a/arcane/src/arcane/tests/MeshPolyhedralTestModule.cc
+++ b/arcane/src/arcane/tests/MeshPolyhedralTestModule.cc
@@ -208,6 +208,19 @@ _testEnumerationAndConnectivities(IMesh* mesh)
       debug(Trace::High) << "edge node lid " << node.localId() << " uid " << node.uniqueId();
     }
   }
+  // Active items : no AMR available with polyhedral mesh but must return all items
+  bool is_active_ok = (mesh->allActiveCells().size() == mesh->allCells().size());
+  is_active_ok &= (mesh->ownActiveCells().size() == mesh->ownCells().size());
+  is_active_ok &= (mesh->allActiveFaces().size() == mesh->allFaces().size());
+  is_active_ok &= (mesh->ownFaces().size() == mesh->ownFaces().size());
+  is_active_ok &= (mesh->innerActiveFaces().size() == mesh->allCells().innerFaceGroup().size());
+  is_active_ok &= (mesh->outerActiveFaces().size() == mesh->outerFaces().size());
+  is_active_ok &= (mesh->allLevelCells(0).size() == mesh->allCells().size());
+  is_active_ok &= (mesh->ownLevelCells(0).size() == mesh->ownCells().size());
+  is_active_ok &= (mesh->allLevelCells(1).empty());
+  is_active_ok &= (mesh->ownLevelCells(1).empty());
+  if (!is_active_ok)
+    ARCANE_FATAL("Polyhedral mesh implem does not handle correctly activeCells methods. Should return all items.");
 }
 
 /*---------------------------------------------------------------------------*/
@@ -370,7 +383,8 @@ _testGroups(IMesh* mesh)
     vc.areEqual(group.size(), group_infos->getSize(), "check group size");
   }
   ValueChecker vc{ A_FUNCINFO };
-  auto nb_group = 8 + options()->nbMeshGroup;
+  auto nb_internal_group = 19;
+  auto nb_group = nb_internal_group + options()->nbMeshGroup;
   vc.areEqual(nb_group, mesh->groups().count(), "check number of groups in the mesh");
 
   for (const auto& boundary_face_group_name : options()->getCheckBoundaryFaceGroup()) {


### PR DESCRIPTION
AMR is not possible with polyhedral mesh, nonetheless the API must be implemented.
- activeCells = cells()
- levelCells(level) = cells() for level == 0; is empty otherwise.