### PR TITLE
Refactor 'AllCellToAllEnvCell'

### DIFF
--- a/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
+++ b/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
@@ -47,6 +47,7 @@ namespace Arcane::Materials
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+class AllCellToAllEnvCellContainer;
 class AllEnvCellVectorView;
 class ComponentCell;
 class IMeshBlock;

--- a/arcane/src/arcane/core/materials/internal/IMeshMaterialMngInternal.h
+++ b/arcane/src/arcane/core/materials/internal/IMeshMaterialMngInternal.h
@@ -88,7 +88,7 @@ class ARCANE_CORE_EXPORT IMeshMaterialMngInternal
    * destinée à être utilisée dans un RUNCOMMAND_ENUMERATE_CELL_ALLENVCELL
    * en conjonction de la macro ENUMERATE_CELL_ALLENVCELL
    */
-  virtual AllCellToAllEnvCell* getAllCellToAllEnvCell() const = 0;
+  virtual AllCellToAllEnvCellContainer* getAllCellToAllEnvCellContainer() const = 0;
 
   /*!
    * \brief Construit la table de "connectivité" CellLocalId -> AllEnvCell

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.cc
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.cc
@@ -18,6 +18,8 @@
 #include "arcane/core/ItemGroup.h"
 #include "arcane/core/materials/internal/IMeshMaterialMngInternal.h"
 
+#include "arcane/materials/internal/AllCellToAllEnvCellContainer.h"
+
 #include "arcane/accelerator/Reduce.h"
 #include "arcane/accelerator/RunCommandEnumerate.h"
 #include "arcane/accelerator/NumArrayViews.h"
@@ -30,7 +32,7 @@
 namespace Arcane::Materials
 {
 
-class AllCellToAllEnvCell::Impl
+class AllCellToAllEnvCellContainer::Impl
 {
  public:
 
@@ -39,13 +41,13 @@ class AllCellToAllEnvCell::Impl
                             ComponentItemLocalId* mem_pool,
                             Span<ComponentItemLocalId>* allcell_allenvcell,
                             Int32 max_nb_env);
-  static void _initialize(AllCellToAllEnvCell* instance);
+  static void _initialize(AllCellToAllEnvCellContainer* instance);
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-Int32 AllCellToAllEnvCell::Impl::
+Int32 AllCellToAllEnvCellContainer::Impl::
 _computeMaxNbEnvPerCell(IMeshMaterialMng* material_mng)
 {
   CellToAllEnvCellConverter allenvcell_converter(material_mng);
@@ -66,7 +68,7 @@ _computeMaxNbEnvPerCell(IMeshMaterialMng* material_mng)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void AllCellToAllEnvCell::Impl::
+void AllCellToAllEnvCellContainer::Impl::
 _updateValues(IMeshMaterialMng* material_mng,
               ComponentItemLocalId* mem_pool,
               Span<ComponentItemLocalId>* allcell_allenvcell,
@@ -101,8 +103,8 @@ _updateValues(IMeshMaterialMng* material_mng,
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void AllCellToAllEnvCell::Impl::
-_initialize(AllCellToAllEnvCell* instance)
+void AllCellToAllEnvCellContainer::Impl::
+_initialize(AllCellToAllEnvCellContainer* instance)
 {
   IMeshMaterialMng* mm = instance->m_material_mng;
   RunQueue queue = mm->_internalApi()->runQueue();
@@ -150,8 +152,8 @@ _initialize(AllCellToAllEnvCell* instance)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-AllCellToAllEnvCell::
-AllCellToAllEnvCell(IMeshMaterialMng* mm)
+AllCellToAllEnvCellContainer::
+AllCellToAllEnvCellContainer(IMeshMaterialMng* mm)
 : m_material_mng(mm)
 {
   m_mem_pool.setDebugName("AllCellToAllEnvCellMemPool");
@@ -161,7 +163,7 @@ AllCellToAllEnvCell(IMeshMaterialMng* mm)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void AllCellToAllEnvCell::
+void AllCellToAllEnvCellContainer::
 reset()
 {
   if (m_allcell_allenvcell_ptr) {
@@ -177,7 +179,7 @@ reset()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-Int32 AllCellToAllEnvCell::
+Int32 AllCellToAllEnvCellContainer::
 maxNbEnvPerCell() const
 {
   return Impl::_computeMaxNbEnvPerCell(m_material_mng);
@@ -186,7 +188,7 @@ maxNbEnvPerCell() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void AllCellToAllEnvCell::
+void AllCellToAllEnvCellContainer::
 initialize()
 {
   Impl::_initialize(this);
@@ -195,7 +197,7 @@ initialize()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void AllCellToAllEnvCell::
+void AllCellToAllEnvCellContainer::
 bruteForceUpdate()
 {
   // Si les ids ont changé, on doit tout refaire
@@ -225,7 +227,7 @@ bruteForceUpdate()
 
 CellToAllEnvCellAccessor::
 CellToAllEnvCellAccessor(const IMeshMaterialMng* mmmng)
-: m_cell_allenvcell(mmmng->_internalApi()->getAllCellToAllEnvCell())
+: m_cell_allenvcell(mmmng->_internalApi()->getAllCellToAllEnvCellContainer())
 {
 }
 

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.cc
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.cc
@@ -111,7 +111,7 @@ _initialize(AllCellToAllEnvCellContainer* instance)
   instance->m_size = mm->mesh()->cellFamily()->maxLocalId() + 1;
 
   instance->m_allcell_allenvcell.resize(instance->m_size);
-  instance->m_allcell_allenvcell_ptr = instance->m_allcell_allenvcell.to1DSpan().data();
+  instance->m_all_cell_to_all_env_cell.m_allcell_allenvcell_ptr = instance->m_allcell_allenvcell.to1DSpan().data();
 
   // On force la valeur initiale sur tous les elmts car dans le ENUMERATE_CELL ci-dessous
   // il se peut que m_size (qui vaut maxLocalId()+1) soit different de allCells().size()
@@ -166,9 +166,9 @@ AllCellToAllEnvCellContainer(IMeshMaterialMng* mm)
 void AllCellToAllEnvCellContainer::
 reset()
 {
-  if (m_allcell_allenvcell_ptr) {
+  if (m_all_cell_to_all_env_cell.m_allcell_allenvcell_ptr) {
     m_allcell_allenvcell.resize(0);
-    m_allcell_allenvcell_ptr = nullptr;
+    m_all_cell_to_all_env_cell.m_allcell_allenvcell_ptr = nullptr;
     m_mem_pool.resize(0);
   }
   m_material_mng = nullptr;
@@ -213,13 +213,13 @@ bruteForceUpdate()
     // On n'oublie pas de mettre a jour la nouvelle valeur !
     m_current_max_nb_env = current_max_nb_env;
     // Si le nb max d'env pour les mailles a changé à cet instant, on doit refaire le memory pool
-    ARCANE_CHECK_POINTER(m_allcell_allenvcell_ptr);
+    ARCANE_CHECK_POINTER(m_all_cell_to_all_env_cell.m_allcell_allenvcell_ptr);
     // on recrée le pool
     Int32 pool_size = CheckedConvert::multiply(m_current_max_nb_env, m_size);
     m_mem_pool.resize(pool_size);
   }
   // Mise a jour des valeurs
-  Impl::_updateValues(m_material_mng, m_mem_pool.to1DSpan().data(), m_allcell_allenvcell_ptr, m_current_max_nb_env);
+  Impl::_updateValues(m_material_mng, m_mem_pool.to1DSpan().data(), m_all_cell_to_all_env_cell.m_allcell_allenvcell_ptr, m_current_max_nb_env);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -227,7 +227,7 @@ bruteForceUpdate()
 
 CellToAllEnvCellAccessor::
 CellToAllEnvCellAccessor(const IMeshMaterialMng* mmmng)
-: m_cell_allenvcell(mmmng->_internalApi()->getAllCellToAllEnvCellContainer())
+: m_cell_allenvcell(mmmng->_internalApi()->getAllCellToAllEnvCellContainer()->view())
 {
 }
 

--- a/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
+++ b/arcane/src/arcane/materials/AllCellToAllEnvCellConverter.h
@@ -16,22 +16,12 @@
 
 #include "arcane/materials/MaterialsGlobal.h"
 
-#include "arcane/utils/PlatformUtils.h"
-#include "arcane/utils/NumArray.h"
-
-#include "arcane/core/IMesh.h"
 #include "arcane/core/materials/MatItem.h"
-#include "arcane/core/materials/IMeshMaterialMng.h"
 #include "arcane/core/materials/MatItemEnumerator.h"
 #include "arcane/core/materials/CellToAllEnvCellConverter.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-namespace ArcaneTest
-{
-class MeshMaterialAcceleratorUnitTest;
-}
 
 namespace Arcane::Materials
 {

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -253,7 +253,7 @@ _computeInfosForAllEnvCells1(RecomputeConstituentCellInfos& work_info)
   // en considérant que les milieux de chaque maille sont rangés consécutivement
   // dans m_env_items_internal.
 
-  work_info.env_cell_indexes.resize(cells_nb_env.size());
+  MemoryUtils::checkResizeArrayWithCapacity(work_info.env_cell_indexes, cells_nb_env.size());
 
   bool do_old = (max_local_id != nb_cell);
   if (do_old) {
@@ -521,7 +521,7 @@ forceRecompute(bool compute_all)
 
   // Met à jour le AllCellToAllEnvCell s'il a été initialisé si la fonctionnalité est activé
   if (m_material_mng->isCellToAllEnvCellForRunCommand()) {
-    auto* all_cell_to_all_env_cell(m_material_mng->_internalApi()->getAllCellToAllEnvCell());
+    auto* all_cell_to_all_env_cell(m_material_mng->_internalApi()->getAllCellToAllEnvCellContainer());
     if (all_cell_to_all_env_cell)
       all_cell_to_all_env_cell->bruteForceUpdate();
     else

--- a/arcane/src/arcane/materials/AllEnvData.cc
+++ b/arcane/src/arcane/materials/AllEnvData.cc
@@ -35,6 +35,7 @@
 #include "arcane/materials/internal/MaterialModifierOperation.h"
 #include "arcane/materials/internal/ConstituentConnectivityList.h"
 #include "arcane/materials/internal/ComponentItemListBuilder.h"
+#include "arcane/materials/internal/AllCellToAllEnvCellContainer.h"
 
 #include "arcane/accelerator/Scan.h"
 #include "arcane/accelerator/RunCommandLoop.h"

--- a/arcane/src/arcane/materials/MaterialsGlobal.h
+++ b/arcane/src/arcane/materials/MaterialsGlobal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MaterialsGlobal.h                                           (C) 2000-2023 */
+/* MaterialsGlobal.h                                           (C) 2000-2024 */
 /*                                                                           */
 /* Déclarations générales des matériaux de Arcane.                           */
 /*---------------------------------------------------------------------------*/
@@ -64,6 +64,7 @@ class MatVarIndex;
 class IMeshMaterialSynchronizeBuffer;
 class ConstituentConnectivityList;
 class MeshMaterialMng;
+class AllCellToAllEnvCellContainer;
 class AllEnvData;
 class MaterialModifierOperation;
 class MeshMaterial;

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -141,7 +141,7 @@ MeshMaterialMng(const MeshHandle& mesh_handle,const String& name)
 
   String s = platform::getEnvironmentVariable("ARCANE_ALLENVCELL_FOR_RUNCOMMAND");
   if (!s.null())
-    m_is_allcell_2_allenvcell = true;
+    m_is_use_accelerator_envcell_container = true;
   m_mms = new MeshMaterialSynchronizer(this);
 }
 
@@ -182,7 +182,7 @@ MeshMaterialMng::
   m_modifier.reset();
   m_internal_api.reset();
 
-  m_allcell_2_allenvcell.reset();
+  m_accelerator_envcell_container.reset();
 
   // On détruit le Runner à la fin pour être sur qu'il n'y a plus de
   // références dessus dans les autres instances.
@@ -1331,9 +1331,9 @@ _dumpStats()
 void MeshMaterialMng::
 createAllCellToAllEnvCell()
 {
-  if (!m_allcell_2_allenvcell){
-    m_allcell_2_allenvcell = std::make_unique<AllCellToAllEnvCellContainer>(this);
-    m_allcell_2_allenvcell->initialize();
+  if (!m_accelerator_envcell_container) {
+    m_accelerator_envcell_container = std::make_unique<AllCellToAllEnvCellContainer>(this);
+    m_accelerator_envcell_container->initialize();
   }
 }
 

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -49,6 +49,7 @@
 #include "arcane/materials/internal/MeshMaterialSynchronizer.h"
 #include "arcane/materials/internal/MeshMaterialVariableSynchronizer.h"
 #include "arcane/materials/internal/ConstituentConnectivityList.h"
+#include "arcane/materials/internal/AllCellToAllEnvCellContainer.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -131,7 +132,6 @@ MeshMaterialMng(const MeshHandle& mesh_handle,const String& name)
 , m_internal_api(std::make_unique<InternalApi>(this))
 , m_variable_mng(mesh_handle.variableMng())
 , m_name(name)
-, m_all_cell_to_all_env_cell(MemoryUtils::getDefaultDataAllocator())
 {
   m_all_env_data = std::make_unique<AllEnvData>(this);
   m_exchange_mng = std::make_unique<MeshMaterialExchangeMng>(this);
@@ -182,10 +182,7 @@ MeshMaterialMng::
   m_modifier.reset();
   m_internal_api.reset();
 
-  if (m_allcell_2_allenvcell){
-    m_all_cell_to_all_env_cell.clear();
-    m_allcell_2_allenvcell = nullptr;
-  }
+  m_allcell_2_allenvcell.reset();
 
   // On détruit le Runner à la fin pour être sur qu'il n'y a plus de
   // références dessus dans les autres instances.
@@ -1335,9 +1332,7 @@ void MeshMaterialMng::
 createAllCellToAllEnvCell()
 {
   if (!m_allcell_2_allenvcell){
-    m_all_cell_to_all_env_cell.reserve(1);
-    m_all_cell_to_all_env_cell.add(AllCellToAllEnvCellContainer(this));
-    m_allcell_2_allenvcell = m_all_cell_to_all_env_cell.view().ptrAt(0);
+    m_allcell_2_allenvcell = std::make_unique<AllCellToAllEnvCellContainer>(this);
     m_allcell_2_allenvcell->initialize();
   }
 }

--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -217,7 +217,7 @@ build()
       m_is_use_accelerator_for_constituent_item_vector = (v.value()!=0);
     }
     // N'active pas l'utilisation des RunQueue pour le calcul
-    // des 'ComponentItemVector' si le multi-threading est actif actuellement
+    // des 'ComponentItemVector' si le multi-threading est actif. Actuellement
     // l'utilisation d'une même RunQueue n'est pas multi-thread (et donc
     // on ne peut pas créer des ComponentItemVector en concurrence)
     if (TaskFactory::isActive())
@@ -1336,7 +1336,7 @@ createAllCellToAllEnvCell()
 {
   if (!m_allcell_2_allenvcell){
     m_all_cell_to_all_env_cell.reserve(1);
-    m_all_cell_to_all_env_cell.add(AllCellToAllEnvCell(this));
+    m_all_cell_to_all_env_cell.add(AllCellToAllEnvCellContainer(this));
     m_allcell_2_allenvcell = m_all_cell_to_all_env_cell.view().ptrAt(0);
     m_allcell_2_allenvcell->initialize();
   }

--- a/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
+++ b/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
@@ -1,0 +1,133 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* AllCellToAllEnvCellContainer.h                              (C) 2000-2024 */
+/*                                                                           */
+/* Conteneur des données pour 'AllCellToAllEnvCell'.                         */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_MATERIALS_INTERNAL_ALLCELLTOALLENVCELLCONTAINER_H
+#define ARCANE_MATERIALS_INTERNAL_ALLCELLTOALLENVCELLCONTAINER_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/materials/MaterialsGlobal.h"
+
+#include "arcane/utils/NumArray.h"
+
+#include "arcane/materials/AllCellToAllEnvCellConverter.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace ArcaneTest
+{
+class MeshMaterialAcceleratorUnitTest;
+}
+
+namespace Arcane::Materials
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \ingroup ArcaneMaterials
+ * \brief Table de connectivité des 'Cell' vers leur(s) 'AllEnvCell' destinée
+ *        à une utilisation sur accélérateur.
+ *
+ * Classe qui conserve la connectivité de toutes les mailles
+ * \a Cell vers toutes leurs mailles \a AllEnvCell.
+ *
+ * On crée une instance via la méthode create().
+ *
+ * Le coût de l'initialisation est cher, il faut allouer la mémoire et remplir les
+ * structures. On parcours toutes les mailles et pour chaque maille on fait
+ * appel au CellToAllEnvCellConverter.
+ *
+ * Une fois l'instance créée, elle doit être mise à jour à chaque fois que
+ * la topologie des matériaux/environnements change (ce qui est également cher).
+ *
+ * Cette classe est une classe interne et ne doit pas être manipulée directement.
+ * Il faut passer par les helpers associés dans le IMeshMaterialMng et
+ * la classe CellToAllEnvCellAccessor.
+ */
+class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
+: public AllCellToAllEnvCell
+{
+ public:
+
+  class Impl;
+
+ public:
+
+  explicit AllCellToAllEnvCellContainer(IMeshMaterialMng* mm);
+
+ public:
+
+  //! Copies interdites
+  AllCellToAllEnvCellContainer& operator=(const AllCellToAllEnvCellContainer&) = delete;
+
+ public:
+
+  /*!
+   * \brief Fonction de création alternative. Il faut attendre que les données
+   * relatives aux matériaux soient finalisées.
+   *
+   * La différence réside dans la gestion de la mémoire.
+   * Ici, on applique un compromis sur la taille de la table cid -> envcells
+   * où la taille du tableau pour ranger les envcells d'une cell est égale à la taille
+   * max du nb d'environnement présent à un instant t dans un maille.
+   * Celà permet de ne pas faire les allocations mémoire dans la boucle interne et de
+   * façon systématique.
+   * => Gain de perf à évaluer.
+   */
+  void initialize();
+
+  //! Méthode d'accès à la table de "connectivité" cell -> all env cells
+  ARCCORE_HOST_DEVICE Span<ComponentItemLocalId>* internal() const
+  {
+    return m_allcell_allenvcell_ptr;
+  }
+
+  /*!
+   * \brief Méthode pour donner le nombre maximal d'environnements
+   * présents sur une maille à l'instant t.
+   *
+   * Le fait d'effectuer cette opération à un instant donné, permet
+   * d'avoir une valeur max <= au nombre total d'environnement présents
+   * dans le jdd (et donc d'économiser un peu de mémoire).
+   */
+  Int32 maxNbEnvPerCell() const;
+
+  /*!
+   * On regarde si le nb max d'env par cell à l'instant t a changé,
+   * et si c'est le cas, on force la reconstruction de la table.
+   * Est appelé par le forceRecompute du IMeshMaterialMng
+   */
+  void bruteForceUpdate();
+
+  void reset();
+
+ private:
+
+  IMeshMaterialMng* m_material_mng = nullptr;
+  Integer m_size = 0;
+  NumArray<Span<ComponentItemLocalId>, MDDim1> m_allcell_allenvcell;
+  //Span<ComponentItemLocalId>* m_allcell_allenvcell_ptr = nullptr;
+  NumArray<ComponentItemLocalId, MDDim1> m_mem_pool;
+  Int32 m_current_max_nb_env = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane::Materials
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif  
+

--- a/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
+++ b/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
@@ -55,7 +55,6 @@ namespace Arcane::Materials
  * la classe CellToAllEnvCellAccessor.
  */
 class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
-: public AllCellToAllEnvCell
 {
  public:
 
@@ -89,7 +88,7 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
   //! Méthode d'accès à la table de "connectivité" cell -> all env cells
   ARCCORE_HOST_DEVICE Span<ComponentItemLocalId>* internal() const
   {
-    return m_allcell_allenvcell_ptr;
+    return m_all_cell_to_all_env_cell._internal();
   }
 
   /*!
@@ -111,6 +110,8 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
 
   void reset();
 
+  const AllCellToAllEnvCell& view() const { return m_all_cell_to_all_env_cell; }
+
  private:
 
   IMeshMaterialMng* m_material_mng = nullptr;
@@ -119,6 +120,7 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
   //Span<ComponentItemLocalId>* m_allcell_allenvcell_ptr = nullptr;
   NumArray<ComponentItemLocalId, MDDim1> m_mem_pool;
   Int32 m_current_max_nb_env = 0;
+  AllCellToAllEnvCell m_all_cell_to_all_env_cell;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
+++ b/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
@@ -85,12 +85,6 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
    */
   void initialize();
 
-  //! Méthode d'accès à la table de "connectivité" cell -> all env cells
-  ARCCORE_HOST_DEVICE Span<ComponentItemLocalId>* internal() const
-  {
-    return m_all_cell_to_all_env_cell._internal();
-  }
-
   /*!
    * \brief Méthode pour donner le nombre maximal d'environnements
    * présents sur une maille à l'instant t.
@@ -99,7 +93,7 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
    * d'avoir une valeur max <= au nombre total d'environnement présents
    * dans le jdd (et donc d'économiser un peu de mémoire).
    */
-  Int32 maxNbEnvPerCell() const;
+  Int32 computeMaxNbEnvPerCell() const;
 
   /*!
    * On regarde si le nb max d'env par cell à l'instant t a changé,
@@ -115,8 +109,8 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
  private:
 
   IMeshMaterialMng* m_material_mng = nullptr;
-  Integer m_size = 0;
-  NumArray<Span<ComponentItemLocalId>, MDDim1> m_allcell_allenvcell;
+  Int32 m_size = 0;
+  NumArray<Span<ComponentItemLocalId>, MDDim1> m_envcell_container;
   NumArray<ComponentItemLocalId, MDDim1> m_mem_pool;
   Int32 m_current_max_nb_env = 0;
   AllCellToAllEnvCell m_all_cell_to_all_env_cell;

--- a/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
+++ b/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
@@ -16,8 +16,6 @@
 
 #include "arcane/materials/MaterialsGlobal.h"
 
-#include "arcane/utils/NumArray.h"
-
 #include "arcane/materials/AllCellToAllEnvCellConverter.h"
 
 /*---------------------------------------------------------------------------*/
@@ -63,11 +61,14 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
  public:
 
   explicit AllCellToAllEnvCellContainer(IMeshMaterialMng* mm);
+  ~AllCellToAllEnvCellContainer();
 
  public:
 
   //! Copies interdites
+  AllCellToAllEnvCellContainer(const AllCellToAllEnvCellContainer&) = delete;
   AllCellToAllEnvCellContainer& operator=(const AllCellToAllEnvCellContainer&) = delete;
+  AllCellToAllEnvCellContainer& operator=(AllCellToAllEnvCellContainer&&) = delete;
 
  public:
 
@@ -104,16 +105,11 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
 
   void reset();
 
-  const AllCellToAllEnvCell& view() const { return m_all_cell_to_all_env_cell; }
+  AllCellToAllEnvCell view() const;
 
  private:
 
-  IMeshMaterialMng* m_material_mng = nullptr;
-  Int32 m_size = 0;
-  NumArray<Span<ComponentItemLocalId>, MDDim1> m_envcell_container;
-  NumArray<ComponentItemLocalId, MDDim1> m_mem_pool;
-  Int32 m_current_max_nb_env = 0;
-  AllCellToAllEnvCell m_all_cell_to_all_env_cell;
+  Impl* m_p = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
+++ b/arcane/src/arcane/materials/internal/AllCellToAllEnvCellContainer.h
@@ -117,7 +117,6 @@ class ARCANE_MATERIALS_EXPORT AllCellToAllEnvCellContainer
   IMeshMaterialMng* m_material_mng = nullptr;
   Integer m_size = 0;
   NumArray<Span<ComponentItemLocalId>, MDDim1> m_allcell_allenvcell;
-  //Span<ComponentItemLocalId>* m_allcell_allenvcell_ptr = nullptr;
   NumArray<ComponentItemLocalId, MDDim1> m_mem_pool;
   Int32 m_current_max_nb_env = 0;
   AllCellToAllEnvCell m_all_cell_to_all_env_cell;

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -300,11 +300,11 @@ class MeshMaterialMng
 
   void enableCellToAllEnvCellForRunCommand(bool is_enable, bool force_create=false) override
   {
-    m_is_allcell_2_allenvcell = is_enable;
+    m_is_use_accelerator_envcell_container = is_enable;
     if (force_create)
       createAllCellToAllEnvCell();
   }
-  bool isCellToAllEnvCellForRunCommand() const override { return m_is_allcell_2_allenvcell; }
+  bool isCellToAllEnvCellForRunCommand() const override { return m_is_use_accelerator_envcell_container; }
 
   IMeshMaterialMngInternal* _internalApi() const override { return m_internal_api.get(); }
 
@@ -319,7 +319,7 @@ class MeshMaterialMng
 
  private:
 
-  AllCellToAllEnvCellContainer* getAllCellToAllEnvCellContainer() const { return m_allcell_2_allenvcell.get(); }
+  AllCellToAllEnvCellContainer* getAllCellToAllEnvCellContainer() const { return m_accelerator_envcell_container.get(); }
   void createAllCellToAllEnvCell();
 
  private:
@@ -381,9 +381,9 @@ class MeshMaterialMng
 
   std::unique_ptr<RunnerInfo> m_runner_info;
 
-  //! Conteneur pour AllEnvCellToAllEnvCell
-  std::unique_ptr<AllCellToAllEnvCellContainer> m_allcell_2_allenvcell;
-  bool m_is_allcell_2_allenvcell = false;
+  //! Conteneur pour AllEnvCellToAllEnvCell pour accélerateur
+  std::unique_ptr<AllCellToAllEnvCellContainer> m_accelerator_envcell_container;
+  bool m_is_use_accelerator_envcell_container = false;
 
   bool m_is_use_accelerator_for_constituent_item_vector = true;
 

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -32,7 +32,6 @@
 #include "arcane/materials/internal/MeshMaterial.h"
 #include "arcane/materials/internal/MeshEnvironment.h"
 #include "arcane/materials/internal/MeshMaterialSynchronizer.h"
-#include "arcane/materials/internal/AllCellToAllEnvCellContainer.h"
 
 #include <map>
 #include <memory>
@@ -320,7 +319,7 @@ class MeshMaterialMng
 
  private:
 
-  AllCellToAllEnvCellContainer* getAllCellToAllEnvCellContainer() const { return m_allcell_2_allenvcell; }
+  AllCellToAllEnvCellContainer* getAllCellToAllEnvCellContainer() const { return m_allcell_2_allenvcell.get(); }
   void createAllCellToAllEnvCell();
 
  private:
@@ -382,13 +381,8 @@ class MeshMaterialMng
 
   std::unique_ptr<RunnerInfo> m_runner_info;
 
-  /*!
-   * \brief Contient une instance de AllCellToAllEnvCell.
-   *
-   * On utilise un tableau avec un seul élément pour l'allouer en mémoire unifiée.
-   */
-  UniqueArray<AllCellToAllEnvCellContainer> m_all_cell_to_all_env_cell;
-  AllCellToAllEnvCellContainer* m_allcell_2_allenvcell = nullptr;
+  //! Conteneur pour AllEnvCellToAllEnvCell
+  std::unique_ptr<AllCellToAllEnvCellContainer> m_allcell_2_allenvcell;
   bool m_is_allcell_2_allenvcell = false;
 
   bool m_is_use_accelerator_for_constituent_item_vector = true;

--- a/arcane/src/arcane/materials/internal/MeshMaterialMng.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterialMng.h
@@ -32,6 +32,7 @@
 #include "arcane/materials/internal/MeshMaterial.h"
 #include "arcane/materials/internal/MeshEnvironment.h"
 #include "arcane/materials/internal/MeshMaterialSynchronizer.h"
+#include "arcane/materials/internal/AllCellToAllEnvCellContainer.h"
 
 #include <map>
 #include <memory>
@@ -96,9 +97,9 @@ class MeshMaterialMng
 
    public:
 
-    AllCellToAllEnvCell* getAllCellToAllEnvCell() const override
+    AllCellToAllEnvCellContainer* getAllCellToAllEnvCellContainer() const override
     {
-      return m_material_mng->getAllCellToAllEnvCell();
+      return m_material_mng->getAllCellToAllEnvCellContainer();
     }
     void createAllCellToAllEnvCell() override
     {
@@ -319,7 +320,7 @@ class MeshMaterialMng
 
  private:
 
-  AllCellToAllEnvCell* getAllCellToAllEnvCell() const { return m_allcell_2_allenvcell; }
+  AllCellToAllEnvCellContainer* getAllCellToAllEnvCellContainer() const { return m_allcell_2_allenvcell; }
   void createAllCellToAllEnvCell();
 
  private:
@@ -386,8 +387,8 @@ class MeshMaterialMng
    *
    * On utilise un tableau avec un seul élément pour l'allouer en mémoire unifiée.
    */
-  UniqueArray<AllCellToAllEnvCell> m_all_cell_to_all_env_cell;
-  AllCellToAllEnvCell* m_allcell_2_allenvcell = nullptr;
+  UniqueArray<AllCellToAllEnvCellContainer> m_all_cell_to_all_env_cell;
+  AllCellToAllEnvCellContainer* m_allcell_2_allenvcell = nullptr;
   bool m_is_allcell_2_allenvcell = false;
 
   bool m_is_use_accelerator_for_constituent_item_vector = true;

--- a/arcane/src/arcane/materials/srcs.cmake
+++ b/arcane/src/arcane/materials/srcs.cmake
@@ -123,6 +123,7 @@ set(ARCANE_SOURCES
   IMeshMaterialSynchronizeBuffer.h
   ItemMaterialVariableBaseT.H
 
+  internal/AllCellToAllEnvCellContainer.h
   internal/AllEnvData.h
   internal/ConstituentConnectivityList.h
   internal/ComponentItemInternalData.h

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -45,6 +45,7 @@
 #include "arcane/materials/MeshEnvironmentVariableRef.h"
 #include "arcane/materials/EnvItemVector.h"
 #include "arcane/materials/CellToAllEnvCellConverter.h"
+#include "arcane/materials/internal/AllCellToAllEnvCellContainer.h"
 
 #include "arcane/accelerator/core/Runner.h"
 #include "arcane/accelerator/core/IAcceleratorMng.h"
@@ -798,8 +799,8 @@ _executeTest4(Integer nb_z, bool use_new_impl)
 
   // Some further functions testing, not really usefull here, but it improves cover
   {
-    UniqueArray<AllCellToAllEnvCell> useless;
-    useless.add(AllCellToAllEnvCell(m_mm_mng));
+    UniqueArray<AllCellToAllEnvCellContainer> useless;
+    useless.add(AllCellToAllEnvCellContainer(m_mm_mng));
     useless[0].initialize();
   }
 

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -799,9 +799,8 @@ _executeTest4(Integer nb_z, bool use_new_impl)
 
   // Some further functions testing, not really usefull here, but it improves cover
   {
-    UniqueArray<AllCellToAllEnvCellContainer> useless;
-    useless.add(AllCellToAllEnvCellContainer(m_mm_mng));
-    useless[0].initialize();
+    AllCellToAllEnvCellContainer useless(m_mm_mng);
+    useless.initialize();
   }
 
   // Call to forceRecompute to test bruteForceUpdate

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -189,6 +189,19 @@ checkResizeArrayWithCapacity(Array<DataType>& array, Int64 new_size, bool force_
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
+ * \brief Redimensionne un tableau en ajoutant une réserve de mémoire.
+ *
+ * Cet appel est équivalent à checkResizeArrayWithCapacity(array, new_size, false).
+ */
+template <typename DataType> inline Int32
+checkResizeArrayWithCapacity(Array<DataType>& array, Int64 new_size)
+{
+  return checkResizeArrayWithCapacity(array, new_size, false);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
  * \brief Copie de \a source vers \a destination en utilisant la file \a queue.
  *
  * Il est possible de spécifier la ressource mémoire où se trouve la source


### PR DESCRIPTION
- Move the container management and the computation in a new class `AllCellToAllEnvCellContainer`.
- Use `Span` instead of raw pointer in some part.

The previous implementation use an instance of `AllCellToAllEnvCell` allocated on UVM because it was acceded on CPU and GPU during constituents update. Because of that there was memory transfer in this part. The refactor create two distinct classes to prevent that.

To improve debugging, use `Span` instead of raw pointer in `AllCellToAllEnvCell` to enable bound checking.
