### PR TITLE
Use Edge instead of Face for 2D item type of non-manifold mesh

### DIFF
--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
@@ -112,6 +112,20 @@ addEdge(Int32 edge_index, Int32 n0, Int32 n1, Int32 f_left, Int32 f_right)
 /*---------------------------------------------------------------------------*/
 
 void ItemTypeInfoBuilder::
+addEdge2D(Integer edge_index, Integer n0, Integer n1)
+{
+  Array<Integer>& buf = m_mng->m_ids_buffer;
+  buf[m_first_item_index + edge_index] = buf.size();
+  buf.add(n0);
+  buf.add(n1);
+  buf.add(-1);
+  buf.add(-1);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemTypeInfoBuilder::
 addFaceVertex(Integer face_index, Integer n0)
 {
   _checkDimension(1);
@@ -138,6 +152,23 @@ addFaceLine(Integer face_index, Integer n0, Integer n1)
   buf.add(n1);
   buf.add(0); // no edge
 }
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemTypeInfoBuilder::
+addEdgeAndFaceLine(Int32 edge_face_index,
+                   std::array<Int16, 2> begin_end_node,
+                   std::array<Int16, 2> left_and_right_face)
+{
+  Int16 n0 = begin_end_node[0];
+  Int16 n1 = begin_end_node[1];
+  addFaceLine(edge_face_index, n0, n1);
+  addEdge(edge_face_index, n0, n1, left_and_right_face[0], left_and_right_face[1]);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 //! Ajoute une ligne quadratique à la liste des faces (pour les elements 2D)
 void ItemTypeInfoBuilder::

--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.h
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.h
@@ -106,11 +106,30 @@ class ItemTypeInfoBuilder
    * \brief Ajoute une arête à la liste des arêtes
    *
    * \a n0 noeud origine
-   * \a n1 noeud extremité
+   * \a n1 noeud extrémité
    * \a f_left numéro local de la face à gauche
    * \a f_right numéro local de la face à droite
    */
   void addEdge(Integer edge_index, Integer n0, Integer n1, Integer f_left, Integer f_right);
+
+  /*!
+   * \brief Ajoute une arête et une face
+   *
+   * \a edge_face_index index local de l'arête et de la face.
+   * \a begin_end_node couple (noeud origine,noeud extrémité) de l'arête et la face à ajouter.
+   * \a left_and_right_face couple numéro local (face à gauche, face à droite) de l'arête à ajouter
+   */
+  void addEdgeAndFaceLine(Int32 edge_face_index,
+                          std::array<Int16, 2> begin_end_node,
+                          std::array<Int16, 2> left_and_right_face);
+
+  /*!
+   * \brief Ajoute une arête pour une maille 2D.
+   *
+   * \a n0 noeud origine
+   * \a n1 noeud extrémité
+   */
+  void addEdge2D(Integer edge_index, Integer n0, Integer n1);
 
   //! Ajoute un sommet à la liste des faces (pour les elements 1D)
   void addFaceVertex(Integer face_index, Integer n0);

--- a/arcane/src/arcane/core/ItemTypeMng.h
+++ b/arcane/src/arcane/core/ItemTypeMng.h
@@ -201,7 +201,7 @@ class ARCANE_CORE_EXPORT ItemTypeMng
  private:
 
   void _buildSingleton(IParallelSuperMng* parallel_mng, ITraceMng* trace);
-  void _buildTypes(IParallelSuperMng* parallel_mng, ITraceMng* trace);
+  void _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace);
   //! Lecture des types a partir d'un fichier de nom filename
   void _readTypes(IParallelSuperMng* parallel_mng, const String& filename);
 };

--- a/arcane/tests/testMesh-2-non-manifold-external-cut.arc
+++ b/arcane/tests/testMesh-2-non-manifold-external-cut.arc
@@ -18,6 +18,7 @@
  <unit-test-module>
   <test name="MeshUnitTest">
     <write-mesh-service-name>VtkLegacyMeshWriter</write-mesh-service-name>
+    <test-adjency>false</test-adjency>
   </test>
  </unit-test-module>
 

--- a/arcane/tests/testMesh-2-non-manifold-write-msh.arc
+++ b/arcane/tests/testMesh-2-non-manifold-write-msh.arc
@@ -15,8 +15,8 @@
 
   <unit-test-module>
     <test name="MeshUnitTest">
-      <create-edges>true</create-edges>
       <write-mesh-service-name>MshMeshWriter</write-mesh-service-name>
+      <test-adjency>false</test-adjency>
     </test>
   </unit-test-module>
 </case>

--- a/arcane/tests/testMesh-2-non-manifold.arc
+++ b/arcane/tests/testMesh-2-non-manifold.arc
@@ -16,9 +16,9 @@
 
  <unit-test-module>
   <test name="MeshUnitTest">
-    <create-edges>true</create-edges>
     <write-mesh-service-name>VtkLegacyMeshWriter</write-mesh-service-name>
     <check-local-ids-from-connectivity>true</check-local-ids-from-connectivity>
+    <test-adjency>false</test-adjency>
   </test>
  </unit-test-module>
 


### PR DESCRIPTION
This is necessary because in this type of case, a 2D cell can be connected to several 2D cells via its boundary. This is not supported in Arcane if the boundary is a face (as there can only be two cells connected to a face). To avoid this, edges are used.

**Important Note** : that partitioning and ghost cell calculation algorithms do not yet take this into account, so non-manifold meshes are not necessarily consistent in parallel.
