### PR TITLE
Disable Tiered PGO support for `.Net 9` and after

### DIFF
--- a/arcane/tools/Directory.Build.props
+++ b/arcane/tools/Directory.Build.props
@@ -34,7 +34,7 @@
     <!-- Le 'BinaryFormatter' est obsolète en '.Net 8' et supprimé en '.Net 9' -->
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
 
-    <!-- Needed with .Net 9 to prevent FPE in profiling for PGO -->
-    <TieredPGO Condition="'$(TargetFramework)'=='net9' or $(TargetFramework)=='netcoreapp9.0'">false</TieredPGO>
+    <!-- Needed with '.Net 9' and newer to prevent FPE in profiling for PGO -->
+    <TieredPGO>false</TieredPGO>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
From '.Net 9' onwards, JIT in PGO mode performs floating-point calculations which can explicitly cause FPEs. To avoid this potential problem, we disable this PGO mode all the time. In theory, this should have a slight negative impact on performance.