### PR TITLE
Add support for external partitioner in `ArcaneCaseMeshService`

### DIFF
--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.axl
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.axl
@@ -9,6 +9,11 @@
     à partir du fichier spécifié. Si c'est `&lt;generator&gt;`, alors le
     maillage sera généré directement en ligne à partir d'un des
     générateurs disponible dans %Arcane.
+
+    La balise `&lt;partitioner;&gt;` indique le partitionneur à utiliser pour
+    le partitionnement initial. La valeur `External` permet d'indiquer que le partitionnement
+    a déjà été fait. Dans ce cas, les fichiers de maillage seront de la
+    forme 'CPU...%n' avec N le numéro de la partie du maillage.
   </description>
     
   <interface name="Arcane::ICaseMeshService" />

--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
@@ -224,26 +224,40 @@ _checkMeshCreationAndAllocation(bool is_check_allocated)
 void ArcaneCaseMeshService::
 _fillReadInfo(CaseMeshReaderReadInfo& read_info)
 {
-  read_info.setFileName(m_mesh_file_name);
-
+  // Cherche l'extension du fichier.
+  String file_extension;
   {
-    String extension;
-    // Cherche l'extension du fichier et la conserve dans \a case_ext
     std::string_view fview = m_mesh_file_name.toStdStringView();
     std::size_t extension_pos = fview.find_last_of('.');
     if (extension_pos!=std::string_view::npos){
       fview.remove_prefix(extension_pos+1);
-      extension = fview;
+      file_extension = fview;
     }
-    read_info.setFormat(extension);
+    read_info.setFormat(file_extension);
   }
+
+  // Nom du maillage à utiliser pour la lecture
+  // Normalement c'est le nom du maillage dans le jeu de données
+  // sauf en cas d'utilisation du partitionneur externe auquel cas
+  // c'est 'CPU%05d.$file_extension'.
+  String mesh_file_name = m_mesh_file_name;
 
   String partitioner_name = options()->partitioner();
   bool use_internal_partitioner = partitioner_name != "External";
-  if (use_internal_partitioner)
+  if (use_internal_partitioner){
     m_partitioner_name = partitioner_name;
+  }
+  else{
+    info() << "Using external partitioner";
+    int mesh_rank = m_sub_domain->parallelMng()->commRank();
+    char buf[128];
+    sprintf(buf,"CPU%05d.%s",mesh_rank,file_extension.localstr());
+    mesh_file_name = String(std::string_view(buf));
+  }
 
-  info() << "Mesh filename=" << m_mesh_file_name
+  read_info.setFileName(mesh_file_name);
+
+  info() << "Mesh filename=" << mesh_file_name
          << " extension=" << read_info.format() << " partitioner=" << partitioner_name;
 
   read_info.setParallelRead(use_internal_partitioner);

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -281,8 +281,6 @@ arcane_copy_mesh(tied_interface_2d_1_v4.2 tied_interface_2d_1_v4.2 vtk)
 arcane_copy_mesh(sphere_v4.2 sphere_v4.2 vtk)
 arcane_copy_mesh(sphere_v4.2_binary sphere_v4.2_binary vtk)
 
-configure_file(test-CasePartVtu.sh.in ${ARCANE_TEST_PATH}/test-CasePartVtu.sh)
-
 # Copie le répertoire des données dans le répertoire d'exécution des tests
 # Cela est nécessaire pour certains cas comme ceux faisant une reprise
 # depuis une ancienne version de Arcane
@@ -1081,8 +1079,16 @@ if(GEOMETRYKERNEL_FOUND)
 endif()
 
 if(UNIX AND MPI_FOUND)
+  set(CASE_PART_TEST_FILE "${TEST_PATH}/testHydro-5-msh.arc")
+  configure_file(test-CasePartVtu.sh.in ${ARCANE_TEST_PATH}/test-CasePartVtu1.sh)
   add_test(NAME partition_mesh_msh
-    COMMAND ${ARCANE_TEST_PATH}/test-CasePartVtu.sh
+    COMMAND ${ARCANE_TEST_PATH}/test-CasePartVtu1.sh
+    WORKING_DIRECTORY "${ARCANE_TEST_WORKDIR}"
+  )
+  set(CASE_PART_TEST_FILE "${TEST_PATH}/testHydro-5-meshservice-msh.arc")
+  configure_file(test-CasePartVtu.sh.in ${ARCANE_TEST_PATH}/test-CasePartVtu2.sh)
+  add_test(NAME partition_mesh_meshservice_msh
+    COMMAND ${ARCANE_TEST_PATH}/test-CasePartVtu2.sh
     WORKING_DIRECTORY "${ARCANE_TEST_WORKDIR}"
   )
 endif()

--- a/arcane/src/arcane/tests/test-CasePartVtu.sh.in
+++ b/arcane/src/arcane/tests/test-CasePartVtu.sh.in
@@ -4,4 +4,4 @@
 #@ARCANEBUILDROOT@/bin/arcane_partition_mesh -n 2 -p 4 --writer Lima --correspondance -f 1 --output-file-pattern "CPU%05d.mli" tube5x5x100.vtk && @ARCANE_TEST_DRIVER@ launch -n 4 -m 2 @TEST_PATH@/testHydro-5-vtk.arc
 
 # TODO: générer cela dans un répertoire spécifique
-@ARCANEBUILDROOT@/bin/arcane_partition_mesh -n 2 -p 4 --writer MshMeshWriter -f 0 --output-file-pattern "CPU%05d.msh" tube5x5x100.vtk && @ARCANE_TEST_DRIVER@ launch -n 4 -m 100 @TEST_PATH@/testHydro-5-msh.arc
+@ARCANEBUILDROOT@/bin/arcane_partition_mesh -n 2 -p 4 --writer MshMeshWriter -f 0 --output-file-pattern "CPU%05d.msh" tube5x5x100.vtk && @ARCANE_TEST_DRIVER@ launch -n 4 -m 100 @CASE_PART_TEST_FILE@

--- a/arcane/tests/testHydro-5-meshservice-msh.arc
+++ b/arcane/tests/testHydro-5-meshservice-msh.arc
@@ -1,0 +1,115 @@
+<?xml version="1.0"?>
+<case codename="ArcaneTest" xml:lang="en" codeversion="1.0">
+ <arcane>
+  <title>Tube a choc de Sod</title>
+  <timeloop>ArcaneHydroLoop</timeloop>
+ </arcane>
+
+  <meshes>
+    <mesh>
+      <filename>tube5x5x100.msh</filename>
+      <partitioner>External</partitioner>
+      <initialization>
+        <variable><name>Density</name><value>1.0</value><group>ZG</group></variable>
+        <variable><name>Density</name><value>0.125</value><group>ZD</group></variable>
+
+        <variable><name>Pressure</name><value>1.0</value><group>ZG</group></variable>
+        <variable><name>Pressure</name><value>0.1</value><group>ZD</group></variable>
+
+        <variable><name>AdiabaticCst</name><value>1.4</value><group>ZG</group></variable>
+        <variable><name>AdiabaticCst</name><value>1.4</value><group>ZD</group></variable>
+      </initialization>
+    </mesh>
+  </meshes>
+
+<!--   <mesh>
+
+  <file format='msh'>tube5x5x100.msh</file>
+
+  <initialisation>
+    <variable nom="Density" valeur="1." groupe="ZG" />
+    <variable nom="Pressure" valeur="1." groupe="ZG" />
+    <variable nom="AdiabaticCst" valeur="1.4" groupe="ZG" />
+    <variable nom="Density" valeur="0.125" groupe="ZD" />
+    <variable nom="Pressure" valeur="0.1" groupe="ZD" />
+    <variable nom="AdiabaticCst" valeur="1.4" groupe="ZD" />
+  </initialisation>
+ </mesh> -->
+
+ <arcane-post-processing>
+   <output-period>5</output-period>
+   <!-- <format name="EnsightHdfPostProcessor" /> -->
+   <output>
+    <variable>CellMass</variable>
+    <variable>CellVolume</variable>
+    <variable>Pressure</variable>
+    <variable>Density</variable>
+    <variable>Velocity</variable>
+    <variable>NodeMass</variable>
+    <variable>InternalEnergy</variable>
+    <group>ZG</group>
+    <group>ZD</group>
+    <group>AllFaces</group>
+    <group>XMIN</group>
+    <group>XMAX</group>
+    <group>YMIN</group>
+    <group>YMAX</group>
+    <group>ZMIN</group>
+    <group>ZMAX</group>
+   </output>
+   <!-- <ensight7gold>
+    <binary-file>true</binary-file>
+   </ensight7gold>-->
+ </arcane-post-processing>
+ <arcane-checkpoint>
+   <checkpoint-service name="ArcaneBasicCheckpointWriter" />
+   <do-dump-at-end>true</do-dump-at-end>
+ </arcane-checkpoint>
+
+ <!-- Configuration du module hydrodynamique -->
+ <simple-hydro>
+
+   <!-- <deltat-init>   0.0000001   </deltat-init>
+   <deltat-min>    0.00000001   </deltat-min>
+   <deltat-max>    0.000001   </deltat-max> -->
+   <deltat-init>   0.001   </deltat-init>
+   <deltat-min>    0.0001   </deltat-min>
+   <deltat-max>    0.01   </deltat-max>
+   <final-time>     0.2    </final-time>
+
+  <viscosity>cell</viscosity>
+  <viscosity-linear-coef>    .5    </viscosity-linear-coef>
+  <viscosity-quadratic-coef> .6    </viscosity-quadratic-coef>
+
+  <boundary-condition>
+    <surface>XMIN</surface><type>Vx</type><value>0.</value>
+  </boundary-condition>
+  <boundary-condition>
+    <surface>XMAX</surface><type>Vx</type><value>0.</value>
+  </boundary-condition>
+  <boundary-condition>
+    <surface>YMIN</surface><type>Vy</type><value>0.</value>
+  </boundary-condition>
+  <boundary-condition>
+    <surface>YMAX</surface><type>Vy</type><value>0.</value>
+  </boundary-condition>
+  <boundary-condition>
+    <surface>ZMIN</surface><type>Vz</type><value>0.</value>
+  </boundary-condition>
+  <boundary-condition>
+    <surface>ZMAX</surface><type>Vz</type><value>0.</value>
+  </boundary-condition>
+ </simple-hydro>
+
+ <load-balance>
+   <active>true</active>
+   <!-- <library>Metis</library> -->
+   <library>MeshPartitionerTester</library>
+   <period>1</period>
+   <statistics>true</statistics>
+   <max-imbalance>0.01</max-imbalance>
+   <min-cpu-time>5</min-cpu-time>
+ </load-balance>
+
+
+</case>


### PR DESCRIPTION
Before that, the external partitioning was only available with legacy mesh tag in case files.
