### PR TITLE
Add support for different kind of multi-dimension mesh

### DIFF
--- a/arcane/src/arcane/core/MeshKind.cc
+++ b/arcane/src/arcane/core/MeshKind.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshKind.cc                                                 (C) 2000-2023 */
+/* MeshKind.cc                                                 (C) 2000-2025 */
 /*                                                                           */
 /* Caractéristiques d'un maillage.                                           */
 /*---------------------------------------------------------------------------*/
@@ -51,20 +51,41 @@ namespace
       return "Invalid";
     }
   }
+  const char* _toName(eMeshCellDimensionKind r)
+  {
+    switch (r) {
+    case eMeshCellDimensionKind::MonoDimension:
+      return "MonoDimension";
+    case eMeshCellDimensionKind::MultiDimension:
+      return "MultiDimension";
+    case eMeshCellDimensionKind::NonManifold:
+      return "NonManifold";
+    default:
+      return "Invalid";
+    }
+  }
+
 } // namespace
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-extern "C++" ARCANE_CORE_EXPORT std::ostream&
+std::ostream&
 operator<<(std::ostream& o, eMeshStructure r)
 {
   o << _toName(r);
   return o;
 }
 
-extern "C++" ARCANE_CORE_EXPORT std::ostream&
+std::ostream&
 operator<<(std::ostream& o, eMeshAMRKind r)
+{
+  o << _toName(r);
+  return o;
+}
+
+std::ostream&
+operator<<(std::ostream& o, eMeshCellDimensionKind r)
 {
   o << _toName(r);
   return o;

--- a/arcane/src/arcane/core/MeshKind.h
+++ b/arcane/src/arcane/core/MeshKind.h
@@ -27,26 +27,65 @@ namespace Arcane
 //! Structure du maillage
 enum class eMeshStructure
 {
+  //! Structure inconnu ou pas initialisée
   Unknown,
+  //! Maillage non structuré
   Unstructured,
+  //! Maillage cartésien
   Cartesian,
+  //! Maillage polyedrique
   Polyhedral
 };
 
 extern "C++" ARCANE_CORE_EXPORT std::ostream&
 operator<<(std::ostream& o, eMeshStructure r);
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 //! Type de maillage AMR
 enum class eMeshAMRKind
 {
+  //! Le maillage n'est pas AMR
   None,
+  //! Le maillage est AMR par maille
   Cell,
+  //! Le maillage est AMR par patch
   Patch,
+  //! Le maillage est AMR par patch cartésien (rectangulaire)
   PatchCartesianMeshOnly
 };
 
 extern "C++" ARCANE_CORE_EXPORT std::ostream&
 operator<<(std::ostream& o, eMeshAMRKind r);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*!
+ * \brief Types de gestion de la dimension du maillage.
+ *
+ * \warning Les modes autres que eMeshCellDimensionKind::MonoDimension sont
+ * expérimentaux et ne sont supportés que pour eMeshStructure::Unstructured.
+ */
+enum class eMeshCellDimensionKind
+{
+  //! Les mailles ont la même dimension que le maillage
+  MonoDimension,
+  //! Les mailles ont la même dimension que le maillage ou une dimension inférieure
+  MultiDimension,
+  /*!
+   * \brief Maillage non manifold.
+   *
+   * Le maillage est MultiDimension et non manifold.
+   * Dans ce cas, si le maillage est 3D, les mailles 2D ont des arêtes (Edge)
+   * au lieu des faces (Face).
+   */
+  NonManifold
+};
+
+extern "C++" ARCANE_CORE_EXPORT std::ostream&
+operator<<(std::ostream& o, eMeshCellDimensionKind r);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -56,9 +95,10 @@ operator<<(std::ostream& o, eMeshAMRKind r);
  * Pour l'instant les caractéristiques sont:
  * - la structure du maillage (eMeshStructure)
  * - le type d'AMR
- * - si le maillage est 'manifold' (le défaut) ou non.
+ * - la gestion de la dimension des mailles (eMeshDimensionKind). Cette dernière
  *
- * \note Le support de maillage non-manifold est expérimental.
+ * \note Le support de maillages autres que eMeshDimensionKind.MonoDimension
+ * est expérimental.
  */
 class ARCANE_CORE_EXPORT MeshKind
 {
@@ -66,17 +106,18 @@ class ARCANE_CORE_EXPORT MeshKind
 
   eMeshStructure meshStructure() const { return m_structure; }
   eMeshAMRKind meshAMRKind() const { return m_amr_kind; }
-  bool isNonManifold() const { return m_is_non_manifold; }
-
+  eMeshCellDimensionKind meshDimensionKind() const { return m_dimension_kind; }
+  bool isNonManifold() const { return m_dimension_kind == eMeshCellDimensionKind::NonManifold; }
+  bool isMonoDimension() const { return m_dimension_kind == eMeshCellDimensionKind::MonoDimension; }
   void setMeshStructure(eMeshStructure v) { m_structure = v; }
   void setMeshAMRKind(eMeshAMRKind v) { m_amr_kind = v; }
-  void setIsNonManifold(bool v) { m_is_non_manifold = v; }
+  void setMeshDimensionKind(eMeshCellDimensionKind v) { m_dimension_kind = v; }
 
  private:
 
   eMeshStructure m_structure = eMeshStructure::Unknown;
   eMeshAMRKind m_amr_kind = eMeshAMRKind::None;
-  bool m_is_non_manifold = false;
+  eMeshCellDimensionKind m_dimension_kind = eMeshCellDimensionKind::MonoDimension;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.axl
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.axl
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?><!-- -*- SGML -*- -->
-<service name="ArcaneCaseMeshService" parent-name="AbstractService" type="caseoption">
+<service name="ArcaneCaseMeshService" version="1.0" parent-name="Arcane::AbstractService" type="caseoption">
   <userclass>User</userclass>
   <description>
     Service %Arcane permettant de lire ou créer un maillage.
@@ -92,17 +92,20 @@
       </description>
     </simple>
 
-    <simple name="non-manifold-mesh"
-            type="bool"
-            default="false"
+    <enumeration name="cell-dimension-kind"
+                 type="Arcane::eMeshCellDimensionKind"
+                 default="mono-dimension"
             >
       <description>
-        Indique si le maillage est 'non-manifold'. Un maillage de ce type contient
+        Indique si le maillage est 'non-manifold' ou multi-dimension. Un maillage de ce type contient
         des mailles de différents dimensions.
 
         AVERTISSEMENT: Ce mode est expérimental. Ne pas utiliser en dehors de %Arcane.
       </description>
-    </simple>
+      <enumvalue genvalue="Arcane::eMeshCellDimensionKind::MonoDimension" name="mono-dimension"/>
+      <enumvalue genvalue="Arcane::eMeshCellDimensionKind::MultiDimension" name="multi-dimension"/>
+      <enumvalue genvalue="Arcane::eMeshCellDimensionKind::NonManifold" name="non-manifold"/>
+    </enumeration>
 
     <!-- Service spécifique de lecture de maillage -->
     <service-instance

--- a/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
+++ b/arcane/src/arcane/impl/ArcaneCaseMeshService.cc
@@ -140,11 +140,11 @@ createMesh(const String& default_name)
 
   ARCANE_CHECK_POINTER(m_mesh_builder);
 
-  // Indique si les entités multi-dimension sont autorisées
-  bool is_non_manifold = options()->nonManifoldMesh;
-  if (is_non_manifold) {
+  // Indique la gestion des dimensions des mailles
+  eMeshCellDimensionKind mesh_dim_kind = options()->cellDimensionKind();
+  if (mesh_dim_kind != build_info.meshKind().meshDimensionKind()) {
     MeshKind mesh_kind = build_info.meshKind();
-    mesh_kind.setIsNonManifold(true);
+    mesh_kind.setMeshDimensionKind(mesh_dim_kind);
     build_info.addMeshKind(mesh_kind);
   }
 

--- a/arcane/tests/testMesh-2-non-manifold-external-cut.arc
+++ b/arcane/tests/testMesh-2-non-manifold-external-cut.arc
@@ -9,7 +9,7 @@
  <meshes>
    <mesh>
      <filename>mesh_with_loose_items.msh</filename>
-     <non-manifold-mesh>true</non-manifold-mesh>
+     <cell-dimension-kind>non-manifold</cell-dimension-kind>
      <partitioner>External</partitioner>
      <face-numbering-version>0</face-numbering-version>
    </mesh>

--- a/arcane/tests/testMesh-2-non-manifold-write-msh.arc
+++ b/arcane/tests/testMesh-2-non-manifold-write-msh.arc
@@ -8,7 +8,7 @@
   <meshes>
     <mesh>
       <filename>mesh_with_loose_items.msh</filename>
-      <non-manifold-mesh>true</non-manifold-mesh>
+     <cell-dimension-kind>non-manifold</cell-dimension-kind>
       <face-numbering-version>0</face-numbering-version>
     </mesh>
   </meshes>

--- a/arcane/tests/testMesh-2-non-manifold.arc
+++ b/arcane/tests/testMesh-2-non-manifold.arc
@@ -9,7 +9,7 @@
  <meshes>
    <mesh>
      <filename>mesh_with_loose_items.msh</filename>
-     <non-manifold-mesh>true</non-manifold-mesh>
+     <cell-dimension-kind>non-manifold</cell-dimension-kind>
      <face-numbering-version>0</face-numbering-version>
    </mesh>
  </meshes>

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.MeshUtilsDriver/MeshUtilsDriver.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.MeshUtilsDriver/MeshUtilsDriver.cs
@@ -69,7 +69,7 @@ namespace Arcane.ExecDrivers.MeshUtilsDriver
             _ErrorArg(String.Format("Name of writer service (-w|--writer) is not specified"));
           _AddToolArg(d, "writer-service-name", mesh_writer_name);
           if (!is_manifold)
-            _AddMeshArg(d,"non-manifold-mesh","true");
+            _AddMeshArg(d,"cell-dimension-kind","non-manifold");
         };
         exec_driver.ParseArgs(remaining_args.ToArray(), opt_set);
         return exec_driver.Execute();
@@ -125,7 +125,7 @@ namespace Arcane.ExecDrivers.MeshUtilsDriver
           if (exec_driver.RemainingArgs.Length == 0)
             _ErrorArg(String.Format("Name of input file is not specified"));
           if (!is_manifold)
-            _AddMeshArg(d,"non-manifold-mesh","true");
+            _AddMeshArg(d,"cell-dimension-kind","non-manifold");
         };
         exec_driver.ParseArgs(remaining_args.ToArray(), opt_set);
         return exec_driver.Execute();


### PR DESCRIPTION
At the moment, there is only two supported kinds: `MonoDimension` (classic mesh) and `NonManifold` (experimental mesh with cells of different dimension).