### PR TITLE
Add support for 'SmallSpan' in arguments of some methods of 'NumArray' and 'MDSpan' for dimension 1

### DIFF
--- a/arcane/src/arcane/accelerator/tests/TestPartition_Kernel.cc
+++ b/arcane/src/arcane/accelerator/tests/TestPartition_Kernel.cc
@@ -27,7 +27,7 @@ extern "C++" void _doPartition1(RunQueue queue, SmallSpan<Real> values, SmallSpa
   const Int32 nb_value = values.size();
   NumArray<Real, MDDim1> input(nb_value);
   //, { 1.3, 4.5, -1.2, 3.5, 7.0, 4.2, 2.3, 1.6 });
-  input.copy(MDSpan<Real, MDDim1>(values.data(), values.size()));
+  input.copy(values, queue);
   NumArray<Real, MDDim1> output(nb_value);
   auto input_values = viewIn(queue, input);
   auto output_values = viewOut(queue, output);

--- a/arcane/src/arcane/utils/MDDim.h
+++ b/arcane/src/arcane/utils/MDDim.h
@@ -59,6 +59,7 @@ class ExtentsV<IndexType_>
 
   static constexpr int rank() { return 0; }
   static constexpr int nb_dynamic = 0;
+  static constexpr bool isDynamic1D() { return false; }
 
   template <int X> using AddedFirstExtentsType = ExtentsV<IndexType_, X>;
   template <int X, int Last> using AddedFirstLastExtentsType = ExtentsV<IndexType_, X, Last>;
@@ -78,6 +79,7 @@ class ExtentsV<IndexType_, X0>
   static constexpr int rank() { return 1; }
   static constexpr int nb_dynamic = impl::extent::nbDynamic(X0);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 1); }
+  static constexpr bool isDynamic1D() { return (nb_dynamic == 1); }
 
   using MDIndexType = MDIndex<1>;
   using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0>;
@@ -104,6 +106,7 @@ class ExtentsV<IndexType_, X0, X1>
   static constexpr int rank() { return 2; }
   static constexpr int nb_dynamic = impl::extent::nbDynamic(X0, X1);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 2); }
+  static constexpr bool isDynamic1D() { return false; }
 
   using MDIndexType = MDIndex<2>;
   using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0, X1>;
@@ -129,6 +132,7 @@ class ExtentsV<IndexType_, X0, X1, X2>
   static constexpr int rank() { return 3; }
   static constexpr int nb_dynamic = impl::extent::nbDynamic(X0, X1, X2);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 3); }
+  static constexpr bool isDynamic1D() { return false; }
 
   using MDIndexType = MDIndex<3>;
   using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0, X1, X2>;
@@ -153,6 +157,7 @@ class ExtentsV<IndexType_, X0, X1, X2, X3>
   static constexpr int rank() { return 4; }
   static constexpr int nb_dynamic = impl::extent::nbDynamic(X0, X1, X2, X3);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 4); }
+  static constexpr bool isDynamic1D() { return false; }
 
   using MDIndexType = MDIndex<4>;
   using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0, X1, X2, X3>;

--- a/arcane/src/arcane/utils/MDSpan.h
+++ b/arcane/src/arcane/utils/MDSpan.h
@@ -46,6 +46,8 @@ class MDSpan
   friend class NumArray<UnqualifiedValueType, Extents, LayoutPolicy>;
   // Pour que MDSpan<const T> ait accès à MDSpan<T>
   friend class MDSpan<const UnqualifiedValueType, Extents, LayoutPolicy>;
+  using ThatClass = MDSpan<DataType, Extents, LayoutPolicy>;
+  static constexpr bool IsConst = std::is_const_v<DataType>;
 
  public:
 
@@ -79,6 +81,26 @@ class MDSpan
   : m_ptr(rhs.m_ptr)
   , m_extents(rhs.m_extents)
   {}
+  constexpr ARCCORE_HOST_DEVICE MDSpan(SmallSpan<DataType> v) requires(Extents::isDynamic1D() && !IsConst)
+  : m_ptr(v.data())
+  , m_extents(DynamicDimsType(v.size()))
+  {}
+  constexpr ARCCORE_HOST_DEVICE MDSpan(SmallSpan<const DataType> v) requires(Extents::isDynamic1D() && IsConst)
+  : m_ptr(v.data())
+  , m_extents(DynamicDimsType(v.size()))
+  {}
+  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(SmallSpan<DataType> v) requires(Extents::isDynamic1D() && !IsConst)
+  {
+    m_ptr = v.data();
+    m_extents = DynamicDimsType(v.size());
+    return (*this);
+  }
+  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(SmallSpan<const DataType> v) requires(Extents::isDynamic1D() && IsConst)
+  {
+    m_ptr = v.data();
+    m_extents = DynamicDimsType(v.size());
+    return (*this);
+  }
 
  public:
 
@@ -107,7 +129,6 @@ class MDSpan
   //! Valeur de la quatrième dimension
   constexpr ARCCORE_HOST_DEVICE Int32 extent3() const requires(Extents::rank() >= 4) { return m_extents.extent3(); }
 
- public:
  public:
 
   //! Valeur pour l'élément \a i,j,k,l

--- a/arcane/src/arcane/utils/NumArray.h
+++ b/arcane/src/arcane/utils/NumArray.h
@@ -159,7 +159,7 @@ class NumArray
 
   //! Construit un tableau à partir de valeurs prédéfinies (uniquement tableaux 1D dynamiques)
   NumArray(Int32 dim1_size, std::initializer_list<DataType> alist)
-  requires(Extents::is_full_dynamic() && Extents::rank() == 1)
+  requires(Extents::isDynamic1D())
   : NumArray(dim1_size)
   {
     this->m_data.copyInitializerList(alist);
@@ -167,7 +167,7 @@ class NumArray
 
   //! Construit une instance à partir d'une vue (uniquement tableaux 1D dynamiques)
   NumArray(SmallSpan<const DataType> v)
-  requires(Extents::is_full_dynamic() && Extents::rank() == 1)
+  requires(Extents::isDynamic1D())
   : NumArray(v.size())
   {
     this->m_data.copy(v);
@@ -175,7 +175,7 @@ class NumArray
 
   //! Construit une instance à partir d'une vue (uniquement tableaux 1D dynamiques)
   NumArray(Span<const DataType> v)
-  requires(Extents::is_full_dynamic() && Extents::rank() == 1)
+  requires(Extents::isDynamic1D())
   : NumArray(arcaneCheckArraySize(v.size()))
   {
     this->m_data.copy(v);
@@ -434,6 +434,17 @@ class NumArray
    * Cette opération est valide quelle que soit la mêmoire associée
    * associée à l'instance.
    */
+  void copy(SmallSpan<const DataType> rhs) requires(Extents::isDynamic1D())
+  {
+    copy(rhs, nullptr);
+  }
+
+  /*!
+   * \brief Copie dans l'instance les valeurs de \a rhs.
+   *
+   * Cette opération est valide quelle que soit la mêmoire associée
+   * associée à l'instance.
+   */
   void copy(ConstMDSpanType rhs) { copy(rhs, nullptr); }
 
   /*!
@@ -452,9 +463,35 @@ class NumArray
    * \a queue peut être nul. Si la file est asynchrone, il faudra la
    * synchroniser avant de pouvoir utiliser l'instance.
    */
+  void copy(SmallSpan<const DataType> rhs, const RunQueue* queue) requires(Extents::isDynamic1D())
+  {
+    _resizeAndCopy(ConstMDSpanType(rhs), eMemoryRessource::Unknown, queue);
+  }
+
+  /*!
+   * \brief Copie dans l'instance les valeurs de \a rhs via la file \a queue.
+   *
+   * Cette opération est valide quelle que soit la mêmoire associée
+   * associée à l'instance.
+   * \a queue peut être nul. Si la file est asynchrone, il faudra la
+   * synchroniser avant de pouvoir utiliser l'instance.
+   */
   void copy(ConstMDSpanType rhs, const RunQueue* queue)
   {
     _resizeAndCopy(rhs, eMemoryRessource::Unknown, queue);
+  }
+
+  /*!
+   * \brief Copie dans l'instance les valeurs de \a rhs via la file \a queue.
+   *
+   * Cette opération est valide quelle que soit la mêmoire associée
+   * associée à l'instance.
+   * \a queue peut être nulle, auquel cas la copie se fait sur l'hôte.
+   * Si la file est asynchrone, il faudra la synchroniser avant de pouvoir utiliser l'instance.
+   */
+  void copy(SmallSpan<const DataType> rhs, const RunQueue& queue) requires(Extents::isDynamic1D())
+  {
+    _resizeAndCopy(ConstMDSpanType(rhs), eMemoryRessource::Unknown, &queue);
   }
 
   /*!

--- a/arcane/src/arcane/utils/tests/TestNumArray.cc
+++ b/arcane/src/arcane/utils/tests/TestNumArray.cc
@@ -28,6 +28,17 @@ using namespace Arcane;
 
 using namespace Arcane;
 
+TEST(NumArray, Empty)
+{
+  std::cout << "TEST_NUMARRAY Empty\n";
+  NumArray<Real, MDDim1> array1;
+  NumArray<Real, MDDim1> array2(array1);
+  NumArray<Real, MDDim1> array3;
+  array1 = array3;
+  NumArray<Real, MDDim1> array4;
+  array4 = array1;
+}
+
 TEST(NumArray, Basic)
 {
   std::cout << "TEST_NUMARRAY Basic\n";
@@ -606,6 +617,36 @@ TEST(NumArray, TestCopy)
   auto test5 = bar2();
   std::cout << "Val 5 = " << &test5 << " " << test5.to1DSpan() << "\n";
   ASSERT_EQ(test4.a_.to1DSpan(), test5.to1DSpan());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(NumArray, SpanUsage)
+{
+  std::cout << "Test_SpanUsage";
+  UniqueArray<Int32> ua1 = { 0, 1, 2, 3, 4, 253, 254, 255, 256, 25 };
+  NumArray<Int32, MDDim1> a1;
+  SmallSpan<const Int32> const_span_ua1 = ua1.smallSpan();
+  SmallSpan<Int32> span_ua1 = ua1.smallSpan();
+  a1.copy(span_ua1);
+  ASSERT_EQ(span_ua1, a1.to1DSmallSpan());
+
+  a1.fill(3);
+  a1.copy(span_ua1, nullptr);
+  ASSERT_EQ(span_ua1, a1.to1DSmallSpan());
+
+  MDSpan<const Int32, MDDim1> md_a1(span_ua1);
+  ASSERT_EQ(span_ua1, md_a1.to1DSmallSpan());
+
+  MDSpan<const Int32, MDDim1> md_a2(const_span_ua1);
+  ASSERT_EQ(const_span_ua1, md_a2.to1DSmallSpan());
+
+  MDSpan<Int32, MDDim1> md_a3(span_ua1);
+  ASSERT_EQ(span_ua1, md_a3.to1DSmallSpan());
+
+  md_a3 = a1.to1DSmallSpan();
+  ASSERT_EQ(a1.to1DSmallSpan(), md_a3.to1DSmallSpan());
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
- Add build `MDSpan<T,MDDim1>` from `SmallSpan<T>`.
- Add `NumArray::copy(SmallSpan)` for 1D dynamic `NumArray`.