### PR TITLE
Use `MemoryUtils::getDefaultDataMemoryResource()` for default memory of `NumArray` and `RunQueue`

### DIFF
--- a/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
@@ -156,7 +156,7 @@ _setDefaultMemoryRessource()
 {
   m_memory_ressource = eMemoryRessource::Host;
   if (isAcceleratorPolicy(m_execution_policy))
-    m_memory_ressource = eMemoryRessource::UnifiedMemory;
+    m_memory_ressource = MemoryUtils::getDefaultDataMemoryResource();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/NumArray.cc
+++ b/arcane/src/arcane/utils/NumArray.cc
@@ -29,7 +29,7 @@ namespace Arcane::impl
 MemoryAllocationOptions NumArrayBaseCommon::
 _getDefaultAllocator()
 {
-  return _getDefaultAllocator(eMemoryRessource::UnifiedMemory);
+  return _getDefaultAllocator(MemoryUtils::getDefaultDataMemoryResource());
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This way these two classes will use the value used in environment variable `ARCANE_DEFAULT_DATA_MEMORY_RESOURCE` to specify the default memory resource to use for accelerator.