### PR TITLE
Make handling of TaskFactory observers thread-safe

### DIFF
--- a/arcane/src/arcane/impl/Application.cc
+++ b/arcane/src/arcane/impl/Application.cc
@@ -34,6 +34,7 @@
 #include "arcane/utils/ITraceMngPolicy.h"
 #include "arcane/utils/JSONReader.h"
 #include "arcane/utils/Profiling.h"
+#include "arcane/utils/internal/TaskFactoryInternal.h"
 
 #include "arcane/core/ArcaneVersion.h"
 #include "arcane/core/ISubDomain.h"
@@ -399,7 +400,7 @@ build()
         String found_name;
         auto sv = _tryCreateService<ITaskImplementation>(names,&found_name);
         if (sv.get()){
-          TaskFactory::_internalSetImplementation(sv.get());
+          TaskFactoryInternal::setImplementation(sv.get());
           //m_trace->info() << "Initialize task with nb_thread=" << nb_thread;
           sv->initialize(nb_task_thread);
           m_used_task_service_name = found_name;

--- a/arcane/src/arcane/impl/Application.cc
+++ b/arcane/src/arcane/impl/Application.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Application.cc                                              (C) 2000-2024 */
+/* Application.cc                                              (C) 2000-2025 */
 /*                                                                           */
 /* Superviseur.                                                              */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ArcaneMain.cc
+++ b/arcane/src/arcane/impl/ArcaneMain.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneMain.cc                                               (C) 2000-2024 */
+/* ArcaneMain.cc                                               (C) 2000-2025 */
 /*                                                                           */
 /* Classe gérant l'exécution.                                                */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ArcaneMain.cc
+++ b/arcane/src/arcane/impl/ArcaneMain.cc
@@ -1237,6 +1237,10 @@ ArcaneMain(const ApplicationInfo& app_info, IMainFactory* factory,
 ArcaneMain::
 ~ArcaneMain()
 {
+  // S'assure qu'on retire les observateurs associés au TheadBindingMng
+  // avant la finalisation pour éviter de punaiser les threads alors que
+  // cela ne sert plus à rien.
+  m_p->m_thread_binding_mng.finalize();
   delete m_application;
   delete m_p;
 }

--- a/arcane/src/arcane/impl/internal/ThreadBindingMng.cc
+++ b/arcane/src/arcane/impl/internal/ThreadBindingMng.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ThreadBindingMng.cc                                         (C) 2000-2021 */
+/* ThreadBindingMng.cc                                         (C) 2000-2024 */
 /*                                                                           */
 /* Gestionnaire pour punaiser les threads.                                   */
 /*---------------------------------------------------------------------------*/
@@ -17,12 +17,32 @@
 #include "arcane/utils/ConcurrencyUtils.h"
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/IProcessorAffinityService.h"
+#include "arcane/utils/internal/TaskFactoryInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 namespace Arcane
 {
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ThreadBindingMng::
+ThreadBindingMng()
+: m_thread_created_callback(new ObserverT<ThreadBindingMng>(this, &ThreadBindingMng::_createThreadCallback))
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ThreadBindingMng::
+~ThreadBindingMng()
+{
+  finalize();
+  delete m_thread_created_callback;
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -40,8 +60,20 @@ initialize(ITraceMng* tm,const String& strategy)
     m_max_thread = TaskFactory::nbAllowedThread();
     if (tm)
       tm->info() << "Thread binding strategy is '" << m_bind_strategy << "'";
-    m_observer_pool.addObserver(this,&ThreadBindingMng::_createThreadCallback,
-                                Arcane::TaskFactory::createThreadObservable());
+    TaskFactoryInternal::addThreadCreateObserver(m_thread_created_callback);
+    m_has_callback = true;
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ThreadBindingMng::
+finalize()
+{
+  if (m_has_callback) {
+    TaskFactoryInternal::removeThreadCreateObserver(m_thread_created_callback);
+    m_has_callback = false;
   }
 }
 

--- a/arcane/src/arcane/impl/internal/ThreadBindingMng.cc
+++ b/arcane/src/arcane/impl/internal/ThreadBindingMng.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ThreadBindingMng.cc                                         (C) 2000-2024 */
+/* ThreadBindingMng.cc                                         (C) 2000-2025 */
 /*                                                                           */
 /* Gestionnaire pour punaiser les threads.                                   */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/ThreadBindingMng.h
+++ b/arcane/src/arcane/impl/internal/ThreadBindingMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ThreadBindingMng.h                                          (C) 2000-2024 */
+/* ThreadBindingMng.h                                          (C) 2000-2025 */
 /*                                                                           */
 /* Gestionnaire pour punaiser les threads.                                   */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/ThreadBindingMng.h
+++ b/arcane/src/arcane/impl/internal/ThreadBindingMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ThreadBindingMng.h                                          (C) 2000-2021 */
+/* ThreadBindingMng.h                                          (C) 2000-2024 */
 /*                                                                           */
 /* Gestionnaire pour punaiser les threads.                                   */
 /*---------------------------------------------------------------------------*/
@@ -31,15 +31,22 @@ class ARCANE_IMPL_EXPORT ThreadBindingMng
 {
  public:
 
-  void initialize(ITraceMng* tm,const String& strategy);
+  ThreadBindingMng();
+  ~ThreadBindingMng();
+
+ public:
+
+  void initialize(ITraceMng* tm, const String& strategy);
+  void finalize();
 
  private:
 
-  ObserverPool m_observer_pool;
   ITraceMng* m_trace_mng = nullptr;
   String m_bind_strategy;
   Int32 m_current_thread_index = 0;
   Int32 m_max_thread = 0;
+  IObserver* m_thread_created_callback = nullptr;
+  bool m_has_callback = false;
 
  private:
 

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TBBTaskImplementation.cc                                    (C) 2000-2024 */
+/* TBBTaskImplementation.cc                                    (C) 2000-2025 */
 /*                                                                           */
 /* Implémentation des tâches utilisant TBB (Intel Threads Building Blocks).  */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -21,8 +21,9 @@
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/Profiling.h"
 #include "arcane/utils/MemoryAllocator.h"
+#include "arcane/utils/internal/TaskFactoryInternal.h"
 
-#include "arcane/FactoryService.h"
+#include "arcane/core/FactoryService.h"
 
 #include <new>
 #include <stack>
@@ -612,25 +613,23 @@ class TBBTaskImplementation::Impl
     m_constructed_thread_map.insert(my_thread_id);
 #endif
 
-    // Il faut toujours un verrou car on n'est pas certain que
-    // les méthodes appelées par l'observable soient thread-safe
-    // (et aussi TaskFactory::createThreadObservable() ne l'est pas)
     {
-      std::scoped_lock sl(m_thread_created_mutex);
       if (TaskFactory::verboseLevel()>=1){
-        std::cout << "TBB: CREATE THREAD"
-                  << " nb_allowed=" << m_nb_allowed_thread
+        std::ostringstream ostr;
+        ostr << "TBB: CREATE THREAD"
+             << " nb_allowed=" << m_nb_allowed_thread
 #ifdef ARCANE_USE_ONETBB
-                  << " tbb_default_allowed=" << tbb::info::default_concurrency()
+             << " tbb_default_allowed=" << tbb::info::default_concurrency()
 #else
-                  << " tbb_default_allowed=" << tbb::task_scheduler_init::default_num_threads()
+             << " tbb_default_allowed=" << tbb::task_scheduler_init::default_num_threads()
 #endif
-                  << " id=" << my_thread_id
-                  << " arena_id=" << _currentTaskTreadIndex()
-                  << " is_worker=" << is_worker
-                  << "\n";
+             << " id=" << my_thread_id
+             << " arena_id=" << _currentTaskTreadIndex()
+             << " is_worker=" << is_worker
+             << "\n";
+        std::cout << ostr.str();
       }
-      TaskFactory::createThreadObservable()->notifyAllObservers();
+      TaskFactoryInternal::notifyThreadCreated();
     }
   }
 
@@ -654,6 +653,7 @@ class TBBTaskImplementation::Impl
                 << " is_worker=" << is_worker
                 << '\n';
     }
+    // TODO: jamais utilisé. Sera supprimé au passage à OneTBB.
     TaskFactory::destroyThreadObservable()->notifyAllObservers();
 #endif
   }

--- a/arcane/src/arcane/tests/TaskUnitTest.cc
+++ b/arcane/src/arcane/tests/TaskUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TaskUnitTest.cc                                             (C) 2000-2024 */
+/* TaskUnitTest.cc                                             (C) 2000-2025 */
 /*                                                                           */
 /* Service de test des tâches.                                               */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ConcurrencyUtils.cc
+++ b/arcane/src/arcane/utils/ConcurrencyUtils.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ConcurrencyUtils.cc                                         (C) 2000-2024 */
+/* ConcurrencyUtils.cc                                         (C) 2000-2025 */
 /*                                                                           */
 /* Classes gérant la concurrence (tâches, boucles parallèles, ...)           */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ConcurrencyUtils.cc
+++ b/arcane/src/arcane/utils/ConcurrencyUtils.cc
@@ -13,8 +13,11 @@
 
 #include "arcane/utils/ConcurrencyUtils.h"
 
+#include "arcane/utils/internal/TaskFactoryInternal.h"
 #include "arcane/utils/TraceInfo.h"
 #include "arcane/utils/Observable.h"
+
+#include <mutex>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -155,10 +158,72 @@ class NullTaskImplementation
 
 NullTaskImplementation NullTaskImplementation::singleton;
 ITaskImplementation* TaskFactory::m_impl = &NullTaskImplementation::singleton;
-IObservable* TaskFactory::m_created_thread_observable = 0;
-IObservable* TaskFactory::m_destroyed_thread_observable = 0;
 Int32 TaskFactory::m_verbose_level = 0;
 ParallelLoopOptions TaskFactory::m_default_loop_options;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+IObservable* global_created_thread_observable = 0;
+IObservable* global_destroyed_thread_observable = 0;
+std::mutex global_observable_mutex;
+
+IObservable*
+_checkCreateGlobalThreadObservable()
+{
+  if (!global_created_thread_observable)
+    global_created_thread_observable = new Observable();
+  return global_created_thread_observable;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void TaskFactoryInternal::
+setImplementation(ITaskImplementation* task_impl)
+{
+  if (TaskFactory::m_impl && TaskFactory::m_impl!=&NullTaskImplementation::singleton)
+    ARCANE_FATAL("TaskFactory already has an implementation");
+  TaskFactory::m_impl = task_impl;
+}
+
+void TaskFactoryInternal::
+addThreadCreateObserver(IObserver* o)
+{
+  std::scoped_lock slock(global_observable_mutex);
+  _checkCreateGlobalThreadObservable();
+  global_created_thread_observable->attachObserver(o);
+}
+
+void TaskFactoryInternal::
+removeThreadCreateObserver(IObserver* o)
+{
+  std::scoped_lock slock(global_observable_mutex);
+  _checkCreateGlobalThreadObservable();
+  global_created_thread_observable->detachObserver(o);
+}
+
+void TaskFactoryInternal::
+notifyThreadCreated()
+{
+  std::scoped_lock slock(global_observable_mutex);
+  if (global_created_thread_observable)
+    global_created_thread_observable->notifyAllObservers();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -166,9 +231,7 @@ ParallelLoopOptions TaskFactory::m_default_loop_options;
 void TaskFactory::
 _internalSetImplementation(ITaskImplementation* task_impl)
 {
-  if (m_impl && m_impl!=&NullTaskImplementation::singleton)
-    ARCANE_FATAL("TaskFactory already has an implementation");
-  m_impl = task_impl;
+  TaskFactoryInternal::setImplementation(task_impl);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -177,9 +240,8 @@ _internalSetImplementation(ITaskImplementation* task_impl)
 IObservable*  TaskFactory::
 createThreadObservable()
 {
-  if (!m_created_thread_observable)
-    m_created_thread_observable = new Observable();
-  return m_created_thread_observable;
+  std::scoped_lock slock(global_observable_mutex);
+  return _checkCreateGlobalThreadObservable();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -188,9 +250,9 @@ createThreadObservable()
 IObservable*  TaskFactory::
 destroyThreadObservable()
 {
-  if (!m_destroyed_thread_observable)
-    m_destroyed_thread_observable = new Observable();
-  return m_destroyed_thread_observable;
+  if (!global_destroyed_thread_observable)
+    global_destroyed_thread_observable = new Observable();
+  return global_destroyed_thread_observable;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/ConcurrencyUtils.h
+++ b/arcane/src/arcane/utils/ConcurrencyUtils.h
@@ -30,6 +30,11 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
+class TaskFactoryInternal;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*
  * TODO:
  * - Vérifier les fuites memoires
@@ -322,9 +327,12 @@ class ARCANE_UTILS_EXPORT ITaskImplementation
  */
 class ARCANE_UTILS_EXPORT TaskFactory
 {
- private:
-  TaskFactory();
+  friend TaskFactoryInternal;
+
  public:
+
+  TaskFactory() = delete;
+
  public:
 
   /*!
@@ -548,6 +556,7 @@ class ARCANE_UTILS_EXPORT TaskFactory
    * la modification de l'observable (ajout/suppression d'observateur)
    * n'est pas thread-safe.
    */
+  ARCANE_DEPRECATED_REASON("Y2024: This method is internal to Arcane. Do not use it")
   static IObservable* createThreadObservable();
 
   /*!
@@ -558,6 +567,7 @@ class ARCANE_UTILS_EXPORT TaskFactory
    * la modification de l'observable (ajout/suppression d'observateur)
    * n'est pas thread-safe.
    */
+  ARCANE_DEPRECATED_REASON("Y2024: This method is internal to Arcane. Do not use it")
   static IObservable* destroyThreadObservable();
 
   /*!
@@ -578,13 +588,13 @@ class ARCANE_UTILS_EXPORT TaskFactory
  public:
 
   //! \internal
+  ARCANE_DEPRECATED_REASON("Y2024: This method is internal to Arcane. "
+                           "Use TaskFactoryInternal::setImplementation() instead")
   static void _internalSetImplementation(ITaskImplementation* task_impl);
 
  private:
 
   static ITaskImplementation* m_impl;
-  static IObservable* m_created_thread_observable;
-  static IObservable* m_destroyed_thread_observable;
   static Int32 m_verbose_level;
   static ParallelLoopOptions m_default_loop_options;
 };

--- a/arcane/src/arcane/utils/ConcurrencyUtils.h
+++ b/arcane/src/arcane/utils/ConcurrencyUtils.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ConcurrencyUtils.h                                          (C) 2000-2024 */
+/* ConcurrencyUtils.h                                          (C) 2000-2025 */
 /*                                                                           */
 /* Classes gérant la concurrence (tâches, boucles parallèles, ...)           */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/TaskFactoryInternal.h
+++ b/arcane/src/arcane/utils/internal/TaskFactoryInternal.h
@@ -1,0 +1,56 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* TaskFactoryInternal.h                                       (C) 2000-2024 */
+/*                                                                           */
+/* API interne à Arcane de 'TaskFactory'.                                    */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_UTILS_INTERNAL_TASKFACTORYINTERNAL_H
+#define ARCANE_UTILS_INTERNAL_TASKFACTORYINTERNAL_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/utils/UtilsTypes.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief API interne à Arcane de 'TaskFactory'.
+ */
+class ARCANE_UTILS_EXPORT TaskFactoryInternal
+{
+ public:
+
+  //! Ajoute un observateur pour la création de thread.
+  static void addThreadCreateObserver(IObserver* o);
+
+  //! Supprime un observateur pour la création de thread.
+  static void removeThreadCreateObserver(IObserver* o);
+
+  //! Notifie tous les observateurs de création de thread
+  static void notifyThreadCreated();
+
+ public:
+
+  static void setImplementation(ITaskImplementation* task_impl);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/utils/internal/TaskFactoryInternal.h
+++ b/arcane/src/arcane/utils/internal/TaskFactoryInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TaskFactoryInternal.h                                       (C) 2000-2024 */
+/* TaskFactoryInternal.h                                       (C) 2000-2025 */
 /*                                                                           */
 /* API interne à Arcane de 'TaskFactory'.                                    */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/srcs.cmake
+++ b/arcane/src/arcane/utils/srcs.cmake
@@ -347,6 +347,7 @@ set(ARCANE_SOURCES
   internal/MemoryBuffer.h
   internal/MemoryPool.h
   internal/ParallelLoopOptionsProperties.h
+  internal/TaskFactoryInternal.h
   )
 
 if (ARCANE_HAS_CXX20)


### PR DESCRIPTION
It is needed to remove potential race-condition at ending when all available threads are not yet launched when finalizing code. It may happen if the only thing we are doing during the execution is the run of a very small concurrent loop.