### PR TITLE
Make type name of `IT_Enneedron14` and `IT_Decaedron16` coherent with other types.

### DIFF
--- a/arcane/src/arcane/core/ItemTypeMng.cc
+++ b/arcane/src/arcane/core/ItemTypeMng.cc
@@ -696,7 +696,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Enneedron14] = type;
 
-    type->setInfos(this, IT_Enneedron14, "IT_Enneedron14", Dimension::Dim3, 14, 21, 9);
+    type->setInfos(this, IT_Enneedron14, "Enneedron14", Dimension::Dim3, 14, 21, 9);
 
     type->addFaceHeptagon(0, 0, 6, 5, 4, 3, 2, 1);
     type->addFaceHeptagon(1, 7, 8, 9, 10, 11, 12, 13);
@@ -735,7 +735,7 @@ _build(IParallelSuperMng* parallel_mng, ITraceMng* trace)
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Decaedron16] = type;
 
-    type->setInfos(this, IT_Decaedron16, "IT_Decaedron16", Dimension::Dim3, 16, 24, 10);
+    type->setInfos(this, IT_Decaedron16, "Decaedron16", Dimension::Dim3, 16, 24, 10);
 
     type->addFaceOctogon(0, 0, 7, 6, 5, 4, 3, 2, 1);
     type->addFaceOctogon(1, 8, 9, 10, 11, 12, 13, 14, 15);

--- a/arcane/src/arcane/tests/ItemTypesUnitTest.cc
+++ b/arcane/src/arcane/tests/ItemTypesUnitTest.cc
@@ -92,7 +92,6 @@ initializeTest()
 /*---------------------------------------------------------------------------*/
 
 #define TEST_ITEM_TYPE(a) _doCheck(ITI_##a, IT_##a, #a)
-#define TEST_ITEM_TYPE_BAD(a) _doCheck(ITI_##a, IT_##a, (String("IT_") + #a))
 
 void ItemTypesUnitTest::
 executeTest()
@@ -124,8 +123,8 @@ executeTest()
   TEST_ITEM_TYPE(FaceVertex);
   TEST_ITEM_TYPE(CellLine2);
   TEST_ITEM_TYPE(DualParticle);
-  TEST_ITEM_TYPE_BAD(Enneedron14);
-  TEST_ITEM_TYPE_BAD(Decaedron16);
+  TEST_ITEM_TYPE(Enneedron14);
+  TEST_ITEM_TYPE(Decaedron16);
   TEST_ITEM_TYPE(Heptagon7);
   TEST_ITEM_TYPE(Octogon8);
   TEST_ITEM_TYPE(Line3);


### PR DESCRIPTION
For a type `IT_*`, the name should be `*`. It was not the case for two types.