### PR TITLE
[CI] Remove from sanitizer worklow the tests launched via 'dotnet'

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -31,7 +31,7 @@ jobs:
       ccache_debug_mode: false
       with_samples: true
       execute_tests: true
-      excluded_tests: '^.*([5-9]proc|[1-9][0-9]+proc|[5-9]thread|[1-9][0-9]+thread).*$'
+      excluded_tests: '^.*([5-9]proc|[1-9][0-9]+proc|[5-9]thread|[1-9][0-9]+thread|coreclr_dotnet).*$'
       excluded_tests_with_labels: 'LARGE_HYBRID'
       ctest_additionnal_args: '-j4 --timeout 1200'
       cache_key_prefix: 'U24_C19_F'


### PR DESCRIPTION
These tests can not be launcher because `dotnet` is not linked with `-fsanitize=address` option.