### PR TITLE
[arccon] Add optional dotnet wrapper to prevent first time use race condition

### DIFF
--- a/arccon/build-system/arccon_dotnet.in
+++ b/arccon/build-system/arccon_dotnet.in
@@ -1,0 +1,6 @@
+#!/bin/sh
+export HOME=@ARCCON_DOTNET_FAKEHOME@
+# To disable telemetry
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+@ARCCON_DOTNET_PATH@/dotnet "$@"


### PR DESCRIPTION
The wrapper is only used on Unix environment and may be disabled when setting CMake variable `ARCCON_NO_WRAPPER_FOR_DOTNET`.

The race condition is described in https://github.com/dotnet/runtime/issues/91987 and
https://github.com/dotnet/runtime/issues/80619 and does not seems to be resolved in `.Net 6` and `.Net 8`.
