### PR TITLE
Add dimension information when building `ItemTypeInfo`

### DIFF
--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemTypeInfoBuilder.cc                                      (C) 2000-2023 */
+/* ItemTypeInfoBuilder.cc                                      (C) 2000-2025 */
 /*                                                                           */
 /* Constructeur de type d'entité de maillage.                                */
 /*---------------------------------------------------------------------------*/
@@ -14,8 +14,8 @@
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/TraceInfo.h"
 
-#include "arcane/ArcaneTypes.h"
-#include "arcane/ItemTypeInfoBuilder.h"
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/ItemTypeInfoBuilder.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -43,11 +43,11 @@ _checkDimension(Int16 dim)
 
 void ItemTypeInfoBuilder::
 setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name,
-         Int16 dimension, Integer nb_node, Integer nb_edge, Integer nb_face)
+         Dimension dimension, Int32 nb_node, Int32 nb_edge, Int32 nb_face)
 {
   m_mng = mng;
   m_type_id = type_id;
-  m_dimension = dimension;
+  m_dimension = static_cast<Int16>(dimension);
   m_nb_node = nb_node;
   m_type_name = type_name;
   _setNbEdgeAndFace(nb_edge, nb_face);
@@ -58,27 +58,36 @@ setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name,
 
 void ItemTypeInfoBuilder::
 setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name,
-         Integer nb_node, Integer nb_edge, Integer nb_face)
+         Int32 nb_node, Int32 nb_edge, Int32 nb_face)
 {
-  setInfos(mng, type_id, type_name, -1, nb_node, nb_edge, nb_face);
+  setInfos(mng, type_id, type_name, Dimension::DimUnknown, nb_node, nb_edge, nb_face);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 void ItemTypeInfoBuilder::
-setInfos(ItemTypeMng* mng,
-         Integer type_id, String type_name,
-         Integer nb_node, Integer nb_edge, Integer nb_face)
+setInfos(ItemTypeMng* mng, Int16 type_id, String type_name,
+         Int32 nb_node, Int32 nb_edge, Int32 nb_face)
 {
-  setInfos(mng,ItemTypeId::fromInteger(type_id),type_name,nb_node,nb_edge,nb_face);
+  setInfos(mng, ItemTypeId::fromInteger(type_id), type_name, nb_node, nb_edge, nb_face);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 void ItemTypeInfoBuilder::
-addEdge(Integer edge_index,Integer n0,Integer n1,Integer f_left,Integer f_right)
+setInfos(ItemTypeMng* mng, Int16 type_id, String type_name, Dimension dimension,
+         Int32 nb_node, Int32 nb_edge, Int32 nb_face)
+{
+  setInfos(mng, ItemTypeId(type_id), type_name, dimension, nb_node, nb_edge, nb_face);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemTypeInfoBuilder::
+addEdge(Int32 edge_index, Int32 n0, Int32 n1, Int32 f_left, Int32 f_right)
 {
   Array<Integer>& buf = m_mng->m_ids_buffer;
   buf[m_first_item_index + edge_index] = buf.size();
@@ -342,33 +351,33 @@ void ItemTypeInfoBuilder::
 computeFaceEdgeInfos()
 {
   Integer cell_nb_edge = nbLocalEdge();
-  for(Integer i_face=0;i_face<nbLocalFace();++i_face) {
+  for (Integer i_face = 0; i_face < nbLocalFace(); ++i_face) {
     Array<Integer>& buf = m_mng->m_ids_buffer;
     Integer fi = buf[m_first_item_index + m_nb_edge + i_face];
     Integer* index = &buf[fi];
     LocalFace local_face(index);
     Integer face_nb_node = local_face.nbNode();
     Integer face_nb_edge = local_face.nbEdge();
-    for(Integer i_edge=0;i_edge<face_nb_edge;++i_edge) {
+    for (Integer i_edge = 0; i_edge < face_nb_edge; ++i_edge) {
       // L'objectif est de trouver l'arête de sommet [i_edge, i_edge+1] dans l'élément
       Integer beginNode = local_face.node(i_edge);
-      Integer endNode   = local_face.node((i_edge+1)%face_nb_edge);
+      Integer endNode = local_face.node((i_edge + 1) % face_nb_edge);
       Integer face_edge = -1;
-      for(Integer i=0;i<cell_nb_edge;++i) {
+      for (Integer i = 0; i < cell_nb_edge; ++i) {
         LocalEdge local_edge = localEdge(i);
         if ((local_edge.beginNode() == beginNode && local_edge.endNode() == endNode) ||
             (local_edge.beginNode() == endNode && local_edge.endNode() == beginNode)) {
           if (face_edge != -1)
             ARCANE_FATAL("Conflicting item definition : duplicated edge [{0}:{1}] found as edge {2} and {3} of item {4}({5})",
-                         beginNode,endNode,face_edge,i,typeName(),typeId());
+                         beginNode, endNode, face_edge, i, typeName(), typeId());
           face_edge = i;
         }
       }
       if (face_edge == -1)
         ARCANE_FATAL("Undefined edge [{0}:{1}] found as edge of item {2}({3})",
-                     beginNode,endNode,typeName(),typeId());
-      index[3+face_nb_node+i_edge] = face_edge;
-      ARCANE_ASSERT((face_edge == local_face.edge(i_edge)),("Inconsitent face-edge allocation"));
+                     beginNode, endNode, typeName(), typeId());
+      index[3 + face_nb_node + i_edge] = face_edge;
+      ARCANE_ASSERT((face_edge == local_face.edge(i_edge)), ("Inconsitent face-edge allocation"));
     }
   }
 }
@@ -377,12 +386,12 @@ computeFaceEdgeInfos()
 /*---------------------------------------------------------------------------*/
 
 void ItemTypeInfoBuilder::
-_setNbEdgeAndFace(Integer nb_edge,Integer nb_face)
+_setNbEdgeAndFace(Integer nb_edge, Integer nb_face)
 {
   m_nb_face = nb_face;
   m_nb_edge = nb_edge;
-  Integer total = m_nb_face+m_nb_edge;
-  if (total!=0){
+  Integer total = m_nb_face + m_nb_edge;
+  if (total != 0) {
     Array<Integer>& buf = m_mng->m_ids_buffer;
     m_first_item_index = buf.size();
     buf.resize(m_first_item_index + total);

--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.h
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.h
@@ -1,20 +1,22 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemTypeInfoBuilder.h                                       (C) 2000-2023 */
+/* ItemTypeInfoBuilder.h                                       (C) 2000-2025 */
 /*                                                                           */
 /* Construction d'un type d'entité du maillage.                              */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ITEMTYPEINFOBUILDER_H
-#define ARCANE_ITEMTYPEINFOBUILDER_H
+#ifndef ARCANE_CORE_ITEMTYPEINFOBUILDER_H
+#define ARCANE_CORE_ITEMTYPEINFOBUILDER_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ItemTypeInfo.h"
+#include "arcane/core/ItemTypeInfo.h"
+
+#include <array>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -48,26 +50,49 @@ class ItemTypeInfoBuilder
 {
  public:
 
+  //! Dimension du type
+  enum class Dimension : Int16
+  {
+    DimUnknown = -1,
+    Dim0 = 0,
+    Dim1 = 1,
+    Dim2 = 2,
+    Dim3 = 3
+  };
+
+ public:
+
   //! Constructeur par défaut
   ItemTypeInfoBuilder() = default;
 
  public:
 
-  // TODO: Rendre obsolète
-  void setInfos(ItemTypeMng* mng,
-                Integer type_id, String type_name,
-                Integer nb_node, Integer nb_edge, Integer nb_face);
+  ARCANE_DEPRECATED_REASON("Y2025: Use setInfo(...,Dimension dimension, ...) instead")
+  void setInfos(ItemTypeMng* mng, Int16 type_id, String type_name,
+                Int32 nb_node, Int32 nb_edge, Int32 nb_face);
 
-  // TODO: Rendre obsolète
-  void setInfos(ItemTypeMng* mng,
-                ItemTypeId type_id, String type_name,
-                Integer nb_node, Integer nb_edge, Integer nb_face);
+  ARCANE_DEPRECATED_REASON("Y2025: Use setInfo(...,Dimension dimension, ...) instead")
+  void setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name,
+                Int32 nb_node, Int32 nb_edge, Int32 nb_face);
 
   /*!
    * \brief Positionne les informations d'un type.
    */
-   void setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name, Int16 dimension,
-                Integer nb_node, Integer nb_edge, Integer nb_face);
+  ARCANE_DEPRECATED_REASON("Y2025: Use setInfo(...,Dimension dimension, ...) instead")
+  void setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name, Int16 dimension,
+                Int32 nb_node, Int32 nb_edge, Int32 nb_face);
+
+  /*!
+   * \brief Positionne les informations d'un type.
+   */
+  void setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name, Dimension dimension,
+                Int32 nb_node, Int32 nb_edge, Int32 nb_face);
+
+  /*!
+   * \brief Positionne les informations d'un type.
+   */
+  void setInfos(ItemTypeMng* mng, Int16 type_id, String type_name, Dimension dimension,
+                Int32 nb_node, Int32 nb_edge, Int32 nb_face);
 
   /*!
    * \brief Ajoute une arête à la liste des arêtes
@@ -77,48 +102,48 @@ class ItemTypeInfoBuilder
    * \a f_left numéro local de la face à gauche
    * \a f_right numéro local de la face à droite
    */
-  void addEdge(Integer edge_index,Integer n0,Integer n1,Integer f_left,Integer f_right);
+  void addEdge(Integer edge_index, Integer n0, Integer n1, Integer f_left, Integer f_right);
 
   //! Ajoute un sommet à la liste des faces (pour les elements 1D)
-  void addFaceVertex(Integer face_index,Integer n0);
+  void addFaceVertex(Integer face_index, Integer n0);
 
   //! Ajoute une ligne à la liste des faces (pour les elements 2D)
-  void addFaceLine(Integer face_index,Integer n0,Integer n1);
+  void addFaceLine(Integer face_index, Integer n0, Integer n1);
 
   //! Ajoute une ligne quadratique à la liste des faces (pour les elements 2D)
-  void addFaceLine3(Integer face_index,Integer n0,Integer n1,Integer n2);
+  void addFaceLine3(Integer face_index, Integer n0, Integer n1, Integer n2);
 
   //! Ajoute un triangle à la liste des faces
-  void addFaceTriangle(Integer face_index,Integer n0,Integer n1,Integer n2);
+  void addFaceTriangle(Integer face_index, Integer n0, Integer n1, Integer n2);
 
   //! Ajoute un triangle quadratique à la liste des faces
-  void addFaceTriangle6(Integer face_index,Integer n0,Integer n1,Integer n2,
+  void addFaceTriangle6(Integer face_index, Integer n0, Integer n1, Integer n2,
                         Integer n3, Integer n4, Integer n5);
 
   //! Ajoute un quadrilatère à la liste des faces
-  void addFaceQuad(Integer face_index,Integer n0,Integer n1,Integer n2,Integer n3);
+  void addFaceQuad(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3);
 
   //! Ajoute un quadrilatère quadratique à la liste des faces
-  void addFaceQuad8(Integer face_index,Integer n0,Integer n1,Integer n2,Integer n3,
-                    Integer n4,Integer n5,Integer n6,Integer n7);
+  void addFaceQuad8(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
+                    Integer n4, Integer n5, Integer n6, Integer n7);
 
   //! Ajoute un pentagone à la liste des faces
-  void addFacePentagon(Integer face_index,Integer n0,Integer n1,Integer n2,Integer n3,Integer n4);
+  void addFacePentagon(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3, Integer n4);
 
   //! Ajoute un hexagone à la liste des faces
-  void addFaceHexagon(Integer face_index,Integer n0,Integer n1,Integer n2,Integer n3,
-                      Integer n4,Integer n5);
+  void addFaceHexagon(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
+                      Integer n4, Integer n5);
 
   //! Ajoute un heptagone à la liste des faces
-  void addFaceHeptagon(Integer face_index,Integer n0,Integer n1,Integer n2,Integer n3,
-                       Integer n4,Integer n5, Integer n6);
+  void addFaceHeptagon(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
+                       Integer n4, Integer n5, Integer n6);
 
   //! Ajoute un heptagone à la liste des faces
-  void addFaceOctogon(Integer face_index,Integer n0,Integer n1,Integer n2,Integer n3,
-                      Integer n4,Integer n5, Integer n6, Integer n7);
+  void addFaceOctogon(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
+                      Integer n4, Integer n5, Integer n6, Integer n7);
 
   //! Ajoute une face générique à la liste des faces
-  void addFaceGeneric(Integer face_index,Integer type_id,ConstArrayView<Integer> n);
+  void addFaceGeneric(Integer face_index, Integer type_id, ConstArrayView<Integer> n);
 
   //! Calcule les relations face->arêtes
   void computeFaceEdgeInfos();

--- a/arcane/src/arcane/core/ItemTypeMng.cc
+++ b/arcane/src/arcane/core/ItemTypeMng.cc
@@ -102,6 +102,8 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
   //
   // https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf
 
+  using Dimension = ItemTypeInfoBuilder::Dimension;
+
   m_trace = trace;
   m_types.resize(m_nb_builtin_item_type);
   m_types_buffer = new MultiBufferT<ItemTypeInfoBuilder>();
@@ -111,7 +113,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_NullType] = type;
 
-    type->setInfos(this, IT_NullType, "NullType", 0, 0, 0);
+    type->setInfos(this, IT_NullType, "NullType", Dimension::DimUnknown, 0, 0, 0);
   }
 
   // Vertex
@@ -119,7 +121,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Vertex] = type;
 
-    type->setInfos(this, IT_Vertex, "Vertex", 0, 0, 0);
+    type->setInfos(this, IT_Vertex, "Vertex", Dimension::Dim0, 0, 0, 0);
     // TODO regarder si ce type est autorisé pour les mailles.
     // Si ce n'est pas le cas, il faudrait définir un type
     // pour les mailles 0D qui sont assimilables à des points.
@@ -130,7 +132,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_FaceVertex] = type;
 
-    type->setInfos(this, IT_FaceVertex, "FaceVertex", 1, 0, 0);
+    type->setInfos(this, IT_FaceVertex, "FaceVertex", Dimension::Dim0, 1, 0, 0);
     type->setIsValidForCell(false);
   }
 
@@ -139,7 +141,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Line2] = type;
 
-    type->setInfos(this, IT_Line2, "Line2", 2, 0, 0);
+    type->setInfos(this, IT_Line2, "Line2", Dimension::Dim1, 2, 0, 0);
     type->setIsValidForCell(false);
   }
 
@@ -148,7 +150,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Line3] = type;
 
-    type->setInfos(this, IT_Line3, "Line3", 3, 0, 0);
+    type->setInfos(this, IT_Line3, "Line3", Dimension::Dim1, 3, 0, 0);
     type->setIsValidForCell(false);
   }
 
@@ -157,7 +159,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_CellLine2] = type;
 
-    type->setInfos(this, IT_CellLine2, "CellLine2", 2, 0, 2);
+    type->setInfos(this, IT_CellLine2, "CellLine2", Dimension::Dim1, 2, 0, 2);
 
     type->addFaceVertex(0, 0);
     type->addFaceVertex(1, 1);
@@ -175,7 +177,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Triangle3] = type;
 
-    type->setInfos(this, IT_Triangle3, "Triangle3", 3, 3, 3);
+    type->setInfos(this, IT_Triangle3, "Triangle3", Dimension::Dim2, 3, 3, 3);
 
     type->addFaceLine(0, 0, 1);
     type->addFaceLine(1, 1, 2);
@@ -192,7 +194,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Triangle6] = type;
 
-    type->setInfos(this, IT_Triangle6, "Triangle6", 6, 3, 3);
+    type->setInfos(this, IT_Triangle6, "Triangle6", Dimension::Dim2, 6, 3, 3);
 
     type->addFaceLine3(0, 0, 1, 3);
     type->addFaceLine3(1, 1, 2, 4);
@@ -208,7 +210,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Quad4] = type;
 
-    type->setInfos(this, IT_Quad4, "Quad4", 4, 4, 4);
+    type->setInfos(this, IT_Quad4, "Quad4", Dimension::Dim2, 4, 4, 4);
 
     type->addFaceLine(0, 0, 1);
     type->addFaceLine(1, 1, 2);
@@ -227,7 +229,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Quad8] = type;
 
-    type->setInfos(this, IT_Quad8, "Quad8", 8, 4, 4);
+    type->setInfos(this, IT_Quad8, "Quad8", Dimension::Dim2, 8, 4, 4);
 
     type->addFaceLine3(0, 0, 1, 4);
     type->addFaceLine3(1, 1, 2, 5);
@@ -245,7 +247,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Pentagon5] = type;
 
-    type->setInfos(this, IT_Pentagon5, "Pentagon5", 5, 5, 5);
+    type->setInfos(this, IT_Pentagon5, "Pentagon5", Dimension::Dim2, 5, 5, 5);
 
     type->addFaceLine(0, 0, 1);
     type->addFaceLine(1, 1, 2);
@@ -265,7 +267,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Hexagon6] = type;
 
-    type->setInfos(this, IT_Hexagon6, "Hexagon6", 6, 6, 6);
+    type->setInfos(this, IT_Hexagon6, "Hexagon6", Dimension::Dim2, 6, 6, 6);
 
     type->addFaceLine(0, 0, 1);
     type->addFaceLine(1, 1, 2);
@@ -287,7 +289,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Hexaedron8] = type;
 
-    type->setInfos(this, IT_Hexaedron8, "Hexaedron8", 8, 12, 6);
+    type->setInfos(this, IT_Hexaedron8, "Hexaedron8", Dimension::Dim3, 8, 12, 6);
 
     type->addFaceQuad(0, 0, 3, 2, 1);
     type->addFaceQuad(1, 0, 4, 7, 3);
@@ -316,7 +318,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Hexaedron20] = type;
 
-    type->setInfos(this, IT_Hexaedron20, "Hexaedron20", 20, 12, 6);
+    type->setInfos(this, IT_Hexaedron20, "Hexaedron20", Dimension::Dim3, 20, 12, 6);
 
     type->addFaceQuad8(0, 0, 3, 2, 1, 11, 10, 9, 8);
     type->addFaceQuad8(1, 0, 4, 7, 3, 16, 15, 19, 11);
@@ -344,7 +346,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Pyramid5] = type;
 
-    type->setInfos(this, IT_Pyramid5, "Pyramid5", 5, 8, 5);
+    type->setInfos(this, IT_Pyramid5, "Pyramid5", Dimension::Dim3, 5, 8, 5);
 
     type->addFaceQuad(0, 0, 3, 2, 1);
     type->addFaceTriangle(1, 0, 4, 3);
@@ -367,7 +369,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Pentaedron6] = type;
 
-    type->setInfos(this, IT_Pentaedron6, "Pentaedron6", 6, 9, 5);
+    type->setInfos(this, IT_Pentaedron6, "Pentaedron6", Dimension::Dim3, 6, 9, 5);
 
     type->addFaceTriangle(0, 0, 2, 1);
     type->addFaceQuad(1, 0, 3, 5, 2);
@@ -391,7 +393,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Tetraedron4] = type;
 
-    type->setInfos(this, IT_Tetraedron4, "Tetraedron4", 4, 6, 4);
+    type->setInfos(this, IT_Tetraedron4, "Tetraedron4", Dimension::Dim3, 4, 6, 4);
 
     type->addFaceTriangle(0, 0, 2, 1);
     type->addFaceTriangle(1, 0, 3, 2);
@@ -412,7 +414,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Tetraedron10] = type;
 
-    type->setInfos(this, IT_Tetraedron10, "Tetraedron10", 10, 6, 4);
+    type->setInfos(this, IT_Tetraedron10, "Tetraedron10", Dimension::Dim3, 10, 6, 4);
 
     type->addFaceTriangle6(0, 0, 2, 1, 6, 5, 4);
     type->addFaceTriangle6(1, 0, 3, 2, 7, 9, 6);
@@ -432,7 +434,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Heptaedron10] = type;
 
-    type->setInfos(this, IT_Heptaedron10, "Heptaedron10", 10, 15, 7);
+    type->setInfos(this, IT_Heptaedron10, "Heptaedron10", Dimension::Dim3, 10, 15, 7);
 
     type->addFacePentagon(0, 0, 4, 3, 2, 1);
     type->addFacePentagon(1, 5, 6, 7, 8, 9);
@@ -464,7 +466,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Octaedron12] = type;
 
-    type->setInfos(this, IT_Octaedron12, "Octaedron12", 12, 18, 8);
+    type->setInfos(this, IT_Octaedron12, "Octaedron12", Dimension::Dim3, 12, 18, 8);
 
     type->addFaceHexagon(0, 0, 5, 4, 3, 2, 1);
     type->addFaceHexagon(1, 6, 7, 8, 9, 10, 11);
@@ -500,7 +502,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_HemiHexa7] = type;
 
-    type->setInfos(this, IT_HemiHexa7, "HemiHexa7", 7, 11, 6);
+    type->setInfos(this, IT_HemiHexa7, "HemiHexa7", Dimension::Dim3, 7, 11, 6);
 
     type->addFaceTriangle(0, 0, 1, 2);
     type->addFaceQuad(1, 0, 2, 3, 4);
@@ -527,7 +529,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_HemiHexa6] = type;
 
-    type->setInfos(this, IT_HemiHexa6, "HemiHexa6", 6, 10, 6);
+    type->setInfos(this, IT_HemiHexa6, "HemiHexa6", Dimension::Dim3, 6, 10, 6);
 
     type->addFaceTriangle(0, 0, 1, 2);
     type->addFaceQuad(1, 0, 2, 3, 4);
@@ -553,7 +555,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_HemiHexa5] = type;
 
-    type->setInfos(this, IT_HemiHexa5, "HemiHexa5", 5, 7, 4);
+    type->setInfos(this, IT_HemiHexa5, "HemiHexa5", Dimension::Dim3, 5, 7, 4);
 
     type->addFaceTriangle(0, 0, 1, 2);
     type->addFaceQuad(1, 0, 2, 3, 4);
@@ -574,7 +576,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_AntiWedgeLeft6] = type;
 
-    type->setInfos(this, IT_AntiWedgeLeft6, "AntiWedgeLeft6", 6, 10, 6);
+    type->setInfos(this, IT_AntiWedgeLeft6, "AntiWedgeLeft6", Dimension::Dim3, 6, 10, 6);
 
     type->addFaceTriangle(0, 0, 2, 1);
     type->addFaceQuad(1, 0, 3, 5, 2);
@@ -600,7 +602,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_AntiWedgeRight6] = type;
 
-    type->setInfos(this, IT_AntiWedgeRight6, "AntiWedgeRight6", 6, 10, 6);
+    type->setInfos(this, IT_AntiWedgeRight6, "AntiWedgeRight6", Dimension::Dim3, 6, 10, 6);
 
     type->addFaceTriangle(0, 0, 2, 1);
     type->addFaceQuad(1, 0, 3, 5, 2);
@@ -626,7 +628,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_DiTetra5] = type;
 
-    type->setInfos(this, IT_DiTetra5, "DiTetra5", 5, 9, 6);
+    type->setInfos(this, IT_DiTetra5, "DiTetra5", Dimension::Dim3, 5, 9, 6);
 
     type->addFaceTriangle(0, 0, 1, 3);
     type->addFaceTriangle(1, 1, 2, 3);
@@ -694,7 +696,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Enneedron14] = type;
 
-    type->setInfos(this, IT_Enneedron14, "IT_Enneedron14", 14, 21, 9);
+    type->setInfos(this, IT_Enneedron14, "IT_Enneedron14", Dimension::Dim3, 14, 21, 9);
 
     type->addFaceHeptagon(0, 0, 6, 5, 4, 3, 2, 1);
     type->addFaceHeptagon(1, 7, 8, 9, 10, 11, 12, 13);
@@ -733,7 +735,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Decaedron16] = type;
 
-    type->setInfos(this, IT_Decaedron16, "IT_Decaedron16", 16, 24, 10);
+    type->setInfos(this, IT_Decaedron16, "IT_Decaedron16", Dimension::Dim3, 16, 24, 10);
 
     type->addFaceOctogon(0, 0, 7, 6, 5, 4, 3, 2, 1);
     type->addFaceOctogon(1, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -777,7 +779,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Heptagon7] = type;
 
-    type->setInfos(this, IT_Heptagon7, "Heptagon7", 7, 7, 7);
+    type->setInfos(this, IT_Heptagon7, "Heptagon7", Dimension::Dim2, 7, 7, 7);
 
     type->addFaceLine(0, 0, 1);
     type->addFaceLine(1, 1, 2);
@@ -801,7 +803,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Octogon8] = type;
 
-    type->setInfos(this, IT_Octogon8, "Octogon8", 8, 8, 8);
+    type->setInfos(this, IT_Octogon8, "Octogon8", Dimension::Dim2, 8, 8, 8);
 
     type->addFaceLine(0, 0, 1);
     type->addFaceLine(1, 1, 2);
@@ -827,7 +829,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Cell3D_Line2] = type;
 
-    type->setInfos(this, ItemTypeId(IT_Cell3D_Line2), "Cell3D_Line2", 1, 2, 0, 0);
+    type->setInfos(this, IT_Cell3D_Line2, "Cell3D_Line2", Dimension::Dim1, 2, 0, 0);
   }
 
   // Cell3D_Triangle3
@@ -835,7 +837,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Cell3D_Triangle3] = type;
 
-    type->setInfos(this, ItemTypeId(IT_Cell3D_Triangle3), "Cell3D_Triangle3", 2, 3, 3, 0);
+    type->setInfos(this, IT_Cell3D_Triangle3, "Cell3D_Triangle3", Dimension::Dim2, 3, 3, 0);
 
     type->addEdge(0, 0, 1, 1, 2);
     type->addEdge(1, 1, 2, 2, 0);
@@ -847,7 +849,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Cell3D_Quad4] = type;
 
-    type->setInfos(this, ItemTypeId(IT_Cell3D_Quad4), "Cell3D_Quad4", 2, 4, 4, 0);
+    type->setInfos(this, IT_Cell3D_Quad4, "Cell3D_Quad4", Dimension::Dim2, 4, 4, 0);
 
     type->addEdge(0, 0, 1, 3, 1);
     type->addEdge(1, 1, 2, 0, 2);
@@ -980,11 +982,11 @@ readTypes(IParallelSuperMng* pm, const String& filename)
 
   // Analyse du fichier de types
   std::istringstream ifile((char*)bytes.unguardedBasePointer(), std::istringstream::in);
-  Integer nb_type;
+  Integer nb_type = 0;
   ifile >> nb_type;
 
   m_types.resize(ItemTypeMng::nbBuiltInItemType() + nb_type);
-  Integer typeId, nbN, nbE, nbF;
+  Int16 typeId = -1, nbN = 0, nbE = 0, nbF = 0;
   for (Integer i = 0; i < nb_type; ++i) {
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     ifile >> typeId >> nbF >> nbE;
@@ -1013,7 +1015,7 @@ readTypes(IParallelSuperMng* pm, const String& filename)
         ifile >> nodeFace[inodeFace];
       }
       PolygonMapper::const_iterator finder = built_polygons.find(nbN);
-      Integer face_type;
+      Int16 face_type = IT_NullType;
       if (finder != built_polygons.end()) {
         face_type = finder->second;
         m_trace->debug(Trace::High) << "\tAdding already existing face type " << face_type


### PR DESCRIPTION
This is optional but it may be used to detect the dimension of an item when mixing item of different dimension.