### PR TITLE
Update `ItemGroup` timestamp after reading from dump

### DIFF
--- a/arcane/src/arcane/core/ItemGroup.cc
+++ b/arcane/src/arcane/core/ItemGroup.cc
@@ -22,6 +22,7 @@
 #include "arcane/core/CaseOptionBase.h"
 #include "arcane/core/ICaseOptionList.h"
 #include "arcane/core/MeshHandle.h"
+#include "arcane/core/internal/ItemGroupInternal.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -655,6 +656,15 @@ checkIsSorted() const
 {
   m_impl->_checkNeedUpdate(false);
   return m_impl->checkIsSorted();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemGroup::
+incrementTimestamp() const
+{
+  m_impl->m_p->updateTimestamp();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemGroup.h
+++ b/arcane/src/arcane/core/ItemGroup.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemGroup.h                                                 (C) 2000-2024 */
+/* ItemGroup.h                                                 (C) 2000-2025 */
 /*                                                                           */
 /* Groupes d'entités du maillage.                                            */
 /*---------------------------------------------------------------------------*/
@@ -282,12 +282,27 @@ class ARCANE_CORE_EXPORT ItemGroup
   //! Indique si le groupe est celui de toutes les entités
   bool isAllItems() const;
 
-  //! Retourne le temps du groupe. Ce temps est incrémenté après chaque modification.
+  /*!
+   * Retourne le temps de dernière modification du groupe.
+   *
+   * Ce temps est incrémenté automatiquement après chaque modification.
+   * Il est possible de l'incrémenter manuellement via l'appel
+   * à incrementTimestamp().
+   */
   Int64 timestamp() const
   {
     return m_impl->timestamp();
   }
   
+  /*!
+   * \brief Incrément le temps de dernière modification du groupe.
+   *
+   * Normalement ce temps est incrémenté automatiquemnt. Il est néanmmoins
+   * possible de le faire manuellement en cas de modification externe des
+   * informations du groupe.
+   */
+  void incrementTimestamp() const;
+
   //! Table des local ids vers une position pour toutes les entités du groupe
   SharedPtrT<GroupIndexTable> localIdToIndex() const
   {

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1431,6 +1431,12 @@ _readGroups()
     if (group.null())
       createGroup(name);
   }
+  // Notifie les groupes qu'ils ont été mis à jour de manière
+  // externe. Cela peut être nécessaire pour recalculer automatiquement
+  // certaines informations (comme le padding pour la vectorisation)
+  for ( ItemGroup& group : m_item_groups) {
+    group.incrementTimestamp();
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/List.h
+++ b/arcane/src/arcane/utils/List.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* List.h                                                      (C) 2000-2022 */
+/* List.h                                                      (C) 2000-2025 */
 /*                                                                           */
 /* Classe collection tableau.                                                */
 /*---------------------------------------------------------------------------*/
@@ -294,6 +294,8 @@ class List
 
   const_iterator begin() const { return _cast().begin(); }
   const_iterator end() const { return _cast().end(); }
+  iterator begin() { return _cast().begin(); }
+  iterator end() { return _cast().end(); }
 
   T* begin2() const { return _cast().begin2(); }
   T* end2() const { return _cast().end2(); }


### PR DESCRIPTION
After reading from dump, the internal variables of an `ItemGroup` may have been modified and we need to signal that to the group if it needs to do some internal update. This is the case for example to recompute the SIMD padding.
