### PR TITLE
Fix compilation with CRAY MPICH version 8+

### DIFF
--- a/arcane/src/arcane/parallel/mpi/ArcaneMpi.cc
+++ b/arcane/src/arcane/parallel/mpi/ArcaneMpi.cc
@@ -60,7 +60,14 @@ arcaneIsHipAwareMPI()
   // MPICH
 #if defined(ARCANE_OS_LINUX)
 #if defined(MPIX_GPU_SUPPORT_HIP)
+  // CRAY MPICH
+#  if defined(CRAY_MPICH_VERSION)
+  int is_supported = 0;
+  MPIX_GPU_query_support(MPIX_GPU_SUPPORT_HIP,&is_supported);
+  is_aware = (is_supported!=0);
+#  else
   is_aware =  (MPIX_Query_hip_support()==1);
+#  endif
 #endif
 
   // OpenMPI:


### PR DESCRIPTION
The Cray implementation of MPI based on MPICH has a minor difference with standard MPICH: it has a method `MPIX_Query_cuda_support()` but no method `MPIX_Query_hip_support()`. Instead we had to use `MPIX_GPU_query_support()`