### PR TITLE
Improve 'Injector::createInstance()'

### DIFF
--- a/arcane/src/arcane/utils/DependencyInjection.cc
+++ b/arcane/src/arcane/utils/DependencyInjection.cc
@@ -213,6 +213,15 @@ hasName(const String& str) const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+void FactoryInfo::
+fillWithImplementationNames(Array<String>& names) const
+{
+  names.add(m_p->m_name);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -337,6 +346,37 @@ void Injector::
 _doError(const TraceInfo& ti, const String& message)
 {
   ARCANE_FATAL("Function: {0} : {1}", ti, message);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void Injector::
+_printValidImplementationAndThrow(const TraceInfo& ti,
+                                  const String& implementation_name,
+                                  FactoryFilterFunc filter_func)
+{
+  // Pas d'implémentation correspondante trouvée.
+  // Dans ce cas on récupère la liste des implémentations valides et on les affiche dans
+  // le message d'erreur.
+  UniqueArray<String> valid_names;
+  for (Int32 i = 0, n = _nbFactory(); i < n; ++i) {
+    impl::IInstanceFactory* f = _factory(i);
+    if (filter_func(f)) {
+      f->factoryInfo()->fillWithImplementationNames(valid_names);
+    }
+  };
+  String message = String::format("No implementation named '{0}' found", implementation_name);
+
+  // TODO: améliorer le message
+  String message2;
+  if (valid_names.size() == 0)
+    message2 = " and no implementation is available.";
+  else if (valid_names.size() == 1)
+    message2 = String::format(". Valid value is: '{0}'.", valid_names[0]);
+  else
+    message2 = String::format(". Valid values are: '{0}'.", String::join(", ", valid_names));
+  _doError(ti, message + message2);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/internal/DependencyInjection.h
+++ b/arcane/src/arcane/utils/internal/DependencyInjection.h
@@ -684,10 +684,15 @@ class ARCANE_UTILS_EXPORT Injector
    * Créé et retourne une instance dont l'implémentation est
    * \a implementation_name et qui implémente l'interface \a InterfaceType.
    *
-   * Lève une exception si aucune instance ne correspond.
+   * Si l'implémentation \a implementation_name n'est pas trouvé ou si
+   * elle n'implémente pas l'interface \a InterfaceType, le comportement
+   * est le suivant:
+   * - si \a allow_null vaut \a true, retourne une référence nulle,
+   * - si \a allow_null vaut \a false, lève une exception de type
+   * FatalErrorException.
    */
   template <typename InterfaceType> Ref<InterfaceType>
-  createInstance(const String& implementation_name)
+  createInstance(const String& implementation_name, bool allow_null = false)
   {
     using FactoryType = impl::InstanceFactory<InterfaceType>;
     Ref<InterfaceType> instance;
@@ -705,7 +710,7 @@ class ARCANE_UTILS_EXPORT Injector
     };
     FactoryVisitorFunctor ff(f);
     _iterateFactories(implementation_name, &ff);
-    if (instance.get())
+    if (instance.get() || allow_null)
       return instance;
 
     // Pas d'implémentation correspondante trouvée.

--- a/arcane/src/arcane/utils/internal/DependencyInjection.h
+++ b/arcane/src/arcane/utils/internal/DependencyInjection.h
@@ -21,8 +21,6 @@
 #include "arcane/utils/Ref.h"
 #include "arcane/utils/ExternalRef.h"
 #include "arcane/utils/GenericRegisterer.h"
-#include "arcane/utils/Array.h"
-#include "arcane/utils/String.h"
 
 #include "arccore/base/ReferenceCounterImpl.h"
 


### PR DESCRIPTION
- Add a list of available implementation it the one wanted is not found.
- Allow to return a null reference instead of throwing an exception.
