### PR TITLE
Deprecate 'MemoryUtils::getAcceleratorHostMemoryAllocator()'

### DIFF
--- a/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableIndexer.cc
@@ -40,8 +40,8 @@ MeshMaterialVariableIndexer::
 MeshMaterialVariableIndexer(ITraceMng* tm, const String& name)
 : TraceAccessor(tm)
 , m_name(name)
-, m_matvar_indexes(platform::getAcceleratorHostMemoryAllocator())
-, m_local_ids(platform::getAcceleratorHostMemoryAllocator())
+, m_matvar_indexes(MemoryUtils::getDefaultDataAllocator())
+, m_local_ids(MemoryUtils::getDefaultDataAllocator())
 {
   _init();
   m_matvar_indexes.setDebugName(String("VariableIndexerMatVarIndexes")+name);

--- a/arcane/src/arcane/tests/accelerator/SimpleHydroAcceleratorService.cc
+++ b/arcane/src/arcane/tests/accelerator/SimpleHydroAcceleratorService.cc
@@ -246,7 +246,7 @@ SimpleHydroAcceleratorService(const ServiceBuildInfo& sbi)
 , m_delta_t_f(VariableBuildInfo(sbi.mesh(),"SplitDeltaT"))
 , m_old_dt_f(VariableBuildInfo(sbi.mesh(),"OldDTf"))
 , m_module(nullptr)
-, m_node_index_in_cells(platform::getAcceleratorHostMemoryAllocator())
+, m_node_index_in_cells(MemoryUtils::getDefaultDataAllocator())
 , m_runner(sbi.subDomain()->acceleratorMng()->defaultRunner())
 , m_default_queue(sbi.subDomain()->acceleratorMng()->defaultQueue())
 {

--- a/arcane/src/arcane/utils/MemoryResourceMng.cc
+++ b/arcane/src/arcane/utils/MemoryResourceMng.cc
@@ -18,6 +18,7 @@
 #include "arcane/utils/Array.h"
 #include "arcane/utils/MemoryView.h"
 #include "arcane/utils/MemoryAllocator.h"
+#include "arcane/utils/MemoryUtils.h"
 #include "arcane/utils/internal/MemoryUtilsInternal.h"
 
 /*---------------------------------------------------------------------------*/
@@ -109,15 +110,15 @@ getAllocator(eMemoryResource r, bool throw_if_not_found)
   // Si pas d'allocateur spécifique et qu'on n'est pas sur accélérateur,
   // utilise platform::getAcceleratorHostMemoryAllocator().
   if (!a && !m_is_accelerator) {
-    if (r == eMemoryRessource::UnifiedMemory || r == eMemoryRessource::HostPinned) {
-      a = platform::getAcceleratorHostMemoryAllocator();
+    if (r == eMemoryResource::UnifiedMemory || r == eMemoryResource::HostPinned) {
+      a = MemoryUtils::getDefaultDataAllocator();
       if (!a)
-        a = m_allocators[(int)eMemoryRessource::Host];
+        a = m_allocators[(int)eMemoryResource::Host];
     }
   }
 
   if (!a && throw_if_not_found)
-    ARCANE_FATAL("Allocator for ressource '{0}' is not available", r);
+    ARCANE_FATAL("Allocator for resource '{0}' is not available", r);
 
   return a;
 }

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -15,7 +15,6 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/MemoryRessource.h"
-#include "arcane/utils/UtilsTypes.h"
 #include "arcane/utils/MemoryView.h"
 
 #include "arccore/collections/MemoryAllocationArgs.h"
@@ -114,10 +113,10 @@ getAllocatorForMostlyReadOnlyData();
 /*!
  * \brief Allocateur spécifique pour les accélérateurs.
  *
- * Si non nul, cet allocateur permet d'allouer de la mémoire sur l'hôte en
- * utilisant le runtime spécique de l'allocateur.
+ * \deprecated Use MemoryUtils::getDefaultDataAllocator() instead.
  */
-extern "C++" ARCANE_UTILS_EXPORT IMemoryAllocator*
+extern "C++" ARCANE_DEPRECATED_REASON("Y2024: Use getDefaultDataAllocator() instead.")
+ARCANE_UTILS_EXPORT IMemoryAllocator*
 getAcceleratorHostMemoryAllocator();
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/PlatformUtils.h
+++ b/arcane/src/arcane/utils/PlatformUtils.h
@@ -253,15 +253,13 @@ callDotNETGarbageCollector();
 /*!
  * \brief Allocateur spécifique pour les accélérateurs.
  *
- * Si non nul, cet allocateur permet d'allouer de la mémoire sur l'hôte en
- * utilisant le runtime spécique de l'allocateur.
- *
- * \todo rendre obsolète (utiliser MemoryUtils::getAcceleratorHostMemoryAllocator()
- * à la place).
+ * \deprecated Use MemoryUtils::getDefaultDataAllocator() instead.
  */
-extern "C++" ARCANE_UTILS_EXPORT
+extern "C++" ARCANE_DEPRECATED_REASON("Y2024: Use MemoryUtils::getDefaultDataAllocator() instead.")
 IMemoryAllocator* getAcceleratorHostMemoryAllocator();
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \brief Positionne l'allocateur spécifique pour les accélérateurs.
  *


### PR DESCRIPTION
We should use `MemoryUtils::getDefaultDataAllocator()` instead.