### PR TITLE
Use IMesh in mesh exchange tools

### DIFF
--- a/arcane/src/arcane/core/internal/IMeshModifierInternal.h
+++ b/arcane/src/arcane/core/internal/IMeshModifierInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IMeshModifierInternal.h                                     (C) 2000-2023 */
+/* IMeshModifierInternal.h                                     (C) 2000-2024 */
 /*                                                                           */
 /* Partie interne à Arcane de IMeshModifier.                                 */
 /*---------------------------------------------------------------------------*/
@@ -33,6 +33,9 @@ class ARCANE_CORE_EXPORT IMeshModifierInternal
  public:
 
   virtual ~IMeshModifierInternal() = default;
+
+  //! Suppression des items qui quittent le sous-domaine. Cette méthode est appelée dans MeshExchanger
+  virtual void removeNeedRemoveMarkedItems() {}
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -183,6 +183,12 @@ class DynamicMesh::InternalApi
   {
     return nullptr;
   }
+
+  void removeNeedRemoveMarkedItems() override
+  {
+    m_mesh->incrementalBuilder()->removeNeedRemoveMarkedItems();
+  }
+
  private:
 
   DynamicMesh* m_mesh = nullptr;

--- a/arcane/src/arcane/mesh/MeshExchangeMng.cc
+++ b/arcane/src/arcane/mesh/MeshExchangeMng.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshExchangeMng.cc                                          (C) 2000-2016 */
+/* MeshExchangeMng.cc                                          (C) 2000-2024 */
 /*                                                                           */
 /* Gestionnaire des échanges de maillages entre sous-domaines.               */
 /*---------------------------------------------------------------------------*/
@@ -14,11 +14,10 @@
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/TraceInfo.h"
 
-#include "arcane/ISubDomain.h"
+#include "arcane/core/ISubDomain.h"
 
 #include "arcane/mesh/MeshExchangeMng.h"
 #include "arcane/mesh/MeshExchanger.h"
-#include "arcane/mesh/DynamicMesh.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -33,7 +32,7 @@ ARCANE_MESH_BEGIN_NAMESPACE
 /*---------------------------------------------------------------------------*/
 
 MeshExchangeMng::
-MeshExchangeMng(DynamicMesh* mesh)
+MeshExchangeMng(IMesh* mesh)
 : TraceAccessor(mesh->traceMng())
 , m_mesh(mesh)
 , m_exchanger(nullptr)
@@ -90,7 +89,7 @@ endExchange()
 IPrimaryMesh* MeshExchangeMng::
 mesh() const
 {
-  return m_mesh;
+  return m_mesh->toPrimaryMesh();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/MeshExchangeMng.h
+++ b/arcane/src/arcane/mesh/MeshExchangeMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshExchangeMng.h                                           (C) 2000-2016 */
+/* MeshExchangeMng.h                                           (C) 2000-2024 */
 /*                                                                           */
 /* Gestionnaire des échanges de maillages entre sous-domaines.               */
 /*---------------------------------------------------------------------------*/
@@ -15,7 +15,8 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/TraceAccessor.h"
-#include "arcane/IMeshExchangeMng.h"
+#include "arcane/core/IMeshExchangeMng.h"
+#include "arcane/core/IMesh.h"
 #include "arcane/mesh/MeshGlobal.h"
 
 /*---------------------------------------------------------------------------*/
@@ -23,11 +24,6 @@
 
 ARCANE_BEGIN_NAMESPACE
 ARCANE_MESH_BEGIN_NAMESPACE
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-class DynamicMesh;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -42,7 +38,7 @@ class ARCANE_MESH_EXPORT MeshExchangeMng
 {
  public:
 
-  MeshExchangeMng(DynamicMesh* mesh);
+  MeshExchangeMng(IMesh* mesh);
   ~MeshExchangeMng();
 
  public:
@@ -58,7 +54,7 @@ class ARCANE_MESH_EXPORT MeshExchangeMng
 
  private:
 
-  DynamicMesh* m_mesh;
+  IMesh* m_mesh;
   IMeshExchanger* m_exchanger;
 };
 

--- a/arcane/src/arcane/mesh/MeshExchanger.cc
+++ b/arcane/src/arcane/mesh/MeshExchanger.cc
@@ -25,7 +25,7 @@
 #include "arcane/mesh/MeshExchanger.h"
 #include "arcane/mesh/DynamicMesh.h"
 #include "arcane/mesh/MeshExchange.h"
-#include "arcane/mesh/DynamicMeshIncrementalBuilder.h"
+#include "arcane/core/internal/IMeshModifierInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -37,7 +37,7 @@ namespace Arcane::mesh
 /*---------------------------------------------------------------------------*/
 
 MeshExchanger::
-MeshExchanger(DynamicMesh* mesh,ITimeStats* stats)
+MeshExchanger(IMesh* mesh,ITimeStats* stats)
 : TraceAccessor(mesh->traceMng())
 , m_mesh(mesh)
 , m_time_stats(stats)
@@ -330,7 +330,7 @@ removeNeededItems()
   }
 
   // Supprime les entités qui ne sont plus liées au sous-domaine
-  m_mesh->incrementalBuilder()->removeNeedRemoveMarkedItems();
+  m_mesh->modifier()->_modifierInternalApi()->removeNeedRemoveMarkedItems();
 
   m_phase = ePhase::AllocateItems;
 }
@@ -450,7 +450,7 @@ findExchanger(IItemFamily* family)
 IPrimaryMesh* MeshExchanger::
 mesh() const
 {
-  return m_mesh;
+  return m_mesh->toPrimaryMesh();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/MeshExchanger.h
+++ b/arcane/src/arcane/mesh/MeshExchanger.h
@@ -16,9 +16,9 @@
 
 #include "arcane/utils/TraceAccessor.h"
 #include "arcane/utils/List.h"
-#include "arcane/IMeshExchanger.h"
-#include "arcane/ParallelExchangerOptions.h"
-#include "arcane/mesh/MeshGlobal.h"
+#include "arcane/core/IMeshExchanger.h"
+#include "arcane/core/ParallelExchangerOptions.h"
+#include "arcane/core/IMesh.h"
 
 #include <map>
 
@@ -35,11 +35,6 @@ namespace Arcane::mesh
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-class DynamicMesh;
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 /*!
  * \brief Informations pour un échange de maillage entre sous-domaines.
  */
@@ -53,7 +48,7 @@ class ARCANE_MESH_EXPORT MeshExchanger
 
  public:
 
-  MeshExchanger(DynamicMesh* mesh,ITimeStats* stats);
+  MeshExchanger(IMesh* mesh,ITimeStats* stats);
   ~MeshExchanger();
 
  public:
@@ -76,7 +71,7 @@ class ARCANE_MESH_EXPORT MeshExchanger
 
  private:
 
-  DynamicMesh* m_mesh;
+  IMesh* m_mesh;
   List<IItemFamilyExchanger*> m_family_exchangers;
   ItemFamilyExchangerMap m_family_exchanger_map;
   ITimeStats* m_time_stats;


### PR DESCRIPTION
- `MeshExchangeMng` and `MeshExchanger` were using DynamicMesh*. 
- Move to IMesh* to be used in PolyhedralMesh.