### PR TITLE
Add C++ constant for type `ItemTypeId`

### DIFF
--- a/arcane/src/arcane/core/ItemTypeId.h
+++ b/arcane/src/arcane/core/ItemTypeId.h
@@ -1,20 +1,20 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemTypeId.h                                                (C) 2000-2022 */
+/* ItemTypeId.h                                                (C) 2000-2025 */
 /*                                                                           */
 /* Type d'une entité.                                                        */
 /*---------------------------------------------------------------------------*/
-#ifndef ARCANE_ITEMTYPEID_H
-#define ARCANE_ITEMTYPEID_H
+#ifndef ARCANE_CORE_ITEMTYPEID_H
+#define ARCANE_CORE_ITEMTYPEID_H
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ItemTypes.h"
+#include "arcane/core/ItemTypes.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -54,6 +54,103 @@ class ARCANE_CORE_EXPORT ItemTypeId
 
   Int16 m_type_id = IT_NullType;
 };
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+//! Numéro du type d'entité inconnu ou null
+static constexpr ItemTypeId ITI_NullType(IT_NullType);
+//! Numéro du type d'entité Noeud (1 sommet 1D, 2D et 3D)
+static constexpr ItemTypeId ITI_Vertex(IT_Vertex);
+//! Numéro du type d'entité Arête (2 sommets, 1D, 2D et 3D)
+static constexpr ItemTypeId ITI_Line2(IT_Line2);
+//! Numéro du type d'entité Triangle (3 sommets, 2D)
+static constexpr ItemTypeId ITI_Triangle3(IT_Triangle3);
+//! Numéro du type d'entité Quadrilatère (4 sommets, 2D)
+static constexpr ItemTypeId ITI_Quad4(IT_Quad4);
+//! Numéro du type d'entité Pentagone (5 sommets, 2D)
+static constexpr ItemTypeId ITI_Pentagon5(IT_Pentagon5);
+//! Numéro du type d'entité Hexagone (6 sommets, 2D)
+static constexpr ItemTypeId ITI_Hexagon6(IT_Hexagon6);
+//! Numéro du type d'entité Tetraèdre (4 sommets, 3D)
+static constexpr ItemTypeId ITI_Tetraedron4(IT_Tetraedron4);
+//! Numéro du type d'entité Pyramide (5 sommets, 3D)
+static constexpr ItemTypeId ITI_Pyramid5(IT_Pyramid5);
+//! Numéro du type d'entité Prisme (6 sommets, 3D)
+static constexpr ItemTypeId ITI_Pentaedron6(IT_Pentaedron6);
+//! Numéro du type d'entité Hexaèdre (8 sommets, 3D)
+static constexpr ItemTypeId ITI_Hexaedron8(IT_Hexaedron8);
+//! Numéro du type d'entité Heptaèdre (prisme à base pentagonale)
+static constexpr ItemTypeId ITI_Heptaedron10(IT_Heptaedron10);
+//! Numéro du type d'entité Octaèdre (prisme à base hexagonale)
+static constexpr ItemTypeId ITI_Octaedron12(IT_Octaedron12);
+//! Numéro du type d'entité HemiHexa7 (héxahèdre à 1 dégénérescence)
+static constexpr ItemTypeId ITI_HemiHexa7(IT_HemiHexa7);
+//! Numéro du type d'entité HemiHexa6 (héxahèdre à 2 dégénérescences non contigues)
+static constexpr ItemTypeId ITI_HemiHexa6(IT_HemiHexa6);
+//! Numéro du type d'entité HemiHexa5 (héxahèdres à 3 dégénérescences non contigues)
+static constexpr ItemTypeId ITI_HemiHexa5(IT_HemiHexa5);
+//! Numéro du type d'entité AntiWedgeLeft6 (héxahèdre à 2 dégénérescences contigues)
+static constexpr ItemTypeId ITI_AntiWedgeLeft6(IT_AntiWedgeLeft6);
+//! Numéro du type d'entité AntiWedgeRight6 (héxahèdre à 2 dégénérescences contigues (seconde forme))
+static constexpr ItemTypeId ITI_AntiWedgeRight6(IT_AntiWedgeRight6);
+//! Numéro du type d'entité DiTetra5 (héxahèdre à 3 dégénérescences orthogonales)
+static constexpr ItemTypeId ITI_DiTetra5(IT_DiTetra5);
+//! Numero du type d'entite noeud dual d'un sommet
+static constexpr ItemTypeId ITI_DualNode(IT_DualNode);
+//! Numero du type d'entite noeud dual d'une arête
+static constexpr ItemTypeId ITI_DualEdge(IT_DualEdge);
+//! Numero du type d'entite noeud dual d'une face
+static constexpr ItemTypeId ITI_DualFace(IT_DualFace);
+//! Numero du type d'entite noeud dual d'une cellule
+static constexpr ItemTypeId ITI_DualCell(IT_DualCell);
+//! Numéro du type d'entité liaison
+static constexpr ItemTypeId ITI_Link(IT_Link);
+//! Numéro du type d'entité Face pour les maillages 1D.
+static constexpr ItemTypeId ITI_FaceVertex(IT_FaceVertex);
+//! Numéro du type d'entité Cell pour les maillages 1D.
+static constexpr ItemTypeId ITI_CellLine2(IT_CellLine2);
+//! Numero du type d'entite noeud dual d'une particule
+static constexpr ItemTypeId ITI_DualParticle(IT_DualParticle);
+
+//! Numéro du type d'entité Enneèdre (prisme à base heptagonale)
+static constexpr ItemTypeId ITI_Enneedron14(IT_Enneedron14);
+//! Numéro du type d'entité Decaèdre (prisme à base Octogonale)
+static constexpr ItemTypeId ITI_Decaedron16(IT_Decaedron16);
+
+//! Numéro du type d'entité Heptagon 2D (heptagonale)
+static constexpr ItemTypeId ITI_Heptagon7(IT_Heptagon7);
+
+//! Numéro du type d'entité Octogon 2D (Octogonale)
+static constexpr ItemTypeId ITI_Octogon8(IT_Octogon8);
+
+//! Éléments quadratiques
+//@{
+//! Ligne d'ordre 2
+static constexpr ItemTypeId ITI_Line3(IT_Line3);
+//! Triangle d'ordre 2
+static constexpr ItemTypeId ITI_Triangle6(IT_Triangle6);
+//! Quadrangle d'ordre 2 (avec 4 noeuds sur les faces)
+static constexpr ItemTypeId ITI_Quad8(IT_Quad8);
+//! Tétraèdre d'ordre 2
+static constexpr ItemTypeId ITI_Tetraedron10(IT_Tetraedron10);
+//! Hexaèdre d'ordre 2
+static constexpr ItemTypeId ITI_Hexaedron20(IT_Hexaedron20);
+//@}
+
+/*!
+ * \brief Mailles 2D dans un maillage 3D.
+ * \warning Ces types sont expérimentaux et ne doivent
+ * pas être utilisés en dehors de %Arcane.
+ */
+//@{
+//! Maille Line2 dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Line2(IT_Cell3D_Line2);
+//! Maille Triangulaire à 3 noeuds dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Triangle3(IT_Cell3D_Triangle3);
+//! Maille Quadrangulaire à 5 noeuds dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Quad4(IT_Cell3D_Quad4);
+//@}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -306,6 +306,7 @@ endmacro()
 
 message(STATUS "ADD AUTOMATED TESTS")
 ARCANE_ADD_TEST_SEQUENTIAL(utils1 testUtils-1.arc)
+arcane_add_test_sequential(itemtypes1 testItemTypes-1.arc)
 ARCANE_ADD_TEST_SEQUENTIAL(json1 testJSON-1.arc)
 ARCANE_ADD_TEST_SEQUENTIAL(xml1 testXml-1.arc -We,ARCANE_XML_PATH,${ARCANE_ARC_PATH})
 ARCANE_ADD_TEST_SEQUENTIAL(random1 testRandom-1.arc)

--- a/arcane/src/arcane/tests/ItemTypesUnitTest.cc
+++ b/arcane/src/arcane/tests/ItemTypesUnitTest.cc
@@ -1,0 +1,147 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ItemTypesUnitTest.cc                                        (C) 2000-2025 */
+/*                                                                           */
+/* Test des types des entités.                                               */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/core/BasicUnitTest.h"
+#include "arcane/core/FactoryService.h"
+
+#include "arcane/core/ItemTypeMng.h"
+#include "arcane/core/IMesh.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace ArcaneTest
+{
+using namespace Arcane;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Service de test du type des entités
+ */
+class ItemTypesUnitTest
+: public BasicUnitTest
+{
+ public:
+
+  explicit ItemTypesUnitTest(const ServiceBuildInfo& cb);
+
+ public:
+
+  void initializeTest() override;
+  void executeTest() override;
+
+ private:
+
+  ItemTypeMng* m_item_type_mng = nullptr;
+
+ private:
+
+  void _doCheck(ItemTypeId item_type_id, Int16 type_id, const String& name);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ARCANE_REGISTER_CASE_OPTIONS_NOAXL_FACTORY(ItemTypesUnitTest, IUnitTest, ItemTypesUnitTest);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ItemTypesUnitTest::
+ItemTypesUnitTest(const ServiceBuildInfo& mb)
+: BasicUnitTest(mb)
+{
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemTypesUnitTest::
+_doCheck(ItemTypeId item_type_id, Int16 type_id, const String& expected_name)
+{
+  ItemTypeInfo* iti = m_item_type_mng->typeFromId(item_type_id);
+  String type_name = iti->typeName();
+  std::cout << "Item id=" << type_id << " name=" << type_name << "\n";
+  if (item_type_id != type_id)
+    ARCANE_FATAL("Bad ItemType type1={0} type2={1}", item_type_id, type_id);
+  if (type_name != expected_name)
+    ARCANE_FATAL("Bad ItemType name name={0} expected={1}", type_name, expected_name);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemTypesUnitTest::
+initializeTest()
+{
+  m_item_type_mng = mesh()->itemTypeMng();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#define TEST_ITEM_TYPE(a) _doCheck(ITI_##a, IT_##a, #a)
+#define TEST_ITEM_TYPE_BAD(a) _doCheck(ITI_##a, IT_##a, (String("IT_") + #a))
+
+void ItemTypesUnitTest::
+executeTest()
+{
+  TEST_ITEM_TYPE(NullType);
+  TEST_ITEM_TYPE(Vertex);
+  TEST_ITEM_TYPE(Line2);
+  TEST_ITEM_TYPE(Triangle3);
+  TEST_ITEM_TYPE(Quad4);
+  TEST_ITEM_TYPE(Pentagon5);
+  TEST_ITEM_TYPE(Hexagon6);
+  TEST_ITEM_TYPE(Tetraedron4);
+  TEST_ITEM_TYPE(Pyramid5);
+  TEST_ITEM_TYPE(Pentaedron6);
+  TEST_ITEM_TYPE(Hexaedron8);
+  TEST_ITEM_TYPE(Heptaedron10);
+  TEST_ITEM_TYPE(Octaedron12);
+  TEST_ITEM_TYPE(HemiHexa7);
+  TEST_ITEM_TYPE(HemiHexa6);
+  TEST_ITEM_TYPE(HemiHexa5);
+  TEST_ITEM_TYPE(AntiWedgeLeft6);
+  TEST_ITEM_TYPE(AntiWedgeRight6);
+  TEST_ITEM_TYPE(DiTetra5);
+  TEST_ITEM_TYPE(DualNode);
+  TEST_ITEM_TYPE(DualEdge);
+  TEST_ITEM_TYPE(DualFace);
+  TEST_ITEM_TYPE(DualCell);
+  TEST_ITEM_TYPE(Link);
+  TEST_ITEM_TYPE(FaceVertex);
+  TEST_ITEM_TYPE(CellLine2);
+  TEST_ITEM_TYPE(DualParticle);
+  TEST_ITEM_TYPE_BAD(Enneedron14);
+  TEST_ITEM_TYPE_BAD(Decaedron16);
+  TEST_ITEM_TYPE(Heptagon7);
+  TEST_ITEM_TYPE(Octogon8);
+  TEST_ITEM_TYPE(Line3);
+  TEST_ITEM_TYPE(Triangle6);
+  TEST_ITEM_TYPE(Quad8);
+  TEST_ITEM_TYPE(Tetraedron10);
+  TEST_ITEM_TYPE(Hexaedron20);
+  TEST_ITEM_TYPE(Cell3D_Line2);
+  TEST_ITEM_TYPE(Cell3D_Triangle3);
+  TEST_ITEM_TYPE(Cell3D_Quad4);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace ArcaneTest
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/srcs.cmake
+++ b/arcane/src/arcane/tests/srcs.cmake
@@ -12,6 +12,7 @@ set(ARCANE_SOURCES
   ParallelTesterModule.cc
   SubMeshTestModule.cc
   HydroAdditionalTestModule.cc
+  ItemTypesUnitTest.cc
   TestTplParameter.cc
   ModuleSimpleHydro.cc
   ModuleSimpleHydroGeneric.cc

--- a/arcane/tests/testItemTypes-1.arc
+++ b/arcane/tests/testItemTypes-1.arc
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<case codename="ArcaneTest" xml:lang="en" codeversion="1.0">
+  <arcane>
+    <title>Test Utils 1</title>
+    <description>Test Utils 1</description>
+    <timeloop>UnitTest</timeloop>
+  </arcane>
+
+  <meshes>
+    <mesh>
+      <generator name="Cartesian2D">
+        <origin>0.0 0.0</origin>
+        <nb-part-x>1</nb-part-x>
+        <nb-part-y>1</nb-part-y>
+        <x><n>10</n><length>1.0</length></x>
+        <y><n>5</n><length>1.0</length></y>
+      </generator>
+    </mesh>
+  </meshes>
+
+  <unit-test-module>
+    <test name="ItemTypesUnitTest"/>
+  </unit-test-module>
+</case>


### PR DESCRIPTION
These constants add strong type for the type of items. They are similar to the values defined in `ArcaneTypes.h` but have the type `ItemTypeId` instead of `Int16`.