### PR TITLE
Uniformize handling of profiling for TaskConcurrency

### DIFF
--- a/arcane/src/arcane/accelerator/RunCommandEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandEnumerate.h
@@ -269,7 +269,6 @@ _applyItems(RunCommand& command, typename TraitsType::ContainerType items,
   using ItemType = TraitsType::ItemType;
   impl::RunCommandLaunchInfo launch_info(command, vsize);
   const eExecutionPolicy exec_policy = launch_info.executionPolicy();
-  launch_info.computeLoopRunInfo();
   launch_info.beginExecute();
   SmallSpan<const Int32> ids = items.localIds();
   switch (exec_policy) {

--- a/arcane/src/arcane/accelerator/RunCommandLoop.h
+++ b/arcane/src/arcane/accelerator/RunCommandLoop.h
@@ -58,7 +58,7 @@ _applyGenericLoop(RunCommand& command, LoopBoundType<N, Int32> bounds,
     arcaneSequentialFor(bounds, func, other_args...);
     break;
   case eExecutionPolicy::Thread:
-    arcaneParallelFor(bounds, launch_info.computeParallelLoopOptions(), func, other_args...);
+    arcaneParallelFor(bounds, launch_info.loopRunInfo(), func, other_args...);
     break;
   default:
     ARCANE_FATAL("Invalid execution policy '{0}'", exec_policy);

--- a/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.h
+++ b/arcane/src/arcane/accelerator/RunCommandMaterialEnumerate.h
@@ -635,7 +635,6 @@ _applyConstituentCells(RunCommand& command, ContainerType items, const Lambda& f
 
   RunCommandLaunchInfo launch_info(command, vsize);
   const eExecutionPolicy exec_policy = launch_info.executionPolicy();
-  launch_info.computeLoopRunInfo();
   launch_info.beginExecute();
   switch (exec_policy) {
   case eExecutionPolicy::CUDA:

--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
@@ -66,6 +66,8 @@ beginExecute()
     ARCANE_FATAL("beginExecute() has already been called");
   m_has_exec_begun = true;
   m_command._internalNotifyBeginLaunchKernel();
+  if (m_exec_policy == eExecutionPolicy::Thread)
+    _computeLoopRunInfo();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -148,12 +150,13 @@ computeParallelLoopOptions() const
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
+/*!
+ * \brief Calcule la valeur de loopRunInfo()
+ *
+ */
 void RunCommandLaunchInfo::
-computeLoopRunInfo()
+_computeLoopRunInfo()
 {
-  if (m_has_exec_begun)
-    ARCANE_FATAL("computeLoopRunInfo() has to be called before beginExecute()");
   ForLoopTraceInfo lti(m_command.traceInfo(), m_command.kernelName());
   m_loop_run_info = ForLoopRunInfo(computeParallelLoopOptions(), lti);
   m_loop_run_info.setExecStat(m_command._internalCommandExecStat());

--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
@@ -83,13 +83,15 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
    */
   KernelLaunchArgs kernelLaunchArgs() const { return m_kernel_launch_args; }
 
-  //! Calcul les informations pour les boucles multi-thread
+  //! Calcule et retourne les informations pour les boucles multi-thread
   ParallelLoopOptions computeParallelLoopOptions() const;
 
-  //! Calcule la valeur de loopRunInfo()
-  void computeLoopRunInfo();
-
-  //! Informations d'exécution de la boucle
+  /*!
+   * \brief Informations d'exécution de la boucle.
+   *
+   * Ces informations ne sont valides si executionPolicy()==eExecutionPolicy::Thread
+   * et si beginExecute() a été appelé.
+   */
   const ForLoopRunInfo& loopRunInfo() const { return m_loop_run_info; }
 
   //! Taille totale de la boucle
@@ -120,6 +122,8 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
   KernelLaunchArgs _computeKernelLaunchArgs() const;
 
  private:
+
+  void _computeLoopRunInfo();
 
   // Pour SYCL: enregistre l'évènement associé à la dernière commande de la file
   // \a sycl_event_ptr est de type 'sycl::event*'.

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -119,8 +119,21 @@ class ScopedExecInfo
   }
   ~ScopedExecInfo()
   {
-    if (m_stat_info_ptr && m_use_own_run_info)
+#ifdef PRINT_STAT_INFO
+    if (m_stat_info_ptr){
+      bool is_valid = m_run_info.traceInfo().isValid();
+      if (!is_valid)
+        std::cout << "ADD_OWN_RUN_INFO nb_chunk=" << m_stat_info_ptr->nbChunk()
+                  << " stack=" << platform::getStackTrace()
+                  << "\n";
+      else
+        std::cout << "ADD_OWN_RUN_INFO nb_chunk=" << m_stat_info_ptr->nbChunk()
+                  << " trace_name=" << m_run_info.traceInfo().traceInfo().name() << "\n";
+    }
+#endif
+    if (m_stat_info_ptr && m_use_own_run_info){
       ProfilingRegistry::_threadLocalForLoopInstance()->merge(*m_stat_info_ptr,m_run_info.traceInfo());
+    }
   }
 
  public:
@@ -442,28 +455,28 @@ class TBBTaskImplementation
   void executeParallelFor(const ParallelFor1DLoopInfo& loop_info) override;
 
   void executeParallelFor(const ComplexForLoopRanges<1>& loop_ranges,
-                          const ParallelLoopOptions& options,
+                          const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<1>* functor) final
   {
-    _executeMDParallelFor<1>(loop_ranges,functor,options);
+    _executeMDParallelFor<1>(loop_ranges,functor,run_info);
   }
   void executeParallelFor(const ComplexForLoopRanges<2>& loop_ranges,
-                          const ParallelLoopOptions& options,
+                          const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<2>* functor) final
   {
-    _executeMDParallelFor<2>(loop_ranges,functor,options);
+    _executeMDParallelFor<2>(loop_ranges,functor,run_info);
   }
   void executeParallelFor(const ComplexForLoopRanges<3>& loop_ranges,
-                          const ParallelLoopOptions& options,
+                          const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<3>* functor) final
   {
-    _executeMDParallelFor<3>(loop_ranges,functor,options);
+    _executeMDParallelFor<3>(loop_ranges,functor,run_info);
   }
   void executeParallelFor(const ComplexForLoopRanges<4>& loop_ranges,
-                          const ParallelLoopOptions& options,
+                          const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<4>* functor) final
   {
-    _executeMDParallelFor<4>(loop_ranges,functor,options);
+    _executeMDParallelFor<4>(loop_ranges,functor,run_info);
   }
 
   bool isActive() const final
@@ -502,7 +515,7 @@ class TBBTaskImplementation
   template<int RankValue> void
   _executeMDParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
                         IMDRangeFunctor<RankValue>* functor,
-                        const ParallelLoopOptions& options);
+                        const ForLoopRunInfo& run_info);
   void _executeParallelFor(const ParallelFor1DLoopInfo& loop_info);
 };
 
@@ -1124,15 +1137,22 @@ executeParallelFor(const ParallelFor1DLoopInfo& loop_info)
  */
 template<int RankValue> void TBBTaskImplementation::
 _executeMDParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
-                       IMDRangeFunctor<RankValue>* functor,
-                       const ParallelLoopOptions& options)
+                      IMDRangeFunctor<RankValue>* functor,
+                      const ForLoopRunInfo& run_info)
 {
-  ScopedExecInfo sei(ForLoopRunInfo{});
+  ParallelLoopOptions options;
+  if (run_info.options().has_value())
+    options = run_info.options().value();
+
+  ScopedExecInfo sei(run_info);
   ForLoopOneExecStat* stat_info = sei.statInfo();
   impl::ScopedStatLoop scoped_loop(sei.isOwn() ? stat_info : nullptr);
 
   if (TaskFactory::verboseLevel()>=1)
-    std::cout << "TBB: TBBTaskImplementation executeMDParallelFor nb_dim=" << RankValue << '\n';
+    std::cout << "TBB: TBBTaskImplementation executeMDParallelFor nb_dim=" << RankValue
+              << " nb_element=" << loop_ranges.nbElement()
+              << " grain_size=" << options.grainSize() << '\n';
+
   Integer max_thread = options.maxThread();
   // En exécution séquentielle, appelle directement la méthode \a f.
   if (max_thread==1 || max_thread==0){

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TBBTaskImplementation.cc                                    (C) 2000-2023 */
+/* TBBTaskImplementation.cc                                    (C) 2000-2024 */
 /*                                                                           */
 /* Implémentation des tâches utilisant TBB (Intel Threads Building Blocks).  */
 /*---------------------------------------------------------------------------*/
@@ -1134,6 +1134,7 @@ executeParallelFor(const ParallelFor1DLoopInfo& loop_info)
  * \brief Exécution d'une boucle N-dimensions.
  *
  * \warning L'implémentation actuelle ne tient pas compte de \a options
+ * pour les boucles autres que une dimension.
  */
 template<int RankValue> void TBBTaskImplementation::
 _executeMDParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,

--- a/arcane/src/arcane/utils/ConcurrencyUtils.cc
+++ b/arcane/src/arcane/utils/ConcurrencyUtils.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ConcurrencyUtils.cc                                         (C) 2000-2021 */
+/* ConcurrencyUtils.cc                                         (C) 2000-2024 */
 /*                                                                           */
 /* Classes gérant la concurrence (tâches, boucles parallèles, ...)           */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ConcurrencyUtils.cc
+++ b/arcane/src/arcane/utils/ConcurrencyUtils.cc
@@ -104,25 +104,25 @@ class NullTaskImplementation
     loop_info.functor()->executeFunctor(loop_info.beginIndex(),loop_info.size());
   }
   void executeParallelFor(const ComplexForLoopRanges<1>& loop_ranges,
-                          [[maybe_unused]] const ParallelLoopOptions& options,
+                          [[maybe_unused]] const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<1>* functor) override
   {
     functor->executeFunctor(loop_ranges);
   }
   void executeParallelFor(const ComplexForLoopRanges<2>& loop_ranges,
-                          [[maybe_unused]] const ParallelLoopOptions& options,
+                          [[maybe_unused]] const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<2>* functor) override
   {
     functor->executeFunctor(loop_ranges);
   }
   void executeParallelFor(const ComplexForLoopRanges<3>& loop_ranges,
-                          [[maybe_unused]] const ParallelLoopOptions& options,
+                          [[maybe_unused]] const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<3>* functor) override
   {
     functor->executeFunctor(loop_ranges);
   }
   void executeParallelFor(const ComplexForLoopRanges<4>& loop_ranges,
-                          [[maybe_unused]] const ParallelLoopOptions& options,
+                          [[maybe_unused]] const ForLoopRunInfo& run_info,
                           IMDRangeFunctor<4>* functor) override
   {
     functor->executeFunctor(loop_ranges);


### PR DESCRIPTION
- Add overload of `TaskConcurrency::executeParallelFor()` which uses `ForLoopRunInfo`.
- Automatically call `RunCommandLaunchInfo::computeLoopRunInfo()` when using `eExecutionPolicy::Thread` to make sure profiling information are always computed if needed. Before it was not used for `RUNCOMMAND_LOOP` commands.