### PR TITLE
STDENV_VERIF : normeMax criterion

### DIFF
--- a/arcane/src/arcane/core/VariableDiff.cc
+++ b/arcane/src/arcane/core/VariableDiff.cc
@@ -65,8 +65,8 @@ dump(ConstArrayView<DiffInfo> diffs_info, IVariable* var, IParallelMng* pm, int 
              << " lid=" << di.m_local_id;
       if (di.m_sub_index != NULL_ITEM_ID)
         ostr() << " [" << di.m_sub_index << "]";
-      ostr() << " val: " << di.m_current
-             << " ref: " << di.m_ref << " rdiff: " << di.m_diff << '\n';
+      ostr() << " val: " << VarDataTypeTraits::normeMax(di.m_current)
+             << " ref: " << VarDataTypeTraits::normeMax(di.m_ref) << " rdiff: " << VarDataTypeTraits::normeMax(di.m_diff) << '\n';
     }
     else {
       // Il s'agit de l'indice d'une variable tableau
@@ -74,8 +74,8 @@ dump(ConstArrayView<DiffInfo> diffs_info, IVariable* var, IParallelMng* pm, int 
              << " index=" << di.m_local_id;
       if (di.m_sub_index != NULL_ITEM_ID)
         ostr() << " [" << di.m_sub_index << "]";
-      ostr() << " val: " << di.m_current
-             << " ref: " << di.m_ref << " rdiff: " << di.m_diff << '\n';
+      ostr() << " val: " << VarDataTypeTraits::normeMax(di.m_current)
+             << " ref: " << VarDataTypeTraits::normeMax(di.m_ref) << " rdiff: " << VarDataTypeTraits::normeMax(di.m_diff) << '\n';
     }
   }
   msg->pinfo() << "Processor " << sid << " : " << nb_diff


### PR DESCRIPTION
This a draft to replace the comparison criterion used when `STDENV_VERIF=READ` is set.

Original criterion : `abs(v1[i] - v2[i])/abs(v1[i])`

New criterion : `abs(v1[i] - v2[i])/max_j (abs(v1[j]))`

In this pull-request, the original criterion is replaced by the new one.

A development is needed if we want to keep the both criteria.

In this case, `STDENV_VERIF=READ_NMAX` could enable the new criterion.
