### PR TITLE
Add experimental support to generate uniqueId of faces from uniqueId of its nodes

### DIFF
--- a/arcane/src/arcane/core/MeshUtils.cc
+++ b/arcane/src/arcane/core/MeshUtils.cc
@@ -1949,7 +1949,7 @@ generateHashUniqueId(SmallSpan<const Int64> nodes_unique_id)
   Int64 truncated_uid0 = uid0 & ((1 << 30) - 1);
   Int64 truncated_hash = hash & ((1LL << 31) - 1);
   Int64 new_uid = truncated_uid0 + (truncated_hash << 31);
-  ARCANE_ASSERT(new_uid > 0, ("UniqueId is not > 0"));
+  ARCANE_ASSERT(new_uid >= 0, ("UniqueId is not >= 0"));
   return new_uid;
 }
 

--- a/arcane/src/arcane/mesh/OneMeshItemAdder.h
+++ b/arcane/src/arcane/mesh/OneMeshItemAdder.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* OneMeshItemAdder.h                                          (C) 2000-2022 */
+/* OneMeshItemAdder.h                                          (C) 2000-2024 */
 /*                                                                           */
 /* Outil de création d'une maille                                            */
 /*---------------------------------------------------------------------------*/
@@ -14,7 +14,7 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/Item.h"
+#include "arcane/core/Item.h"
 
 #include "arcane/mesh/MeshGlobal.h"
 #include "arcane/mesh/FullItemInfo.h"
@@ -44,17 +44,19 @@ class DynamicMeshIncrementalBuilder;
 class OneMeshItemAdder
   : public TraceAccessor
 {
-private:
+ private:
   
   // Classe servant à rendre compatible les données FullCellInfo
   // et les données fragmentées de description d'une maille
   class CellInfoProxy;
   
-public:
+ public:
   
-  OneMeshItemAdder(DynamicMeshIncrementalBuilder* mesh_builder);
+  explicit OneMeshItemAdder(DynamicMeshIncrementalBuilder* mesh_builder);
   ~OneMeshItemAdder() {}
   
+ public:
+
   ItemInternal* addOneNode(Int64 node_uid,Int32 owner);
 
   // DEPRECATED
@@ -150,26 +152,29 @@ public:
 
  private:
  
-  DynamicMesh* m_mesh;
-  DynamicMeshIncrementalBuilder* m_mesh_builder;
+  DynamicMesh* m_mesh = nullptr;
+  DynamicMeshIncrementalBuilder* m_mesh_builder = nullptr;
  
   CellFamily& m_cell_family;
   NodeFamily& m_node_family;
   FaceFamily& m_face_family;
   EdgeFamily& m_edge_family;
   
-  ItemTypeMng* m_item_type_mng;
+  ItemTypeMng* m_item_type_mng = nullptr;
  
   MeshInfos m_mesh_info;//!<  Info générale sur le maillage (numéro de sous-domaine, nombre d'items...)
   
-  Int64 m_next_face_uid; //!< Numéro du uniqueId() suivant utilisé pour générer les faces
-  Int64 m_next_edge_uid; //!< Numéro du uniqueId() suivant utilisé pour générer les arêtes
+  Int64 m_next_face_uid = 0; //!< Numéro du uniqueId() suivant utilisé pour générer les faces
+  Int64 m_next_edge_uid = 0; //!< Numéro du uniqueId() suivant utilisé pour générer les arêtes
   
   //! Tableaux de travail
-  Int64UniqueArray m_work_face_sorted_nodes;
-  Int64UniqueArray m_work_face_orig_nodes_uid;
-  Int64UniqueArray m_work_edge_sorted_nodes;
-  Int64UniqueArray m_work_edge_orig_nodes_uid;
+  UniqueArray<Int64> m_work_face_sorted_nodes;
+  UniqueArray<Int64> m_work_face_orig_nodes_uid;
+  UniqueArray<Int64> m_work_edge_sorted_nodes;
+  UniqueArray<Int64> m_work_edge_orig_nodes_uid;
+
+  //! Si vrai, génère les uniqueId() des faces à partir de ceux des noeuds.
+  bool m_use_hash_for_face_unique_id = false;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -557,6 +557,7 @@ if(PARTITIONER_FOUND)
 endif()
 
 arcane_add_test(mesh2 testMesh-2.arc "-We,ARCANE_METIS_INPUT_OUTPUT_DIGEST,1")
+arcane_add_test(mesh2_generate_face_uid testMesh-2.arc "-We,ARCANE_GENERATE_UNIQUE_ID_FROM_NODES,1")
 arcane_add_test_sequential(mesh2_sort_faces testMesh-2-sorted-faces.arc)
 arcane_add_test_sequential(mesh2_init_nan testMesh-2.arc "-We,ARCANE_DATA_INIT_POLICY,NAN")
 arcane_add_test_sequential(mesh2_init_default testMesh-2.arc "-We,ARCANE_DATA_INIT_POLICY,DEFAULT" "-We,ARCANE_ITEMFAMILY_SHRINK_AFTER_ALLOCATE,1")


### PR DESCRIPTION
This may be activated using environment variable `ARCANE_GENERATE_UNIQUE_ID_FROM_NODES`.
