### PR TITLE
Fix typo in names of some IMemoryAllocator methods

### DIFF
--- a/arccore/src/collections/arccore/collections/IMemoryAllocator.h
+++ b/arccore/src/collections/arccore/collections/IMemoryAllocator.h
@@ -117,6 +117,14 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
    *
    * S'il n'y a aucune garantie, retourne 0.
    */
+  virtual size_t guaranteedAlignment(MemoryAllocationArgs args) const;
+
+  /*!
+   * \brief Valeur de l'alignement garanti par l'allocateur.
+   *
+   * \sa guaranteedAlignment()
+   */
+  ARCCORE_DEPRECATED_REASON("Y2024: Use guaranteedAlignment() instead")
   virtual size_t guarantedAlignment(MemoryAllocationArgs args) const;
 
   /*!
@@ -157,7 +165,7 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
   virtual void deallocate(void* ptr) = 0;
   ARCCORE_DEPRECATED_REASON("Y2023: use adjustedCapacity(MemoryAllocationArgs,Int64,Int64) instead")
   virtual size_t adjustCapacity(size_t wanted_capacity, size_t element_size) = 0;
-  ARCCORE_DEPRECATED_REASON("Y2023: use guarantedAlignment(MemoryAllocationArgs) instead")
+  ARCCORE_DEPRECATED_REASON("Y2023: use guaranteedAlignment(MemoryAllocationArgs) instead")
   virtual size_t guarantedAlignment() = 0;
 };
 

--- a/arccore/src/collections/arccore/collections/IMemoryAllocator.h
+++ b/arccore/src/collections/arccore/collections/IMemoryAllocator.h
@@ -140,7 +140,7 @@ class ARCCORE_COLLECTIONS_EXPORT IMemoryAllocator
   virtual void copyMemory(MemoryAllocationArgs args, AllocatedMemoryInfo destination, AllocatedMemoryInfo source);
 
   //! Ressource mémoire fournie par l'allocateur
-  virtual eMemoryResource memoryRessource() const { return eMemoryResource::Unknown; }
+  virtual eMemoryResource memoryResource() const { return eMemoryResource::Unknown; }
 
  public:
 
@@ -278,6 +278,7 @@ class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator
   void deallocate(void* ptr) override;
   size_t adjustCapacity(size_t wanted_capacity, size_t element_size) override;
   size_t guarantedAlignment() override { return 0; }
+  eMemoryResource memoryResource() const override { return eMemoryResource::Host; }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -313,6 +314,7 @@ class ARCCORE_COLLECTIONS_EXPORT DefaultMemoryAllocator3
   void deallocate(MemoryAllocationArgs, AllocatedMemoryInfo ptr) override;
   Int64 adjustedCapacity(MemoryAllocationArgs, Int64 wanted_capacity, Int64 element_size) const override;
   size_t guarantedAlignment(MemoryAllocationArgs) const override { return 0; }
+  eMemoryResource memoryResource() const override { return eMemoryResource::Host; }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -407,6 +409,7 @@ class ARCCORE_COLLECTIONS_EXPORT AlignedMemoryAllocator
   void deallocate(void* ptr) override;
   size_t adjustCapacity(size_t wanted_capacity, size_t element_size) override;
   size_t guarantedAlignment() override { return m_alignment; }
+  eMemoryResource memoryResource() const override { return eMemoryResource::Host; }
 
  private:
 
@@ -494,6 +497,7 @@ class ARCCORE_COLLECTIONS_EXPORT AlignedMemoryAllocator3
   void deallocate(MemoryAllocationArgs args, AllocatedMemoryInfo ptr) override;
   Int64 adjustedCapacity(MemoryAllocationArgs args, Int64 wanted_capacity, Int64 element_size) const override;
   size_t guarantedAlignment(MemoryAllocationArgs) const override { return m_alignment; }
+  eMemoryResource memoryResource() const override { return eMemoryResource::Host; }
 
  private:
 

--- a/arccore/src/collections/arccore/collections/MemoryAllocator.cc
+++ b/arccore/src/collections/arccore/collections/MemoryAllocator.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryAllocator.cc                                          (C) 2000-2023 */
+/* MemoryAllocator.cc                                          (C) 2000-2024 */
 /*                                                                           */
 /* Allocateurs mémoires.                                                     */
 /*---------------------------------------------------------------------------*/
@@ -436,6 +436,15 @@ guarantedAlignment(MemoryAllocationArgs) const
 {
   auto* x = const_cast<IMemoryAllocator*>(this);
   return x->guarantedAlignment();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+size_t IMemoryAllocator::
+guaranteedAlignment(MemoryAllocationArgs args) const
+{
+  return guarantedAlignment(args);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/collections/tests/TestArray.cc
+++ b/arccore/src/collections/tests/TestArray.cc
@@ -897,7 +897,7 @@ class TesterMemoryAllocatorV3
   size_t guarantedAlignment(MemoryAllocationArgs args) const override
   {
     _checkValid(args);
-    return m_default_allocator.guarantedAlignment(args);
+    return m_default_allocator.guaranteedAlignment(args);
   }
 
   void notifyMemoryArgsChanged(MemoryAllocationArgs old_args, MemoryAllocationArgs new_args, AllocatedMemoryInfo ptr) override


### PR DESCRIPTION
Change `memoryRessource()` to `memoryResource()` and `guarantedAlignment()` to `guaranteedAlignment()`.
