### PR TITLE
Add utilitary functions to get the underlying native stream of a RunQueue

### DIFF
--- a/arcane/src/arcane/accelerator/AcceleratorUtils.h
+++ b/arcane/src/arcane/accelerator/AcceleratorUtils.h
@@ -1,0 +1,149 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* AcceleratorUtils.h                                          (C) 2000-2024 */
+/*                                                                           */
+/* Fonctions utilitaires communes à tous les runtimes.                       */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_ACCELERATOR_ACCELERATORUTILS_H
+#define ARCANE_ACCELERATOR_ACCELERATORUTILS_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/Array.h"
+
+#include "arcane/accelerator/AcceleratorGlobal.h"
+#include "arcane/accelerator/core/RunQueue.h"
+
+#if defined(ARCANE_COMPILING_HIP)
+#include "arcane/accelerator/hip/HipAccelerator.h"
+#include <hip/hip_runtime.h>
+#include <rocprim/rocprim.hpp>
+#endif
+#if defined(ARCANE_COMPILING_CUDA)
+#include "arcane/accelerator/cuda/CudaAccelerator.h"
+#include <cub/cub.cuh>
+#endif
+#if defined(ARCANE_COMPILING_SYCL)
+#include "arcane/accelerator/sycl/SyclAccelerator.h"
+#include <sycl/sycl.hpp>
+#if defined(__INTEL_LLVM_COMPILER)
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
+#endif
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator::impl
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(ARCANE_COMPILING_CUDA)
+class ARCANE_ACCELERATOR_EXPORT CudaUtils
+{
+ public:
+
+  static cudaStream_t toNativeStream(const RunQueue* queue);
+  static cudaStream_t toNativeStream(const RunQueue& queue);
+};
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(ARCANE_COMPILING_HIP)
+class ARCANE_ACCELERATOR_EXPORT HipUtils
+{
+ public:
+
+  static hipStream_t toNativeStream(const RunQueue* queue);
+  static hipStream_t toNativeStream(const RunQueue& queue);
+};
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(ARCANE_COMPILING_SYCL)
+class ARCANE_ACCELERATOR_EXPORT SyclUtils
+{
+ public:
+
+  static sycl::queue toNativeStream(const RunQueue* queue);
+  static sycl::queue toNativeStream(const RunQueue& queue);
+};
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::impl
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator::AcceleratorUtils
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(ARCANE_COMPILING_CUDA)
+/*!
+ * \brief Retourne l'instance de cudaStream_t associée à \q queue.
+ *
+ * Une exception est levée si queue.executionPolicy() != eExecutionPolicy::CUDA.
+ */
+inline cudaStream_t
+toCudaNativeStream(const RunQueue& queue)
+{
+  return impl::CudaUtils::toNativeStream(queue);
+}
+#endif
+
+#if defined(ARCANE_COMPILING_HIP)
+/*!
+ * \brief Retourne l'instance de hipStream_t associée à \q queue.
+ *
+ * Une exception est levée si queue.executionPolicy() != eExecutionPolicy::HIP.
+ */
+inline hipStream_t
+toHipNativeStream(const RunQueue& queue)
+{
+  return impl::HipUtils::toNativeStream(queue);
+}
+#endif
+
+#if defined(ARCANE_COMPILING_SYCL)
+/*!
+ * \brief Retourne l'instance de hipStream_t associée à \q queue.
+ *
+ * Une exception est levée si queue.executionPolicy() != eExecutionPolicy::SYCL.
+ */
+inline sycl::queue
+toSyclNativeStream(const RunQueue& queue)
+{
+  return impl::SyclUtils::toNativeStream(queue);
+}
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::AcceleratorUtils
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/CommonUtils.h
+++ b/arcane/src/arcane/accelerator/CommonUtils.h
@@ -18,6 +18,7 @@
 
 #include "arcane/accelerator/AcceleratorGlobal.h"
 #include "arcane/accelerator/core/RunQueue.h"
+#include "arcane/accelerator/AcceleratorUtils.h"
 
 #if defined(ARCANE_COMPILING_HIP)
 #include "arcane/accelerator/hip/HipAccelerator.h"
@@ -28,13 +29,9 @@
 #include "arcane/accelerator/cuda/CudaAccelerator.h"
 #include <cub/cub.cuh>
 #endif
-#if defined(ARCANE_COMPILING_SYCL)
-#include "arcane/accelerator/sycl/SyclAccelerator.h"
-#include <sycl/sycl.hpp>
-#if defined(__INTEL_LLVM_COMPILER)
+#if defined(ARCANE_COMPILING_SYCL) && defined(__INTEL_LLVM_COMPILER)
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-#endif
 #endif
 
 /*---------------------------------------------------------------------------*/
@@ -42,45 +39,6 @@
 
 namespace Arcane::Accelerator::impl
 {
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-#if defined(ARCANE_COMPILING_CUDA)
-class ARCANE_ACCELERATOR_EXPORT CudaUtils
-{
- public:
-
-  static cudaStream_t toNativeStream(const RunQueue* queue);
-  static cudaStream_t toNativeStream(const RunQueue& queue);
-};
-#endif
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-#if defined(ARCANE_COMPILING_HIP)
-class ARCANE_ACCELERATOR_EXPORT HipUtils
-{
- public:
-
-  static hipStream_t toNativeStream(const RunQueue* queue);
-  static hipStream_t toNativeStream(const RunQueue& queue);
-};
-#endif
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-#if defined(ARCANE_COMPILING_SYCL)
-class ARCANE_ACCELERATOR_EXPORT SyclUtils
-{
- public:
-
-  static sycl::queue toNativeStream(const RunQueue* queue);
-  static sycl::queue toNativeStream(const RunQueue& queue);
-};
-#endif
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -147,7 +105,7 @@ class ARCANE_ACCELERATOR_EXPORT DeviceStorageBase
  * \internal
  * \brief Gère l'allocation interne sur le device pour un type donné.
  */
-template <typename DataType,Int32 N = 1>
+template <typename DataType, Int32 N = 1>
 class DeviceStorage
 : public DeviceStorageBase
 {
@@ -468,9 +426,17 @@ class SetterLambdaIterator
 
 namespace Arcane::Accelerator
 {
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 template <typename DataType> using ScannerSumOperator = impl::SumOperator<DataType>;
 template <typename DataType> using ScannerMaxOperator = impl::MaxOperator<DataType>;
 template <typename DataType> using ScannerMinOperator = impl::MinOperator<DataType>;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // namespace Arcane::Accelerator
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/Filter.h
+++ b/arcane/src/arcane/accelerator/Filter.h
@@ -100,7 +100,7 @@ class SyclGenericFilteringImpl
     RunQueue queue = s.m_queue;
     using DataType = std::iterator_traits<OutputIterator>::value_type;
 #if defined(ARCANE_USE_SCAN_ONEDPL) && defined(__INTEL_LLVM_COMPILER)
-    sycl::queue true_queue = impl::SyclUtils::toNativeStream(queue);
+    sycl::queue true_queue = AcceleratorUtils::toSyclNativeStream(queue);
     auto policy = oneapi::dpl::execution::make_device_policy(true_queue);
     auto out_iter = oneapi::dpl::copy_if(policy, input_iter, input_iter + nb_item, output_iter, select_lambda);
     Int32 nb_output = out_iter - output_iter;
@@ -192,7 +192,7 @@ class GenericFilteringFlag
 #if defined(ARCANE_COMPILING_CUDA)
     case eExecutionPolicy::CUDA: {
       size_t temp_storage_size = 0;
-      cudaStream_t stream = impl::CudaUtils::toNativeStream(queue);
+      cudaStream_t stream = AcceleratorUtils::toCudaNativeStream(queue);
       // Premier appel pour connaitre la taille pour l'allocation
       int* nb_out_ptr = nullptr;
       ARCANE_CHECK_CUDA(::cub::DeviceSelect::Flagged(nullptr, temp_storage_size,
@@ -209,7 +209,7 @@ class GenericFilteringFlag
     case eExecutionPolicy::HIP: {
       size_t temp_storage_size = 0;
       // Premier appel pour connaitre la taille pour l'allocation
-      hipStream_t stream = impl::HipUtils::toNativeStream(queue);
+      hipStream_t stream = AcceleratorUtils::toHipNativeStream(queue);
       int* nb_out_ptr = nullptr;
       ARCANE_CHECK_HIP(rocprim::select(nullptr, temp_storage_size, input_data, flag_data, output_data,
                                        nb_out_ptr, nb_item, stream));

--- a/arcane/src/arcane/accelerator/core/RunQueue.h
+++ b/arcane/src/arcane/accelerator/core/RunQueue.h
@@ -202,7 +202,11 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
    *
    * Avec CUDA, le pointeur retourné est un 'cudaStream_t*'. Avec HIP, il
    * s'agit d'un 'hipStream_t*'.
+   *
+   * \deprecated Utiliser toCudaNativeStream(), toHipNativeStream()
+   * ou toSyclNativeStream() à la place
    */
+  ARCANE_DEPRECATED_REASON("Y2024: Use toCudaNativeStream(), toHipNativeStream() or toSyclNativeStream() instead")
   void* platformStream() const;
 
  private:

--- a/arcane/src/arcane/accelerator/srcs.cmake
+++ b/arcane/src/arcane/accelerator/srcs.cmake
@@ -2,6 +2,7 @@ set( ARCANE_SOURCES
   Accelerator.cc
   Accelerator.h
   AcceleratorGlobal.h
+  AcceleratorUtils.h
   AsyncRunQueuePool.h
   Atomic.h
   CommonCudaHipReduceImpl.h


### PR DESCRIPTION
The added functions are type safe.
Make `RunQueue::platformStream()` deprecated.
