### PR TITLE
Do not renumber by default uniqueId of edges and faces for non manifold mesh

### DIFF
--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -2982,16 +2982,23 @@ _setDimension(Integer dim)
     ARCANE_FATAL("DynamicMesh::setDimension(): mesh is already allocated");
   info() << "Mesh name=" << name() << " set dimension = " << dim;
   m_mesh_dimension = dim;
+  const bool is_non_manifold = meshKind().isNonManifold();
+  // Force le fait de ne pas re-numéroter les faces et les arêtes
+  // dans le cas d'un maillage non-manifold
+  if (is_non_manifold){
+    info() << "Force no-renumbering of edge and face uid because we are using non manifold mesh";
+    m_mesh_unique_id_mng->setFaceBuilderVersion(0);
+    m_mesh_unique_id_mng->setEdgeBuilderVersion(0);
+  }
   bool v = m_mesh_unique_id_mng->isUseNodeUniqueIdToGenerateEdgeAndFaceUniqueId();
   // Si le maillage est non-manifold, alors il faut obligatoirement utiliser
   // la génération à partir des uniqueId() à partir des noeuds pour garantir
   // la cohérence des entités créées.
   // Cette contrainte pourra être éventuellement être supprimée lorsque ce type
   // de maillage ne sera plus expérimental.
-  bool is_non_manifold = meshKind().isNonManifold();
   if (!v && is_non_manifold) {
     v = true;
-    info() << "Force using edge and face uid generation from nodes because loose items are allowed";
+    info() << "Force using edge and face uid generation from nodes because we are using non manifold mesh";
   }
   if (m_mesh_builder){
     auto* adder = m_mesh_builder->oneMeshItemAdder();

--- a/arcane/src/arcane/mesh/EdgeUniqueIdBuilder.cc
+++ b/arcane/src/arcane/mesh/EdgeUniqueIdBuilder.cc
@@ -63,14 +63,18 @@ computeEdgesUniqueIds()
 
   info() << "Using version=" << edge_version << " to compute edges unique ids"
          << " mesh=" << m_mesh->name();
+  bool need_compute_owner = false;
   bool has_renumbering = true;
   if (edge_version == 1)
     _computeEdgesUniqueIdsParallel3();
   else if (edge_version == 2)
     _computeEdgesUniqueIdsParallelV2();
-  else if (edge_version == 3)
+  else if (edge_version == 3) {
+    need_compute_owner = true;
     _computeEdgesUniqueIdsParallel64bit();
+  }
   else if (edge_version == 0) {
+    need_compute_owner = true;
     has_renumbering = false;
     info() << "No renumbering for edges";
   }
@@ -84,7 +88,7 @@ computeEdgesUniqueIds()
   ItemInternalMap& edges_map = m_mesh->edgesMap();
 
   // Il faut ranger à nouveau #m_edges_map si les uniqueId() des
-  // edges ont été modifiés.
+  // arêtes ont été modifiés.
   if (has_renumbering)
     edges_map.notifyUniqueIdsChanged();
 
@@ -97,7 +101,7 @@ computeEdgesUniqueIds()
 
   // S'il n'y a pas de renumérotation, il n'y a pas non de
   // calcul des propriétaires. Il faut donc le faire maintenant
-  if (!has_renumbering) {
+  if (need_compute_owner) {
     ItemsOwnerBuilder owner_builder(m_mesh);
     owner_builder.computeEdgesOwner();
   }

--- a/arcane/tests/testMesh-2-non-manifold-external-cut.arc
+++ b/arcane/tests/testMesh-2-non-manifold-external-cut.arc
@@ -11,7 +11,6 @@
      <filename>mesh_with_loose_items.msh</filename>
      <cell-dimension-kind>non-manifold</cell-dimension-kind>
      <partitioner>External</partitioner>
-     <face-numbering-version>0</face-numbering-version>
    </mesh>
  </meshes>
 

--- a/arcane/tests/testMesh-2-non-manifold-write-msh.arc
+++ b/arcane/tests/testMesh-2-non-manifold-write-msh.arc
@@ -8,8 +8,7 @@
   <meshes>
     <mesh>
       <filename>mesh_with_loose_items.msh</filename>
-     <cell-dimension-kind>non-manifold</cell-dimension-kind>
-      <face-numbering-version>0</face-numbering-version>
+      <cell-dimension-kind>non-manifold</cell-dimension-kind>
     </mesh>
   </meshes>
 

--- a/arcane/tests/testMesh-2-non-manifold.arc
+++ b/arcane/tests/testMesh-2-non-manifold.arc
@@ -10,7 +10,6 @@
    <mesh>
      <filename>mesh_with_loose_items.msh</filename>
      <cell-dimension-kind>non-manifold</cell-dimension-kind>
-     <face-numbering-version>0</face-numbering-version>
    </mesh>
  </meshes>
 


### PR DESCRIPTION
For non manifold mesh, the uniqueId of edges and faces are generated from uniqueId of nodes so there is no need to renumber them.