### PR TITLE
Fix memory leak when using commands with a RunQueue created with a specific priority

### DIFF
--- a/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunQueueImpl.cc                                             (C) 2000-2024 */
+/* RunQueueImpl.cc                                             (C) 2000-2025 */
 /*                                                                           */
 /* Gestion d'une file d'exécution sur accélérateur.                          */
 /*---------------------------------------------------------------------------*/
@@ -144,7 +144,7 @@ _release()
   if (_isInPool())
     m_runner_impl->_internalPutRunQueueImplInPool(this);
   else {
-    delete this;
+    RunQueueImpl::_destroy(this);
   }
 }
 


### PR DESCRIPTION
The created `RunCommand` were not deleted when the `RunQueue` was destroyed.