### PR TITLE
Rename name of services for reading and writing MSH files

### DIFF
--- a/arcane/src/arcane/std/MshMeshReader.cc
+++ b/arcane/src/arcane/std/MshMeshReader.cc
@@ -1235,8 +1235,13 @@ class MshMeshReaderService
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+// Obsolète. Utiliser 'MshMeshReader' à la place
 ARCANE_REGISTER_SERVICE(MshMeshReaderService,
                         ServiceProperty("MshNewMeshReader", ST_SubDomain),
+                        ARCANE_SERVICE_INTERFACE(IMeshReader));
+
+ARCANE_REGISTER_SERVICE(MshMeshReaderService,
+                        ServiceProperty("MshMeshReader", ST_SubDomain),
                         ARCANE_SERVICE_INTERFACE(IMeshReader));
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/std/MshMeshWriter.cc
+++ b/arcane/src/arcane/std/MshMeshWriter.cc
@@ -136,7 +136,12 @@ class MshMeshWriter
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+// Obsolète. Utiliser 'MshMeshReader' à la place
 ARCANE_REGISTER_SUB_DOMAIN_FACTORY(MshMeshWriter, IMeshWriter, MshNewMeshWriter);
+
+ARCANE_REGISTER_SERVICE(MshMeshWriter,
+                        ServiceProperty("MshMeshWriter", ST_SubDomain),
+                        ARCANE_SERVICE_INTERFACE(IMeshWriter));
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/test-CasePartVtu.sh.in
+++ b/arcane/src/arcane/tests/test-CasePartVtu.sh.in
@@ -4,4 +4,4 @@
 #@ARCANEBUILDROOT@/bin/arcane_partition_mesh -n 2 -p 4 --writer Lima --correspondance -f 1 --output-file-pattern "CPU%05d.mli" tube5x5x100.vtk && @ARCANE_TEST_DRIVER@ launch -n 4 -m 2 @TEST_PATH@/testHydro-5-vtk.arc
 
 # TODO: générer cela dans un répertoire spécifique
-@ARCANEBUILDROOT@/bin/arcane_partition_mesh -n 2 -p 4 --writer MshNewMeshWriter -f 0 --output-file-pattern "CPU%05d.msh" tube5x5x100.vtk && @ARCANE_TEST_DRIVER@ launch -n 4 -m 100 @TEST_PATH@/testHydro-5-msh.arc
+@ARCANEBUILDROOT@/bin/arcane_partition_mesh -n 2 -p 4 --writer MshMeshWriter -f 0 --output-file-pattern "CPU%05d.msh" tube5x5x100.vtk && @ARCANE_TEST_DRIVER@ launch -n 4 -m 100 @TEST_PATH@/testHydro-5-msh.arc

--- a/arcane/tests/testMesh-2-non-manifold-write-msh.arc
+++ b/arcane/tests/testMesh-2-non-manifold-write-msh.arc
@@ -16,7 +16,7 @@
   <unit-test-module>
     <test name="MeshUnitTest">
       <create-edges>true</create-edges>
-      <write-mesh-service-name>MshNewMeshWriter</write-mesh-service-name>
+      <write-mesh-service-name>MshMeshWriter</write-mesh-service-name>
     </test>
   </unit-test-module>
 </case>


### PR DESCRIPTION
Rename `MshNewMeshReader` to `MshMeshReader` and `MshNewMeshWriter` to `MshMeshWriter`.
The old name is still available for compatibility.