### PR TITLE
Add observable to update views for ItemFamily variables

### DIFF
--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemFamily.cc                                               (C) 2000-2024 */
+/* ItemFamily.cc                                               (C) 2000-2025 */
 /*                                                                           */
 /* Infos de maillage pour un genre d'entité donnée.                          */
 /*---------------------------------------------------------------------------*/
@@ -366,6 +366,14 @@ build()
     m_items_flags = &m_internal_variables->m_items_flags._internalTrueData()->_internalDeprecatedValue();
     m_items_type_id = &m_internal_variables->m_items_type_id._internalTrueData()->_internalDeprecatedValue();
     m_items_nb_parent = &m_internal_variables->m_items_nb_parent._internalTrueData()->_internalDeprecatedValue();
+
+    // Ajoute notification pour la mise à jour des vues après un changement externe
+    _addOnSizeChangedObservable(m_internal_variables->m_items_unique_id);
+    _addOnSizeChangedObservable(m_internal_variables->m_items_owner);
+    _addOnSizeChangedObservable(m_internal_variables->m_items_flags);
+    _addOnSizeChangedObservable(m_internal_variables->m_items_type_id);
+    _addOnSizeChangedObservable(m_internal_variables->m_items_nb_parent);
+
     _updateItemViews();
   }
 
@@ -2666,6 +2674,7 @@ ArrayView<DataType> _getView(Array<DataType>* v)
  }
 
 }
+
 void ItemFamily::
 _updateItemViews()
 {
@@ -2676,6 +2685,16 @@ _updateItemViews()
   m_common_item_shared_info->m_parent_item_ids = m_items_nb_parent->view();
 
   m_items_unique_id_view = _getView(m_items_unique_id);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemFamily::
+_addOnSizeChangedObservable(VariableRef& var_ref)
+{
+  m_observers.addObserver(this,&ItemFamily::_updateItemViews,
+                          var_ref.variable()->onSizeChangedObservable());
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemFamily.h                                                (C) 2000-2024 */
+/* ItemFamily.h                                                (C) 2000-2025 */
 /*                                                                           */
 /* Famille d'entités.                                                        */
 /*---------------------------------------------------------------------------*/
@@ -520,6 +520,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   void _removeVariable(IVariable* var);
   void _resizeVariables(bool force_resize);
   void _shrinkConnectivityAndPrintInfos();
+  void _addOnSizeChangedObservable(VariableRef& var_ref);
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
`ItemFamily` variables (like `uniqueId` or `typeId`) are private to that class and should not be modified outside. But they are still accessible from outside via `IVariableMng`. Adding an observable make sure views are always valid.
 