### PR TITLE
Add support to pass arguments for accelerator runtime initialization

### DIFF
--- a/arcane/src/arcane/accelerator/core/internal/RegisterRuntimeInfo.h
+++ b/arcane/src/arcane/accelerator/core/internal/RegisterRuntimeInfo.h
@@ -1,0 +1,50 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* RegisterRuntimeInfo.h                                       (C) 2000-2024 */
+/*                                                                           */
+/* Informations pour initialiser le runtime accélérateur.                    */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_ACCELERATOR_CORE_INTERNAL_REGISTERRUNTIMEINFO_H
+#define ARCANE_ACCELERATOR_CORE_INTERNAL_REGISTERRUNTIMEINFO_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/accelerator/core/internal/AcceleratorCoreGlobalInternal.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations pour initialiser le runtime accélérateur.
+ */
+class RegisterRuntimeInfo
+{
+ public:
+
+  void setVerbose(bool v) { m_is_verbose = v; }
+  bool isVerbose() const { return m_is_verbose; }
+
+ private:
+
+  bool m_is_verbose = false;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/accelerator/core/srcs.cmake
+++ b/arcane/src/arcane/accelerator/core/srcs.cmake
@@ -42,6 +42,7 @@ set( ARCANE_SOURCES
   internal/RunCommandImpl.h
   internal/RunQueueImpl.h
   internal/ReduceMemoryImpl.h
+  internal/RegisterRuntimeInfo.h
   internal/RunnerImpl.h
   internal/RunnerInternal.h
 )

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -416,7 +416,7 @@ class CudaRunnerRuntime
 
  public:
 
-  void fillDevices();
+  void fillDevices(bool is_verbose);
 
  private:
 
@@ -429,12 +429,13 @@ class CudaRunnerRuntime
 /*---------------------------------------------------------------------------*/
 
 void CudaRunnerRuntime::
-fillDevices()
+fillDevices(bool is_verbose)
 {
   int nb_device = 0;
   ARCANE_CHECK_CUDA(cudaGetDeviceCount(&nb_device));
   std::ostream& omain = std::cout;
-  omain << "ArcaneCUDA: Initialize Arcane CUDA runtime nb_available_device=" << nb_device << "\n";
+  if (is_verbose)
+    omain << "ArcaneCUDA: Initialize Arcane CUDA runtime nb_available_device=" << nb_device << "\n";
   for (int i = 0; i < nb_device; ++i) {
     cudaDeviceProp dp;
     cudaGetDeviceProperties(&dp, i);
@@ -476,7 +477,8 @@ fillDevices()
       o << "\n";
     }
     String description(ostr.str());
-    omain << description;
+    if (is_verbose)
+      omain << description;
 
     DeviceInfo device_info;
     device_info.setDescription(description);
@@ -543,7 +545,7 @@ Arcane::Accelerator::Cuda::CudaMemoryCopier global_cuda_memory_copier;
 // Cette fonction est le point d'entrée utilisé lors du chargement
 // dynamique de cette bibliothèque
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimecuda(Arcane::Accelerator::RegisterRuntimeInfo&)
+arcaneRegisterAcceleratorRuntimecuda(Arcane::Accelerator::RegisterRuntimeInfo& init_info)
 {
   using namespace Arcane;
   using namespace Arcane::Accelerator::Cuda;
@@ -557,7 +559,7 @@ arcaneRegisterAcceleratorRuntimecuda(Arcane::Accelerator::RegisterRuntimeInfo&)
   mrm->setAllocator(eMemoryRessource::HostPinned, getCudaHostPinnedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::Device, getCudaDeviceMemoryAllocator());
   mrm->setCopier(&global_cuda_memory_copier);
-  global_cuda_runtime.fillDevices();
+  global_cuda_runtime.fillDevices(init_info.isVerbose());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -30,7 +30,7 @@
 #include "arcane/accelerator/core/DeviceInfoList.h"
 
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
-#include "arcane/accelerator/core/internal/AcceleratorCoreGlobalInternal.h"
+#include "arcane/accelerator/core/internal/RegisterRuntimeInfo.h"
 #include "arcane/accelerator/core/internal/RunCommandImpl.h"
 #include "arcane/accelerator/core/internal/IRunQueueStream.h"
 #include "arcane/accelerator/core/internal/IRunQueueEventImpl.h"
@@ -543,7 +543,7 @@ Arcane::Accelerator::Cuda::CudaMemoryCopier global_cuda_memory_copier;
 // Cette fonction est le point d'entrée utilisé lors du chargement
 // dynamique de cette bibliothèque
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimecuda()
+arcaneRegisterAcceleratorRuntimecuda(Arcane::Accelerator::RegisterRuntimeInfo&)
 {
   using namespace Arcane;
   using namespace Arcane::Accelerator::Cuda;

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -25,7 +25,7 @@
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
 #include "arcane/accelerator/core/Memory.h"
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
-#include "arcane/accelerator/core/internal/AcceleratorCoreGlobalInternal.h"
+#include "arcane/accelerator/core/internal/RegisterRuntimeInfo.h"
 #include "arcane/accelerator/core/internal/IRunQueueStream.h"
 #include "arcane/accelerator/core/internal/IRunQueueEventImpl.h"
 #include "arcane/accelerator/core/DeviceInfoList.h"
@@ -442,7 +442,7 @@ Arcane::Accelerator::Hip::HipMemoryCopier global_hip_memory_copier;
 // Cette fonction est le point d'entrée utilisé lors du chargement
 // dynamique de cette bibliothèque
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimehip()
+arcaneRegisterAcceleratorRuntimehip(Arcane::Accelerator::RegisterRuntimeInfo&)
 {
   using namespace Arcane;
   using namespace Arcane::Accelerator::Hip;

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -92,7 +92,7 @@ class HipRunQueueStream
   }
   bool _barrierNoException() override
   {
-    return hipStreamSynchronize(m_hip_stream) != HIP_SUCCESS;
+    return hipStreamSynchronize(m_hip_stream) != hipSuccess;
   }
   void copyMemory(const MemoryCopyArgs& args) override
   {
@@ -342,7 +342,7 @@ class HipRunnerRuntime
 
  public:
 
-  void fillDevices();
+  void fillDevices(bool is_verbose);
 
  private:
 
@@ -355,12 +355,13 @@ class HipRunnerRuntime
 /*---------------------------------------------------------------------------*/
 
 void HipRunnerRuntime::
-fillDevices()
+fillDevices(bool is_verbose)
 {
   int nb_device = 0;
   ARCANE_CHECK_HIP(hipGetDeviceCount(&nb_device));
   std::ostream& omain = std::cout;
-  omain << "ArcaneHIP: Initialize Arcane HIP runtime nb_available_device=" << nb_device << "\n";
+  if (is_verbose)
+    omain << "ArcaneHIP: Initialize Arcane HIP runtime nb_available_device=" << nb_device << "\n";
   for (int i = 0; i < nb_device; ++i) {
     OStringStream ostr;
     std::ostream& o = ostr.stream();
@@ -394,7 +395,8 @@ fillDevices()
     o << " hasManagedMemory = " << has_managed_memory << "\n";
 
     String description(ostr.str());
-    omain << description;
+    if (is_verbose)
+      omain << description;
 
     DeviceInfo device_info;
     device_info.setDescription(description);
@@ -442,7 +444,7 @@ Arcane::Accelerator::Hip::HipMemoryCopier global_hip_memory_copier;
 // Cette fonction est le point d'entrée utilisé lors du chargement
 // dynamique de cette bibliothèque
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimehip(Arcane::Accelerator::RegisterRuntimeInfo&)
+arcaneRegisterAcceleratorRuntimehip(Arcane::Accelerator::RegisterRuntimeInfo& init_info)
 {
   using namespace Arcane;
   using namespace Arcane::Accelerator::Hip;
@@ -455,7 +457,7 @@ arcaneRegisterAcceleratorRuntimehip(Arcane::Accelerator::RegisterRuntimeInfo&)
   mrm->setAllocator(eMemoryRessource::HostPinned, getHipHostPinnedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::Device, getHipDeviceMemoryAllocator());
   mrm->setCopier(&global_hip_memory_copier);
-  global_hip_runtime.fillDevices();
+  global_hip_runtime.fillDevices(init_info.isVerbose());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
@@ -23,7 +23,7 @@
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
 #include "arcane/accelerator/core/Memory.h"
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
-#include "arcane/accelerator/core/internal/AcceleratorCoreGlobalInternal.h"
+#include "arcane/accelerator/core/internal/RegisterRuntimeInfo.h"
 #include "arcane/accelerator/core/internal/IRunQueueStream.h"
 #include "arcane/accelerator/core/internal/IRunQueueEventImpl.h"
 #include "arcane/accelerator/core/DeviceInfoList.h"
@@ -429,7 +429,7 @@ copy(ConstMemoryView from, [[maybe_unused]] eMemoryRessource from_mem,
 // Cette fonction est le point d'entrée utilisé lors du chargement
 // dynamique de cette bibliothèque
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimesycl()
+arcaneRegisterAcceleratorRuntimesycl(Arcane::Accelerator::RegisterRuntimeInfo&)
 {
   using namespace Arcane;
   using namespace Arcane::Accelerator::Sycl;


### PR DESCRIPTION
At the moment it is only used to add a verbose mode to display the list of available devices.
By default now this list is not displayed. You have to set environment variable `ARCANE_DEBUG_ACCELERATOR` to `1` to display this list.