### PR TITLE
Fix compilation if type '__float128' is an alias to a built-in type

### DIFF
--- a/arccore/src/base/arccore/base/Float128.h
+++ b/arccore/src/base/arccore/base/Float128.h
@@ -18,7 +18,11 @@
 
 // Tous les compilateurs Linux supportés par Arccore ont le type '__float128'
 #if defined(ARCCORE_OS_LINUX)
-#define ARCCORE_HAS_NATIVE_FLOAT128
+// Sur certaines plateformes (par exemple ARM64 Grace), le type 'float128'
+// correspond à un type pré-défini (en général 'long double')
+#  if !defined(__HAVE_DISTINCT_FLOAT128)
+#    define ARCCORE_HAS_NATIVE_FLOAT128
+#  endif
 #endif
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This is the case on Grace processors where `_Float128` is `long double`.
