### PR TITLE
Use `std::from_chars()` instead of `std::strtod()` to convert strings to double if C++20 is enabled

### DIFF
--- a/arcane/src/arcane/impl/ArcaneMain.cc
+++ b/arcane/src/arcane/impl/ArcaneMain.cc
@@ -35,6 +35,7 @@
 #include "arcane/utils/TestLogger.h"
 #include "arcane/utils/MemoryUtils.h"
 #include "arcane/utils/internal/MemoryUtilsInternal.h"
+#include "arcane/utils/internal/ValueConvertInternal.h"
 
 #include "arcane/core/IMainFactory.h"
 #include "arcane/core/IApplication.h"
@@ -725,6 +726,12 @@ arcaneInitialize()
     Exception::staticInit();
     dom::DOMImplementation::initialize();
     platform::platformInitialize();
+
+    // Regarde si on souhaite utiliser l'ancien mécanisme (avant la 3.15)
+    // pour convertir les chaînes de caractères en types numériques
+    if (auto v = Convert::Type<Int32>::tryParseFromEnvironment("ARCANE_USE_LEGACY_BUILTINVALUECONVERT", true))
+      impl::arcaneSetIsValueConvertUseFromChars(v.value()==0);
+
     // Crée le singleton gestionnaire des types
     ItemTypeMng::_singleton();
     initializeStringConverter();

--- a/arcane/src/arcane/utils/ValueConvert.cc
+++ b/arcane/src/arcane/utils/ValueConvert.cc
@@ -16,6 +16,20 @@
 #include "arcane/utils/OStringStream.h"
 #include "arcane/utils/internal/ValueConvertInternal.h"
 
+// En théorie std::from_chars() est disponible avec le C++17 mais pour
+// GCC cela n'est implémenté pour les flottants qu'à partir de GCC 11.
+// Comme c'est la version requise pour le C++20, on n'active cette fonctionnalité
+// qu'à partir du C++20.
+#if defined(ARCANE_HAS_CXX20)
+#define ARCANE_USE_FROMCHARS
+#endif
+
+#if defined(ARCANE_USE_FROMCHARS)
+#include <charconv>
+#endif
+
+// TODO: Pour builtInGetValue(), retourner `true` si la chaîne en entrée est vide.
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -47,12 +61,117 @@ StringViewInputStream(StringView v)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+namespace
+{
+  Int32 global_value_convert_verbosity = 0;
+  bool global_use_from_chars = true;
+} // namespace
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void impl::
+arcaneSetIsValueConvertUseFromChars(bool v)
+{
+  global_use_from_chars = v;
+}
+
+void impl::
+arcaneSetValueConvertVerbosity(Int32 v)
+{
+  global_value_convert_verbosity = v;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#if defined(ARCANE_USE_FROMCHARS)
+namespace
+{
+  /*!
+   * \brief Converti une chaîne de caractères en un double.
+   *
+   * Converti \a s en un double et range la valeur dans \a v.
+   * Il ne doit pas y avoir de caractères blancs au début de \a s.
+   *
+   * Le comportement de cette méthode est identique à std::strtod()
+   * avec le locale 'C' si on est en C++20. Sinon il est identique
+   * à std::strtod() avec le locale actuel (ce qui peut changer par exemple
+   * le séparateur décimal). La documentation de référence est
+   * ici: https://en.cppreference.com/w/cpp/utility/from_chars.
+   *
+   * \retval (-1) si la conversion a échouée.
+   * \retval la position dans \s du dernier caratère lu plus 1.
+   */
+  Int64 _getDoubleValue(double& v, StringView s)
+  {
+    // ATTENTION: il ne faut pas d'espace en début de \a s
+    auto bytes = s.bytes();
+    Int64 size = bytes.size();
+    if (size == 0)
+      // NOTE: Avec la version historique d'Arcane (avant la 3.15) il
+      // n'y avait pas d'erreur retournée lorsqu'on converti une chaîne vide.
+      // A priori cela n'était jamais utilisé donc cela ne pose pas de
+      // problème de corriger ce bug.
+      return (-1);
+    const char* orig_data = reinterpret_cast<const char*>(bytes.data());
+    const char* last_ptr = nullptr;
+    std::chars_format fmt = std::chars_format::general;
+    const char* data = orig_data;
+    bool do_negatif = false;
+    const bool is_verbose = global_value_convert_verbosity > 0;
+    // std::from_chars() peut lire les valeurs au format hexadécimal
+    // mais il ne doit pas contenir le '0x' ou '0X' du début, contrairement
+    // à std::strtod(). On détecte ce cas et on commence la conversion
+    // après le '0x' ou '0X'.
+
+    // Détecte '-0x' ou '-0X'
+    if (size >= 3 && (bytes[0] == '-') && (bytes[1] == '0') && (bytes[2] == 'x' || bytes[2] == 'X')) {
+      fmt = std::chars_format::hex;
+      data += 3;
+      do_negatif = true;
+    }
+    // Détecte '0x' ou '0X'
+    else if (size >= 2 && (bytes[0] == '0') && (bytes[1] == 'x' || bytes[1] == 'X')) {
+      fmt = std::chars_format::hex;
+      data += 2;
+    }
+    // Cas général
+    {
+      auto [ptr, ec] = std::from_chars(data, data + size, v, fmt);
+      last_ptr = ptr;
+      if (is_verbose)
+        std::cout << "FromChars:TRY GET_DOUBLE data=" << data << " v=" << v << " is_ok=" << (ec == std::errc()) << "\n";
+      if (ec != std::errc())
+        return (-1);
+    }
+    // Prend en compte le signe '-' si demandé
+    if (do_negatif)
+      v = -v;
+    if (is_verbose) {
+      char* ptr2 = nullptr;
+      double v2 = ::strtod(orig_data, &ptr2);
+      std::cout << "FromChars: COMPARE GET_DOUBLE via strtod v2=" << v2 << " pos=" << (ptr2 - orig_data) << "\n";
+    }
+    return (last_ptr - orig_data);
+  }
+
+} // namespace
+#endif
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 template <> ARCANE_UTILS_EXPORT bool
 builtInGetValue(double& v, StringView s)
 {
+#if defined(ARCANE_USE_FROMCHARS)
+  if (global_use_from_chars) {
+    Int64 p = _getDoubleValue(v, s);
+    return (p == (-1) || (p != s.size()));
+  }
+#endif
+
   const char* ptr = _stringViewData(s);
 #ifdef WIN32
   if (s == "infinity" || s == "inf") {
@@ -60,10 +179,13 @@ builtInGetValue(double& v, StringView s)
     return false;
   }
 #endif
-  char* ptr2 = 0;
+  char* ptr2 = nullptr;
   v = ::strtod(ptr, &ptr2);
   return (ptr2 != (ptr + s.length()));
 }
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 template <> ARCANE_UTILS_EXPORT bool
 builtInGetValue(BFloat16& v, StringView s)

--- a/arcane/src/arcane/utils/ValueConvert.cc
+++ b/arcane/src/arcane/utils/ValueConvert.cc
@@ -168,6 +168,29 @@ builtInGetValue(long long& v, StringView s)
 }
 
 template <> ARCANE_UTILS_EXPORT bool
+builtInGetValue(Real2& v, StringView s)
+{
+  return impl::builtInGetValueGeneric(v, s);
+}
+template <> ARCANE_UTILS_EXPORT bool
+builtInGetValue(Real3& v, StringView s)
+{
+  return impl::builtInGetValueGeneric(v, s);
+}
+
+template <> ARCANE_UTILS_EXPORT bool
+builtInGetValue(Real2x2& v, StringView s)
+{
+  return impl::builtInGetValueGeneric(v, s);
+}
+
+template <> ARCANE_UTILS_EXPORT bool
+builtInGetValue(Real3x3& v, StringView s)
+{
+  return impl::builtInGetValueGeneric(v, s);
+}
+
+template <> ARCANE_UTILS_EXPORT bool
 builtInGetValue(Int128& v, StringView s)
 {
   // Pour l'instant (12/2024), il n'y a pas de fonctions natives pour lire un Int128.

--- a/arcane/src/arcane/utils/ValueConvert.h
+++ b/arcane/src/arcane/utils/ValueConvert.h
@@ -55,6 +55,33 @@ class ARCANE_UTILS_EXPORT StringViewInputStream
   std::istream m_stream;
 };
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Converti la valeur de la chaîne \a s dans le type basique \a T
+ * et stocke la valeur dans \a v.
+ *
+ * \retval true en cas d'échec.
+ * \retval false en cas de succès
+ */
+template <class T> inline bool
+builtInGetValueGeneric(T& v, StringView s)
+{
+  T read_val = T();
+  impl::StringViewInputStream svis(s);
+  std::istream& sbuf = svis.stream();
+  sbuf >> read_val;
+  if (sbuf.fail() || sbuf.bad())
+    return true;
+  if (!sbuf.eof())
+    return true;
+  v = read_val;
+  return false;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // namespace impl
 
 /*---------------------------------------------------------------------------*/
@@ -69,16 +96,7 @@ class ARCANE_UTILS_EXPORT StringViewInputStream
 template <class T> inline bool
 builtInGetValue(T& v, StringView s)
 {
-  T read_val = T();
-  impl::StringViewInputStream svis(s);
-  std::istream& sbuf = svis.stream();
-  sbuf >> read_val;
-  if (sbuf.fail() || sbuf.bad())
-    return true;
-  if (!sbuf.eof())
-    return true;
-  v = read_val;
-  return false;
+  return impl::builtInGetValueGeneric(v, s);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -102,6 +120,10 @@ template <> ARCANE_UTILS_EXPORT bool builtInGetValue(Int128& v, StringView s);
 #ifdef ARCANE_REAL_NOT_BUILTIN
 template <> ARCANE_UTILS_EXPORT bool builtInGetValue(Real& v, StringView s);
 #endif
+template <> ARCANE_UTILS_EXPORT bool builtInGetValue(Real2& v, StringView s);
+template <> ARCANE_UTILS_EXPORT bool builtInGetValue(Real3& v, StringView s);
+template <> ARCANE_UTILS_EXPORT bool builtInGetValue(Real2x2& v, StringView s);
+template <> ARCANE_UTILS_EXPORT bool builtInGetValue(Real3x3& v, StringView s);
 
 template <> ARCANE_UTILS_EXPORT bool builtInGetValue(RealArray& v, StringView s);
 template <> ARCANE_UTILS_EXPORT bool builtInGetValue(Real2Array& v, StringView s);

--- a/arcane/src/arcane/utils/internal/ValueConvertInternal.h
+++ b/arcane/src/arcane/utils/internal/ValueConvertInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ValueConvertInternal.h                                      (C) 2000-2022 */
+/* ValueConvertInternal.h                                      (C) 2000-2025 */
 /*                                                                           */
 /* Fonctions pour convertir une chaîne de caractère en un type donné.        */
 /*---------------------------------------------------------------------------*/
@@ -53,6 +53,28 @@ builtInGetArrayValue(Array<T>& v, const String& s)
   std::istringstream sbuf(s.localstr());
   return builtInGetArrayValueFromStream(v, sbuf);
 }
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace impl
+{
+  /*!
+   * \brief Indique si on utilise 'std::from_chars' pour convertir
+   * les chaînes de caractères en un type numérique.
+   *
+   * Si on n'utilise pas 'std::from_chars', alors on utilise les fonctions
+   * telles que strtod(), strtol(), ...
+   *
+   * Le défaut en C++20 est d'utiliser std::from_chars().
+   */
+  extern "C++" ARCANE_UTILS_EXPORT void
+  arcaneSetIsValueConvertUseFromChars(bool v);
+
+  //! Positionne le niveau de verbosité pour les fonctions de conversion.
+  extern "C++" ARCANE_UTILS_EXPORT void
+  arcaneSetValueConvertVerbosity(Int32 v);
+} // namespace impl
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/TestValueConvert.cc
+++ b/arcane/src/arcane/utils/tests/TestValueConvert.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -8,25 +8,113 @@
 #include <gtest/gtest.h>
 
 #include "arcane/utils/ValueConvert.h"
+#include "arcane/utils/internal/ValueConvertInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 using namespace Arcane;
 
-TEST(ValueConvert,Basic)
+namespace
 {
-  std::cout << "TEST_ValueConvert Basic\n";
+
+void _checkBadDouble(const String& s)
+{
+  Real x = 0;
+  bool is_bad = builtInGetValue(x, s);
+  std::cout << "S=" << s << " X=" << x << " is_bad?=" << is_bad << "\n";
+  ASSERT_TRUE(is_bad);
+}
+
+void _checkDouble(const String& s, double expected_x)
+{
+  Real x = 0;
+  bool is_bad = builtInGetValue(x, s);
+  std::cout << "S=" << s << " X=" << x << " is_bad?=" << is_bad << "\n";
+  ASSERT_FALSE(is_bad);
+  ASSERT_EQ(x, expected_x);
+}
+
+void _checkNaN(const String& s)
+{
+  Real x = 0;
+  bool is_bad = builtInGetValue(x, s);
+  std::cout << "S=" << s << " X=" << x << " is_bad?=" << is_bad << "\n";
+  ASSERT_FALSE(is_bad);
+  ASSERT_TRUE(std::isnan(x));
+}
+
+void _testDoubleConvert(bool use_from_chars)
+{
 
   {
     // TODO: tester les autres conversions
     String s = "25e3";
     Int32 x = 0;
-    bool is_bad = builtInGetValue(x,s);
+    bool is_bad = builtInGetValue(x, s);
     std::cout << "S=" << s << " X=" << x << " is_bad?=" << is_bad << "\n";
     ASSERT_TRUE(is_bad);
   }
+  // Avec la version 'from_chars', convertir une chaîne vide est une erreur
+  // mais pas avec la version historique.
+  if (use_from_chars)
+    _checkBadDouble("");
+  _checkDouble("-0x1.81e03f705857bp-16", -2.3e-05);
+  _checkDouble("0x1.81e03f705857bp-16", 2.3e-05);
 
+  {
+    Real inf_x = std::numeric_limits<Real>::infinity();
+    _checkDouble("inf", inf_x);
+    _checkDouble("INF", inf_x);
+    _checkDouble("infinity", inf_x);
+    _checkDouble("INFINITY", inf_x);
+  }
+  {
+    Real minus_inf_x = -std::numeric_limits<Real>::infinity();
+    _checkDouble("-inf", minus_inf_x);
+    _checkDouble("-INF", minus_inf_x);
+    _checkDouble("-infinity", minus_inf_x);
+    _checkDouble("-INFINITY", minus_inf_x);
+  }
+
+  {
+    _checkNaN("nan");
+    _checkNaN("NAN");
+    _checkNaN("NaN");
+    _checkNaN("nAN");
+  }
+  {
+    String s3 = "23123.132e123";
+    Real total = 0.0;
+    Int32 nb_iter = 1000000 * 10;
+    nb_iter = 1;
+    for (Int32 i = 0; i < nb_iter; ++i) {
+      Real v = {};
+      builtInGetValue(v, s3);
+      total += v;
+    }
+    std::cout << "Total=" << total << "\n";
+  }
+}
+
+} // namespace
+
+TEST(ValueConvert, Basic)
+{
+  std::cout << "TEST_ValueConvert Basic\n";
+  impl::arcaneSetValueConvertVerbosity(1);
+
+#if defined(ARCANE_HAS_CXX20)
+  impl::arcaneSetIsValueConvertUseFromChars(true);
+  _testDoubleConvert(true);
+#endif
+
+  impl::arcaneSetIsValueConvertUseFromChars(false);
+  _testDoubleConvert(false);
+}
+
+TEST(ValueConvert, TryParse)
+{
   {
     String s2;
     auto v = Convert::Type<Int32>::tryParse(s2);
@@ -35,15 +123,15 @@ TEST(ValueConvert,Basic)
 
   {
     String s2;
-    auto v = Convert::Type<Int32>::tryParseIfNotEmpty(s2,4);
+    auto v = Convert::Type<Int32>::tryParseIfNotEmpty(s2, 4);
     ASSERT_TRUE(v.has_value());
-    ASSERT_EQ(v,4);
+    ASSERT_EQ(v, 4);
   }
 
   {
     String s2("2.3");
     auto v = Convert::Type<Real>::tryParse(s2);
-    ASSERT_EQ(v,2.3);
+    ASSERT_EQ(v, 2.3);
   }
 
   {


### PR DESCRIPTION
`std::from_chars()` is faster than `std::strtod()` and is locale independent.
The new function should have the same behavior than the legacy one except for one point: the new one returns an error if the string to convert is empty (which was a bug in the legacy one).

Because `std::from_chars()` is only available for floating point values in recent versions (11+) of GCC and `libstdc++.so`, we use it only when C++20 is enabled.

It is possible to revert to use `std::strtod()` when setting the environment variable `ARCANE_USE_LEGACY_BUILTINVALUECONVERT` to `1`.