### PR TITLE
Use more explicit name for some NumArray methods

### DIFF
--- a/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
@@ -455,7 +455,7 @@ _executeTest3()
   CellGroup own_cells = allCells().own();
   Int32 max_local_id = own_cells.itemFamily()->maxLocalId();
   NumArray<Int32, MDDim1> checked_local_ids(max_local_id);
-  checked_local_ids.fill(-1, &queue);
+  checked_local_ids.fill(-1, queue);
   {
     // Remplit out_checked_local_ids avec le i-ème localId() du groupe.
     auto out_checked_local_ids = ax::viewOut(command, checked_local_ids);

--- a/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryCopyUnitTest.cc                                       (C) 2000-2023 */
+/* MemoryCopyUnitTest.cc                                       (C) 2000-2024 */
 /*                                                                           */
 /* Service de test des noyaux de recopie mémoire.                            */
 /*---------------------------------------------------------------------------*/
@@ -351,7 +351,7 @@ _executeFill(eMemoryRessource mem_kind, bool use_queue, bool use_index)
   info() << "Execute Fill memory_ressource=" << mem_kind
          << " use_queue=" << use_queue << " use_index=" << use_index;
 
-  auto queue = makeQueue(m_runner);
+  RunQueue queue = makeQueue(m_runner);
   RunQueue* queue_ptr = &queue;
   if (!use_queue)
     queue_ptr = nullptr;
@@ -409,7 +409,7 @@ _executeFill(eMemoryRessource mem_kind, bool use_queue, bool use_index)
     if (use_index) {
       NumArray<Int16, MDDim1> filter(eMemoryRessource::Host);
       filter.resize(n1);
-      filter.fill(0);
+      filter.fillHost(0);
       for (Int32 i = 0; i < nb_index; ++i)
         filter[indexes[i]] = 1;
 

--- a/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/NumArrayUnitTest.cc
@@ -389,7 +389,7 @@ _executeTest1(eMemoryRessource mem_kind)
   // Tableaux 2D
   {
     NumArray<double, MDDim2> t1(mem_kind);
-    t1.resize(n1, n2);
+    t1.resizeDestructive(n1, n2);
     _doRank2(queue, t1, expected_sum2);
   }
   {
@@ -410,12 +410,12 @@ _executeTest1(eMemoryRessource mem_kind)
   // Tableaux 3D
   {
     NumArray<double, MDDim3, LeftLayout> t1(mem_kind);
-    t1.resize(n1, n2, n3);
+    t1.resizeDestructive(n1, n2, n3);
     _doRank3(queue, t1, expected_sum3);
   }
   {
     NumArray<double, MDDim3, RightLayout> t1(mem_kind);
-    t1.resize(n1, n2, n3);
+    t1.resizeDestructive(n1, n2, n3);
     _doRank3(queue, t1, expected_sum3);
   }
   {
@@ -638,7 +638,7 @@ _executeTest4(eMemoryRessource mem_kind)
           out_t1[i] = _getValue(i);
       };
       NumArray<double, MDDim1> host_t1(eMemoryRessource::Host);
-      host_t1.copy(_toMDSpan(t1), &queue);
+      host_t1.copy(_toMDSpan(t1), queue);
       double s1 = _doSum(host_t1, { n1 }, &queue);
       info() << "SUM1 = " << s1;
       vc.areEqual(s1, expected_sum1, "SUM1");
@@ -657,7 +657,7 @@ _executeTest4(eMemoryRessource mem_kind)
       };
 
       NumArray<double, MDDim1> host_t2(eMemoryRessource::Host);
-      host_t2.copy(_toMDSpan(t2), &queue);
+      host_t2.copy(_toMDSpan(t2), queue);
       double s2 = _doSum(host_t2, { n1 }, &queue);
       info() << "SUM1_2 = " << s2;
       vc.areEqual(s2, expected_sum1, "SUM1_2");
@@ -784,15 +784,15 @@ _arcaneNumArraySamples()
   // Redimensionne t2 avec 6x5 valeurs
   t2.resize(6);
   // Redimensionne t3 avec 2x7x4 valeurs
-  t3.resize(2, 4);
+  t3.resizeDestructive(2, 4);
   // Redimensionne a1 avec 12 valeurs
-  a1.resize(12);
+  a1.resizeDestructive(12);
   // Redimensionne a2 avec 3x4 valeurs
-  a2.resize(3, 4);
+  a2.resizeDestructive(3, 4);
   // Redimensionne a3 avec 2x7x6 valeurs
-  a3.resize(2, 7, 6);
+  a3.resizeDestructive(2, 7, 6);
   // Redimensionne a1 avec 2x9x4x6 valeurs
-  a4.resize(2, 9, 4, 6);
+  a4.resizeDestructive(2, 9, 4, 6);
   //![SampleNumArrayResize]
 
   //![SampleNumArrayDeclarationsMemory]

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -285,33 +285,73 @@ class NumArray
 
  public:
 
+  //! Modifie la taille du tableau en gardant pas les valeurs actuelles
+  void resize(Int32 dim1_size) requires(Extents::nb_dynamic == 1)
+  {
+    m_span.m_extents = DynamicDimsType(dim1_size);
+    _resize();
+  }
+
+  // TODO: Rendre obsolète (juin 2025)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, Int32 dim4_size) requires(Extents::nb_dynamic == 4)
+  {
+    this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size, dim4_size));
+  }
+
+  // TODO: Rendre obsolète (juin 2025)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size) requires(Extents::nb_dynamic == 3)
+  {
+    this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size));
+  }
+
+  // TODO: Rendre obsolète (juin 2025)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resize(Int32 dim1_size, Int32 dim2_size) requires(Extents::nb_dynamic == 2)
+  {
+    this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size));
+  }
+
   /*!
    * \brief Modifie la taille du tableau.
    * \warning Les valeurs actuelles ne sont pas conservées lors de cette opération
    * et les nouvelles valeurs ne sont pas initialisées.
    */
   //@{
-  void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, Int32 dim4_size) requires(Extents::nb_dynamic == 4)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resizeDestructive(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, Int32 dim4_size) requires(Extents::nb_dynamic == 4)
   {
-    this->resize(DynamicDimsType(dim1_size, dim2_size, dim3_size, dim4_size));
+    this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size, dim4_size));
   }
 
-  void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size) requires(Extents::nb_dynamic == 3)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resizeDestructive(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size) requires(Extents::nb_dynamic == 3)
   {
-    this->resize(DynamicDimsType(dim1_size, dim2_size, dim3_size));
+    this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size));
   }
 
-  void resize(Int32 dim1_size, Int32 dim2_size) requires(Extents::nb_dynamic == 2)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resizeDestructive(Int32 dim1_size, Int32 dim2_size) requires(Extents::nb_dynamic == 2)
   {
-    this->resize(DynamicDimsType(dim1_size, dim2_size));
+    this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size));
   }
 
-  void resize(Int32 dim1_size) requires(Extents::nb_dynamic == 1)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resizeDestructive(Int32 dim1_size) requires(Extents::nb_dynamic == 1)
   {
-    this->resize(DynamicDimsType(dim1_size));
+    this->resizeDestructive(DynamicDimsType(dim1_size));
   }
 
+  // TODO: Rendre obsolète (juin 2025)
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
   void resize(const DynamicDimsType& dims)
+  {
+    resizeDestructive(dims);
+  }
+
+  //! Modifie la taille du tableau en ne gardant pas les valeurs actuelles
+  void resizeDestructive(const DynamicDimsType& dims)
   {
     m_span.m_extents = dims;
     _resize();
@@ -328,8 +368,7 @@ class NumArray
    */
   void fill(const DataType& v)
   {
-    _checkHost(memoryRessource());
-    m_data.fill(v);
+    fillHost(v);
   }
 
   /*!
@@ -349,6 +388,18 @@ class NumArray
   void fill(const DataType& v, const RunQueue* queue)
   {
     m_data.fill(v, queue);
+  }
+
+  /*!
+   * \brief Remplit les valeurs du tableau par \a v.
+   *
+   * L'opération se fait sur l'hôte donc la mémoire associée
+   * à l'instance doit être accessible sur l'hôte.
+   */
+  void fillHost(const DataType& v)
+  {
+    _checkHost(memoryRessource());
+    m_data.fill(v);
   }
 
  public:


### PR DESCRIPTION
- Rename `NumArray::fill()` to `NumArray::fillHost()`
- Rename `NumArray::resize()` to `NumArray::resizeDestructive()` for rank greater than 1.
- Add `const RunQueue&` overload to `NumArray::fill()` and `NumArray::copy()`.
