### PR TITLE
Use 'ArcaneBasic2CheckpointWriter' for checkpoint service of mesh criteria tests

### DIFF
--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-DefaultPartitioner-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-DefaultPartitioner-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>

--- a/arcane/tests/testMeshCriteriaLoadBalanceMng-MeshPartitionerTester-4-1.arc
+++ b/arcane/tests/testMeshCriteriaLoadBalanceMng-MeshPartitionerTester-4-1.arc
@@ -79,4 +79,8 @@
     </mesh-params>
   </mesh-criteria-load-balance-mng-test>
 
+  <arcane-checkpoint>
+    <checkpoint-service name="ArcaneBasic2CheckpointWriter" />
+  </arcane-checkpoint>
+
 </case>


### PR DESCRIPTION
The default checkpoint writer uses `Hdf5` and these tests are failing if Hdf5 is not available.
