### PR TITLE
Minor improvement in mesh utils scripts

### DIFF
--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CommandArgs.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/CommandArgs.cs
@@ -1,0 +1,120 @@
+//-----------------------------------------------------------------------------
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace Arcane.ExecDrivers.Common
+{
+  //! Lecteur des arguments de la ligne de commande
+  public class CommandArgs
+  {
+    public int NbProc;
+    public int NbThreadPerProcess;
+    public int NbTaskPerProcess;
+    public int NbReplication;
+    public int MaxIteration;
+    public int NbContinue;
+
+    public bool UseDotNet;
+    public string DotNetRuntime = "coreclr";
+    public string DotNetAssembly;
+    public string DotNetUserCompile;
+    public string DotNetUserOutputDll;
+    public string[] ParallelArgs;
+
+    public string DebugTool;
+
+    public string[] RemainingArguments;
+    public string ExecName;
+    public string DirectExecMethod;
+    public CommandArgs()
+    {
+      RemainingArguments = new string[0];
+    }
+
+    public void ParseArgs(string[] args, Mono.Options.OptionSet additional_options)
+    {
+      List<string> parallel_args = new List<string>();
+      foreach (string s in args) {
+        Console.WriteLine("PARSING ARG '{0}'", s);
+      }
+      List<string> additional_args = new List<string>();
+      Mono.Options.OptionSet opt_set = new Mono.Options.OptionSet();
+      bool show_help = false;
+      NbTaskPerProcess = -1;
+      opt_set.Add("h|help|?", "ce message d'aide", (v) => show_help = v != null);
+      opt_set.Add("n|nb-proc=", "nombre de processeurs", (int v) => NbProc = v);
+      opt_set.Add("T|threads=", "nombre de sous-domaines geres par les threads par processus", (int v) => NbThreadPerProcess = v);
+      opt_set.Add("K|tasks=", "nombre de thread par processus pour gerer les taches", (int v) => NbTaskPerProcess = v);
+      opt_set.Add("m|max-iteration=", "nombre d'itérations à effectuer", (int v) => MaxIteration = v);
+      opt_set.Add("c|nb-continue=", "nombre de reprises", (int v) => NbContinue = v);
+      opt_set.Add("C|build-config=", "configuration de build à utiliser (Debug, Release, ...)", (string v) => Utils.OutDir = v);
+      opt_set.Add("Z|dotnet", "indique un cas .NET", (v) => UseDotNet = true);
+      opt_set.Add("dotnet-runtime=", "nom du runtime '.Net' à utiliser (mono|coreclr)", (string v) => DotNetRuntime = v);
+      opt_set.Add("dotnet-assembly=", "nom complet de l'assembly '.Net' à charger au démarrage", (string v) => DotNetAssembly = v);
+      opt_set.Add("dotnet-compile=", "liste de fichiers C# à compiler", (string v) => DotNetUserCompile = v);
+      opt_set.Add("dotnet-output-dll=", "chemin et nom du fichier .dll généré", (string v) => DotNetUserOutputDll = v);
+      opt_set.Add("P|parallelarg=", "option passee au gestionnaire parallele", (string v) => parallel_args.Add(v));
+      opt_set.Add("d|debugtool=", "outil de debug (tv,gdb,memcheck,...)", (string v) => DebugTool = v);
+      opt_set.Add("R|replication=", "nombre de replication de sous-domaines", (int v) => NbReplication = v);
+      opt_set.Add("D|direct-method=", "méthode à lancer en exécution directe",(string v) => DirectExecMethod = v);
+      opt_set.Add("E|exec-name=", "nom de l'exécutable de test (sans extension ni chemin)", (string v) => ExecName = v);
+      opt_set.Add("W=", "paramètres spécifiques:\n-We,VARIABLE,VALUE pour spécifier" +
+                  "la variable d'environnement VARIABLE avec la valeur VALUE.\n" +
+                  "-Wp,ARG1,ARG2,... pour spécifier des paramètres pour le lanceur parallèle", (string v) => additional_args.Add(v));
+      if (additional_options != null) {
+        foreach (Mono.Options.Option opt in additional_options)
+          opt_set.Add(opt);
+      }
+      List<string> remaining_args = opt_set.Parse(args);
+      foreach (string s in remaining_args) {
+        Console.WriteLine("REMAINING ARG '{0}'", s);
+      }
+
+      RemainingArguments = remaining_args.ToArray();
+
+      if (show_help) {
+        Console.WriteLine("Options:");
+        opt_set.WriteOptionDescriptions(Console.Out);
+        Environment.Exit(0);
+      }
+      string env_parallel_args = Utils.GetEnvironmentVariable("ARCANE_PARALLEL_ARGS");
+      if (!String.IsNullOrEmpty(env_parallel_args)) {
+        parallel_args.AddRange(env_parallel_args.Split(new char[] { ' ' }));
+      }
+      foreach (string s in additional_args) {
+        Console.WriteLine("ADDITIONAL_ARG = '{0}'", s);
+        string[] vals = s.Split(',');
+        if (vals.Length <= 1) {
+          Console.WriteLine("Invalid value for argument '-W' : '{0}'", s);
+          continue;
+        }
+        string val0 = vals[0];
+        if (val0.Length != 1) {
+          Console.WriteLine("Invalid value '{0}' in '{1}'", val0, s);
+        }
+        char t = val0[0];
+        if (t == 'e') {
+          if (vals.Length != 3) {
+            Console.WriteLine("Invalid option '{0}' : valid form is e,VARIABLE,VALUE", s);
+          }
+          else {
+            Utils.SetEnvironmentVariable(vals[1], vals[2]);
+          }
+        }
+        else if (t == 'p') {
+          for (int z = 1; z < vals.Length; ++z)
+            parallel_args.Add(vals[z]);
+        }
+      }
+
+      ParallelArgs = parallel_args.ToArray();
+      foreach (string s in remaining_args) {
+        Console.WriteLine("REMAINING ARG (2) '{0}'", s);
+      }
+    }
+  }
+}

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
@@ -50,6 +50,7 @@ namespace Arcane.ExecDrivers.Common
 
     public delegate void AddAdditionalArgsCallback(ExecDriver driver);
 
+    //! Arguments additionnels. Ils doivent être positionnés lors de l'évènement OnAddAdditionalArgs.
     public List<string> AdditionalArgs;
 
     public event AddAdditionalArgsCallback OnAddAdditionalArgs;
@@ -65,7 +66,6 @@ namespace Arcane.ExecDrivers.Common
     public void ParseArgs(string[] args, Mono.Options.OptionSet additional_options)
     {
       AdditionalArgs = new List<string>();
-
       CommandArgs command_args = new CommandArgs();
       m_command_args = command_args;
       command_args.ParseArgs(args, additional_options);
@@ -380,11 +380,13 @@ namespace Arcane.ExecDrivers.Common
           if (String.IsNullOrEmpty(env_parallel_service))
             args.Add("-A,MessagePassingService=Sequential");
         }
+
         if (OnAddAdditionalArgs != null)
           OnAddAdditionalArgs(this);
         args.AddRange(AdditionalArgs);
         args.AddRange(m_remaining_args);
         string args_str = String.Join(" ", args.ToArray());
+
         int r = 0;
         if (m_use_dotnet && want_dotnet_shared && m_properties.NbProc == 0) {
           Console.WriteLine("Launching '.Net' sequential test");

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriver.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -11,117 +11,6 @@ using System.Text;
 
 namespace Arcane.ExecDrivers.Common
 {
-  //! Lecteur des arguments de la ligne de commande
-  public class CommandArgs
-  {
-    public int NbProc;
-    public int NbThreadPerProcess;
-    public int NbTaskPerProcess;
-    public int NbReplication;
-    public int MaxIteration;
-    public int NbContinue;
-
-    public bool UseDotNet;
-    public string DotNetRuntime = "coreclr";
-    public string DotNetAssembly;
-    public string DotNetUserCompile;
-    public string DotNetUserOutputDll;
-    public string[] ParallelArgs;
-    public string[] AdditionalArgs;
-
-    public string DebugTool;
-
-    public string[] RemainingArguments;
-    public string ExecName;
-    public string DirectExecMethod;
-    public CommandArgs()
-    {
-      RemainingArguments = new string[0];
-    }
-
-    public void ParseArgs(string[] args, Mono.Options.OptionSet additional_options)
-    {
-      List<string> parallel_args = new List<string>();
-      foreach (string s in args) {
-        Console.WriteLine("PARSING ARG '{0}'", s);
-      }
-      List<string> additional_args = new List<string>();
-      Mono.Options.OptionSet opt_set = new Mono.Options.OptionSet();
-      bool show_help = false;
-      NbTaskPerProcess = -1;
-      opt_set.Add("h|help|?", "ce message d'aide", (v) => show_help = v != null);
-      opt_set.Add("n|nb-proc=", "nombre de processeurs", (int v) => NbProc = v);
-      opt_set.Add("T|threads=", "nombre de sous-domaines geres par les threads par processus", (int v) => NbThreadPerProcess = v);
-      opt_set.Add("K|tasks=", "nombre de thread par processus pour gerer les taches", (int v) => NbTaskPerProcess = v);
-      opt_set.Add("m|max-iteration=", "nombre d'itérations à effectuer", (int v) => MaxIteration = v);
-      opt_set.Add("c|nb-continue=", "nombre de reprises", (int v) => NbContinue = v);
-      opt_set.Add("C|build-config=", "configuration de build à utiliser (Debug, Release, ...)", (string v) => Utils.OutDir = v);
-      opt_set.Add("Z|dotnet", "indique un cas .NET", (v) => UseDotNet = true);
-      opt_set.Add("dotnet-runtime=", "nom du runtime '.Net' à utiliser (mono|coreclr)", (string v) => DotNetRuntime = v);
-      opt_set.Add("dotnet-assembly=", "nom complet de l'assembly '.Net' à charger au démarrage", (string v) => DotNetAssembly = v);
-      opt_set.Add("dotnet-compile=", "liste de fichiers C# à compiler", (string v) => DotNetUserCompile = v);
-      opt_set.Add("dotnet-output-dll=", "chemin et nom du fichier .dll généré", (string v) => DotNetUserOutputDll = v);
-      opt_set.Add("P|parallelarg=", "option passee au gestionnaire parallele", (string v) => parallel_args.Add(v));
-      opt_set.Add("d|debugtool=", "outil de debug (tv,gdb,memcheck,...)", (string v) => DebugTool = v);
-      opt_set.Add("R|replication=", "nombre de replication de sous-domaines", (int v) => NbReplication = v);
-      opt_set.Add("D|direct-method=", "méthode à lancer en exécution directe",(string v) => DirectExecMethod = v);
-      opt_set.Add("E|exec-name=", "nom de l'exécutable de test (sans extension ni chemin)", (string v) => ExecName = v);
-      opt_set.Add("W=", "paramètres spécifiques:\n-We,VARIABLE,VALUE pour spécifier" +
-                  "la variable d'environnement VARIABLE avec la valeur VALUE.\n" +
-                  "-Wp,ARG1,ARG2,... pour spécifier des paramètres pour le lanceur parallèle", (string v) => additional_args.Add(v));
-      if (additional_options != null) {
-        foreach (Mono.Options.Option opt in additional_options)
-          opt_set.Add(opt);
-      }
-      List<string> remaining_args = opt_set.Parse(args);
-      foreach (string s in remaining_args) {
-        Console.WriteLine("REMAINING ARG '{0}'", s);
-      }
-
-      RemainingArguments = remaining_args.ToArray();
-
-      if (show_help) {
-        Console.WriteLine("Options:");
-        opt_set.WriteOptionDescriptions(Console.Out);
-        Environment.Exit(0);
-      }
-      string env_parallel_args = Utils.GetEnvironmentVariable("ARCANE_PARALLEL_ARGS");
-      if (!String.IsNullOrEmpty(env_parallel_args)) {
-        parallel_args.AddRange(env_parallel_args.Split(new char[] { ' ' }));
-      }
-      foreach (string s in additional_args) {
-        Console.WriteLine("ADDITIONAL_ARG = '{0}'", s);
-        string[] vals = s.Split(',');
-        if (vals.Length <= 1) {
-          Console.WriteLine("Invalid value for argument '-W' : '{0}'", s);
-          continue;
-        }
-        string val0 = vals[0];
-        if (val0.Length != 1) {
-          Console.WriteLine("Invalid value '{0}' in '{1}'", val0, s);
-        }
-        char t = val0[0];
-        if (t == 'e') {
-          if (vals.Length != 3) {
-            Console.WriteLine("Invalid option '{0}' : valid form is e,VARIABLE,VALUE", s);
-          }
-          else {
-            Utils.SetEnvironmentVariable(vals[1], vals[2]);
-          }
-        }
-        else if (t == 'p') {
-          for (int z = 1; z < vals.Length; ++z)
-            parallel_args.Add(vals[z]);
-        }
-      }
-
-      ParallelArgs = parallel_args.ToArray();
-      foreach (string s in remaining_args) {
-        Console.WriteLine("REMAINING ARG (2) '{0}'", s);
-      }
-    }
-  }
-
   public interface ICustomExecDriver
   {
     string Name { get; }
@@ -137,27 +26,6 @@ namespace Arcane.ExecDrivers.Common
     /// A <see cref="System.Boolean"/>
     /// </returns>
     bool HandleMpiLauncher(ExecDriverProperties p, string mpi_launcher);
-  }
-
-  public class ExecDriverProperties
-  {
-    public string ExecName { get; internal set; }
-    public int NbProc { get; internal set; }
-    public int NbIteration { get; internal set; }
-    public int NbContinue { get; internal set; }
-    public int NbSharedMemorySubDomain { get; internal set; }
-    public int NbTaskPerProcess { get; internal set; }
-    public int NbReplication { get; internal set; }
-    public bool UseTotalview { get; set; }
-    public bool UseDdt { get; set; }
-    public string DirectExecMethod { get; set; }
-    public List<string> MpiLauncherArgs;
-    public string MpiLauncher;
-    public ExecDriverProperties()
-    {
-      MpiLauncherArgs = new List<string>();
-      ExecName = "arcane_tests_exec";
-    }
   }
 
   public class ExecDriver

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriverProperties.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.Common/ExecDriverProperties.cs
@@ -1,0 +1,30 @@
+//-----------------------------------------------------------------------------
+// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+using System.Collections.Generic;
+
+namespace Arcane.ExecDrivers.Common
+{
+  public class ExecDriverProperties
+  {
+    public string ExecName { get; internal set; }
+    public int NbProc { get; internal set; }
+    public int NbIteration { get; internal set; }
+    public int NbContinue { get; internal set; }
+    public int NbSharedMemorySubDomain { get; internal set; }
+    public int NbTaskPerProcess { get; internal set; }
+    public int NbReplication { get; internal set; }
+    public bool UseTotalview { get; set; }
+    public bool UseDdt { get; set; }
+    public string DirectExecMethod { get; set; }
+    public List<string> MpiLauncherArgs;
+    public string MpiLauncher;
+    public ExecDriverProperties()
+    {
+      MpiLauncherArgs = new List<string>();
+      ExecName = "arcane_tests_exec";
+    }
+  }
+}

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.MeshUtilsDriver/MeshUtilsDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.MeshUtilsDriver/MeshUtilsDriver.cs
@@ -16,7 +16,7 @@ namespace Arcane.ExecDrivers.MeshUtilsDriver
     {
       void _ErrorArg(string msg)
       {
-        Console.WriteLine("ERREUR:{0}",msg);
+        Console.WriteLine("ERROR: {0}", msg);
         Environment.Exit(1);
       }
       public int Execute(List<string> remaining_args)
@@ -24,9 +24,9 @@ namespace Arcane.ExecDrivers.MeshUtilsDriver
         // Il faut mettre les arguments additionels au debut pour etre sur qu'il
         // se trouve avant le fichier de maillage a partitionner (qui doit etre le dernier argument)
         string test_path = Arcane.ExecDrivers.Common.Utils.GetTestPath();
-        string exec_name = Path.Combine(test_path,"arcane_driver");
-        remaining_args.InsertRange(0,new string[]{ "--exec-name", exec_name,"-arcane_opt","direct_exec","ArcaneCasePartitioner"});
-        Arcane.ExecDrivers.Common.ExecDriver exec_driver = new Arcane.ExecDrivers.Common.ExecDriver();
+        string exec_name = Path.Combine(test_path, "arcane_driver");
+        remaining_args.InsertRange(0,new string[]{ "--exec-name", exec_name});
+        ExecDriver exec_driver = new ExecDriver();
         Mono.Options.OptionSet opt_set = new Mono.Options.OptionSet();
         int nb_part = 0;
         int nb_ghost = 0;
@@ -35,49 +35,56 @@ namespace Arcane.ExecDrivers.MeshUtilsDriver
         string mesh_writer_name = Utils.ReadConfig("DefaultMeshWriter");
         string output_file_pattern = null;
         List<string> constrained_groups = new List<string>();
-        opt_set.Add("p|parties|nb-part=","nombre de parties a decouper",(int v) => nb_part= v);
-        opt_set.Add("f|fantomes|nb-ghost-layer=","nombre de couches de mailles fantomes",(int v) => nb_ghost= v);
-        opt_set.Add("correspondance","genere le fichier de correspondance",(string v) => generate_correspondance_file = (v!=null));
-        opt_set.Add("I|indivisible=","groupe d'entites indivisibles",(string v) => constrained_groups.Add(v));
-        opt_set.Add("A|algorithme=","nom du partitionneur a utiliser (Metis, Zoltan ou PTScotch)",(string v) => partitioner_name = v);
-        opt_set.Add("writer|ecrivain=","nom du service pour l'ecriture des maillages decoupes",(string v) => mesh_writer_name = v);
-        opt_set.Add("output-file-pattern=","file pattern for output file (default to CPU%05d)",(string v) => output_file_pattern = v);
-        exec_driver.OnAddAdditionalArgs += delegate (ExecDriver d){
+        opt_set.Add("p|parties|nb-part=", "nombre de parties a decouper", (int v) => nb_part = v);
+        opt_set.Add("f|fantomes|nb-ghost-layer=", "nombre de couches de mailles fantomes", (int v) => nb_ghost = v);
+        opt_set.Add("correspondance", "genere le fichier de correspondance", (string v) => generate_correspondance_file = (v != null));
+        opt_set.Add("I|indivisible=", "groupe d'entites indivisibles", (string v) => constrained_groups.Add(v));
+        opt_set.Add("A|algorithme=", "nom du partitionneur a utiliser (Metis, Zoltan ou PTScotch)", (string v) => partitioner_name = v);
+        opt_set.Add("writer|ecrivain=", "nom du service pour l'ecriture des maillages decoupes", (string v) => mesh_writer_name = v);
+        opt_set.Add("output-file-pattern=", "file pattern for output file (default to CPU%05d)", (string v) => output_file_pattern = v);
+        exec_driver.OnAddAdditionalArgs += delegate (ExecDriver d)
+        {
           // Si le nombre de parties n'est pas specifie, il est egal au nombre de processeurs
-          if (nb_part==0)
+          if (nb_part == 0)
             nb_part = d.NbProc;
-          if (d.NbProc<2){
-            _ErrorArg(String.Format("le nombre de processeurs (option -n) doit etre superieur a 1 (actuellement {0})",d.NbProc));
+          if (d.NbProc < 2)
+          {
+            _ErrorArg(String.Format("le nombre de processeurs (option -n) doit etre superieur a 1 (actuellement {0})", d.NbProc));
           }
-          _AddArg(d,"nb-ghost-layer",nb_ghost.ToString());
-          _AddArg(d,"create-correspondances",generate_correspondance_file ? "1" : "0" );
-          _AddArg(d,"library",partitioner_name);
-          _AddArg(d,"nb-cut-part",nb_part.ToString());
-          if (!String.IsNullOrEmpty(output_file_pattern)){
-            _AddArg(d,"mesh-file-name-pattern",output_file_pattern);
+          d.AdditionalArgs.AddRange(new string[] { "-arcane_opt", "direct_exec", "ArcaneCasePartitioner" });
+          _AddArg(d, "nb-ghost-layer", nb_ghost.ToString());
+          _AddArg(d, "create-correspondances", generate_correspondance_file ? "1" : "0");
+          _AddArg(d, "library", partitioner_name);
+          _AddArg(d, "nb-cut-part", nb_part.ToString());
+          if (!String.IsNullOrEmpty(output_file_pattern))
+          {
+            _AddArg(d, "mesh-file-name-pattern", output_file_pattern);
           }
-          foreach(string s in constrained_groups){
-            d.AdditionalArgs.AddRange(new string[]{ "-arcane_opt","tool_arg","constraints",s });
+          foreach (string s in constrained_groups)
+          {
+            d.AdditionalArgs.AddRange(new string[] { "-arcane_opt", "tool_arg", "constraints", s });
           }
-          if (!String.IsNullOrEmpty(mesh_writer_name)){
+          if (!String.IsNullOrEmpty(mesh_writer_name))
+          {
             _AddArg(d, "writer-service-name", mesh_writer_name);
           }
         };
-        exec_driver.ParseArgs(remaining_args.ToArray(),opt_set);
+        exec_driver.ParseArgs(remaining_args.ToArray(), opt_set);
         return exec_driver.Execute();
       }
-      
-      void _AddArg(ExecDriver d,string parameter,string param_value)
+
+      void _AddArg(ExecDriver d, string parameter, string param_value)
       {
-        d.AdditionalArgs.AddRange(new string[]{ "-arcane_opt","tool_arg",parameter,param_value });
+        d.AdditionalArgs.AddRange(new string[] { "-arcane_opt", "tool_arg", parameter, param_value });
       }
     }
-    
+
     internal class MeshConvertDriver
     {
       void _ErrorArg(string msg)
       {
-        Console.WriteLine("ERREUR:{0}",msg);
+        Console.WriteLine("ERROR: {0}", msg);
+        Console.WriteLine("Usage: program --file output_file --writer write_service input_file");
         Environment.Exit(1);
       }
       public int Execute(List<string> remaining_args)
@@ -85,58 +92,63 @@ namespace Arcane.ExecDrivers.MeshUtilsDriver
         // Il faut mettre les arguments additionels au debut pour etre sur qu'ils
         // se trouvent avant le fichier de maillage à convertir (qui doit etre le dernier argument)
         string test_path = Arcane.ExecDrivers.Common.Utils.GetTestPath();
-        string exec_name = Path.Combine(test_path,"arcane_driver");
-        remaining_args.InsertRange(0,new string[]{ "--exec-name",exec_name,"-arcane_opt","direct_exec","ArcaneMeshConverter"});
-        Arcane.ExecDrivers.Common.ExecDriver exec_driver = new Arcane.ExecDrivers.Common.ExecDriver();
+        string exec_name = Path.Combine(test_path, "arcane_driver");
+        remaining_args.InsertRange(0,new string[]{ "--exec-name", exec_name});
+        ExecDriver exec_driver = new ExecDriver();
         Mono.Options.OptionSet opt_set = new Mono.Options.OptionSet();
 
         string mesh_writer_name = Utils.ReadConfig("DefaultMeshWriter");
         string output_file_name = null;
-        opt_set.Add("f|fichier|file=","nom du fichier de sortie",(string v) => output_file_name = v);
-        opt_set.Add("ecrivain|writer=","nom du service pour l'écriture du maillage",(string v) => mesh_writer_name = v);
-        exec_driver.OnAddAdditionalArgs += delegate (ExecDriver d){
-          if (!String.IsNullOrEmpty(mesh_writer_name)){
+        opt_set.Add("f|fichier|file=", "nom du fichier de sortie", (string v) => output_file_name = v);
+        opt_set.Add("ecrivain|writer=", "nom du service pour l'écriture du maillage", (string v) => mesh_writer_name = v);
+        exec_driver.OnAddAdditionalArgs += delegate (ExecDriver d)
+        {
+          d.AdditionalArgs.AddRange(new string[] { "-arcane_opt", "direct_exec", "ArcaneMeshConverter" });
+          if (!String.IsNullOrEmpty(mesh_writer_name))
             _AddArg(d, "writer-service-name", mesh_writer_name);
-          }
           if (String.IsNullOrEmpty(output_file_name))
-            _ErrorArg(String.Format("le nom du fichier de sortie (option -f) n'est pas spécifié"));
-          _AddArg(d,"file-name",output_file_name);
+            _ErrorArg(String.Format("Name of output file (-f|--file) is not specified"));
+          _AddArg(d, "file-name", output_file_name);
+          if (exec_driver.RemainingArgs.Length == 0)
+            _ErrorArg(String.Format("Name of input file is not specified"));
         };
-        exec_driver.ParseArgs(remaining_args.ToArray(),opt_set);
+        exec_driver.ParseArgs(remaining_args.ToArray(), opt_set);
         return exec_driver.Execute();
       }
-      
-      void _AddArg(ExecDriver d,string parameter,string param_value)
+
+      void _AddArg(ExecDriver d, string parameter, string param_value)
       {
-        d.AdditionalArgs.AddRange(new string[]{ "-arcane_opt","tool_arg",parameter,param_value });
+        d.AdditionalArgs.AddRange(new string[] { "-arcane_opt", "tool_arg", parameter, param_value });
       }
     }
 
-    public static int MainExec (string[] args)
+    public static int MainExec(string[] args)
     {
       Arcane.ExecDrivers.Common.Utils.Init();
-      
+
       int nb_arg = args.Length;
-      if (nb_arg==0){
+      if (nb_arg == 0)
+      {
         Console.WriteLine("Usage: program partition|convert [options]");
         return (-1);
       }
       List<string> l_remaining_args = new List<string>();
-      
-      for( int i=1; i<nb_arg; ++i )
+
+      for (int i = 1; i < nb_arg; ++i)
         l_remaining_args.Add(args[i]);
       int r = 0;
-      switch(args[0]){
-      case "partition":
-        CasePartitionDriver e = new CasePartitionDriver();
-        r = e.Execute(l_remaining_args);
-         break;
-      case "convert":
-        MeshConvertDriver e2 = new MeshConvertDriver();
-        r = e2.Execute(l_remaining_args);
-        break;
-      default:
-        throw new ApplicationException(String.Format("Bad option '{0}' for driver. Valid values are 'partition' or 'convert'",args[0]));
+      switch (args[0])
+      {
+        case "partition":
+          CasePartitionDriver e = new CasePartitionDriver();
+          r = e.Execute(l_remaining_args);
+          break;
+        case "convert":
+          MeshConvertDriver e2 = new MeshConvertDriver();
+          r = e2.Execute(l_remaining_args);
+          break;
+        default:
+          throw new ApplicationException(String.Format("Bad option '{0}' for driver. Valid values are 'partition' or 'convert'", args[0]));
       }
       return r;
     }


### PR DESCRIPTION
- Add more explicit error messages if some arguments are missing.
- Use `MshMeshWriter` for default mesh writer service in no default value is available and no value is provided by the user.

Also refactor a bit and put `CommandArgs` and `ExecDriverProperties` in their own C# file.
