### PR TITLE
Cleanup classes handling Events

### DIFF
--- a/arcane/src/arcane/tests/UtilsUnitTest.cc
+++ b/arcane/src/arcane/tests/UtilsUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* UtilsUnitTest.cc                                            (C) 2000-2024 */
+/* UtilsUnitTest.cc                                            (C) 2000-2025 */
 /*                                                                           */
 /* Test des fonctions utilitaires de Arcane.                                 */
 /*---------------------------------------------------------------------------*/
@@ -16,7 +16,6 @@
 #include "arcane/utils/ArgumentException.h"
 #include "arcane/utils/AutoDestroyUserData.h"
 #include "arcane/utils/HPReal.h"
-#include "arcane/utils/IFunctorWithArgument.h"
 #include "arcane/utils/IMemoryInfo.h"
 #include "arcane/utils/ITraceMng.h"
 #include "arcane/utils/PlatformUtils.h"
@@ -33,18 +32,10 @@
 #include "arcane/core/FactoryService.h"
 #include "arcane/core/ServiceBuilder.h"
 
-#include "arcane/tests/ArcaneTestGlobal.h"
-
 #include <fenv.h>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-namespace Arcane
-{
-extern "C++" ARCANE_UTILS_EXPORT void
-_internalTestEvent();
-}
 
 namespace ArcaneTest
 {
@@ -119,7 +110,6 @@ class UtilsUnitTest
   void _testStackTrace();
   void _testSetClassConfig();
   void _testFloatingException();
-  void _testEvents();
   void _testConvertFromString();
   void _testConvertFromStringToInt32Array();
   void _testCommandLine();
@@ -164,7 +154,6 @@ executeTest()
   _testUserData();
   _testHPReal();
   _testTruncateReal();
-  _testEvents();
 
   info() << Trace::Color::darkRed()     << "[TEST_COLOR] DARK_RED";
   info() << Trace::Color::darkGreen()   << "[TEST_COLOR] DARK_GREEN";
@@ -755,16 +744,6 @@ _printMemoryInfos()
     MemoryInfoPrinter mip(traceMng());
     mem_info->visitAllocatedBlocks(&mip);
   }
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-void UtilsUnitTest::
-_testEvents()
-{
-  info() << "INTERNAL TEST EVENT";
-  _internalTestEvent();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/Event.cc
+++ b/arcane/src/arcane/utils/Event.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Event.cc                                                    (C) 2000-2023 */
+/* Event.cc                                                    (C) 2000-2025 */
 /*                                                                           */
 /* Gestionnaires d'évènements.                                               */
 /*---------------------------------------------------------------------------*/
@@ -213,79 +213,6 @@ void EventObserverPool::
 add(EventObserverBase* obs)
 {
   m_observers.add(obs);
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-namespace
-{
-class TestMemberCall
-{
- public:
-  void my_func(int a,int b)
-  {
-    std::cout << "THIS_IS_MY FUNC XA=" << a << " B=" << b << '\n';
-  }
-  void operator()(int a,int b)
-  {
-    std::cout << "THIS_IS OPERATOR() FUNC XA=" << a << " B=" << b << '\n';
-  }
-};
-}
-extern "C++" ARCANE_UTILS_EXPORT void
- _internalTestEvent()
-{
-  using std::placeholders::_1;
-  using std::placeholders::_2;
-
-  int f = 3;
-  auto func = [&](int a,int b){
-    std::cout << "XA=" << a << " B=" << b << " f=" << f << '\n';
-    f = a+b;
-  };
-  auto func2 = [&](int a,int b){
-    std::cout << "FUNC2: XA=" << a << " B=" << b << " f=" << f << '\n';
-  };
-  TestMemberCall tmc;
-  EventObserver<int,int> x2(func);
-  {
-    EventObservable<int,int> xevent;
-    EventObserverPool pool;
-    {
-      EventObserver<int,int> xobserver;
-      // NOTE: le test suivnant ne marche pas avec MSVS2013
-      //std::function<void(TestMemberCall*,int,int)> kk1(&TestMemberCall::my_func);
-      std::function<void(int,int)> kk( std::bind( &TestMemberCall::my_func, tmc, _1, _2 ) );
-      //std::function<void(int,int)> kk2( std::bind( &TestMemberCall::my_func, tmc ) );
-      //auto kk( std::bind( &TestMemberCall::my_func, &tmc ) );
-      EventObserver<int,int> x4(kk);
-      EventObserver<int,int> x3(tmc);
-      xevent.attach(&x2);
-      xevent.attach(&x3);
-      xevent.attach(&x4);
-      xevent.attach(&xobserver);
-      xevent.notify(2,3);
-      xevent.detach(&x4);
-    }
-    xevent.attach(pool,func2);
-  }
-  std::cout << "(After) F=" << f << '\n';
-  if (f!=5)
-    ARCANE_FATAL("Bad value for f");
-  {
-    EventObserver<int,int>* eo1 = nullptr;
-    EventObservable<int,int> xevent;
-    {
-      eo1 = new EventObserver<int,int>( std::bind( &TestMemberCall::my_func, tmc, _1, _2 ) );
-      xevent.attach(eo1);
-    }
-    xevent.notify(2,4);
-    delete eo1;
-  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/Event.h
+++ b/arcane/src/arcane/utils/Event.h
@@ -55,18 +55,26 @@ class ARCANE_UTILS_EXPORT EventObservableBase
 
  public:
 
-  bool hasObservers() const;
+  bool hasObservers() const { return !m_observers_array.empty(); }
   void detachAllObservers();
 
  protected:
 
   void _attachObserver(EventObserverBase* obs, bool is_auto_destroy);
   void _detachObserver(EventObserverBase* obs);
-  ConstArrayView<EventObserverBase*> _observers() const;
+  ConstArrayView<EventObserverBase*> _observers() const
+  {
+    return m_observers_array;
+  }
 
  private:
 
   Impl* m_p = nullptr;
+  UniqueArray<EventObserverBase*> m_observers_array;
+
+ private:
+
+  void _rebuildObserversArray();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/Event.h
+++ b/arcane/src/arcane/utils/Event.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Event.h                                                     (C) 2000-2023 */
+/* Event.h                                                     (C) 2000-2025 */
 /*                                                                           */
 /* Gestionnaires d'évènements.                                               */
 /*---------------------------------------------------------------------------*/
@@ -40,18 +40,33 @@ class ARCANE_UTILS_EXPORT EventObservableBase
 {
   friend class EventObserverBase;
   class Impl;
+
  public:
+
   EventObservableBase();
   virtual ~EventObservableBase();
+
  public:
+
+  EventObservableBase(const EventObservableBase&) = delete;
+  EventObservableBase(EventObservableBase&&) = delete;
+  EventObservableBase& operator=(const EventObservableBase&) = delete;
+  EventObservableBase& operator=(EventObservableBase&&) = delete;
+
+ public:
+
   bool hasObservers() const;
   void detachAllObservers();
+
  protected:
-  void _attachObserver(EventObserverBase* obs,bool is_auto_destroy);
+
+  void _attachObserver(EventObserverBase* obs, bool is_auto_destroy);
   void _detachObserver(EventObserverBase* obs);
   ConstArrayView<EventObserverBase*> _observers() const;
+
  private:
-  Impl* m_p;
+
+  Impl* m_p = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -66,14 +81,20 @@ class ARCANE_UTILS_EXPORT EventObservableBase
 class ARCANE_UTILS_EXPORT EventObserverBase
 {
   friend class EventObservableBase;
+
  public:
-  EventObserverBase() : m_observable(nullptr) {}
+
+  EventObserverBase() = default;
   virtual ~EventObserverBase() ARCANE_NOEXCEPT_FALSE;
+
  protected:
+
   void _notifyDetach();
   void _notifyAttach(EventObservableBase* obs);
+
  private:
-  EventObservableBase* m_observable;
+
+  EventObservableBase* m_observable = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -82,24 +103,31 @@ class ARCANE_UTILS_EXPORT EventObserverBase
  * \ingroup Utils
  * \brief Observateur d'évènements.
  */
-template<typename... Args>
+template <typename... Args>
 class EventObserver
 : public EventObserverBase
 {
  public:
+
   typedef EventObservable<Args...> ObservableType;
+
  public:
+
   EventObserver() {}
   EventObserver(const std::function<void(Args...)>& func)
-  : m_functor(func){}
+  : m_functor(func)
+  {}
   EventObserver(std::function<void(Args...)>&& func)
-  : m_functor(func){}
+  : m_functor(func)
+  {}
   void observerUpdate(Args... args)
   {
     if (m_functor)
       m_functor(args...);
   }
+
  private:
+
   std::function<void(Args...)> m_functor;
 };
 
@@ -111,13 +139,18 @@ class EventObserver
 class ARCANE_UTILS_EXPORT EventObserverPool
 {
  public:
+
   ~EventObserverPool();
+
  public:
+
   //! Ajoute l'observateur \a x
   void add(EventObserverBase* x);
   //! Supprime tous les observateurs associés à cette instance.
   void clear();
+
  private:
+
   UniqueArray<EventObserverBase*> m_observers;
 };
 
@@ -151,7 +184,7 @@ class ARCANE_UTILS_EXPORT EventObserverPool
  \endcode
  *
  */
-template<typename... Args>
+template <typename... Args>
 class EventObservable
 : public EventObservableBase
 {
@@ -161,12 +194,7 @@ class EventObservable
 
  public:
 
-  EventObservable() {}
-
- public:
-
-  EventObservable(const EventObservable<Args...>& rhs) = delete;
-  void operator=(const EventObservable<Args...>& rhs) = delete;
+  EventObservable() = default;
 
  public:
 
@@ -175,7 +203,7 @@ class EventObservable
    *
    * Une exception est levée si l'observateur est déjà attaché à un observable.
    */
-  void attach(ObserverType* o) { _attachObserver(o,false); }
+  void attach(ObserverType* o) { _attachObserver(o, false); }
   /*!
    * \brief Détache l'observateur \a o de cet observable.
    *
@@ -187,11 +215,11 @@ class EventObservable
    * \brief Ajoute un observateur utilisant la lambda \a lambda
    * et conserve une référence dans \a pool.
    */
-  template<typename Lambda>
-  void attach(EventObserverPool& pool,const Lambda& lambda)
+  template <typename Lambda>
+  void attach(EventObserverPool& pool, const Lambda& lambda)
   {
     auto x = new ObserverType(lambda);
-    _attachObserver(x,false);
+    _attachObserver(x, false);
     pool.add(x);
   }
 
@@ -200,7 +228,7 @@ class EventObservable
   {
     if (!hasObservers())
       return;
-    for( auto o : _observers() )
+    for (auto o : _observers())
       ((ObserverType*)o)->observerUpdate(args...);
   }
 };
@@ -208,7 +236,7 @@ class EventObservable
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-}
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/CMakeLists.txt
+++ b/arcane/src/arcane/utils/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 ﻿set(SOURCE_FILES
   TestAutoRef.cc
   TestDependencyInjection.cc
+  TestEvent.cc
   TestRealN.cc
   TestNumVector.cc
   TestValueConvert.cc

--- a/arcane/src/arcane/utils/tests/TestEvent.cc
+++ b/arcane/src/arcane/utils/tests/TestEvent.cc
@@ -1,0 +1,89 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "arcane/utils/Event.h"
+#include "arcane/utils/FatalErrorException.h"
+
+#include <iostream>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+using namespace Arcane;
+
+
+namespace
+{
+class TestMemberCall
+{
+ public:
+  void my_func(int a,int b)
+  {
+    std::cout << "THIS_IS_MY FUNC XA=" << a << " B=" << b << '\n';
+  }
+  void operator()(int a,int b)
+  {
+    std::cout << "THIS_IS OPERATOR() FUNC XA=" << a << " B=" << b << '\n';
+  }
+};
+}
+TEST(TestEvent, Misc)
+{
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+
+  int f = 3;
+  auto func = [&](int a, int b) {
+    std::cout << "XA=" << a << " B=" << b << " f=" << f << '\n';
+    f = a + b;
+  };
+  auto func2 = [&](int a, int b) {
+    std::cout << "FUNC2: XA=" << a << " B=" << b << " f=" << f << '\n';
+  };
+  TestMemberCall tmc;
+  EventObserver<int, int> x2(func);
+  {
+    EventObservable<int, int> xevent;
+    EventObserverPool pool;
+    {
+      EventObserver<int, int> xobserver;
+      // NOTE: le test suivnant ne marche pas avec MSVS2013
+      std::function<void(TestMemberCall*, int, int)> kk1(&TestMemberCall::my_func);
+      std::function<void(int, int)> kk(std::bind(&TestMemberCall::my_func, tmc, _1, _2));
+      //std::function<void(int,int)> kk2( std::bind( &TestMemberCall::my_func, tmc ) );
+      //auto kk( std::bind( &TestMemberCall::my_func, &tmc ) );
+      EventObserver<int, int> x4(kk);
+      EventObserver<int, int> x3(tmc);
+      xevent.attach(&x2);
+      xevent.attach(&x3);
+      xevent.attach(&x4);
+      xevent.attach(&xobserver);
+      xevent.notify(2, 3);
+      xevent.detach(&x4);
+    }
+    xevent.attach(pool, func2);
+  }
+  std::cout << "(After) F=" << f << '\n';
+
+  ASSERT_EQ(f, 5);
+
+  {
+    EventObserver<int, int>* eo1 = nullptr;
+    EventObservable<int, int> xevent;
+    {
+      eo1 = new EventObserver<int, int>(std::bind(&TestMemberCall::my_func, tmc, _1, _2));
+      xevent.attach(eo1);
+    }
+    xevent.notify(2, 4);
+    delete eo1;
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
- Use googlest to test theses classes
- Prevent copy or assignment for `EventObservableBase`
- Make some functions inline.