### PR TITLE
Remove writing of mesh via Lima in test 'subdivide1'

### DIFF
--- a/arcane/tests/testArcaneBasicMeshSubdividerService1-subdivide1-parmetis.arc
+++ b/arcane/tests/testArcaneBasicMeshSubdividerService1-subdivide1-parmetis.arc
@@ -17,6 +17,7 @@
   <unit-test-module>
     <test name="MeshUnitTest">
       <test-adjency>0</test-adjency>
+      <write-mesh>false</write-mesh>
     </test>
   </unit-test-module>
 


### PR DESCRIPTION
It seems writing of the mesh is this case is not thread-safe.
So we remove the writing until further inspection.
