### PR TITLE
Reduce overhead when launching RunCommand

### DIFF
--- a/arcane/src/arcane/accelerator/KernelLauncher.h
+++ b/arcane/src/arcane/accelerator/KernelLauncher.h
@@ -323,7 +323,7 @@ _applyKernelCUDA(impl::RunCommandLaunchInfo& launch_info, const CudaKernel& kern
 #if defined(ARCANE_COMPILING_CUDA)
   Int32 wanted_shared_memory = 0;
   auto tbi = launch_info._threadBlockInfo(reinterpret_cast<const void*>(kernel), wanted_shared_memory);
-  cudaStream_t* s = reinterpret_cast<cudaStream_t*>(launch_info._internalStreamImpl());
+  cudaStream_t* s = reinterpret_cast<cudaStream_t*>(launch_info._internalPlatformStream());
   // TODO: utiliser cudaLaunchKernel() à la place.
   kernel<<<tbi.nbBlockPerGrid(), tbi.nbThreadPerBlock(), wanted_shared_memory, *s>>>(args, func, other_args...);
 #else
@@ -351,7 +351,7 @@ _applyKernelHIP(impl::RunCommandLaunchInfo& launch_info, const HipKernel& kernel
 #if defined(ARCANE_COMPILING_HIP)
   Int32 wanted_shared_memory = 0;
   auto tbi = launch_info._threadBlockInfo(reinterpret_cast<const void*>(kernel), wanted_shared_memory);
-  hipStream_t* s = reinterpret_cast<hipStream_t*>(launch_info._internalStreamImpl());
+  hipStream_t* s = reinterpret_cast<hipStream_t*>(launch_info._internalPlatformStream());
   hipLaunchKernelGGL(kernel, tbi.nbBlockPerGrid(), tbi.nbThreadPerBlock(), wanted_shared_memory, *s, args, func, other_args...);
 #else
   ARCANE_UNUSED(launch_info);
@@ -376,7 +376,7 @@ void _applyKernelSYCL(impl::RunCommandLaunchInfo& launch_info, SyclKernel kernel
                       const LambdaArgs& args, [[maybe_unused]] const ReducerArgs&... reducer_args)
 {
 #if defined(ARCANE_COMPILING_SYCL)
-  sycl::queue* s = reinterpret_cast<sycl::queue*>(launch_info._internalStreamImpl());
+  sycl::queue* s = reinterpret_cast<sycl::queue*>(launch_info._internalPlatformStream());
   sycl::event event;
   if constexpr (sizeof...(ReducerArgs) > 0) {
     auto tbi = launch_info.kernelLaunchArgs();

--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -17,6 +17,7 @@
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
 #include "arcane/accelerator/core/internal/ReduceMemoryImpl.h"
 #include "arcane/accelerator/core/internal/RunCommandImpl.h"
+#include "arcane/accelerator/core/internal/IRunQueueStream.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -139,10 +140,10 @@ operator<<(RunCommand& command, const TraceInfo& trace_info)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-RunQueue RunCommand::
-_internalQueue() const
+void* RunCommand::
+_internalPlatformStream() const
 {
-  return RunQueue(m_p->m_queue);
+  return m_p->internalStream()->_internalImpl();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunCommand.h
+++ b/arcane/src/arcane/accelerator/core/RunCommand.h
@@ -123,8 +123,8 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
  private:
 
   //! \internal
-  RunQueue _internalQueue() const;
   impl::RunQueueImpl* _internalQueueImpl() const;
+  void* _internalPlatformStream() const;
   static impl::RunCommandImpl* _internalCreateImpl(impl::RunQueueImpl* queue);
   static void _internalDestroyImpl(impl::RunCommandImpl* p);
 

--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
@@ -76,7 +76,11 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
    */
   void endExecute();
 
-  //! Informations sur le nombre de block/thread/grille du noyau à lancer.
+  /*!
+   * \brief Informations sur le nombre de block/thread/grille du noyau à lancer.
+   *
+   * Cette valeur n'est valide que pour si la commande est associée à un accélérateur.
+   */
   KernelLaunchArgs kernelLaunchArgs() const { return m_kernel_launch_args; }
 
   //! Calcul les informations pour les boucles multi-thread
@@ -96,12 +100,11 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
   RunCommand& m_command;
   bool m_has_exec_begun = false;
   bool m_is_notify_end_kernel_done = false;
-  IRunnerRuntime* m_runtime = nullptr;
-  IRunQueueStream* m_queue_stream = nullptr;
   eExecutionPolicy m_exec_policy = eExecutionPolicy::Sequential;
   KernelLaunchArgs m_kernel_launch_args;
   ForLoopRunInfo m_loop_run_info;
   Int64 m_total_loop_size = 0;
+  impl::RunQueueImpl* m_queue_impl = nullptr;
 
  private:
 
@@ -112,8 +115,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
    * sous-jacent.
    */
   KernelLaunchArgs _threadBlockInfo(const void* func, Int64 shared_memory_size) const;
-  void* _internalStreamImpl();
-  void _begin();
+  void* _internalPlatformStream();
   void _doEndKernelLaunch();
   KernelLaunchArgs _computeKernelLaunchArgs() const;
 

--- a/arcane/src/arcane/accelerator/core/RunQueue.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueue.cc
@@ -178,7 +178,6 @@ executionPolicy() const
 impl::IRunnerRuntime* RunQueue::
 _internalRuntime() const
 {
-  _checkNotNull();
   return m_p->_internalRuntime();
 }
 
@@ -188,7 +187,6 @@ _internalRuntime() const
 impl::IRunQueueStream* RunQueue::
 _internalStream() const
 {
-  _checkNotNull();
   return m_p->_internalStream();
 }
 
@@ -198,7 +196,6 @@ _internalStream() const
 impl::RunCommandImpl* RunQueue::
 _getCommandImpl() const
 {
-  _checkNotNull();
   return m_p->_internalCreateOrGetRunCommandImpl();
 }
 

--- a/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
@@ -269,8 +269,8 @@ _internalCreateOrGetRunCommandImpl()
 void RunQueueImpl::
 _internalFreeRunningCommands()
 {
-  SmallArray<RunCommandImpl*> command_list;
   if (m_use_pool_mutex) {
+    SmallArray<RunCommandImpl*> command_list;
     // Recopie les commandes dans un tableau local car m_active_run_command_list
     // peut être modifié par un autre thread.
     {

--- a/arcane/src/arcane/accelerator/core/internal/RunCommandImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunCommandImpl.h
@@ -62,7 +62,6 @@ class RunCommandImpl
   void notifyEndLaunchKernel();
   void notifyEndExecuteKernel();
   impl::IReduceMemoryImpl* getOrCreateReduceMemoryImpl();
-
   void releaseReduceMemoryImpl(ReduceMemoryImpl* p);
   IRunQueueStream* internalStream() const;
   RunnerImpl* runner() const;
@@ -95,11 +94,15 @@ class RunCommandImpl
   //! Indique si la commande a été lancée.
   bool m_has_been_launched = false;
 
+  //! Indique si on souhaite le profiling
+  bool m_use_profiling = false;
+
   //! Indique si on utilise les évènements séquentiels pour calculer le temps d'exécution
   bool m_use_sequential_timer_event = false;
-  //! Evènements pour le début et la fin de l'exécution.
+
+  //! Évènements pour le début et la fin de l'exécution.
   IRunQueueEventImpl* m_start_event = nullptr;
-  //! Evènements pour la fin de l'exécution.
+  //! Évènements pour la fin de l'exécution.
   IRunQueueEventImpl* m_stop_event = nullptr;
 
   //! Temps au lancement de la commande

--- a/arcane/src/arcane/accelerator/core/internal/RunQueueImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/RunQueueImpl.h
@@ -86,6 +86,11 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueueImpl
   bool isConcurrentCommandCreation() const { return m_use_pool_mutex; }
 
   void dumpStats(std::ostream& ostr) const;
+  bool isAsync() const { return m_is_async; }
+
+  void _internalBarrier();
+  IRunnerRuntime* _internalRuntime() const { return m_runtime; }
+  IRunQueueStream* _internalStream() const { return m_queue_stream; }
 
  public:
 
@@ -103,10 +108,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueueImpl
  private:
 
   RunCommandImpl* _internalCreateOrGetRunCommandImpl();
-  IRunnerRuntime* _internalRuntime() const { return m_runtime; }
-  IRunQueueStream* _internalStream() const { return m_queue_stream; }
   void _internalFreeRunningCommands();
-  void _internalBarrier();
   bool _isInPool() const { return m_is_in_pool; }
   void _release();
   void _setDefaultMemoryRessource();


### PR DESCRIPTION
Do the following optimizations
- Only use timers or record events if the profiling is active
- Do not compute accelerator information (for example the number of thread/blocks) if execution policy is on host
- Remove some useless tests

These optimizations are only useful when using the host back-end because the overhead of launching kernel on accelerators is far greater.
