### PR TITLE
Add typedef 'AlephInt' to handle indexing of matrix and vectors in Aleph

### DIFF
--- a/arcane/src/arcane/aleph/AlephGlobal.h
+++ b/arcane/src/arcane/aleph/AlephGlobal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephGlobal.h                                               (C) 2000-2023 */
+/* AlephGlobal.h                                               (C) 2000-2024 */
 /*                                                                           */
 /* Déclarations générales de la composante 'arcane_aleph'.                   */
 /*---------------------------------------------------------------------------*/
@@ -36,12 +36,18 @@ namespace Arcane
 
 class IAlephFactory;
 class IAlephTopology;
+class IAlephMatrix;
+class IAlephVector;
+class AlephKernel;
 class AlephTopology;
 class AlephMatrix;
 class AlephOrdering;
 class AlephIndexing;
 class AlephVector;
 class AlephParams;
+
+//! Type par défaut pour indexer les lignes et les colonnes des matrices et vecteurs
+using AlephInt = int;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/AlephInterface.h
+++ b/arcane/src/arcane/aleph/AlephInterface.h
@@ -1,16 +1,16 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephInterface.h                                            (C) 2000-2011 */
+/* AlephInterface.h                                            (C) 2000-2024 */
 /*                                                                           */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ALEPH_ALEPHINTERFACE_H_
-#define ARCANE_ALEPH_ALEPHINTERFACE_H_
+#ifndef ARCANE_ALEPH_ALEPHINTERFACE_H
+#define ARCANE_ALEPH_ALEPHINTERFACE_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -20,7 +20,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -32,9 +33,11 @@ class AlephVector;
 /******************************************************************************
  * IAlephTopology
  *****************************************************************************/
-class IAlephTopology : public TraceAccessor
+class IAlephTopology
+: public TraceAccessor
 {
  public:
+
   IAlephTopology(ITraceMng* tm,
                  AlephKernel* kernel,
                  Integer index,
@@ -57,10 +60,12 @@ class IAlephTopology : public TraceAccessor
   }
 
  public:
+
   virtual void backupAndInitialize() = 0;
   virtual void restore() = 0;
 
  protected:
+
   Integer m_index;
   AlephKernel* m_kernel;
   bool m_participating_in_solver;
@@ -69,9 +74,11 @@ class IAlephTopology : public TraceAccessor
 /******************************************************************************
  * IAlephVector
  *****************************************************************************/
-class IAlephVector : public TraceAccessor
+class IAlephVector
+: public TraceAccessor
 {
  public:
+
   IAlephVector(ITraceMng* tm,
                AlephKernel* kernel,
                Integer index)
@@ -89,13 +96,15 @@ class IAlephVector : public TraceAccessor
   }
 
  public:
+
   virtual void AlephVectorCreate(void) = 0;
-  virtual void AlephVectorSet(const double*, const int*, Integer) = 0;
+  virtual void AlephVectorSet(const double*, const AlephInt*, Integer) = 0;
   virtual int AlephVectorAssemble(void) = 0;
-  virtual void AlephVectorGet(double*, const int*, Integer) = 0;
+  virtual void AlephVectorGet(double*, const AlephInt*, Integer) = 0;
   virtual void writeToFile(const String) = 0;
 
  protected:
+
   Integer m_index;
   AlephKernel* m_kernel;
 };
@@ -103,9 +112,11 @@ class IAlephVector : public TraceAccessor
 /******************************************************************************
  * IAlephMatrix
  *****************************************************************************/
-class IAlephMatrix : public TraceAccessor
+class IAlephMatrix
+: public TraceAccessor
 {
  public:
+
   IAlephMatrix(ITraceMng* tm,
                AlephKernel* kernel,
                Integer index)
@@ -123,10 +134,11 @@ class IAlephMatrix : public TraceAccessor
   }
 
  public:
+
   virtual void AlephMatrixCreate(void) = 0;
   virtual void AlephMatrixSetFilled(bool) = 0;
   virtual int AlephMatrixAssemble(void) = 0;
-  virtual void AlephMatrixFill(int, int*, int*, double*) = 0;
+  virtual void AlephMatrixFill(int, AlephInt*, AlephInt*, double*) = 0;
   virtual int AlephMatrixSolve(AlephVector*,
                                AlephVector*,
                                AlephVector*,
@@ -136,14 +148,20 @@ class IAlephMatrix : public TraceAccessor
   virtual void writeToFile(const String) = 0;
 
  protected:
+
   Integer m_index;
   AlephKernel* m_kernel;
 };
 
-class IAlephFactory : public TraceAccessor
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class IAlephFactory
+: public TraceAccessor
 {
  public:
-  IAlephFactory(ITraceMng* tm)
+
+  explicit IAlephFactory(ITraceMng* tm)
   : TraceAccessor(tm)
   {
     debug() << "\33[1;34m[IAlephFactory] NEW IAlephFactory"
@@ -170,6 +188,7 @@ class IAlephFactory : public TraceAccessor
 class IAlephFactoryImpl
 {
  public:
+
   virtual ~IAlephFactoryImpl() {}
   virtual void initialize() = 0;
   virtual IAlephTopology* createTopology(ITraceMng*, AlephKernel*, Integer, Integer) = 0;
@@ -180,7 +199,7 @@ class IAlephFactoryImpl
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/AlephMatrix.cc
+++ b/arcane/src/arcane/aleph/AlephMatrix.cc
@@ -1,21 +1,23 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephMatrix.cc                                             (C) 2010 */
+/* AlephMatrix.cc                                              (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-#include "AlephArcane.h"
+
+#include "arcane/aleph/AlephArcane.h"
 #include "arcane/MeshVariableScalarRef.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -124,10 +126,10 @@ void AlephMatrix::addValue(const VariableRef& rowVar, const Item& rowItm,
                            const VariableRef& colVar, const Item& colItm,
                            const Real val)
 {
-  Integer row = m_kernel->indexing()->get(rowVar, rowItm);
-  Integer col = m_kernel->indexing()->get(colVar, colItm);
+  AlephInt row = m_kernel->indexing()->get(rowVar, rowItm);
+  AlephInt col = m_kernel->indexing()->get(colVar, colItm);
   if (m_kernel->isInitialized()) {
-    const Integer row_offset = m_kernel->topology()->part()[m_kernel->rank()];
+    const AlephInt row_offset = m_kernel->topology()->part()[m_kernel->rank()];
     row += row_offset;
     col += row_offset;
   }
@@ -496,25 +498,25 @@ assemble_waitAndFill(void)
       m_implementation->AlephMatrixSetFilled(false); // Activation de la protection de remplissage
     debug() << "\33[1;32m[AlephMatrix::assemble_waitAndFill] " << m_index << " fill"
             << "\33[0m";
-    int* bfr_row_implem;
-    int* bfr_col_implem;
+    AlephInt* bfr_row_implem;
+    AlephInt* bfr_col_implem;
     double* bfr_val_implem;
     for (int iCpu = 0; iCpu < m_kernel->size(); ++iCpu) {
       if (m_kernel->rank() != m_ranks[iCpu])
         continue;
       if (iCpu == m_kernel->rank()) {
-        bfr_row_implem = reinterpret_cast<int*>(m_setValue_row.unguardedBasePointer());
-        bfr_col_implem = reinterpret_cast<int*>(m_setValue_col.unguardedBasePointer());
-        bfr_val_implem = reinterpret_cast<double*>(m_setValue_val.unguardedBasePointer());
+        bfr_row_implem = m_setValue_row.data();
+        bfr_col_implem = m_setValue_col.data();
+        bfr_val_implem = m_setValue_val.data();
         m_implementation->AlephMatrixFill(m_setValue_val.size(),
                                           bfr_row_implem,
                                           bfr_col_implem,
                                           bfr_val_implem);
       }
       else {
-        bfr_row_implem = reinterpret_cast<int*>(m_aleph_matrix_buffer_rows[iCpu].unguardedBasePointer());
-        bfr_col_implem = reinterpret_cast<int*>(m_aleph_matrix_buffer_cols[iCpu].unguardedBasePointer());
-        bfr_val_implem = reinterpret_cast<double*>(m_aleph_matrix_buffer_vals[iCpu].unguardedBasePointer());
+        bfr_row_implem = m_aleph_matrix_buffer_rows[iCpu].data();
+        bfr_col_implem = m_aleph_matrix_buffer_cols[iCpu].data();
+        bfr_val_implem = m_aleph_matrix_buffer_vals[iCpu].data();
         m_implementation->AlephMatrixFill(m_aleph_matrix_buffer_vals[iCpu].size(),
                                           bfr_row_implem,
                                           bfr_col_implem,
@@ -719,7 +721,7 @@ writeToFile(const String file_name)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/AlephMatrix.h
+++ b/arcane/src/arcane/aleph/AlephMatrix.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephMatrix.h                                               (C) 2000-2022 */
+/* AlephMatrix.h                                               (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCANE_ALEPH_MATRIX_H
@@ -23,8 +23,6 @@
 namespace Arcane
 {
 
-class IAlephMatrix;
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
@@ -34,7 +32,8 @@ class ARCANE_ALEPH_EXPORT AlephMatrix
 : public TraceAccessor
 {
  public:
-  AlephMatrix(AlephKernel*);
+
+  explicit AlephMatrix(AlephKernel*);
   ~AlephMatrix();
 
  public:
@@ -67,6 +66,7 @@ class ARCANE_ALEPH_EXPORT AlephMatrix
   void solveNow(AlephVector*, AlephVector*, AlephVector*, Integer&, Real*, AlephParams*);
 
  private:
+
   AlephKernel* m_kernel = nullptr;
   Integer m_index;
   ArrayView<Integer> m_ranks;
@@ -74,14 +74,15 @@ class ARCANE_ALEPH_EXPORT AlephMatrix
   IAlephMatrix* m_implementation = nullptr;
 
  private:
+
   // Matrice utilisée dans le cas où nous sommes le solveur
-  MultiArray2<Int32> m_aleph_matrix_buffer_rows;
-  MultiArray2<Int32> m_aleph_matrix_buffer_cols;
+  MultiArray2<AlephInt> m_aleph_matrix_buffer_rows;
+  MultiArray2<AlephInt> m_aleph_matrix_buffer_cols;
   MultiArray2<Real> m_aleph_matrix_buffer_vals;
   // Tableaux tampons des setValues
   Integer m_setValue_idx;
-  UniqueArray<Int32> m_setValue_row;
-  UniqueArray<Int32> m_setValue_col;
+  UniqueArray<AlephInt> m_setValue_row;
+  UniqueArray<AlephInt> m_setValue_col;
   UniqueArray<Real> m_setValue_val;
 
  private: // Tableaux tampons des addValues

--- a/arcane/src/arcane/aleph/AlephOrdering.cc
+++ b/arcane/src/arcane/aleph/AlephOrdering.cc
@@ -1,21 +1,23 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephOrdering.cc                                                 (C) 2012 */
+/* AlephOrdering.cc                                            (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-#include "AlephArcane.h"
-#include "arcane/IMesh.h"
+
+#include "arcane/aleph/AlephArcane.h"
+#include "arcane/core/IMesh.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -289,7 +291,7 @@ initCellNodeOrder(void)
   m_swap.resize(m_swap_cell.size() + m_swap_node.size());
   Integer iCell = 0;
   for (Integer i = 0; i < m_kernel->size(); ++i) {
-    Integer offset = m_kernel->topology()->gathered_nb_row(i);
+    AlephInt offset = m_kernel->topology()->gathered_nb_row(i);
     for (Integer j = 0; j < gathered_nb_cells.at(i); ++j) {
       m_swap[offset + j] = m_swap_cell.at(iCell);
       iCell += 1;
@@ -297,7 +299,7 @@ initCellNodeOrder(void)
   }
   Integer iNode = 0;
   for (Integer i = 0; i < m_kernel->size(); ++i) {
-    Integer offset = 0;
+    AlephInt offset = 0;
     if (i > 0)
       offset = m_kernel->topology()->gathered_nb_row(i);
     offset += gathered_nb_cells.at(i);
@@ -365,7 +367,7 @@ initTwiceCellNodeOrder(void)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/AlephOrdering.h
+++ b/arcane/src/arcane/aleph/AlephOrdering.h
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephOrdering.h                                                  (C) 2012 */
+/* AlephOrdering.h                                             (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
-#ifndef ALEPH_ORDERING_H
-#define ALEPH_ORDERING_H
+#ifndef ARCANE_ALEPH_ALEPHORDERING_H
+#define ARCANE_ALEPH_ALEPHORDERING_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -18,22 +18,25 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Gestionaire de reordering
+ * \brief Gestionnaire de reordering
  */
 class AlephOrdering
 : public TraceAccessor
 {
  public:
-  AlephOrdering(AlephKernel*);
+
+  explicit AlephOrdering(AlephKernel*);
   AlephOrdering(AlephKernel*, Integer, Integer, bool = false);
   ~AlephOrdering();
 
  public:
+
   Integer swap(Integer i)
   {
     if (m_do_swap)
@@ -42,25 +45,25 @@ class AlephOrdering
   }
 
  private:
-  void initCellOrder(void);
-  void initTwiceCellOrder(void);
-  void initFaceOrder(void);
-  void initCellFaceOrder(void);
-  void initCellNodeOrder(void);
-  void initTwiceCellNodeOrder(void);
+
+  void initCellOrder();
+  void initTwiceCellOrder();
+  void initFaceOrder();
+  void initCellFaceOrder();
+  void initCellNodeOrder();
+  void initTwiceCellNodeOrder();
 
  private:
-  bool m_do_swap;
-  AlephKernel* m_kernel;
 
- private:
+  bool m_do_swap = false;
+  AlephKernel* m_kernel = nullptr;
   UniqueArray<Int64> m_swap;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/AlephTopology.cc
+++ b/arcane/src/arcane/aleph/AlephTopology.cc
@@ -1,20 +1,25 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephTopology.cc                                                 (C) 2010 */
+/* AlephTopology.cc                                            (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-#include "AlephArcane.h"
+
+#include "arcane/aleph/AlephTopology.h"
+
+#include "arcane/aleph/AlephKernel.h"
+#include "arcane/aleph/AlephArcane.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -134,7 +139,7 @@ create(Integer setValue_idx)
   }
 
   // Nous allons nous échanger tous les setValue_idx
-  UniqueArray<Integer> all;
+  UniqueArray<AlephInt> all;
   all.add(setValue_idx);
   m_kernel->parallel()->allGather(all, m_gathered_nb_setValued);
 
@@ -183,7 +188,7 @@ setRowNbElements(IntegerConstArrayView row_nb_element)
     return;
   }
 
-  UniqueArray<Integer> local_row_nb_element(m_nb_row_rank);
+  UniqueArray<AlephInt> local_row_nb_element(m_nb_row_rank);
   for (int i = 0; i < m_nb_row_rank; ++i)
     local_row_nb_element[i] = row_nb_element[i];
   m_kernel->parallel()->allGatherVariable(local_row_nb_element, m_gathered_nb_row_elements);
@@ -208,7 +213,7 @@ ptr_low_up_array()
 
 /******************************************************************************
  *****************************************************************************/
-IntegerConstArrayView AlephTopology::
+ConstArrayView<AlephInt> AlephTopology::
 part()
 {
   checkForInit();
@@ -264,7 +269,7 @@ rowLocalRange(const Integer index)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/AlephTopology.h
+++ b/arcane/src/arcane/aleph/AlephTopology.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephTopology.h                                                  (C) 2010 */
+/* AlephTopology.h                                             (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 #ifndef ALEPH_TOPOLOGY_H
@@ -15,26 +15,27 @@
 
 #include "arcane/aleph/AlephGlobal.h"
 
+#include "arcane/utils/TraceAccessor.h"
+#include "arcane/utils/Array.h"
+#include "arcane/utils/FatalErrorException.h"
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-class IAlephTopology;
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Informations sur l'environement parallèle.
+ * \brief Informations sur l'environnement parallèle.
  */
 class ARCANE_ALEPH_EXPORT AlephTopology
 : public TraceAccessor
 {
  public:
-  AlephTopology(AlephKernel*);
+
+  explicit AlephTopology(AlephKernel*);
   AlephTopology(ITraceMng*, AlephKernel*, Integer, Integer);
   virtual ~AlephTopology();
 
@@ -42,7 +43,7 @@ class ARCANE_ALEPH_EXPORT AlephTopology
   void create(Integer);
   void setRowNbElements(IntegerConstArrayView row_nb_element);
   IntegerConstArrayView ptr_low_up_array();
-  IntegerConstArrayView part();
+  ConstArrayView<AlephInt> part();
   IParallelMng* parallelMng();
   void rowRange(Integer& min_row, Integer& max_row);
 
@@ -65,22 +66,22 @@ class ARCANE_ALEPH_EXPORT AlephTopology
     checkForInit();
     return m_nb_row_rank;
   }
-  Integer gathered_nb_row(Integer i)
+  AlephInt gathered_nb_row(Integer i)
   {
     checkForInit();
     return m_gathered_nb_row[i];
   }
-  ArrayView<Integer> gathered_nb_row_elements(void)
+  ArrayView<AlephInt> gathered_nb_row_elements(void)
   {
     checkForInit();
     return m_gathered_nb_row_elements;
   }
-  ArrayView<Integer> gathered_nb_setValued(void)
+  ArrayView<AlephInt> gathered_nb_setValued(void)
   {
     checkForInit();
     return m_gathered_nb_setValued;
   }
-  Integer gathered_nb_setValued(Integer i)
+  AlephInt gathered_nb_setValued(Integer i)
   {
     checkForInit();
     return m_gathered_nb_setValued[i];
@@ -91,9 +92,9 @@ class ARCANE_ALEPH_EXPORT AlephTopology
   AlephKernel* m_kernel;
   Integer m_nb_row_size; // Nombre de lignes de la matrice réparties sur l'ensemble
   Integer m_nb_row_rank; // Nombre de lignes de la matrice vue de mon rang
-  UniqueArray<Integer> m_gathered_nb_row; // Indices des lignes par CPU
-  UniqueArray<Integer> m_gathered_nb_row_elements; // nombre d'éléments par ligne
-  UniqueArray<Integer> m_gathered_nb_setValued; // nombre d'éléments setValué par CPU
+  UniqueArray<AlephInt> m_gathered_nb_row; // Indices des lignes par CPU
+  UniqueArray<AlephInt> m_gathered_nb_row_elements; // nombre d'éléments par ligne
+  UniqueArray<AlephInt> m_gathered_nb_setValued; // nombre d'éléments setValué par CPU
   bool m_created;
   bool m_has_set_row_nb_elements;
   bool m_has_been_initialized;

--- a/arcane/src/arcane/aleph/AlephVector.h
+++ b/arcane/src/arcane/aleph/AlephVector.h
@@ -1,95 +1,93 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephVector.h                                                    (C) 2010 */
+/* AlephVector.h                                               (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
-#ifndef ALEPH_VECTOR_H
-#define ALEPH_VECTOR_H
+#ifndef ARCANE_ALEPH_ALEPHVECTOR_H
+#define ARCANE_ALEPH_ALEPHVECTOR_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/aleph/AlephGlobal.h"
 
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANE_BEGIN_NAMESPACE
+#include "arcane/utils/TraceAccessor.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-class IAlephVector;
-class AlephTopology;
-class AlephKernel;
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
  * \brief Vecteur d'un système linéaire.
  */
-class ARCANE_ALEPH_EXPORT AlephVector : public TraceAccessor
+class ARCANE_ALEPH_EXPORT AlephVector
+: public TraceAccessor
 {
  public:
-  AlephVector(AlephKernel*);
+
+  explicit AlephVector(AlephKernel*);
   ~AlephVector();
 
  public:
-  void create(void);
-  void create_really(void);
-  void update(void) { throw NotImplementedException(A_FUNCINFO); }
+
+  void create();
+  void create_really();
+  void update() { throw NotImplementedException(A_FUNCINFO); }
   void reSetLocalComponents(AlephVector*);
   void setLocalComponents(Integer num_values,
-                          ConstArrayView<int> glob_indices,
+                          ConstArrayView<AlephInt> glob_indices,
                           ConstArrayView<double> values);
   void setLocalComponents(ConstArrayView<double> values);
   void getLocalComponents(Integer vector_size,
-                          ConstArrayView<int> global_indice,
+                          ConstArrayView<AlephInt> global_indice,
                           ArrayView<double> vector_values);
   void getLocalComponents(Array<double>& values);
-  void startFilling(void);
-  void assemble(void);
-  void assemble_waitAndFill(void);
-  void reassemble(void);
-  void reassemble_waitAndFill(void);
+  void startFilling();
+  void assemble();
+  void assemble_waitAndFill();
+  void reassemble();
+  void reassemble_waitAndFill();
   void copy(AlephVector*) { throw NotImplementedException(A_FUNCINFO); }
   void writeToFile(const String);
   IAlephVector* implementation(void) { return m_implementation; }
 
  private:
-  AlephKernel* m_kernel;
-  Integer m_index;
+
+  AlephKernel* m_kernel = nullptr;
+  Integer m_index = -1;
   ArrayView<Integer> m_ranks;
-  bool m_participating_in_solver;
+  bool m_participating_in_solver = false;
   IAlephVector* m_implementation = nullptr;
 
  private:
+
   // Buffers utilisés dans le cas où nous sommes le solveur
-  UniqueArray<Int32> m_aleph_vector_buffer_idxs;
+  UniqueArray<AlephInt> m_aleph_vector_buffer_idxs;
   UniqueArray<Real> m_aleph_vector_buffer_vals;
-
- private:
-  UniqueArray<Int32> m_aleph_vector_buffer_idx;
+  UniqueArray<AlephInt> m_aleph_vector_buffer_idx;
   UniqueArray<Real> m_aleph_vector_buffer_val;
-
- private:
   UniqueArray<Parallel::Request> m_parallel_requests;
   UniqueArray<Parallel::Request> m_parallel_reassemble_requests;
 
  public:
+
   Integer m_bkp_num_values;
-  UniqueArray<int> m_bkp_indexs;
+  UniqueArray<AlephInt> m_bkp_indexs;
   UniqueArray<double> m_bkp_values;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/hypre/AlephHypre.cc
+++ b/arcane/src/arcane/aleph/hypre/AlephHypre.cc
@@ -31,6 +31,11 @@
 
 #include "arcane/aleph/AlephArcane.h"
 
+// Le type HYPRE_BigInt n'existe qu'à partir de Hypre 2.16.0
+#if HYPRE_RELEASE_NUMBER < 21600
+using HYPRE_BigInt = HYPRE_Int;
+#endif
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/arcane/src/arcane/aleph/hypre/AlephHypre.cc
+++ b/arcane/src/arcane/aleph/hypre/AlephHypre.cc
@@ -52,7 +52,7 @@ namespace Arcane
 namespace
 {
 inline void
-check(const char* hypre_func, int error_code)
+check(const char* hypre_func, HYPRE_Int error_code)
 {
   if (error_code == 0)
     return;
@@ -86,10 +86,10 @@ _callocHypre(Integer size)
 }
 
 inline void
-hypreCheck(const char* hypre_func, int error_code)
+hypreCheck(const char* hypre_func, HYPRE_Int error_code)
 {
   check(hypre_func, error_code);
-  int r = HYPRE_GetError();
+  HYPRE_Int r = HYPRE_GetError();
   if (r != 0)
     cout << "HYPRE GET ERROR r=" << r
          << " error_code=" << error_code << " func=" << hypre_func << '\n';
@@ -162,7 +162,7 @@ class AlephVectorHypre
 
   /******************************************************************************
    *****************************************************************************/
-  void AlephVectorSet(const double* bfr_val, const int* bfr_idx, Integer size)
+  void AlephVectorSet(const double* bfr_val, const AlephInt* bfr_idx, Integer size)
   {
     debug() << "[AlephVectorHypre::AlephVectorSet] size=" << size;
     hypreCheck("IJVectorSetValues", HYPRE_IJVectorSetValues(m_hypre_ijvector, size, bfr_idx, bfr_val));
@@ -179,8 +179,9 @@ class AlephVectorHypre
 
   /******************************************************************************
    *****************************************************************************/
-  void AlephVectorGet(double* bfr_val, const int* bfr_idx, Integer size)
+  void AlephVectorGet(double* bfr_val, const AlephInt* bfr_idx, Integer size)
   {
+    //HYPRE_Int* hypre_bfr_idx = static
     debug() << "[AlephVectorHypre::AlephVectorGet] size=" << size;
     hypreCheck("HYPRE_IJVectorGetValues", HYPRE_IJVectorGetValues(m_hypre_ijvector, size, bfr_idx, bfr_val));
   }
@@ -191,13 +192,13 @@ class AlephVectorHypre
   Real norm_max()
   {
     Real normInf = 0.0;
-    UniqueArray<HYPRE_Int> bfr_idx(jSize);
+    UniqueArray<HYPRE_BigInt> bfr_idx(jSize);
     UniqueArray<double> bfr_val(jSize);
 
     for (HYPRE_Int i = 0; i < jSize; ++i)
       bfr_idx[i] = jLower + i;
 
-    hypreCheck("HYPRE_IJVectorGetValues", HYPRE_IJVectorGetValues(m_hypre_ijvector, jSize, bfr_idx.unguardedBasePointer(), bfr_val.unguardedBasePointer()));
+    hypreCheck("HYPRE_IJVectorGetValues", HYPRE_IJVectorGetValues(m_hypre_ijvector, jSize, bfr_idx.data(), bfr_val.data()));
     for (HYPRE_Int i = 0; i < jSize; ++i) {
       const Real abs_val = math::abs(bfr_val[i]);
       if (abs_val > normInf)
@@ -263,8 +264,8 @@ class AlephMatrixHypre
   {
     debug() << "[AlephMatrixHypre::AlephMatrixCreate] HYPRE MatrixCreate idx:" << m_index;
     void* object;
-    Integer ilower = -1;
-    Integer iupper = 0;
+    AlephInt ilower = -1;
+    AlephInt iupper = 0;
     for (int iCpu = 0; iCpu < m_kernel->size(); ++iCpu) {
       if (m_kernel->rank() != m_kernel->solverRanks(m_index)[iCpu])
         continue;
@@ -274,8 +275,8 @@ class AlephMatrixHypre
     }
     debug() << "[AlephMatrixHypre::AlephMatrixCreate] ilower=" << ilower << ", iupper=" << iupper;
 
-    Integer jlower = ilower; //0;
-    Integer jupper = iupper; //m_kernel->topology()->gathered_nb_row(m_kernel->size())-1;
+    AlephInt jlower = ilower; //0;
+    AlephInt jupper = iupper; //m_kernel->topology()->gathered_nb_row(m_kernel->size())-1;
     debug() << "[AlephMatrixHypre::AlephMatrixCreate] jlower=" << jlower << ", jupper=" << jupper;
 
     hypreCheck("HYPRE_IJMatrixCreate",
@@ -310,11 +311,11 @@ class AlephMatrixHypre
 
   /******************************************************************************
    *****************************************************************************/
-  void AlephMatrixFill(int size, int* rows, int* cols, double* values)
+  void AlephMatrixFill(int size, HYPRE_Int* rows, HYPRE_Int* cols, double* values)
   {
     debug() << "[AlephMatrixHypre::AlephMatrixFill] size=" << size;
-    int rtn = 0;
-    int col[1] = { 1 };
+    HYPRE_Int rtn = 0;
+    HYPRE_Int col[1] = { 1 };
     for (int i = 0; i < size; i++) {
       rtn += HYPRE_IJMatrixSetValues(m_hypre_ijmatrix, 1, col, &rows[i], &cols[i], &values[i]);
     }
@@ -481,7 +482,7 @@ class AlephMatrixHypre
     }
 
     // résolution du système algébrique
-    int iteration = 0;
+    HYPRE_Int iteration = 0;
     double residue = 0.0;
 
     switch (solver_method) {
@@ -728,9 +729,9 @@ class AlephMatrixHypre
     // news
     Integer output_level = solver_param->getOutputLevel();
 
-    int* num_grid_sweeps = _allocHypre<int>(4);
-    int* grid_relax_type = _allocHypre<int>(4);
-    int** grid_relax_points = _allocHypre<int*>(4);
+    HYPRE_Int* num_grid_sweeps = _allocHypre<HYPRE_Int>(4);
+    HYPRE_Int* grid_relax_type = _allocHypre<HYPRE_Int>(4);
+    HYPRE_Int** grid_relax_points = _allocHypre<HYPRE_Int*>(4);
     double* relax_weight = _allocHypre<double>(max_levels);
 
     for (int i = 0; i < max_levels; i++)
@@ -740,7 +741,7 @@ class AlephMatrixHypre
       /* fine grid */
       num_grid_sweeps[0] = 3;
       grid_relax_type[0] = relax_default;
-      grid_relax_points[0] = _allocHypre<int>(3);
+      grid_relax_points[0] = _allocHypre<HYPRE_Int>(3);
       grid_relax_points[0][0] = -2;
       grid_relax_points[0][1] = -1;
       grid_relax_points[0][2] = 1;
@@ -748,7 +749,7 @@ class AlephMatrixHypre
       /* down cycle */
       num_grid_sweeps[1] = 4;
       grid_relax_type[1] = relax_default;
-      grid_relax_points[1] = _callocHypre<int>(4);
+      grid_relax_points[1] = _callocHypre<HYPRE_Int>(4);
       grid_relax_points[1][0] = -1;
       grid_relax_points[1][1] = 1;
       grid_relax_points[1][2] = -2;
@@ -757,7 +758,7 @@ class AlephMatrixHypre
       /* up cycle */
       num_grid_sweeps[2] = 4;
       grid_relax_type[2] = relax_default;
-      grid_relax_points[2] = _allocHypre<int>(4);
+      grid_relax_points[2] = _allocHypre<HYPRE_Int>(4);
       grid_relax_points[2][0] = -2;
       grid_relax_points[2][1] = -2;
       grid_relax_points[2][2] = 1;
@@ -767,7 +768,7 @@ class AlephMatrixHypre
       /* fine grid */
       num_grid_sweeps[0] = 2 * num_sweep;
       grid_relax_type[0] = relax_default;
-      grid_relax_points[0] = _allocHypre<int>(2 * num_sweep);
+      grid_relax_points[0] = _allocHypre<HYPRE_Int>(2 * num_sweep);
       for (int i = 0; i < 2 * num_sweep; i += 2) {
         grid_relax_points[0][i] = -1;
         grid_relax_points[0][i + 1] = 1;
@@ -776,7 +777,7 @@ class AlephMatrixHypre
       /* down cycle */
       num_grid_sweeps[1] = 2 * num_sweep;
       grid_relax_type[1] = relax_default;
-      grid_relax_points[1] = _allocHypre<int>(2 * num_sweep);
+      grid_relax_points[1] = _allocHypre<HYPRE_Int>(2 * num_sweep);
       for (int i = 0; i < 2 * num_sweep; i += 2) {
         grid_relax_points[1][i] = -1;
         grid_relax_points[1][i + 1] = 1;
@@ -785,7 +786,7 @@ class AlephMatrixHypre
       /* up cycle */
       num_grid_sweeps[2] = 2 * num_sweep;
       grid_relax_type[2] = relax_default;
-      grid_relax_points[2] = _allocHypre<int>(2 * num_sweep);
+      grid_relax_points[2] = _allocHypre<HYPRE_Int>(2 * num_sweep);
       for (int i = 0; i < 2 * num_sweep; i += 2) {
         grid_relax_points[2][i] = -1;
         grid_relax_points[2][i + 1] = 1;
@@ -795,7 +796,7 @@ class AlephMatrixHypre
     /* coarsest grid */
     num_grid_sweeps[3] = 1;
     grid_relax_type[3] = 9;
-    grid_relax_points[3] = _allocHypre<int>(1);
+    grid_relax_points[3] = _allocHypre<HYPRE_Int>(1);
     grid_relax_points[3][0] = 0;
 
     // end of default seting
@@ -847,7 +848,7 @@ class AlephMatrixHypre
                 HYPRE_ParCSRMatrix& M,
                 HYPRE_ParVector& B,
                 HYPRE_ParVector& X,
-                int& iteration,
+                HYPRE_Int& iteration,
                 double& residue)
   {
     const String func_name = "SolverMatrixHypre::solvePCG";
@@ -861,7 +862,7 @@ class AlephMatrixHypre
     HYPRE_ParCSRPCGGetNumIterations(solver, &iteration);
     HYPRE_ParCSRPCGGetFinalRelativeResidualNorm(solver, &residue);
 
-    int converged = 0;
+    HYPRE_Int converged = 0;
     HYPRE_PCGGetConverged(solver, &converged);
     error |= (!converged);
 
@@ -876,7 +877,7 @@ class AlephMatrixHypre
                      HYPRE_ParCSRMatrix& M,
                      HYPRE_ParVector& B,
                      HYPRE_ParVector& X,
-                     int& iteration,
+                     HYPRE_Int& iteration,
                      double& residue)
   {
     const String func_name = "SolverMatrixHypre::solveBiCGStab";
@@ -887,7 +888,7 @@ class AlephMatrixHypre
     HYPRE_ParCSRBiCGSTABGetNumIterations(solver, &iteration);
     HYPRE_ParCSRBiCGSTABGetFinalRelativeResidualNorm(solver, &residue);
 
-    int converged = 0;
+    HYPRE_Int converged = 0;
     hypre_BiCGSTABGetConverged(solver, &converged);
     error |= (!converged);
 
@@ -902,7 +903,7 @@ class AlephMatrixHypre
                   HYPRE_ParCSRMatrix& M,
                   HYPRE_ParVector& B,
                   HYPRE_ParVector& X,
-                  int& iteration,
+                  HYPRE_Int& iteration,
                   double& residue)
   {
     const String func_name = "SolverMatrixHypre::solveGMRES";
@@ -912,7 +913,7 @@ class AlephMatrixHypre
     HYPRE_ParCSRGMRESGetNumIterations(solver, &iteration);
     HYPRE_ParCSRGMRESGetFinalRelativeResidualNorm(solver, &residue);
 
-    int converged = 0;
+    HYPRE_Int converged = 0;
     HYPRE_GMRESGetConverged(solver, &converged);
     error |= (!converged);
 

--- a/arcane/src/arcane/aleph/petsc/AlephPETSc.cc
+++ b/arcane/src/arcane/aleph/petsc/AlephPETSc.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephPETSc.cc                                               (C) 2000-2023 */
+/* AlephPETSc.cc                                               (C) 2000-2024 */
 /*                                                                           */
 /* Implémentation PETSc de Aleph.                                            */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/tests/AlephTestModule.cc
+++ b/arcane/src/arcane/aleph/tests/AlephTestModule.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephUnitTest.cc                                            (C) 2000-2023 */
+/* AlephUnitTest.cc                                            (C) 2000-2024 */
 /*                                                                           */
 /* Service du test du service Aleph.                                         */
 /*---------------------------------------------------------------------------*/
@@ -182,12 +182,12 @@ initAlgebra()
   // Et on prépare une fois pour toutes les indices des vecteurs
   m_cell_matrix_idx.fill(-1);
   {
-    Integer idx = 0;
+    AlephInt idx = 0;
     // Tres important, car on y revient lors de la reconfiguration!!
     m_vector_indexs.resize(0);
     m_vector_zeroes.resize(0);
     m_vector_lhs.resize(0);
-    const Integer row_offset = m_aleph_kernel->topology()->part()[m_aleph_kernel->rank()];
+    const AlephInt row_offset = m_aleph_kernel->topology()->part()[m_aleph_kernel->rank()];
     ENUMERATE_CELL (iCell, MESH_OWN_ACTIVE_CELLS(mesh())) {
       m_cell_matrix_idx[iCell] = row_offset + idx;
       m_vector_indexs.add(m_cell_matrix_idx[iCell] = row_offset + idx);

--- a/arcane/src/arcane/aleph/tests/AlephTestModule.h
+++ b/arcane/src/arcane/aleph/tests/AlephTestModule.h
@@ -5,11 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephTestModule.h                                                (C) 2011 */
+/* AlephTestModule.h                                           (C) 2000-2024 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
-#ifndef ALEPH_TEST_MODULE_H
-#define ALEPH_TEST_MODULE_H
+#ifndef ARCANE_TESTS_ALEPHTESTMODULE_H
+#define ARCANE_TESTS_ALEPHTESTMODULE_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 #include "arcane/aleph/tests/AlephTest.h"
 #include "arcane/aleph/tests/AlephTestModule_axl.h"
@@ -17,36 +19,43 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANETEST_BEGIN_NAMESPACE
+namespace ArcaneTest
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
 using namespace Arcane;
 
-/******************************************************************************
- * ALEPH TEST MODULE                                                          *
- ******************************************************************************/
-class AlephTestModule : public ArcaneAlephTestModuleObject
+/*!
+ * \brief Module de test pour Aleph.
+ */
+class AlephTestModule
+: public ArcaneAlephTestModuleObject
 {
  public:
-  AlephTestModule(const ModuleBuildInfo&);
+
+  explicit AlephTestModule(const ModuleBuildInfo&);
   ~AlephTestModule();
   void init();
   void compute();
   void postSolver(const Integer);
 
  private:
+
   void initAmrRefineMesh(Integer nb_to_refine);
   void initAlgebra();
 
  public:
+
   static Real geoFaceSurface(Face, VariableItemReal3&);
 
  public:
+
   Integer m_total_nb_cell;
   Integer m_local_nb_cell;
   UniqueArray<Integer> m_rows_nb_element;
-  UniqueArray<Integer> m_vector_indexs;
+  UniqueArray<AlephInt> m_vector_indexs;
   UniqueArray<Real> m_vector_zeroes;
   UniqueArray<Real> m_vector_rhs;
   UniqueArray<Real> m_vector_lhs;
@@ -64,7 +73,7 @@ class AlephTestModule : public ArcaneAlephTestModuleObject
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANETEST_END_NAMESPACE
+} // namespace ArcaneTest
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
At the moment `AlephInt` has type `int` but it will change when we will add support for 64bit indexing.
