### PR TITLE
Use 'mli2' instead of 'mli' for default file format with Lima

### DIFF
--- a/arcane/ceapart/src/arcane/cea/Lima.cc
+++ b/arcane/ceapart/src/arcane/cea/Lima.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Lima.cc                                                     (C) 2000-2023 */
+/* Lima.cc                                                     (C) 2000-2024 */
 /*                                                                           */
 /* Lecture/Ecriture d'un fichier au format Lima.                             */
 /*---------------------------------------------------------------------------*/
@@ -1353,11 +1353,11 @@ writeMeshToFile(IMesh* mesh,const String& file_name)
 
   std::string std_file_name = file_name.localstr();
 	//TODO: FAIRE EXTENSION si non presente
-  // Regarde si le fichier a l'extension '.unf' ou '.mli'.
-  // Sinon, ajoute '.mli'
+  // Regarde si le fichier a l'extension '.unf', '.mli' ou '.mli2'.
+  // Sinon, ajoute '.mli2'
   std::string::size_type std_end = std::string::npos;
-  if (std_file_name.rfind(".mli")==std_end && std_file_name.rfind(".unf")==std_end){
-    std_file_name += ".mli";
+  if (std_file_name.rfind(".mli2")==std_end && std_file_name.rfind(".mli")==std_end && std_file_name.rfind(".unf")==std_end){
+    std_file_name += ".mli2";
   }
   info() << "FINAL_FILE_NAME=" << std_file_name;
   Lima::Maillage lima(std_file_name);

--- a/arcane/src/arcane/impl/internal/LegacyMeshBuilder.cc
+++ b/arcane/src/arcane/impl/internal/LegacyMeshBuilder.cc
@@ -103,7 +103,7 @@ readCaseMeshes()
       internal_partitioner = internal_partitioner_env;
     }
     IParallelMng* pm = sd->parallelMng();
-    // Dans le cas où Arcane est retranché à un coeur, on va pas chercher les CPU*.mli
+    // Dans le cas où Arcane est retranché à un coeur, on ne va pas chercher les CPU*.mli2
     if (pm->isParallel() && (pm->commSize()>1)){
       m_use_internal_mesh_partitioner = internal_cut;
         
@@ -122,7 +122,7 @@ readCaseMeshes()
         debug() << "MESH CUT DIR " << mesh_cut_dir << ' ' << cut_dir_str;
         if (has_mesh_file && !internal_cut){
           char buf[128];
-          String file_format_str = "mli";
+          String file_format_str = "mli2";
           if (!file_format.null())
             file_format_str = file_format;
           sprintf(buf,"CPU%05d.%s",(int)sub_domain_id,file_format_str.localstr());

--- a/arcane/src/arcane/std/ArcaneCasePartitioner.cc
+++ b/arcane/src/arcane/std/ArcaneCasePartitioner.cc
@@ -194,7 +194,7 @@ _mergeConstraints(ConstArrayView<IMesh*> meshes)
 
   StringBuilder filename = "cut_mesh_after_";
   filename += my_rank;
-  filename += ".mli";
+  filename += ".mli2";
   mesh_writer->writeMeshToFile(mesh,filename);
 #endif
 #endif
@@ -509,7 +509,7 @@ _partitionMesh(Int32 nb_part)
     if (pattern.empty()){
       StringBuilder sfilename = "cut_mesh_";
       sfilename += i;
-      sfilename += ".mli";
+      sfilename += ".mli2";
       filename = sfilename;
     }
     else{


### PR DESCRIPTION
The format `mli` is deprecated and can not be used for writing mesh with recent versions of Lima.