### PR TITLE
Create classes 'Int128' and 'Float128' to handle these data types

### DIFF
--- a/arccore/src/base/arccore/base/CMakeLists.txt
+++ b/arccore/src/base/arccore/base/CMakeLists.txt
@@ -35,10 +35,12 @@ set(SOURCES
   FatalErrorException.cc
   FatalErrorException.h
   Float16.h
+  Float128.h
   FloatConversion.h
   Iterator.h
   IndexOutOfRangeException.cc
   IndexOutOfRangeException.h
+  Int128.h
   IStackTraceService.h
   NotSupportedException.h
   NotSupportedException.cc

--- a/arccore/src/base/arccore/base/Float128.h
+++ b/arccore/src/base/arccore/base/Float128.h
@@ -1,0 +1,103 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* Float128.h                                                  (C) 2000-2024 */
+/*                                                                           */
+/* Type flottant 128bit.                                                     */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCCORE_BASE_FLOAT128_H
+#define ARCCORE_BASE_FLOAT128_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/base/ArccoreGlobal.h"
+
+#include <cstdalign>
+
+// Tous les compilateurs Linux supportés par Arccore ont le type '__float128'
+#if defined(ARCCORE_OS_LINUX)
+#define ARCCORE_HAS_NATIVE_FLOAT128
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arccore
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Type flottant demi-précision
+ */
+class alignas(16) Float128
+{
+ public:
+
+  Float128() = default;
+  Float128(long double v)
+  {
+    _setFromLongDouble(v);
+  }
+  Float128& operator=(long double v)
+  {
+    _setFromLongDouble(v);
+    return (*this);
+  }
+  operator long double() const { return _toLongDouble(); }
+
+ private:
+
+#ifdef ARCCORE_HAS_NATIVE_FLOAT128
+  using NativeType = __float128;
+  explicit Float128(__float128 x)
+  : m_v(x)
+  {}
+#else
+  using NativeType = long double;
+#endif
+
+  NativeType m_v;
+
+  long double _toLongDouble() const
+  {
+    return static_cast<long double>(m_v);
+  }
+  void _setFromLongDouble(long double v)
+  {
+    m_v = static_cast<NativeType>(v);
+  }
+  friend Float128 operator+(Float128 a, Float128 b)
+  {
+    return Float128(a.m_v + b.m_v);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arccore
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arccore/src/base/arccore/base/FloatConversion.h
+++ b/arccore/src/base/arccore/base/FloatConversion.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* FloatConversion.h                                           (C) 2000-2023 */
+/* FloatConversion.h                                           (C) 2000-2024 */
 /*                                                                           */
 /* Opérations de conversion entre 'float' et 'Float16' et 'BFloat16'.        */
 /*---------------------------------------------------------------------------*/
@@ -165,7 +165,7 @@ convertToBFloat16Impl(uint16_t val)
   char* const first = reinterpret_cast<char*>(&result);
   char* const second = first + sizeof(uint16_t);
   // Les macros suivantes ne sont pas définies sous Windows mais ce dernier
-  // ne supporte que des architectures little-endian donc cela ne pose pas
+  // ne supporte que des architectures big-endian donc cela ne pose pas
   // de problèmes.
 #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
   std::memcpy(first, &val, sizeof(uint16_t));

--- a/arccore/src/base/arccore/base/Int128.h
+++ b/arccore/src/base/arccore/base/Int128.h
@@ -1,0 +1,98 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* Int128.h                                                    (C) 2000-2024 */
+/*                                                                           */
+/* Type flottant 128bit.                                                     */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCCORE_BASE_INT128_H
+#define ARCCORE_BASE_INT128_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/base/ArccoreGlobal.h"
+
+#include <cstdalign>
+
+// Tous les compilateurs Linux supportés par Arccore ont le type '__int128'
+#if defined(ARCCORE_OS_LINUX)
+#define ARCCORE_HAS_NATIVE_INT128
+#endif
+
+#if defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arccore
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Type flottant demi-précision
+ */
+class alignas(16) Int128
+{
+ public:
+
+  Int128() = default;
+  Int128(Int64 v)
+  {
+    _setFromInt64(v);
+  }
+  Int128& operator=(Int64 v)
+  {
+    _setFromInt64(v);
+    return (*this);
+  }
+  Int64 toInt64() const { return _toInt64(); }
+  operator Int64() const { return _toInt64(); }
+
+ private:
+
+#ifdef ARCCORE_HAS_NATIVE_INT128
+  using NativeType = __int128;
+  NativeType m_v;
+  explicit Int128(__int128 x)
+  : m_v(x)
+  {}
+#else
+  Int64 m_v;
+  Int64 m_v2;
+#endif
+
+  Int64 _toInt64() const
+  {
+    return static_cast<Int64>(m_v);
+  }
+  void _setFromInt64(Int64 v)
+  {
+    m_v = v;
+  }
+  friend Int128 operator+(Int128 a, Int128 b)
+  {
+    return Int128(a.m_v + b.m_v);
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
+
+} // namespace Arccore
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arccore/src/base/tests/TestBasicDataType.cc
+++ b/arccore/src/base/tests/TestBasicDataType.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -10,6 +10,8 @@
 #include "arccore/base/String.h"
 #include "arccore/base/BFloat16.h"
 #include "arccore/base/Float16.h"
+#include "arccore/base/Float128.h"
+#include "arccore/base/Int128.h"
 
 #include <string>
 
@@ -86,9 +88,9 @@ class RefValue
 {
  public:
 
-  float original_value = 0.0;
+  float original_value = 0.0f;
   uint16_t raw_value = 0;
-  float converted_value = 0.0;
+  float converted_value = 0.0f;
 
  public:
 
@@ -190,6 +192,32 @@ TEST(BasicDataType, Float16)
   ASSERT_EQ(bf3, bf1);
   ASSERT_TRUE(bf2 < bf1);
   ASSERT_FALSE(bf1 < bf2);
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+TEST(BasicDataType, Float128)
+{
+  Float128 a = 1.0;
+  Float128 b = 2.0;
+  Float128 c = a + b;
+  double c_as_double = static_cast<double>(c);
+  std::cout << "F128=" << c_as_double << "\n";
+  ASSERT_EQ(sizeof(Float128), 16);
+}
+
+TEST(BasicDataType, Int128)
+{
+  Int128 a = 1;
+  Int128 b = 2;
+  Int128 c = a + b;
+  std::cout << "I128=" << static_cast<int64_t>(c) << "\n";
+  std::cout << "sizeof(Int128) = " << sizeof(Int128) << "\n";
+  std::cout << "sizeof(intmax_t) = " << sizeof(intmax_t) << "\n";
+  ASSERT_EQ(sizeof(Int128), 16);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
These classes use `__int128` and `__float128` if possible. This should always be always on Linux with the compilers supported by Arcane.