### PR TITLE
Fix memory leak in Aleph for underlying matrix and vector 

### DIFF
--- a/arcane/src/arcane/aleph/hypre/AlephHypre.cc
+++ b/arcane/src/arcane/aleph/hypre/AlephHypre.cc
@@ -111,16 +111,20 @@ class AlephVectorHypre
  public:
   AlephVectorHypre(ITraceMng* tm, AlephKernel* kernel, Integer index)
   : IAlephVector(tm, kernel, index)
-  , m_hypre_ijvector(0)
-  , m_hypre_parvector(0)
   , jSize(0)
   , jUpper(0)
   , jLower(-1)
   {
     debug() << "[AlephVectorHypre::AlephVectorHypre] new SolverVectorHypre";
   }
+  ~AlephVectorHypre()
+  {
+    if (m_hypre_ijvector)
+      HYPRE_IJVectorDestroy(m_hypre_ijvector);
+  }
 
  public:
+
   /******************************************************************************
    * The Create() routine creates an empty vector object that lives on the comm communicator. This is
    * a collective call, with each process passing its own index extents, jLower and jupper. The names
@@ -224,8 +228,8 @@ class AlephVectorHypre
   }
 
  public:
-  HYPRE_IJVector m_hypre_ijvector;
-  HYPRE_ParVector m_hypre_parvector;
+  HYPRE_IJVector m_hypre_ijvector = nullptr;
+  HYPRE_ParVector m_hypre_parvector = nullptr;
   HYPRE_Int jSize;
   HYPRE_Int jUpper;
   HYPRE_Int jLower;
@@ -251,6 +255,8 @@ class AlephMatrixHypre
   ~AlephMatrixHypre()
   {
     debug() << "[~AlephMatrixHypre]";
+    if (m_hypre_ijmatrix)
+      HYPRE_IJMatrixDestroy(m_hypre_ijmatrix);
   }
 
  public:

--- a/arcane/src/arcane/aleph/hypre/AlephHypre.cc
+++ b/arcane/src/arcane/aleph/hypre/AlephHypre.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephHypre.cc                                               (C) 2000-2024 */
+/* AlephHypre.cc                                               (C) 2000-2025 */
 /*                                                                           */
 /* Implémentation Hypre de Aleph.                                            */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/petsc/AlephPETSc.cc
+++ b/arcane/src/arcane/aleph/petsc/AlephPETSc.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AlephPETSc.cc                                               (C) 2000-2024 */
+/* AlephPETSc.cc                                               (C) 2000-2025 */
 /*                                                                           */
 /* Implémentation PETSc de Aleph.                                            */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/trilinos/AlephTrilinos.cc
+++ b/arcane/src/arcane/aleph/trilinos/AlephTrilinos.cc
@@ -35,20 +35,15 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-/******************************************************************************
- AlephVectorTrilinos
-*****************************************************************************/
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 class AlephVectorTrilinos : public IAlephVector
 {
  public:
-  /******************************************************************************
- * AlephVectorTrilinos
- *****************************************************************************/
-  AlephVectorTrilinos(ITraceMng* tm,
-                      AlephKernel* kernel,
-                      Integer index)
+
+  AlephVectorTrilinos(ITraceMng* tm, AlephKernel* kernel, Integer index)
   : IAlephVector(tm, kernel, index)
-  , m_trilinos_vector(NULL)
   {
     debug() << "\t\t[AlephVectorTrilinos::AlephVectorTrilinos] new SolverVectorTrilinos";
 #ifdef HAVE_MPI
@@ -57,6 +52,14 @@ class AlephVectorTrilinos : public IAlephVector
     m_trilinos_Comm = new Epetra_SerialComm();
 #endif // HAVE_MPI
   }
+
+  ~AlephVectorTrilinos()
+  {
+    delete m_trilinos_vector;
+    delete m_trilinos_Comm;
+  }
+
+ public:
 
   /******************************************************************************
  * AlephVectorCreate
@@ -148,24 +151,25 @@ class AlephVectorTrilinos : public IAlephVector
   }
 
  public:
-  Epetra_Vector* m_trilinos_vector;
-  Epetra_Comm* m_trilinos_Comm;
+  Epetra_Vector* m_trilinos_vector = nullptr;
+  Epetra_Comm* m_trilinos_Comm = nullptr;
 };
 
-/******************************************************************************
- AlephMatrixTrilinos
-*****************************************************************************/
-class AlephMatrixTrilinos : public IAlephMatrix
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+class AlephMatrixTrilinos
+: public IAlephMatrix
 {
  public:
   /******************************************************************************
  AlephMatrixTrilinos
-*****************************************************************************/
-  AlephMatrixTrilinos(ITraceMng* tm,
-                      AlephKernel* kernel,
-                      Integer index)
+  *****************************************************************************/
+  AlephMatrixTrilinos(ITraceMng* tm, AlephKernel* kernel, Integer index)
   : IAlephMatrix(tm, kernel, index)
-  , m_trilinos_matrix(NULL)
   {
     debug() << "\t\t[AlephMatrixTrilinos::AlephMatrixTrilinos] new AlephMatrixTrilinos";
 #ifdef HAVE_MPI
@@ -173,6 +177,12 @@ class AlephMatrixTrilinos : public IAlephMatrix
 #else
     m_trilinos_Comm = new Epetra_SerialComm();
 #endif // HAVE_MPI
+  }
+
+  ~AlephMatrixTrilinos()
+  {
+    delete m_trilinos_matrix;
+    delete m_trilinos_Comm;
   }
 
   /******************************************************************************
@@ -508,8 +518,8 @@ class AlephMatrixTrilinos : public IAlephMatrix
   }
 
  private:
-  Epetra_CrsMatrix* m_trilinos_matrix;
-  Epetra_Comm* m_trilinos_Comm;
+  Epetra_CrsMatrix* m_trilinos_matrix = nullptr;
+  Epetra_Comm* m_trilinos_Comm = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/aleph/trilinos/AlephTrilinos.cc
+++ b/arcane/src/arcane/aleph/trilinos/AlephTrilinos.cc
@@ -1,18 +1,15 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
-/*****************************************************************************
- * IAlephTrilinos.h                                            (C) 2010-2023 *
- * constants for output types
- #define AZ_all             -4  Print out everything including matrix
- #define AZ_none             0  Print out no results (not even warnings)
- #define AZ_last            -1  Print out final residual and warnings
- #define AZ_summary         -2  Print out summary, final residual and warnings
- #define AZ_warnings        -3  Print out only warning messages
- *****************************************************************************/
+/*---------------------------------------------------------------------------*/
+/* AlephTrilinos.cc                                            (C) 2000-2025 */
+/*                                                                           */
+/* Implémentation Trilinos/Epetra de Aleph.                                  */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 #include "arcane/aleph/AlephArcane.h"
 


### PR DESCRIPTION
The underlying matrix and vector used by Aleph were not destroyed.
It was not very important in our simulation because these matrix and vectors are only created one time but it needs to be fixed.