### PR TITLE
Force using resize without initialization when updating materials

### DIFF
--- a/arcane/src/arcane/core/Array2Variable.cc
+++ b/arcane/src/arcane/core/Array2Variable.cc
@@ -509,10 +509,10 @@ _internalResize(const VariableResizeArgs& resize_args)
          << " dim1_size=" << value().dim1Size()
          << " dim2size=" << dim2_size
          << " total=" << value().totalNbElement();*/
-  if (init_policy==DIP_InitWithDefault)
-    data_values.resize(new_size,dim2_size);
-  else
+  if (use_no_init || (init_policy!=DIP_InitWithDefault))
     data_values.resizeNoInit(new_size,dim2_size);
+  else
+    data_values.resize(new_size,dim2_size);
 
   if (new_size>current_size){
     bool use_nan = (init_policy==DIP_InitWithNan);

--- a/arcane/src/arcane/core/Array2Variable.cc
+++ b/arcane/src/arcane/core/Array2Variable.cc
@@ -40,6 +40,7 @@
 
 #include "arcane/core/internal/IDataInternal.h"
 #include "arcane/core/internal/IVariableMngInternal.h"
+#include "arcane/core/internal/IVariableInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -474,8 +475,12 @@ _checkIfSameOnAllReplica(IParallelMng* replica_pm,Integer max_print)
 /*---------------------------------------------------------------------------*/
 
 template<typename T> void Array2VariableT<T>::
-_internalResize(Integer new_size,Integer nb_additional_element)
+_internalResize(const VariableResizeArgs& resize_args)
 {
+  Int32 new_size = resize_args.newSize();
+  Int32 nb_additional_element = resize_args.nbAdditionalCapacity();
+  bool use_no_init = resize_args.isUseNoInit();
+
   // Exception deplace de ItemGroupImpl::removeItems.
   // C'est un probleme d'implementation des variables partielles Arcane et non
   // du concept de variable partielle (cf ItemGroupMap qui l'implemente).

--- a/arcane/src/arcane/core/Array2Variable.h
+++ b/arcane/src/arcane/core/Array2Variable.h
@@ -87,7 +87,7 @@ class Array2VariableT
 
  protected:
   
-  void _internalResize(Integer new_size,Integer added_memory) override;
+  void _internalResize(const VariableResizeArgs& resize_args) override;
   Integer _checkIfSameOnAllReplica(IParallelMng* replica_pm,int max_print) override;
 
  private:

--- a/arcane/src/arcane/core/Variable.cc
+++ b/arcane/src/arcane/core/Variable.cc
@@ -153,7 +153,7 @@ class VariablePrivate
   //!@{ \name Implémentation de IVariableInternal
   String computeComparisonHashCollective(IHashAlgorithm* hash_algo, IData* sorted_data) override;
   void changeAllocator(const MemoryAllocationOptions& alloc_info) override;
-  void resizeWithReserve(Int32 new_size,Int32 additional_capacity) override;
+  void resizeWithReserve(const VariableResizeArgs& resize_args) override;
   //!@}
 
  private:
@@ -940,13 +940,13 @@ serialize(ISerializer* sbuffer,IDataOperation* operation)
 /*---------------------------------------------------------------------------*/
 
 void Variable::
-_resizeWithReserve(Int32 new_size,Int32 additional_capacity)
+_resizeWithReserve(const VariableResizeArgs& resize_args)
 {
   eItemKind ik = itemKind();
   if (ik!=IK_Unknown){
     ARCANE_FATAL("This call is invalid for item variable. Use resizeFromGroup() instead");
   }
-  _internalResize(new_size, additional_capacity);
+  _internalResize(resize_args);
   syncReferences();
 }
 
@@ -956,7 +956,7 @@ _resizeWithReserve(Int32 new_size,Int32 additional_capacity)
 void Variable::
 resize(Integer new_size)
 {
-  _resizeWithReserve(new_size,0);
+  _resizeWithReserve(VariableResizeArgs(new_size));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -985,7 +985,7 @@ resizeFromGroup()
   debug(Trace::High) << "Variable::resizeFromGroup() var='" << fullName()
                      << "' with " << new_size << " items "
                      << " this=" << this;
-  _internalResize(new_size,new_size/20);
+  _internalResize(VariableResizeArgs(new_size,new_size/20));
   syncReferences();
 }
 
@@ -1442,9 +1442,9 @@ changeAllocator(const MemoryAllocationOptions& mem_options)
 /*---------------------------------------------------------------------------*/
 
 void VariablePrivate::
-resizeWithReserve(Int32 new_size,Int32 additional_capacity)
+resizeWithReserve(const VariableResizeArgs& resize_args)
 {
-  return m_variable->_resizeWithReserve(new_size,additional_capacity);
+  return m_variable->_resizeWithReserve(resize_args);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/Variable.cc
+++ b/arcane/src/arcane/core/Variable.cc
@@ -153,7 +153,7 @@ class VariablePrivate
   //!@{ \name Implémentation de IVariableInternal
   String computeComparisonHashCollective(IHashAlgorithm* hash_algo, IData* sorted_data) override;
   void changeAllocator(const MemoryAllocationOptions& alloc_info) override;
-  void resizeWithReserve(const VariableResizeArgs& resize_args) override;
+  void resize(const VariableResizeArgs& resize_args) override;
   //!@}
 
  private:
@@ -940,7 +940,7 @@ serialize(ISerializer* sbuffer,IDataOperation* operation)
 /*---------------------------------------------------------------------------*/
 
 void Variable::
-_resizeWithReserve(const VariableResizeArgs& resize_args)
+_resize(const VariableResizeArgs& resize_args)
 {
   eItemKind ik = itemKind();
   if (ik!=IK_Unknown){
@@ -956,7 +956,7 @@ _resizeWithReserve(const VariableResizeArgs& resize_args)
 void Variable::
 resize(Integer new_size)
 {
-  _resizeWithReserve(VariableResizeArgs(new_size));
+  _resize(VariableResizeArgs(new_size));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1442,9 +1442,9 @@ changeAllocator(const MemoryAllocationOptions& mem_options)
 /*---------------------------------------------------------------------------*/
 
 void VariablePrivate::
-resizeWithReserve(const VariableResizeArgs& resize_args)
+resize(const VariableResizeArgs& resize_args)
 {
-  return m_variable->_resizeWithReserve(resize_args);
+  return m_variable->_resize(resize_args);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/Variable.h
+++ b/arcane/src/arcane/core/Variable.h
@@ -37,6 +37,7 @@ template<typename T> class IDataTracerT;
 class VariablePrivate;
 class MemoryAccessInfo;
 class IParallelMng;
+class VariableResizeArgs;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -219,7 +220,7 @@ class ARCANE_CORE_EXPORT Variable
 
  protected:
 
-  virtual void _internalResize(Integer new_size,Integer nb_additional_element) =0;
+  virtual void _internalResize(const VariableResizeArgs& resize_args) =0;
   virtual Integer _checkIfSameOnAllReplica(IParallelMng* replica_pm,int max_print) =0;
   void _checkSwapIsValid(Variable* rhs);
   // Temporaire pour test libération mémoire
@@ -227,7 +228,7 @@ class ARCANE_CORE_EXPORT Variable
 
   // Accès via VariablePrivate pour l'API interne
   friend class VariablePrivate;
-  void _resizeWithReserve(Int32 new_size,Int32 additional_capacity);
+  void _resizeWithReserve(const VariableResizeArgs& resize_args);
 
  private:
 

--- a/arcane/src/arcane/core/Variable.h
+++ b/arcane/src/arcane/core/Variable.h
@@ -228,7 +228,7 @@ class ARCANE_CORE_EXPORT Variable
 
   // Accès via VariablePrivate pour l'API interne
   friend class VariablePrivate;
-  void _resizeWithReserve(const VariableResizeArgs& resize_args);
+  void _resize(const VariableResizeArgs& resize_args);
 
  private:
 

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -623,7 +623,7 @@ _internalResize(const VariableResizeArgs& resize_args)
 template<typename DataType> void VariableArrayT<DataType>::
 resizeWithReserve(Integer n,Integer nb_additional)
 {
-  _resizeWithReserve(VariableResizeArgs(n,nb_additional));
+  _resize(VariableResizeArgs(n,nb_additional));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -41,6 +41,7 @@
 
 #include "arcane/core/internal/IDataInternal.h"
 #include "arcane/core/internal/IVariableMngInternal.h"
+#include "arcane/core/internal/IVariableInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -555,8 +556,12 @@ setIsSynchronized(const ItemGroup& group)
 /*---------------------------------------------------------------------------*/
 
 template<typename T> void VariableArrayT<T>::
-_internalResize(Integer new_size,Integer nb_additional_element)
+_internalResize(const VariableResizeArgs& resize_args)
 {
+  Int32 new_size = resize_args.newSize();
+  Int32 nb_additional_element = resize_args.nbAdditionalCapacity();
+  bool use_no_init = resize_args.isUseNoInit();
+
   auto* value_internal = m_value->_internal();
 
   if (nb_additional_element!=0){
@@ -615,7 +620,7 @@ _internalResize(Integer new_size,Integer nb_additional_element)
 template<typename DataType> void VariableArrayT<DataType>::
 resizeWithReserve(Integer n,Integer nb_additional)
 {
-  _resizeWithReserve(n,nb_additional);
+  _resizeWithReserve(VariableResizeArgs(n,nb_additional));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -579,7 +579,10 @@ _internalResize(const VariableResizeArgs& resize_args)
     // associée.
     value_internal->dispose();
   }
-  value_internal->resize(new_size);
+  if (use_no_init)
+    value_internal->_internalDeprecatedValue().resizeNoInit(new_size);
+  else
+    value_internal->resize(new_size);
   if (new_size>current_size){
     if (init_policy==DIP_InitWithDefault){
       ArrayView<T> values = this->valueView();

--- a/arcane/src/arcane/core/VariableArray.h
+++ b/arcane/src/arcane/core/VariableArray.h
@@ -93,7 +93,7 @@ class VariableArrayT
 
  protected:
 
-  void _internalResize(Integer new_size,Integer nb_additional_element) override;
+  void _internalResize(const VariableResizeArgs& resize_args) override;
   Integer _checkIfSameOnAllReplica(IParallelMng* replica_pm,int max_print) override;
 
  private:

--- a/arcane/src/arcane/core/VariableScalar.h
+++ b/arcane/src/arcane/core/VariableScalar.h
@@ -78,10 +78,9 @@ class VariableScalarT
 
  protected:
 
-  void _internalResize(Integer new_size,Integer nb_additional_element) override
+  void _internalResize(const VariableResizeArgs& resize_args) override
   {
-    ARCANE_UNUSED(new_size);
-    ARCANE_UNUSED(nb_additional_element);
+    ARCANE_UNUSED(resize_args);
   }
   Integer _checkIfSameOnAllReplica(IParallelMng* replica_pm,int max_print) override;
 

--- a/arcane/src/arcane/core/internal/IVariableInternal.h
+++ b/arcane/src/arcane/core/internal/IVariableInternal.h
@@ -21,6 +21,43 @@
 
 namespace Arcane
 {
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Arguments pour redimensionner une variable.
+ */
+class VariableResizeArgs
+{
+ public:
+
+  explicit VariableResizeArgs(Int32 new_size)
+  : m_new_size(new_size)
+  {
+  }
+
+  explicit VariableResizeArgs(Int32 new_size, Int32 additional_capacity)
+  : m_new_size(new_size)
+  , m_additional_capacity(additional_capacity)
+  {
+  }
+
+  explicit VariableResizeArgs(Int32 new_size, Int32 additional_capacity, bool use_no_init)
+  : m_new_size(new_size)
+  , m_additional_capacity(additional_capacity)
+  , m_is_use_no_init(use_no_init)
+  {
+  }
+
+  Int32 newSize() const { return m_new_size; }
+  Int32 nbAdditionalCapacity() const { return m_additional_capacity; }
+  bool isUseNoInit() const { return m_is_use_no_init; }
+
+ private:
+
+  Int32 m_new_size = 0;
+  Int32 m_additional_capacity = 0;
+  bool m_is_use_no_init = false;
+};
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -64,7 +101,7 @@ class ARCANE_CORE_EXPORT IVariableInternal
   virtual void changeAllocator(const MemoryAllocationOptions& alloc_info) = 0;
 
   //! Redimensionne la variable en ajoutant une capacité additionnelle
-  virtual void resizeWithReserve(Int32 new_size,Int32 additional_capacity) =0;
+  virtual void resizeWithReserve(const VariableResizeArgs& resize_args) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/internal/IVariableInternal.h
+++ b/arcane/src/arcane/core/internal/IVariableInternal.h
@@ -101,7 +101,7 @@ class ARCANE_CORE_EXPORT IVariableInternal
   virtual void changeAllocator(const MemoryAllocationOptions& alloc_info) = 0;
 
   //! Redimensionne la variable en ajoutant une capacité additionnelle
-  virtual void resizeWithReserve(const VariableResizeArgs& resize_args) = 0;
+  virtual void resize(const VariableResizeArgs& resize_args) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariableArray.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableArray.cc
@@ -93,7 +93,7 @@ resizeWithReserve(PrivatePartType* var, Integer dim1_size, Real reserve_ratio)
   // nombre de mailles matériaux, alloue un petit peu plus que nécessaire.
   // Par défaut, on alloue 5% de plus.
   Int32 nb_add = static_cast<Int32>(dim1_size * reserve_ratio);
-  var->_internalApi()->resizeWithReserve(dim1_size, nb_add);
+  var->_internalApi()->resizeWithReserve(VariableResizeArgs(dim1_size, nb_add, true));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariableArray.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableArray.cc
@@ -93,7 +93,7 @@ resizeWithReserve(PrivatePartType* var, Integer dim1_size, Real reserve_ratio)
   // nombre de mailles matériaux, alloue un petit peu plus que nécessaire.
   // Par défaut, on alloue 5% de plus.
   Int32 nb_add = static_cast<Int32>(dim1_size * reserve_ratio);
-  var->_internalApi()->resizeWithReserve(VariableResizeArgs(dim1_size, nb_add, true));
+  var->_internalApi()->resize(VariableResizeArgs(dim1_size, nb_add, true));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
@@ -126,7 +126,7 @@ resizeWithReserve(PrivatePartType* var, Integer dim1_size, Real reserve_ratio)
   // nombre de mailles matériaux, alloue un petit peu plus que nécessaire.
   // Par défaut, on alloue 5% de plus.
   Int32 nb_add = static_cast<Int32>(dim1_size * reserve_ratio);
-  var->_internalApi()->resizeWithReserve(VariableResizeArgs(dim1_size, nb_add, true));
+  var->_internalApi()->resize(VariableResizeArgs(dim1_size, nb_add, true));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariableScalar.cc
@@ -126,7 +126,7 @@ resizeWithReserve(PrivatePartType* var, Integer dim1_size, Real reserve_ratio)
   // nombre de mailles matériaux, alloue un petit peu plus que nécessaire.
   // Par défaut, on alloue 5% de plus.
   Int32 nb_add = static_cast<Int32>(dim1_size * reserve_ratio);
-  var->_internalApi()->resizeWithReserve(dim1_size, nb_add);
+  var->_internalApi()->resizeWithReserve(VariableResizeArgs(dim1_size, nb_add, true));
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
When using complex type like `Real3` or `Real3x3`, the resizing of the variables also initialize the new elements. This operation is done on CPU. Because the values of the new elements will be overridden in the next phase (with zero or the value of the global cell), we can remove the first initialization.
