### PR TITLE
Always use 'add_subdirectory' to build Arccore from Arcane

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Configure build script
         shell: bash
         run: |
-          cmake -S "${{ github.workspace }}/_common/build_all" -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_VERBOSE_MAKEFILE=TRUE -DVCPKG_INSTALLED_DIR="${{ env.VCPKG_BUILD_DIR }}/installed" -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.cmake_specific_args }} -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" -GNinja
+          cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_VERBOSE_MAKEFILE=TRUE -DVCPKG_INSTALLED_DIR="${{ env.VCPKG_BUILD_DIR }}/installed" -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.cmake_specific_args }} -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" -GNinja
 
       - name: Dump Some Generated files
         shell: bash

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -4,11 +4,10 @@ message(STATUS "CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} CMAKE_CURRENT_SOURCE_DIR=${
 
 # ----------------------------------------------------------------------------
 # Vérifie qu'on a bien lancé la configuration depuis le répertoire racine
-# du dépot. Il faut la politique CMP0139 pour pouvoir utilier 'PATH_EQUAL'
-if(POLICY CMP0139)
-  cmake_policy(SET CMP0139 NEW)
-endif()
-if (CMAKE_SOURCE_DIR PATH_EQUAL CMAKE_CURRENT_SOURCE_DIR)
+# du dépot.
+cmake_path(COMPARE "${CMAKE_SOURCE_DIR}" EQUAL "${CMAKE_CURRENT_SOURCE_DIR}" IS_NOT_FROM_BASE_REPO)
+message(STATUS "IS_NOT_FROM_BASE_REPO=${IS_NOT_FROM_BASE_REPO}")
+if (IS_NOT_FROM_BASE_REPO)
   cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH PARENT_SOURCE_DIR)
   message(FATAL_ERROR
       "Compiling in 'arcane' subdirectory is not supported."

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -380,24 +380,18 @@ if (ARCANE_WANT_CHECK)
   set(ARCCORE_CHECK TRUE)
 endif()
 
-set(ARCANE_ARCCORE_NEEDED_VERSION "2.8.0")
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Charge 'Arccore' depuis le répertoire de base.
 if (NOT Arccore_FOUND)
-  find_package(Arccore ${ARCANE_ARCCORE_NEEDED_VERSION} REQUIRED)
-endif ()
-message(STATUS "Arccore_DIR = ${Arccore_DIR}")
-if (Arccore_VERSION VERSION_LESS ARCANE_ARCCORE_NEEDED_VERSION)
-  message(FATAL_ERROR "Arccore version '${Arccore_VERSION}' is too old."
-    " Version ${ARCANE_ARCCORE_NEEDED_VERSION} required")
+  add_subdirectory(${CMAKE_SOURCE_DIR}/arccore arccore)
+  set(Arccore_FOUND YES)
+  set(Arccore_FOUND YES PARENT_SCOPE)
 endif()
 
-# Si arccore a déjà été installé, on prend le mode check de arccore
-# pour garantir la cohérence avec Arcane.
-if (Arccore_DIR)
-  # TODO: à terme, supprimer ces deux variables 'ARCANE_WANT_CHECK' et 'ARCANE_WANT_DEBUG'
-  message(STATUS "[arcane] Setting 'ARCANE_WANT_CHECK' and 'ARCANE_WANT_DEBUG' from arccore")
-  set(ARCANE_WANT_CHECK ${ARCCORE_CHECK})
-  set(ARCANE_WANT_DEBUG ${ARCCORE_DEBUG})
-endif()
+# ----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+
 message(STATUS "[arcane] Is Check mode enabled ? ${ARCANE_WANT_CHECK} (from arccore: ${ARCCORE_CHECK})")
 message(STATUS "[arcane] Is Debug mode enabled ? ${ARCANE_WANT_DEBUG} (from arccore: ${ARCCORE_DEBUG})")
 

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -1,6 +1,20 @@
 ﻿cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
-message(STATUS "CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} CMAKE_VERSION=${CMAKE_VERSION}")
+message(STATUS "CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}  CMAKE_VERSION=${CMAKE_VERSION}")
+
+# ----------------------------------------------------------------------------
+# Vérifie qu'on a bien lancé la configuration depuis le répertoire racine
+# du dépot. Il faut la politique CMP0139 pour pouvoir utilier 'PATH_EQUAL'
+if(POLICY CMP0139)
+  cmake_policy(SET CMP0139 NEW)
+endif()
+if (CMAKE_SOURCE_DIR PATH_EQUAL CMAKE_CURRENT_SOURCE_DIR)
+  cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH PARENT_SOURCE_DIR)
+  message(FATAL_ERROR
+      "Compiling in 'arcane' subdirectory is not supported."
+      " Use CMakeLists.txt from repository base directory: '${PARENT_SOURCE_DIR}'"
+    )
+endif()
 
 # ----------------------------------------------------------------------------
 # Récupère numéro de version de Arcane à partir du fichier 'version' et
@@ -15,6 +29,8 @@ project(Arcane VERSION ${ARCANE_VERSION} LANGUAGES C CXX)
 math(EXPR ARCANE_VERSION_NUMERIC "((10000 * ${Arcane_VERSION_MAJOR}) + 100 * ${Arcane_VERSION_MINOR}) + ${Arcane_VERSION_PATCH}")
 configure_file(arcane_version.h.in ${CMAKE_BINARY_DIR}/arcane_version.h @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/arcane_version.h DESTINATION include)
+
+# ----------------------------------------------------------------------------
 
 if (NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "Arcane has to be compiled with BUILD_SHARED_LIBS=TRUE. Static linking does not work")


### PR DESCRIPTION
This is to make sure Arcane and Arccore are compiled from the same set of sources.
This MR also disables building of Arcane from `arcane` subdirectory: you have to use base directory of the git repository.