### PR TITLE
Add class NativeStream to handle native stream of the accelerator runtime

### DIFF
--- a/arcane/src/arcane/accelerator/AcceleratorUtils.h
+++ b/arcane/src/arcane/accelerator/AcceleratorUtils.h
@@ -14,27 +14,15 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/Array.h"
-
 #include "arcane/accelerator/AcceleratorGlobal.h"
-#include "arcane/accelerator/core/RunQueue.h"
 
 #if defined(ARCANE_COMPILING_HIP)
-#include "arcane/accelerator/hip/HipAccelerator.h"
 #include <hip/hip_runtime.h>
-#include <rocprim/rocprim.hpp>
 #endif
 #if defined(ARCANE_COMPILING_CUDA)
-#include "arcane/accelerator/cuda/CudaAccelerator.h"
-#include <cub/cub.cuh>
 #endif
 #if defined(ARCANE_COMPILING_SYCL)
-#include "arcane/accelerator/sycl/SyclAccelerator.h"
 #include <sycl/sycl.hpp>
-#if defined(__INTEL_LLVM_COMPILER)
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/algorithm>
-#endif
 #endif
 
 /*---------------------------------------------------------------------------*/
@@ -53,6 +41,7 @@ class ARCANE_ACCELERATOR_EXPORT CudaUtils
 
   static cudaStream_t toNativeStream(const RunQueue* queue);
   static cudaStream_t toNativeStream(const RunQueue& queue);
+  static cudaStream_t toNativeStream(const NativeStream& v);
 };
 #endif
 
@@ -66,6 +55,7 @@ class ARCANE_ACCELERATOR_EXPORT HipUtils
 
   static hipStream_t toNativeStream(const RunQueue* queue);
   static hipStream_t toNativeStream(const RunQueue& queue);
+  static hipStream_t toNativeStream(const NativeStream& v);
 };
 #endif
 
@@ -79,6 +69,7 @@ class ARCANE_ACCELERATOR_EXPORT SyclUtils
 
   static sycl::queue toNativeStream(const RunQueue* queue);
   static sycl::queue toNativeStream(const RunQueue& queue);
+  static sycl::queue toNativeStream(const NativeStream& v);
 };
 #endif
 

--- a/arcane/src/arcane/accelerator/CommonUtils.cc
+++ b/arcane/src/arcane/accelerator/CommonUtils.cc
@@ -16,12 +16,8 @@
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/MemoryUtils.h"
 
-#if defined(ARCANE_COMPILING_HIP)
-#include "arcane/accelerator/hip/HipAccelerator.h"
-#endif
-#if defined(ARCANE_COMPILING_CUDA)
-#include "arcane/accelerator/cuda/CudaAccelerator.h"
-#endif
+#include "arcane/accelerator/core/NativeStream.h"
+#include "arcane/accelerator/CommonUtils.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -44,6 +40,15 @@ namespace Arcane::Accelerator::impl
 #if defined(ARCANE_COMPILING_CUDA)
 
 cudaStream_t CudaUtils::
+toNativeStream(const NativeStream& v)
+{
+  cudaStream_t* s = reinterpret_cast<cudaStream_t*>(v.m_native_pointer);
+  if (!s)
+    ARCANE_FATAL("Null CUDA stream");
+  return *s;
+}
+
+cudaStream_t CudaUtils::
 toNativeStream(const RunQueue* queue)
 {
   eExecutionPolicy p = eExecutionPolicy::None;
@@ -51,10 +56,7 @@ toNativeStream(const RunQueue* queue)
     p = queue->executionPolicy();
   if (p != eExecutionPolicy::CUDA)
     ARCANE_FATAL("RunQueue is not a CUDA queue");
-  cudaStream_t* s = reinterpret_cast<cudaStream_t*>(queue->platformStream());
-  if (!s)
-    ARCANE_FATAL("Null stream");
-  return *s;
+  return toNativeStream(queue->_internalNativeStream());
 }
 
 cudaStream_t CudaUtils::
@@ -71,6 +73,15 @@ toNativeStream(const RunQueue& queue)
 #if defined(ARCANE_COMPILING_HIP)
 
 hipStream_t HipUtils::
+toNativeStream(const NativeStream& v)
+{
+  hipStream_t* s = reinterpret_cast<hipStream_t*>(v.m_native_pointer);
+  if (!s)
+    ARCANE_FATAL("Null HIP stream");
+  return *s;
+}
+
+hipStream_t HipUtils::
 toNativeStream(const RunQueue* queue)
 {
   eExecutionPolicy p = eExecutionPolicy::None;
@@ -78,10 +89,7 @@ toNativeStream(const RunQueue* queue)
     p = queue->executionPolicy();
   if (p != eExecutionPolicy::HIP)
     ARCANE_FATAL("RunQueue is not a HIP queue");
-  hipStream_t* s = reinterpret_cast<hipStream_t*>(queue->platformStream());
-  if (!s)
-    ARCANE_FATAL("Null stream");
-  return *s;
+  return toNativeStream(queue->_internalNativeStream());
 }
 
 hipStream_t HipUtils::
@@ -98,6 +106,15 @@ toNativeStream(const RunQueue& queue)
 #if defined(ARCANE_COMPILING_SYCL)
 
 sycl::queue SyclUtils::
+toNativeStream(const NativeStream& v)
+{
+  sycl::queue* s = reinterpret_cast<sycl::queue*>(v.m_native_pointer);
+  if (!s)
+    ARCANE_FATAL("Null SYCL stream");
+  return *s;
+}
+
+sycl::queue SyclUtils::
 toNativeStream(const RunQueue* queue)
 {
   eExecutionPolicy p = eExecutionPolicy::None;
@@ -105,10 +122,7 @@ toNativeStream(const RunQueue* queue)
     p = queue->executionPolicy();
   if (p != eExecutionPolicy::SYCL)
     ARCANE_FATAL("RunQueue is not a SYCL queue");
-  sycl::queue* s = reinterpret_cast<sycl::queue*>(queue->platformStream());
-  if (!s)
-    ARCANE_FATAL("Null stream");
-  return *s;
+  return toNativeStream(queue->_internalNativeStream());
 }
 
 sycl::queue SyclUtils::

--- a/arcane/src/arcane/accelerator/CommonUtils.h
+++ b/arcane/src/arcane/accelerator/CommonUtils.h
@@ -22,17 +22,20 @@
 
 #if defined(ARCANE_COMPILING_HIP)
 #include "arcane/accelerator/hip/HipAccelerator.h"
-#include <hip/hip_runtime.h>
 #include <rocprim/rocprim.hpp>
 #endif
 #if defined(ARCANE_COMPILING_CUDA)
 #include "arcane/accelerator/cuda/CudaAccelerator.h"
 #include <cub/cub.cuh>
 #endif
-#if defined(ARCANE_COMPILING_SYCL) && defined(__INTEL_LLVM_COMPILER)
+#if defined(ARCANE_COMPILING_SYCL)
+#include "arcane/accelerator/sycl/SyclAccelerator.h"
+#if defined(__INTEL_LLVM_COMPILER)
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #endif
+#endif
+
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
@@ -78,6 +78,10 @@ namespace impl
   class RunCommandLaunchInfo;
   class RunnerImpl;
   class RunQueueImplStack;
+  class NativeStream;
+  class CudaUtils;
+  class HipUtils;
+  class SyclUtils;
 } // namespace impl
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/NativeStream.h
+++ b/arcane/src/arcane/accelerator/core/NativeStream.h
@@ -1,0 +1,87 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* NativeStream.h                                              (C) 2000-2024 */
+/*                                                                           */
+/* Type opaque pour encapsuler une 'stream' native.                          */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_ACCELERATOR_CORE_PLATFORMSTREAM_H
+#define ARCANE_ACCELERATOR_CORE_PLATFORMSTREAM_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/accelerator/core/AcceleratorCoreGlobal.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+namespace Arcane::Accelerator
+{
+namespace Cuda
+{
+  class CudaRunQueueStream;
+}
+namespace Hip
+{
+  class HipRunQueueStream;
+}
+namespace Sycl
+{
+  class SyclRunQueueStream;
+}
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator::impl
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Type opaque pour encapsuler une 'stream' native.
+ *
+ * Cette classe permet de conserver *temporairement* une stream native.
+ * Le type exact dépend du runtime: cudaStream_t, hipStream_to ou sycl::queue.
+ *
+ * Les instances de cette classe ne doivent pas être conservées.
+ */
+class ARCANE_ACCELERATOR_CORE_EXPORT NativeStream
+{
+  friend Arcane::Accelerator::RunQueue;
+  friend Arcane::Accelerator::RunCommand;
+  friend Arcane::Accelerator::Cuda::CudaRunQueueStream;
+  friend Arcane::Accelerator::Hip::HipRunQueueStream;
+  friend Arcane::Accelerator::Sycl::SyclRunQueueStream;
+  friend Arcane::Accelerator::impl::CudaUtils;
+  friend Arcane::Accelerator::impl::HipUtils;
+  friend Arcane::Accelerator::impl::SyclUtils;
+
+ public:
+
+  NativeStream() = default;
+
+ private:
+
+  explicit NativeStream(void* ptr)
+  : m_native_pointer(ptr)
+  {}
+
+ private:
+
+  void* m_native_pointer = nullptr;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::impl
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/accelerator/core/RunCommand.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommand.cc
@@ -14,6 +14,7 @@
 #include "arcane/accelerator/core/RunCommand.h"
 
 #include "arcane/accelerator/core/RunQueue.h"
+#include "arcane/accelerator/core/NativeStream.h"
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
 #include "arcane/accelerator/core/internal/ReduceMemoryImpl.h"
 #include "arcane/accelerator/core/internal/RunCommandImpl.h"
@@ -140,10 +141,10 @@ operator<<(RunCommand& command, const TraceInfo& trace_info)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void* RunCommand::
-_internalPlatformStream() const
+impl::NativeStream RunCommand::
+_internalNativeStream() const
 {
-  return m_p->internalStream()->_internalImpl();
+  return m_p->internalStream()->nativeStream();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunCommand.h
+++ b/arcane/src/arcane/accelerator/core/RunCommand.h
@@ -124,7 +124,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommand
 
   //! \internal
   impl::RunQueueImpl* _internalQueueImpl() const;
-  void* _internalPlatformStream() const;
+  impl::NativeStream _internalNativeStream() const;
   static impl::RunCommandImpl* _internalCreateImpl(impl::RunQueueImpl* queue);
   static void _internalDestroyImpl(impl::RunCommandImpl* p);
 

--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
@@ -19,6 +19,7 @@
 #include "arcane/accelerator/core/RunQueue.h"
 #include "arcane/accelerator/core/internal/IRunQueueStream.h"
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
+#include "arcane/accelerator/core/NativeStream.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -102,10 +103,10 @@ _doEndKernelLaunch()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void* RunCommandLaunchInfo::
-_internalPlatformStream()
+NativeStream RunCommandLaunchInfo::
+_internalNativeStream()
 {
-  return m_command._internalPlatformStream();
+  return m_command._internalNativeStream();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
@@ -115,7 +115,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
    * sous-jacent.
    */
   KernelLaunchArgs _threadBlockInfo(const void* func, Int64 shared_memory_size) const;
-  void* _internalPlatformStream();
+  NativeStream _internalNativeStream();
   void _doEndKernelLaunch();
   KernelLaunchArgs _computeKernelLaunchArgs() const;
 

--- a/arcane/src/arcane/accelerator/core/RunQueue.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueue.cc
@@ -24,6 +24,7 @@
 #include "arcane/accelerator/core/Runner.h"
 #include "arcane/accelerator/core/RunQueueEvent.h"
 #include "arcane/accelerator/core/Memory.h"
+#include "arcane/accelerator/core/NativeStream.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -212,12 +213,21 @@ _internalImpl() const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+impl::NativeStream RunQueue::
+_internalNativeStream() const
+{
+  if (m_p)
+    return m_p->_internalStream()->nativeStream();
+  return {};
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 void* RunQueue::
 platformStream() const
 {
-  if (m_p)
-    return m_p->_internalStream()->_internalImpl();
-  return nullptr;
+  return _internalNativeStream().m_native_pointer;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunQueue.h
+++ b/arcane/src/arcane/accelerator/core/RunQueue.h
@@ -57,6 +57,10 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
   friend class impl::RunCommandLaunchInfo;
   friend RunCommand makeCommand(const RunQueue& run_queue);
   friend RunCommand makeCommand(const RunQueue* run_queue);
+  // Pour _internalNativeStream()
+  friend class impl::CudaUtils;
+  friend class impl::HipUtils;
+  friend class impl::SyclUtils;
 
  public:
 
@@ -255,6 +259,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunQueue
   impl::IRunnerRuntime* _internalRuntime() const;
   impl::IRunQueueStream* _internalStream() const;
   impl::RunCommandImpl* _getCommandImpl() const;
+  impl::NativeStream _internalNativeStream() const;
   void _checkNotNull() const;
 
   // Pour VariableViewBase

--- a/arcane/src/arcane/accelerator/core/RunQueueRuntime.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueRuntime.cc
@@ -22,6 +22,7 @@
 #include "arcane/accelerator/core/Memory.h"
 #include "arcane/accelerator/core/DeviceInfoList.h"
 #include "arcane/accelerator/core/DeviceMemoryInfo.h"
+#include "arcane/accelerator/core/NativeStream.h"
 
 #include <cstring>
 
@@ -53,7 +54,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT HostRunQueueStream
     args.destination().copyHost(args.source());
   }
   void prefetchMemory(const MemoryPrefetchArgs&) override {}
-  void* _internalImpl() override { return nullptr; }
+  NativeStream nativeStream() override { return {}; }
   bool _barrierNoException() override { return false; }
 
  private:

--- a/arcane/src/arcane/accelerator/core/internal/IRunQueueStream.h
+++ b/arcane/src/arcane/accelerator/core/internal/IRunQueueStream.h
@@ -64,7 +64,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT IRunQueueStream
  public:
 
   //! Pointeur sur la structure interne dépendante de l'implémentation
-  virtual void* _internalImpl() = 0;
+  virtual NativeStream nativeStream() = 0;
 
   //! Barrière sans exception. Retourne \a true en cas d'erreur
   virtual bool _barrierNoException() = 0;

--- a/arcane/src/arcane/accelerator/core/srcs.cmake
+++ b/arcane/src/arcane/accelerator/core/srcs.cmake
@@ -12,6 +12,7 @@ set( ARCANE_SOURCES
   IReduceMemoryImpl.h
   IDeviceInfoList.h
   KernelLaunchArgs.h
+  NativeStream.h
   Memory.h
   Memory.cc
   MemoryTracer.cc

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -37,6 +37,8 @@
 #include "arcane/accelerator/core/PointerAttribute.h"
 #include "arcane/accelerator/core/RunQueue.h"
 #include "arcane/accelerator/core/DeviceMemoryInfo.h"
+#include "arcane/accelerator/core/NativeStream.h"
+
 #include "arcane/accelerator/cuda/runtime/internal/Cupti.h"
 
 #include <iostream>
@@ -156,9 +158,9 @@ class CudaRunQueueStream
     if (!args.isAsync())
       barrier();
   }
-  void* _internalImpl() override
+  impl::NativeStream nativeStream() override
   {
-    return &m_cuda_stream;
+    return impl::NativeStream(&m_cuda_stream);
   }
 
  public:

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -24,13 +24,14 @@
 
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
 #include "arcane/accelerator/core/Memory.h"
+#include "arcane/accelerator/core/DeviceInfoList.h"
+#include "arcane/accelerator/core/RunQueue.h"
+#include "arcane/accelerator/core/DeviceMemoryInfo.h"
+#include "arcane/accelerator/core/NativeStream.h"
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
 #include "arcane/accelerator/core/internal/RegisterRuntimeInfo.h"
 #include "arcane/accelerator/core/internal/IRunQueueStream.h"
 #include "arcane/accelerator/core/internal/IRunQueueEventImpl.h"
-#include "arcane/accelerator/core/DeviceInfoList.h"
-#include "arcane/accelerator/core/RunQueue.h"
-#include "arcane/accelerator/core/DeviceMemoryInfo.h"
 #include "arcane/accelerator/core/internal/RunCommandImpl.h"
 
 #include <iostream>
@@ -117,9 +118,9 @@ class HipRunQueueStream
     if (!args.isAsync())
       barrier();
   }
-  void* _internalImpl() override
+  impl::NativeStream nativeStream() override
   {
-    return &m_hip_stream;
+    return impl::NativeStream(&m_hip_stream);
   }
 
  public:

--- a/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
@@ -22,13 +22,14 @@
 
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
 #include "arcane/accelerator/core/Memory.h"
+#include "arcane/accelerator/core/DeviceInfoList.h"
+#include "arcane/accelerator/core/RunQueue.h"
+#include "arcane/accelerator/core/DeviceMemoryInfo.h"
+#include "arcane/accelerator/core/NativeStream.h"
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
 #include "arcane/accelerator/core/internal/RegisterRuntimeInfo.h"
 #include "arcane/accelerator/core/internal/IRunQueueStream.h"
 #include "arcane/accelerator/core/internal/IRunQueueEventImpl.h"
-#include "arcane/accelerator/core/DeviceInfoList.h"
-#include "arcane/accelerator/core/RunQueue.h"
-#include "arcane/accelerator/core/DeviceMemoryInfo.h"
 
 #include <iostream>
 
@@ -92,9 +93,9 @@ class SyclRunQueueStream
     if (!args.isAsync())
       this->barrier();
   }
-  void* _internalImpl() override
+  impl::NativeStream nativeStream() override
   {
-    return m_sycl_stream.get();
+    return impl::NativeStream(m_sycl_stream.get());
   }
 
   void _setSyclLastCommandEvent([[maybe_unused]] void* sycl_event_ptr) override


### PR DESCRIPTION
Before we used `void*` to handle that. Using an opaque type has a bit of type safety.
