### PR TITLE
Decouple the type of the property setter class from the type of the instance set

### DIFF
--- a/arcane/src/arcane/utils/ApplicationInfo.cc
+++ b/arcane/src/arcane/utils/ApplicationInfo.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ApplicationInfo.cc                                          (C) 2000-2020 */
+/* ApplicationInfo.cc                                          (C) 2000-2024 */
 /*                                                                           */
 /* Informations sur une application.                                         */
 /*---------------------------------------------------------------------------*/
@@ -17,6 +17,7 @@
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/List.h"
 #include "arcane/utils/Property.h"
+#include "arcane/utils/internal/ApplicationInfoProperties.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -443,7 +444,10 @@ addParameterLine(const String& line)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename V> void ApplicationInfo::
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template<typename V> void ApplicationInfoProperties::
 _applyPropertyVisitor(V& p)
 {
   auto b = p.builder();
@@ -486,7 +490,7 @@ _applyPropertyVisitor(V& p)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_REGISTER_PROPERTY_CLASS(ApplicationInfo,());
+ARCANE_REGISTER_PROPERTY_CLASS(ApplicationInfoProperties,());
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ApplicationInfo.h
+++ b/arcane/src/arcane/utils/ApplicationInfo.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ApplicationInfo.h                                           (C) 2000-2020 */
+/* ApplicationInfo.h                                           (C) 2000-2024 */
 /*                                                                           */
 /* Informations sur une application.                                         */
 /*---------------------------------------------------------------------------*/
@@ -17,7 +17,6 @@
 #include "arcane/utils/VersionInfo.h"
 #include "arcane/utils/String.h"
 #include "arcane/utils/UtilsTypes.h"
-#include "arcane/utils/PropertyDeclarations.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -38,7 +37,6 @@ class CommandLineArguments;
  */
 class ARCANE_UTILS_EXPORT ApplicationInfo
 {
-  ARCANE_DECLARE_PROPERTY_CLASS(ApplicationInfo);
  public:
 
   ApplicationInfo();

--- a/arcane/src/arcane/utils/JSONPropertyReader.h
+++ b/arcane/src/arcane/utils/JSONPropertyReader.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* JSONPropertyReader.h                                        (C) 2000-2020 */
+/* JSONPropertyReader.h                                        (C) 2000-2024 */
 /*                                                                           */
 /* Lecture de propriétés au format JSON.                                     */
 /*---------------------------------------------------------------------------*/
@@ -59,15 +59,15 @@ class JSONPropertyReader
  * Les valeurs de la propriété doivent être dans un élément fils de \a jv
  * dont le nom est celui de la classe \a T.
  */
-template<typename T> inline void
+template<typename T, typename PropertyType = T> inline void
 readFromJSON(JSONValue jv,T& instance)
 {
-  const char* instance_property_name = T :: propertyClassName();
+  const char* instance_property_name = PropertyType :: propertyClassName();
   JSONValue child_value = jv.child(instance_property_name);
   if (child_value.null())
     return;
   JSONPropertyReader reader(child_value,instance);
-  T :: applyPropertyVisitor(reader);
+  PropertyType :: applyPropertyVisitor(reader);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ParallelLoopOptions.cc
+++ b/arcane/src/arcane/utils/ParallelLoopOptions.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelLoopOptions.cc                                      (C) 2000-2022 */
+/* ParallelLoopOptions.cc                                      (C) 2000-2024 */
 /*                                                                           */
 /* Options de configuration pour les boucles parallèles en multi-thread.     */
 /*---------------------------------------------------------------------------*/
@@ -15,6 +15,7 @@
 
 #include "arcane/utils/Property.h"
 #include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/internal/ParallelLoopOptionsProperties.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -57,7 +58,7 @@ namespace
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template <typename V> void ParallelLoopOptions::
+template <typename V> void ParallelLoopOptionsProperties::
 _applyPropertyVisitor(V& p)
 {
   auto b = p.builder();
@@ -77,7 +78,7 @@ _applyPropertyVisitor(V& p)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_REGISTER_PROPERTY_CLASS(ParallelLoopOptions, ());
+ARCANE_REGISTER_PROPERTY_CLASS(ParallelLoopOptionsProperties, ());
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ParallelLoopOptions.h
+++ b/arcane/src/arcane/utils/ParallelLoopOptions.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelLoopOptions.h                                       (C) 2000-2022 */
+/* ParallelLoopOptions.h                                       (C) 2000-2024 */
 /*                                                                           */
 /* Options de configuration pour les boucles parallèles en multi-thread.     */
 /*---------------------------------------------------------------------------*/
@@ -15,7 +15,6 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/UtilsTypes.h"
-#include "arcane/utils/PropertyDeclarations.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -34,8 +33,6 @@ namespace Arcane
  */
 class ARCANE_UTILS_EXPORT ParallelLoopOptions
 {
-  ARCANE_DECLARE_PROPERTY_CLASS(ParallelLoopOptions);
-
  private:
 
   //! Drapeau pour indiquer quels champs ont été positionnés.

--- a/arcane/src/arcane/utils/ParameterListPropertyReader.h
+++ b/arcane/src/arcane/utils/ParameterListPropertyReader.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParameterListPropertyReader.h                               (C) 2000-2021 */
+/* ParameterListPropertyReader.h                               (C) 2000-2024 */
 /*                                                                           */
 /* Lecture de propriétés au format JSON.                                     */
 /*---------------------------------------------------------------------------*/
@@ -30,7 +30,7 @@ namespace Arcane::properties
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 //! \internal
-template<typename T>
+template<typename T, typename PropertyType = T>
 class ParameterListPropertyVisitor
 : public properties::PropertyVisitor<T>
 {
@@ -61,11 +61,11 @@ class ParameterListPropertyVisitor
 /*!
  * \brief Remplit les valeurs de \a instance à partir des paramètres \a args.
  */
-template<typename T> inline void
+template<typename T, typename PropertyType = T> inline void
 readFromParameterList(const ParameterList& args,T& instance)
 {
-  ParameterListPropertyVisitor reader(args,instance);
-  T :: applyPropertyVisitor(reader);
+  ParameterListPropertyVisitor<T,PropertyType> reader(args,instance);
+  PropertyType :: applyPropertyVisitor(reader);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/PropertyDeclarations.h
+++ b/arcane/src/arcane/utils/PropertyDeclarations.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* PropertyDeclarations.h                                      (C) 2000-2020 */
+/* PropertyDeclarations.h                                      (C) 2000-2024 */
 /*                                                                           */
 /* Déclaration des types et macros pour la gestion des propriétés.           */
 /*---------------------------------------------------------------------------*/
@@ -57,12 +57,13 @@ class PropertyDeclaration
  * class MyClass
  * {
  *  public:
- *   ARCANE_DECLARE_PROPERTY_CLASS(MyClass);
+ *   ARCANE_DECLARE_PROPERTY_CLASS(MyClass,InstanceType);
  * };
  * \endcode
  */
-#define ARCANE_DECLARE_PROPERTY_CLASS(class_name)\
+#define ARCANE_DECLARE_PROPERTY_CLASS(class_name)  \
  public:\
+  using PropertyInstanceType = class_name; \
   static const char* propertyClassName() { return #class_name; }\
   template<typename V> static void _applyPropertyVisitor(V& visitor);\
   static void applyPropertyVisitor(Arcane::properties::PropertyVisitor<class_name>& p); \
@@ -109,7 +110,7 @@ namespace\
   }\
 }\
 void aclass :: \
-applyPropertyVisitor(Arcane::properties::PropertyVisitor<aclass>& p)\
+ applyPropertyVisitor(Arcane::properties::PropertyVisitor<typename aclass :: PropertyInstanceType >& p) \
 {\
   aclass :: _applyPropertyVisitor(p);\
 }\

--- a/arcane/src/arcane/utils/internal/ApplicationInfoProperties.h
+++ b/arcane/src/arcane/utils/internal/ApplicationInfoProperties.h
@@ -1,0 +1,45 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ApplicationInfoProperties.h                                 (C) 2000-2024 */
+/*                                                                           */
+/* Informations sur une application.                                         */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_UTILS_INTERNAL_APPLICATIONINFOPROPERTIES_H
+#define ARCANE_UTILS_INTERNAL_APPLICATIONINFOPROPERTIES_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/ApplicationInfo.h"
+#include "arcane/utils/PropertyDeclarations.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Informations sur une application.
+ */
+class ARCANE_UTILS_EXPORT ApplicationInfoProperties
+: public ApplicationInfo
+{
+  ARCANE_DECLARE_PROPERTY_CLASS(ApplicationInfo);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/utils/internal/ParallelLoopOptionsProperties.h
+++ b/arcane/src/arcane/utils/internal/ParallelLoopOptionsProperties.h
@@ -1,0 +1,45 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ParallelLoopOptionsProperties.h                             (C) 2000-2024 */
+/*                                                                           */
+/* Options de configuration pour les boucles parallèles en multi-thread.     */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_UTILS_INTERNAL_PARALLELLOOPOPTIONSPROPERTIES_H
+#define ARCANE_UTILS_INTERANL_PARALLELLOOPOPTIONSPROPERTIES_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/ParallelLoopOptions.h"
+#include "arcane/utils/PropertyDeclarations.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Classe pour fixer les valeurs de ParallelLoopOptions via des propriétés.
+ */
+class ARCANE_UTILS_EXPORT ParallelLoopOptionsProperties
+: public ParallelLoopOptions
+{
+  ARCANE_DECLARE_PROPERTY_CLASS(ParallelLoopOptions);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif  

--- a/arcane/src/arcane/utils/srcs.cmake
+++ b/arcane/src/arcane/utils/srcs.cmake
@@ -333,6 +333,7 @@ set(ARCANE_SOURCES
   GraphBaseT.h
   DirectedGraphT.h
   DirectedAcyclicGraphT.h
+  internal/ApplicationInfoProperties.h
   internal/MemoryRessourceMng.h
   internal/IMemoryRessourceMngInternal.h
   internal/IMemoryCopier.h
@@ -341,6 +342,7 @@ set(ARCANE_SOURCES
   internal/SpecificMemoryCopyList.h
   internal/MemoryBuffer.h
   internal/MemoryPool.h
+  internal/ParallelLoopOptionsProperties.h
   )
 
 if (ARCANE_HAS_CXX20)


### PR DESCRIPTION
The goal is to hide implementation of the property machinery.
Update `ParallelLoopOptions` and `ApplicationInfo` to use the new mechanism.
