### PR TITLE
Disallow reusing the command to launch two kernels

### DIFF
--- a/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.cc
+++ b/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.cc
@@ -245,12 +245,10 @@ _testDirCellAccelerator()
   CellDirectionMng cdm2;
   CellDirectionMng cdm3;
 
-  auto queue = m_accelerator_mng->defaultQueue();
-  auto command = makeCommand(*queue);
+  auto queue = m_accelerator_mng->queue();
 
   VariableCellInt32 dummy_var(VariableBuildInfo(mesh, "DummyCellVariable"));
   dummy_var.fill(0);
-  auto inout_dummy_var = viewInOut(command, dummy_var);
 
   for (Integer idir = 0; idir < nb_dir; ++idir) {
     CellDirectionMng cdm(m_cartesian_mesh->cellDirection(idir));
@@ -258,6 +256,8 @@ _testDirCellAccelerator()
     cdm3 = cdm;
     info() << "ACCELERATOR_DIRECTION=" << idir << " Cells=" << cdm.allCells().name();
     _checkItemGroupIsSorted(cdm.allCells());
+    auto command = makeCommand(queue);
+    auto inout_dummy_var = viewInOut(command, dummy_var);
     command << RUNCOMMAND_ENUMERATE(Cell, icell, cdm.allCells())
     {
       DirCellLocalId dir_cell(cdm.dirCellId(icell));

--- a/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.cc
+++ b/arcane/ceapart/src/arcane/tests/CartesianMeshTestUtils.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CartesianMeshTestUtils.cc                                   (C) 2000-2023 */
+/* CartesianMeshTestUtils.cc                                   (C) 2000-2024 */
 /*                                                                           */
 /* Fonctions utilitaires pour les tests de 'CartesianMesh'.                  */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
@@ -191,6 +191,7 @@ _internalCreateOrGetRunCommandImpl()
   else {
     p = RunCommand::_internalCreateImpl(this);
   }
+  p->_reset();
   m_active_run_command_list.add(p);
   return p;
 }

--- a/arcane/src/arcane/accelerator/core/internal/RunCommandImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunCommandImpl.h
@@ -38,6 +38,7 @@ namespace Arcane::Accelerator::impl
 class RunCommandImpl
 {
   friend RunCommand;
+  friend RunQueueImpl;
 
  public:
 
@@ -109,6 +110,15 @@ class RunCommandImpl
 
   //! Indique si la commande s'exécute sur accélérateur
   const bool m_use_accelerator = false;
+
+  /*!
+  * \brief Indique si on autorise à utiliser plusieurs fois la même commande.
+   *
+   * Normalement cela est interdit mais avant novembre 2024, il n'y avait pas
+   * de mécanisme pour détecter cela. On peut donc temporairement autoriser
+   * cela et dans un on supprimera cette possibilité.
+   */
+  bool m_is_allow_reuse_command = false;
 
  private:
 

--- a/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
@@ -55,7 +55,8 @@ class AcceleratorViewsUnitTest
 
  private:
 
-  ax::Runner* m_runner = nullptr;
+  ax::Runner m_runner;
+  ax::RunQueue m_queue;
   VariableCellArrayReal m_cell_array1;
   VariableCellArrayReal m_cell_array2;
   VariableCellReal2 m_cell1_real2;
@@ -136,7 +137,8 @@ AcceleratorViewsUnitTest::
 void AcceleratorViewsUnitTest::
 initializeTest()
 {
-  m_runner = subDomain()->acceleratorMng()->defaultRunner();
+  m_runner = subDomain()->acceleratorMng()->runner();
+  m_queue = subDomain()->acceleratorMng()->queue();
 
   m_cell_array1.resize(12);
   m_cell_array2.resize(12);
@@ -217,7 +219,6 @@ _executeTest1()
 {
   info() << "Test1";
   auto queue = makeQueue(m_runner);
-  auto command = makeCommand(queue);
 
   Integer dim2_size = m_cell_array1.arraySize();
 
@@ -225,56 +226,63 @@ _executeTest1()
     int seed = 37;
     _setCellArrayValue(seed);
 
-    auto in_cell_array1 = ax::viewIn(command, m_cell_array1);
-    auto out_cell_array2 = ax::viewOut(command, m_cell_array2);
-    auto in_partial_cell_array1 = ax::viewIn(command, m_partial_cell_array1);
-    auto out_partial_cell_array2 = ax::viewOut(command, m_partial_cell_array2);
-    auto inout_partial_cell_array2 = ax::viewInOut(command, m_partial_cell_array2);
-
-    auto in_partial_cell1 = ax::viewIn(command, m_partial_cell1);
-    auto out_partial_cell2 = ax::viewOut(command, m_partial_cell2);
-    auto inout_partial_cell2 = ax::viewOut(command, m_partial_cell2);
-
-    auto in_partial_cell1_real3 = ax::viewIn(command, m_partial_cell1_real3);
-    auto out_partial_cell2_real3 = ax::viewOut(command, m_partial_cell2_real3);
-    auto inout_partial_cell2_real3 = ax::viewInOut(command, m_partial_cell2_real3);
-
-    command << RUNCOMMAND_ENUMERATE (CellLocalId, vi, allCells())
     {
-      out_cell_array2[vi].copy(in_cell_array1[vi]);
-    };
+      auto command = makeCommand(m_queue);
+      auto in_cell_array1 = viewIn(command, m_cell_array1);
+      auto out_cell_array2 = viewOut(command, m_cell_array2);
+
+      command << RUNCOMMAND_ENUMERATE (CellLocalId, vi, allCells())
+      {
+        out_cell_array2[vi].copy(in_cell_array1[vi]);
+      };
+    }
 
     _checkCellArrayValue("View1");
 
-    command << RUNCOMMAND_ENUMERATE (IteratorWithIndex<CellLocalId>, vi, m_partial_cell_array1.itemGroup())
     {
-      CellEnumeratorIndex iter_index(vi.index());
-      CellLocalId cell_lid(vi.value());
-      out_partial_cell_array2[iter_index].copy(in_cell_array1[cell_lid]);
-      out_partial_cell_array2[iter_index][0] = in_partial_cell_array1[cell_lid][1];
-      Real3 xyz(in_partial_cell1_real3[iter_index].y, in_partial_cell1_real3[iter_index].z, in_partial_cell1_real3[iter_index].x);
-      Int32 modulo = vi.index() % 4;
-      if (modulo == 3) {
-        out_partial_cell_array2[iter_index][1] = in_partial_cell1[iter_index];
-        out_partial_cell2[iter_index] = in_partial_cell1[iter_index];
-        out_partial_cell2_real3[iter_index] = xyz;
-      }
-      else if (modulo == 2) {
-        inout_partial_cell_array2[cell_lid][1] = in_partial_cell1[cell_lid];
-        inout_partial_cell2[cell_lid] = in_partial_cell1[iter_index];
-        inout_partial_cell2_real3[cell_lid] = xyz;
-      }
-      else if (modulo == 1) {
-        out_partial_cell_array2[cell_lid][1] = in_partial_cell1[iter_index];
-        out_partial_cell2[cell_lid] = in_partial_cell1[iter_index];
-        out_partial_cell2_real3[cell_lid] = xyz;
-      }
-      else {
-        inout_partial_cell_array2[iter_index][1] = in_partial_cell1[cell_lid];
-        inout_partial_cell2[iter_index] = in_partial_cell1[iter_index];
-        inout_partial_cell2_real3[iter_index] = xyz;
-      }
-    };
+      auto command = makeCommand(m_queue);
+      auto in_cell_array1 = viewIn(command, m_cell_array1);
+      auto in_partial_cell_array1 = viewIn(command, m_partial_cell_array1);
+      auto out_partial_cell_array2 = viewOut(command, m_partial_cell_array2);
+      auto inout_partial_cell_array2 = viewInOut(command, m_partial_cell_array2);
+
+      auto in_partial_cell1 = viewIn(command, m_partial_cell1);
+      auto out_partial_cell2 = viewOut(command, m_partial_cell2);
+      auto inout_partial_cell2 = viewOut(command, m_partial_cell2);
+
+      auto in_partial_cell1_real3 = viewIn(command, m_partial_cell1_real3);
+      auto out_partial_cell2_real3 = viewOut(command, m_partial_cell2_real3);
+      auto inout_partial_cell2_real3 = viewInOut(command, m_partial_cell2_real3);
+      command << RUNCOMMAND_ENUMERATE (IteratorWithIndex<CellLocalId>, vi, m_partial_cell_array1.itemGroup())
+      {
+        CellEnumeratorIndex iter_index(vi.index());
+        CellLocalId cell_lid(vi.value());
+        out_partial_cell_array2[iter_index].copy(in_cell_array1[cell_lid]);
+        out_partial_cell_array2[iter_index][0] = in_partial_cell_array1[cell_lid][1];
+        Real3 xyz(in_partial_cell1_real3[iter_index].y, in_partial_cell1_real3[iter_index].z, in_partial_cell1_real3[iter_index].x);
+        Int32 modulo = vi.index() % 4;
+        if (modulo == 3) {
+          out_partial_cell_array2[iter_index][1] = in_partial_cell1[iter_index];
+          out_partial_cell2[iter_index] = in_partial_cell1[iter_index];
+          out_partial_cell2_real3[iter_index] = xyz;
+        }
+        else if (modulo == 2) {
+          inout_partial_cell_array2[cell_lid][1] = in_partial_cell1[cell_lid];
+          inout_partial_cell2[cell_lid] = in_partial_cell1[iter_index];
+          inout_partial_cell2_real3[cell_lid] = xyz;
+        }
+        else if (modulo == 1) {
+          out_partial_cell_array2[cell_lid][1] = in_partial_cell1[iter_index];
+          out_partial_cell2[cell_lid] = in_partial_cell1[iter_index];
+          out_partial_cell2_real3[cell_lid] = xyz;
+        }
+        else {
+          inout_partial_cell_array2[iter_index][1] = in_partial_cell1[cell_lid];
+          inout_partial_cell2[iter_index] = in_partial_cell1[iter_index];
+          inout_partial_cell2_real3[iter_index] = xyz;
+        }
+      };
+    }
     info() << "Check Partial values";
     ENUMERATE_ (Cell, iter, m_partial_cell_array1.itemGroup()) {
       CellEnumeratorIndex iter_index(iter.index());
@@ -289,6 +297,8 @@ _executeTest1()
   {
     int seed = 23;
     _setCellArrayValue(seed);
+
+    auto command = makeCommand(m_queue);
 
     auto in_cell_array1 = viewIn(command, m_cell_array1);
     auto out_cell_array2 = viewOut(command, m_cell_array2);
@@ -305,6 +315,8 @@ _executeTest1()
     int seed = 53;
     _setCellArrayValue(seed);
 
+    auto command = makeCommand(m_queue);
+
     auto in_cell_array1 = viewInOut(command, m_cell_array1);
     auto out_cell_array2 = viewOut(command, m_cell_array2);
 
@@ -320,6 +332,8 @@ _executeTest1()
     int seed = 93;
     _setCellArrayValue(seed);
 
+    auto command = makeCommand(m_queue);
+
     auto in_cell_array1 = ax::viewIn(command, m_cell_array1);
     auto out_cell_array2 = ax::viewInOut(command, m_cell_array2);
 
@@ -334,6 +348,8 @@ _executeTest1()
   {
     int seed = 43;
     _setCellArrayValue(seed);
+
+    auto command = makeCommand(m_queue);
 
     auto inout_cell_array1 = ax::viewInOut(command, m_cell_array1);
     auto out_cell_array2 = ax::viewInOut(command, m_cell_array2);
@@ -686,7 +702,7 @@ _executeTestMemoryCopy()
   info() << "Execute Test MemoryCopy";
   eMemoryRessource source_mem = eMemoryRessource::Host;
   eMemoryRessource dest_mem = eMemoryRessource::Host;
-  if (ax::impl::isAcceleratorPolicy(m_runner->executionPolicy()))
+  if (ax::impl::isAcceleratorPolicy(m_runner.executionPolicy()))
     dest_mem = eMemoryRessource::Device;
 
   const int nb_value = 100000;

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -414,15 +414,15 @@ _executeTest1(Integer nb_z, EnvCellVectorView env1)
   // GPU
   {
     auto queue = makeQueue(m_runner);
-    auto cmd = makeCommand(queue);
-
-    auto out_a = ax::viewOut(cmd, m_mat_a);
-    auto in_b = ax::viewIn(cmd, m_mat_b);
-    auto in_c = ax::viewIn(cmd, m_mat_c);
-    auto in_d = ax::viewIn(cmd, m_mat_d);
-    auto in_e = ax::viewIn(cmd, m_mat_e);
 
     for (Integer z = 0, iz = nb_z; z < iz; ++z) {
+      auto cmd = makeCommand(queue);
+
+      auto out_a = viewOut(cmd, m_mat_a);
+      auto in_b = viewIn(cmd, m_mat_b);
+      auto in_c = viewIn(cmd, m_mat_c);
+      auto in_d = viewIn(cmd, m_mat_d);
+      auto in_e = viewIn(cmd, m_mat_e);
       cmd << RUNCOMMAND_MAT_ENUMERATE(EnvCell, evi, env1)
       {
         out_a[evi] = in_b[evi] + in_c[evi] * in_d[evi] + in_e[evi];
@@ -538,23 +538,21 @@ _executeTest2(Integer nb_z)
   // GPU
   {
     auto queue = makeQueue(m_runner);
-    auto cmd = makeCommand(queue);
-
-    auto inout_a = ax::viewInOut(cmd, m_mat_a);
-    auto in_b = ax::viewIn(cmd, m_mat_b);
-    auto out_c = ax::viewOut(cmd, m_mat_c);
-    auto in_d = ax::viewIn(cmd, m_mat_d.globalVariable());
-    auto in_e = ax::viewIn(cmd, m_mat_e.globalVariable());
-
-    auto inout_env_a = ax::viewInOut(cmd, m_env_a);
-    auto in_env_b = ax::viewIn(cmd, m_env_b);
-    auto out_env_c = ax::viewOut(cmd, m_env_c);
 
     for (Integer z = 0, iz = nb_z; z < iz; ++z) {
+
       ENUMERATE_ENV (ienv, m_mm_mng) {
         IMeshEnvironment* env = *ienv;
         EnvCellVectorView envcellsv = env->envView();
         {
+          auto cmd = makeCommand(queue);
+
+          auto inout_a = viewInOut(cmd, m_mat_a);
+          auto in_b = viewIn(cmd, m_mat_b);
+          auto in_e = viewIn(cmd, m_mat_e.globalVariable());
+
+          auto inout_env_a = viewInOut(cmd, m_env_a);
+          auto in_env_b = viewIn(cmd, m_env_b);
           cmd << RUNCOMMAND_MAT_ENUMERATE(EnvAndGlobalCell, evi, envcellsv)
           {
             auto [mvi, cid] = evi();
@@ -570,6 +568,11 @@ _executeTest2(Integer nb_z)
           };
         }
         {
+          auto cmd = makeCommand(queue);
+          auto inout_env_a = viewInOut(cmd, m_env_a);
+          auto out_c = viewOut(cmd, m_mat_c);
+          auto in_d = viewIn(cmd, m_mat_d.globalVariable());
+          auto out_env_c = viewOut(cmd, m_env_c);
           ax::ReducerSum2<Real> reducer2(cmd);
           cmd << RUNCOMMAND_MAT_ENUMERATE(EnvAndGlobalCell, evi, envcellsv, reducer2)
           {
@@ -636,15 +639,12 @@ _executeTest3(Integer nb_z)
         IMeshEnvironment* env = *ienv;
         EnvCellVectorView envcellsv = env->envView();
 
-        auto cmd = makeCommand(async_queues[env->id()]);
-
-        auto inout_a = ax::viewInOut(cmd, m_mat_a);
-        auto in_b = ax::viewIn(cmd, m_mat_b);
-        auto out_c = ax::viewOut(cmd, m_mat_c);
-        auto in_d = ax::viewIn(cmd, m_mat_d.globalVariable());
-        auto in_e = ax::viewIn(cmd, m_mat_e.globalVariable());
-
         {
+          auto cmd = makeCommand(async_queues[env->id()]);
+          auto inout_a = viewInOut(cmd, m_mat_a);
+          auto in_b = viewIn(cmd, m_mat_b);
+          auto in_e = viewIn(cmd, m_mat_e.globalVariable());
+
           cmd << RUNCOMMAND_MAT_ENUMERATE(EnvAndGlobalCell, evi, envcellsv)
           {
             auto [mvi, cid] = evi();
@@ -653,6 +653,11 @@ _executeTest3(Integer nb_z)
           };
         }
         {
+          auto cmd = makeCommand(async_queues[env->id()]);
+          auto inout_a = viewInOut(cmd, m_mat_a);
+          auto out_c = viewOut(cmd, m_mat_c);
+          auto in_d = viewIn(cmd, m_mat_d.globalVariable());
+
           cmd << RUNCOMMAND_MAT_ENUMERATE(EnvAndGlobalCell, evi, envcellsv)
           {
             auto [mvi, cid] = evi();
@@ -708,16 +713,15 @@ _executeTest4(Integer nb_z, bool use_new_impl)
   // GPU
   {
     auto queue = makeQueue(m_runner);
-    auto cmd = makeCommand(queue);
-
-    auto in_b = viewIn(cmd, m_mat_b);
-    auto out_c = viewOut(cmd, m_mat_c);
-    auto in_c_g = viewIn(cmd, m_mat_c.globalVariable());
-    auto out_a_g = viewOut(cmd, m_mat_a);
 
     if (use_new_impl) {
       for (Integer z = 0, iz = nb_z; z < iz; ++z) {
         AllEnvCellVectorView all_env_view = m_mm_mng->view(allCells());
+        auto cmd = makeCommand(queue);
+        auto in_b = viewIn(cmd, m_mat_b);
+        auto out_c = viewOut(cmd, m_mat_c);
+        auto in_c_g = viewIn(cmd, m_mat_c.globalVariable());
+        auto out_a_g = viewOut(cmd, m_mat_a);
         cmd << RUNCOMMAND_MAT_ENUMERATE(AllEnvCell, all_env_cell, all_env_view)
         {
           CellLocalId cid = all_env_cell.globalCellId();
@@ -743,6 +747,11 @@ _executeTest4(Integer nb_z, bool use_new_impl)
       CellToAllEnvCellAccessor cell2allenvcell(m_mm_mng);
 
       for (Integer z = 0, iz = nb_z; z < iz; ++z) {
+        auto cmd = makeCommand(queue);
+        auto in_b = viewIn(cmd, m_mat_b);
+        auto out_c = viewOut(cmd, m_mat_c);
+        auto in_c_g = viewIn(cmd, m_mat_c.globalVariable());
+        auto out_a_g = viewOut(cmd, m_mat_a);
         cmd << RUNCOMMAND_ENUMERATE_CELL_ALLENVCELL(cell2allenvcell, cid, allCells())
         {
 
@@ -836,17 +845,17 @@ _executeTest4(Integer nb_z, bool use_new_impl)
   // GPU
   {
     auto queue = makeQueue(m_runner);
-    auto cmd = makeCommand(queue);
-
-    auto in_b = ax::viewIn(cmd, m_mat_b);
-    auto out_c = ax::viewOut(cmd, m_mat_c);
-    auto in_c_g = ax::viewIn(cmd, m_mat_c.globalVariable());
-    auto out_a_g = ax::viewOut(cmd, m_mat_a);
 
     m_mm_mng->enableCellToAllEnvCellForRunCommand(true, true);
     CellToAllEnvCellAccessor cell2allenvcell(m_mm_mng);
 
     for (Integer z = 0, iz = nb_z; z < iz; ++z) {
+      auto cmd = makeCommand(queue);
+
+      auto in_b = ax::viewIn(cmd, m_mat_b);
+      auto out_c = ax::viewOut(cmd, m_mat_c);
+      auto in_c_g = ax::viewIn(cmd, m_mat_c.globalVariable());
+      auto out_a_g = ax::viewOut(cmd, m_mat_a);
       cmd << RUNCOMMAND_ENUMERATE_CELL_ALLENVCELL(cell2allenvcell, cid, allCells())
       {
 

--- a/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
+++ b/arcane/src/arcane/tests/accelerator/MiniWeatherArray.cc
@@ -588,27 +588,31 @@ template <typename LayoutType>
 void MiniWeatherArray<LayoutType>::
 set_halo_values_x(NumArray3Type& nstate)
 {
-  auto command = makeCommand(m_queue);
-
-  auto state_in_out = ax::viewInOut(command, nstate);
-  auto in_hy_dens_cell = ax::viewIn(command, hy_dens_cell);
-  auto in_hy_dens_theta_cell = ax::viewIn(command, hy_dens_theta_cell);
 
   const auto nx = this->nx();
   const auto nz = this->nz();
   const auto dz = this->dz();
   const auto k_beg = this->k_beg();
 
-  command << RUNCOMMAND_LOOP (iter, ArrayBounds<MDDim2>(NUM_VARS, nz))
   {
-    auto [ll, k] = iter();
-    state_in_out(ll, k + hs, 0) = state_in_out(ll, k + hs, nx + hs - 2);
-    state_in_out(ll, k + hs, 1) = state_in_out(ll, k + hs, nx + hs - 1);
-    state_in_out(ll, k + hs, nx + hs) = state_in_out(ll, k + hs, hs);
-    state_in_out(ll, k + hs, nx + hs + 1) = state_in_out(ll, k + hs, hs + 1);
-  };
+    auto command = makeCommand(m_queue);
+    auto state_in_out = ax::viewInOut(command, nstate);
+
+    command << RUNCOMMAND_LOOP (iter, ArrayBounds<MDDim2>(NUM_VARS, nz))
+    {
+      auto [ll, k] = iter();
+      state_in_out(ll, k + hs, 0) = state_in_out(ll, k + hs, nx + hs - 2);
+      state_in_out(ll, k + hs, 1) = state_in_out(ll, k + hs, nx + hs - 1);
+      state_in_out(ll, k + hs, nx + hs) = state_in_out(ll, k + hs, hs);
+      state_in_out(ll, k + hs, nx + hs + 1) = state_in_out(ll, k + hs, hs + 1);
+    };
+  }
 
   if (m_const.myrank == 0) {
+    auto command = makeCommand(m_queue);
+    auto state_in_out = ax::viewInOut(command, nstate);
+    auto in_hy_dens_cell = ax::viewIn(command, hy_dens_cell);
+    auto in_hy_dens_theta_cell = ax::viewIn(command, hy_dens_theta_cell);
     command << RUNCOMMAND_LOOP (iter, ArrayBounds<MDDim2>(nz, hs))
     {
       auto [k, i] = iter();


### PR DESCRIPTION
It was never allowed but there was no test to check it.
Re-using the same command will make profiling results wrong and may also have unknown side effects.
We can temporarily set the environment variable `ARCANE_ACCELERATOR_ALLOW_REUSE_COMMAND` to `1` allows to revert to previous behavior.