### PR TITLE
Fix value of CMake variable ARCANE_MSBUILD_EXEC in `ArcaneSwigConfig.cmake.in`

### DIFF
--- a/arcane/tools/wrapper/ArcaneSwigConfig.cmake.in
+++ b/arcane/tools/wrapper/ArcaneSwigConfig.cmake.in
@@ -21,10 +21,7 @@ endif()
 
 # TODO Mettre la partie '.Net' (mais pas swig) dans un fichier de configuration séparé
 if (NOT ARCANE_MSBUILD_EXEC)
-  set (ARCANE_MSBUILD_EXEC @ARCCON_MSBUILD_EXEC_coreclr@)
-  if (NOT ARCANE_MSBUILD_EXEC)
-    set (ARCANE_MSBUILD_EXEC @ARCCON_MSBUILD_EXEC_mono@)
-  endif()
+  set (ARCANE_MSBUILD_EXEC @DOTNET_EXEC@)
 endif()
 
 set(ArcaneSwig_FOUND FALSE)


### PR DESCRIPTION
This variable used the `dotnet` wrapper added in #1791, but it should use the real path of the executable because the wrapper is not installed.