### PR TITLE
Use checkpoint service 'ArcaneBasic2CheckpointWriter' for mesh criteria tests

### DIFF
--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-DefaultPartitioner-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-DefaultPartitioner-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-DefaultPartitioner-MeshPartitionerTester-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-DefaultPartitioner-MeshPartitionerTester-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-MeshPartitionerTester-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-MeshPartitionerTester-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-PTScotch-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-PTScotch-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-PTScotch-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-PTScotch-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-PTScotch-4-2.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-PTScotch-4-2.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-Zoltan-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-Zoltan-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-Zoltan-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-Zoltan-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-Zoltan-4-2.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Metis-Zoltan-4-2.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-Zoltan-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-Zoltan-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-Zoltan-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-Zoltan-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-Zoltan-4-2.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-PTScotch-Zoltan-4-2.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Zoltan-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Zoltan-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-Zoltan-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-Zoltan-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>


### PR DESCRIPTION
This is needed to use these tests even if HDF5 is not installed (because the default checkpoint service use HDF5).