### PR TITLE
Add support for several CellGroup and physical names in MSH writer

### DIFF
--- a/arcane/src/arcane/std/MshMeshWriter.cc
+++ b/arcane/src/arcane/std/MshMeshWriter.cc
@@ -13,6 +13,8 @@
 
 #include "arcane/utils/IOException.h"
 #include "arcane/utils/FixedArray.h"
+#include "arcane/utils/Collection.h"
+#include "arcane/utils/ITraceMng.h"
 
 #include "arcane/core/FactoryService.h"
 #include "arcane/core/IMesh.h"
@@ -43,11 +45,40 @@ class MshMeshWriter
 {
  public:
 
+  class ItemFamilyWriteInfo
+  : public TraceAccessor
+  {
+   public:
+
+    explicit ItemFamilyWriteInfo(ITraceMng* tm)
+    : TraceAccessor(tm)
+    {
+    }
+  };
+
   struct EntityInfo
   {
     Int32 m_dim = -1;
     Int32 m_item_type = IT_NullType;
     Int32 m_entity_tag = -1;
+  };
+
+  class ItemGroupWriteInfo
+  {
+   public:
+
+    void processGroup(ItemGroup group, Int32 base_entity_index);
+
+   public:
+
+    ConstArrayView<EntityInfo> entitiesByType() const { return m_entities_by_type; }
+    ConstArrayView<Int32> itemsByType(Int32 item_type) const { return m_items_by_type[item_type]; }
+
+   private:
+
+    UniqueArray<EntityInfo> m_entities_by_type;
+    FixedArray<UniqueArray<Int32>, NB_BASIC_ITEM_TYPE> m_items_by_type;
+    UniqueArray<Int32> m_existing_items_type;
   };
 
  public:
@@ -142,7 +173,7 @@ _convertToMshType(Int32 arcane_type)
   default:
     break;
   }
-  ARCANE_THROW(NotSupportedException, "Arcane type '{0}'", m_item_type_mng->typeFromId(arcane_type));
+  ARCANE_THROW(NotSupportedException, "Arcane type '{0}'", m_item_type_mng->typeFromId(arcane_type)->typeName());
 }
 
 /*---------------------------------------------------------------------------*/
@@ -152,6 +183,48 @@ bool MshMeshWriter::
 writeMeshToFile(IMesh* mesh, const String& file_name)
 {
   return _writeMeshToFileV4(mesh, file_name);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MshMeshWriter::ItemGroupWriteInfo::
+processGroup(ItemGroup group, Int32 base_entity_index)
+{
+  IItemFamily* family = group.itemFamily();
+  ItemTypeMng* item_type_mng = family->mesh()->itemTypeMng();
+  ITraceMng* tm = family->traceMng();
+
+  // Pour GMSH, il faut trier les mailles par leur type (Triangle, Quadrangle, ...)
+  // On fait une entity MSH par type d'entité Arcane.
+
+  ENUMERATE_ (Item, iitem, group) {
+    Item item = *iitem;
+    Int16 item_type = item.type();
+    if (item_type >= NB_BASIC_ITEM_TYPE || item_type <= 0)
+      ARCANE_FATAL("Only pre-defined Item type are supported (current item type is '{0}')",
+                   item_type_mng->typeFromId(item_type)->typeName());
+    m_items_by_type[item_type].add(item.localId());
+  }
+
+  // Conserve les types pré-définis qui ont des éléments
+  Int64 total_nb_item = 0;
+  for (Int32 i = 0; i < NB_BASIC_ITEM_TYPE; ++i) {
+    Int64 nb_type = m_items_by_type[i].size();
+    if (nb_type > 0)
+      m_existing_items_type.add(i);
+    total_nb_item += nb_type;
+  }
+
+  Int32 nb_existing_type = m_existing_items_type.size();
+  tm->info() << "NbExistingType=" << nb_existing_type;
+  for (Int32 type_index = 0; type_index < nb_existing_type; ++type_index) {
+    Int32 item_type = m_existing_items_type[type_index];
+    ItemTypeInfo* item_type_info = item_type_mng->typeFromId(item_type);
+    Int32 type_dimension = item_type_info->dimension();
+    m_entities_by_type.add(EntityInfo{ type_dimension, item_type, base_entity_index + type_index });
+    //++nb_entities_by_dim[type_dimension];
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -172,9 +245,9 @@ _writeMeshToFileV4(IMesh* mesh, const String& file_name)
   std::ofstream ofile(mshFileName.localstr());
   ofile.precision(20);
   if (!ofile)
-    throw IOException("VtkMeshIOService::writeMeshToFile(): Unable to open file");
+    ARCANE_THROW(IOException, "Unable to open file '{0}' for writing", mshFileName);
 
-  info() << "[writNodes=" << mesh->nbNode() << " nCells=" << mesh->nbCell();
+  info() << "writing file '" << mshFileName << "'";
 
   ofile << "$MeshFormat\n";
   // 4.1 pour le format
@@ -189,44 +262,57 @@ _writeMeshToFileV4(IMesh* mesh, const String& file_name)
   IItemFamily* node_family = mesh->nodeFamily();
   ItemGroup all_nodes = mesh->allNodes();
 
+  UniqueArray<ItemGroup> items_groups;
+  // Parcours tous les groupes
+  // NOTE: Pour l'instant on suppose que cela forme une partition
+  // du maillage.
+  for (ItemGroup group : cell_family->groups()) {
+    if (group.isAllItems())
+      continue;
+    if (group.isAutoComputed())
+      continue;
+    info() << "Processing ItemGroup group=" << group.name() << " family=" << group.itemFamily()->name();
+    items_groups.add(group);
+  }
+  // Si pas de groupes, on prend celui de toutes les mailles
+  // TODO: toujours prendre ce groupe pour les entités qui n'auraient pas
+  // été traitées par les autres groupes lorsqu'on n'est pas sur
+  // que l'ensemble des groupes forme une partition.
+  if (items_groups.empty())
+    items_groups.add(cell_family->allItems());
+
+  std::vector<std::unique_ptr<ItemGroupWriteInfo>> groups_write_info_list;
+  Int32 base_entity_index = 1000;
+  for (ItemGroup group : items_groups) {
+    auto x(std::make_unique<ItemGroupWriteInfo>());
+    x->processGroup(group, base_entity_index);
+    groups_write_info_list.emplace_back(std::move(x));
+    base_entity_index += 1000;
+  }
+
   // Pour GMSH, il faut commencer par les 'Entities'.
   // Il faut une entité par type de maille.
   // On commence donc par calculer les types de mailles.
   // Pour les maillages non-manifold les mailles peuvent être de dimension
   // différentes
-  FixedArray<EntityInfo, NB_BASIC_ITEM_TYPE> entities_by_type;
 
-  // Pour GMSH, il faut trier les mailles par leur type (Triangle, Quadrangle, ...)
-  // On fait une entity par type de maille.
-  FixedArray<UniqueArray<Int32>, NB_BASIC_ITEM_TYPE> cells_by_type;
-  ENUMERATE_ (Cell, icell, all_cells) {
-    Cell cell = *icell;
-    Int16 cell_type = cell.type();
-    if (cell_type >= NB_BASIC_ITEM_TYPE || cell_type <= 0)
-      ARCANE_FATAL("Only pre-defined cell type are supported (current cell type is '{0}')",
-                   m_item_type_mng->typeFromId(cell_type));
-    cells_by_type[cell_type].add(cell.localId());
-  }
-
+  // Calcule le nombre d'entités par dimension
   FixedArray<Int32, 4> nb_entities_by_dim;
 
-  // Conserve les types pré-définis qui ont des éléments
-  UniqueArray<Int32> existing_cells_type;
+  // Calcule le nombre total d'éléments.
+  // Toutes les entités qui ne sont pas de dimension 0 sont des éléments.
   Int64 total_nb_cell = 0;
-  for (Int32 i = 0; i < NB_BASIC_ITEM_TYPE; ++i) {
-    Int64 nb_type = cells_by_type[i].size();
-    if (nb_type > 0)
-      existing_cells_type.add(i);
-    total_nb_cell += nb_type;
-  }
-  Int32 nb_existing_type = existing_cells_type.size();
-  info() << "NbExistingType=" << nb_existing_type;
-  for (Int32 type_index = 0; type_index < nb_existing_type; ++type_index) {
-    Int32 cell_type = existing_cells_type[type_index];
-    ItemTypeInfo* item_type_info = m_item_type_mng->typeFromId(cell_type);
-    Int32 type_dimension = item_type_info->dimension();
-    entities_by_type[cell_type] = EntityInfo{ type_dimension, cell_type, (type_index + 1) * 100 };
-    ++nb_entities_by_dim[type_dimension];
+  for (const auto& ginfo : groups_write_info_list) {
+    for (const EntityInfo& entity_info : ginfo->entitiesByType()) {
+      Int32 dim = entity_info.m_dim;
+      if (dim >= 0)
+        ++nb_entities_by_dim[dim];
+      if (dim > 0) {
+        Int32 item_type = entity_info.m_item_type;
+        Int32 nb_item = ginfo->itemsByType(item_type).size();
+        total_nb_cell += nb_item;
+      }
+    }
   }
 
   // Calcule la bounding box des noeuds
@@ -271,21 +357,25 @@ _writeMeshToFileV4(IMesh* mesh, const String& file_name)
   // $EndEntities
   {
     ofile << "$Entities\n";
-    nb_entities_by_dim[0] = 0;
+    //nb_entities_by_dim[0] = 0;
     ofile << nb_entities_by_dim[0] << " " << nb_entities_by_dim[1]
           << " " << nb_entities_by_dim[2] << " " << nb_entities_by_dim[3] << "\n";
     for (Int32 idim = 1; idim < 4; ++idim) {
-      for (Int32 k = 0; k < NB_BASIC_ITEM_TYPE; ++k) {
-        const EntityInfo& entity_info = entities_by_type[k];
-        if (entity_info.m_dim != idim)
-          continue;
-        ofile << entity_info.m_entity_tag << " " << node_min_bounding_box.x << " " << node_min_bounding_box.y << " " << node_min_bounding_box.z
-              << " " << node_max_bounding_box.x << " " << node_max_bounding_box.y << " " << node_max_bounding_box.z;
-        // Pas de tag pour l'instant
-        ofile << " 0";
-        // Pas de bounding pour l'instant
-        ofile << " 0";
-        ofile << "\n";
+      for (const auto& ginfo : groups_write_info_list) {
+        for (const EntityInfo& entity_info : ginfo->entitiesByType()) {
+          //Int32 dim = entity_info.m_dim;
+          //for (Int32 k = 0; k < NB_BASIC_ITEM_TYPE; ++k) {
+          //const EntityInfo& entity_info = entities_by_type[k];
+          if (entity_info.m_dim != idim)
+            continue;
+          ofile << entity_info.m_entity_tag << " " << node_min_bounding_box.x << " " << node_min_bounding_box.y << " " << node_min_bounding_box.z
+                << " " << node_max_bounding_box.x << " " << node_max_bounding_box.y << " " << node_max_bounding_box.z;
+          // Pas de tag pour l'instant
+          ofile << " 0";
+          // Pas de boundary pour l'instant
+          ofile << " 0";
+          ofile << "\n";
+        }
       }
     }
     ofile << "$EndEntities\n";
@@ -344,26 +434,30 @@ _writeMeshToFileV4(IMesh* mesh, const String& file_name)
   // Bloc contenant les mailles
   ofile << "$Elements\n";
 
+  Int32 nb_existing_type = nb_entities_by_dim[1] + nb_entities_by_dim[2] + nb_entities_by_dim[3];
   ofile << nb_existing_type << " " << total_nb_cell << " " << cell_min_uid << " " << cell_max_uid << "\n";
-  for (Int32 type_index = 0; type_index < nb_existing_type; ++type_index) {
-    Int32 cell_type = existing_cells_type[type_index];
-    const EntityInfo& entity_info = entities_by_type[cell_type];
-    ConstArrayView<Int32> cells_of_current_type = cells_by_type[cell_type];
-    ItemTypeInfo* item_type_info = m_item_type_mng->typeFromId(cell_type);
-    Int32 type_dimension = item_type_info->dimension();
-    ofile << "\n";
-    ofile << type_dimension << " " << entity_info.m_entity_tag << " " << _convertToMshType(cell_type)
-          << " " << cells_of_current_type.size() << "\n";
-    info() << "Writing cells of type=" << item_type_info->typeName()
-           << " n=" << cells_of_current_type.size()
-           << " dimension=" << type_dimension;
-    Int32 nb_node_for_type = item_type_info->nbLocalNode();
-    ENUMERATE_ (Cell, icell, cell_family->view(cells_of_current_type)) {
-      Cell cell = *icell;
-      ofile << cell.uniqueId();
-      for (Int32 i = 0; i < nb_node_for_type; ++i)
-        ofile << " " << cell.node(i).uniqueId();
+  for (const auto& ginfo : groups_write_info_list) {
+    for (const EntityInfo& entity_info : ginfo->entitiesByType()) {
+      //for (Int32 type_index = 0; type_index < nb_existing_type; ++type_index) {
+      Int32 cell_type = entity_info.m_item_type; //existing_cells_type[type_index];
+      //const EntityInfo& entity_info = entities_by_type[cell_type];
+      ConstArrayView<Int32> cells_of_current_type = ginfo->itemsByType(cell_type);
+      ItemTypeInfo* item_type_info = m_item_type_mng->typeFromId(cell_type);
+      Int32 type_dimension = entity_info.m_dim;
       ofile << "\n";
+      ofile << type_dimension << " " << entity_info.m_entity_tag << " " << _convertToMshType(cell_type)
+            << " " << cells_of_current_type.size() << "\n";
+      info() << "Writing cells of type=" << item_type_info->typeName()
+             << " n=" << cells_of_current_type.size()
+             << " dimension=" << type_dimension;
+      Int32 nb_node_for_type = item_type_info->nbLocalNode();
+      ENUMERATE_ (Cell, icell, cell_family->view(cells_of_current_type)) {
+        Cell cell = *icell;
+        ofile << cell.uniqueId();
+        for (Int32 i = 0; i < nb_node_for_type; ++i)
+          ofile << " " << cell.node(i).uniqueId();
+        ofile << "\n";
+      }
     }
   }
   ofile << "$EndElements\n";


### PR DESCRIPTION
At the moment, the `CellGroup` have to be a partition of the mesh.