### PR TITLE
Add methods `Item::hasFlags()` and `ItemBase::hasFlags()`

### DIFF
--- a/arcane/src/arcane/core/Item.h
+++ b/arcane/src/arcane/core/Item.h
@@ -334,6 +334,12 @@ class ARCANE_CORE_EXPORT Item
     return (ik==IK_Unknown || ik==IK_DoF);
   }
 
+  //! Retourne si les flags \a flags sont positionnées pour l'entité
+  bool hasFlags(Int32 flags) const { return (_flags() & flags); }
+
+  //! Flags de l'entité
+  Int32 flags() const { return m_shared_info->_flagsV2(m_local_id); }
+
  public:
 
  /*!

--- a/arcane/src/arcane/core/ItemFlags.h
+++ b/arcane/src/arcane/core/ItemFlags.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemFlags.h                                                 (C) 2000-2024 */
+/* ItemFlags.h                                                 (C) 2000-2025 */
 /*                                                                           */
 /* Drapeaux contenant les caractéristiques d'une entité.                     */
 /*---------------------------------------------------------------------------*/
@@ -26,6 +26,13 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*!
  * \brief Flags pour les caractéristiques des entités.
+ *
+ * Ces flags permettent de conserver des informations sur les entités (Item).
+ * Ils sont réservés à %Arcane et ne doivent pas être utilisés en dehors
+ * d'Arcane. La seule exception concerne les valeurs ItemFlags::II_UserMark1
+ * et ItemFlags::II_UserMark2. Ils peuvent être associés aux entités via
+ * les méthodes MutableItemBase::addFlags(), MutableItemBase::removeFlags() ou
+ * ItemBase::hasFlags().
  */
 class ARCANE_CORE_EXPORT ItemFlags
 {
@@ -35,8 +42,8 @@ class ARCANE_CORE_EXPORT ItemFlags
 
  public:
 
-  // L'affichage 'lisible' des flags est implémenté dans ItemPrinter
-  // Il doit être updaté si des flags sont ici changés
+  // L'affichage 'lisible' des flags est implémenté dans ItemPrinter.
+  // Il doit être mis à jour si des valeurs ici sont modifiées ou ajoutées.
 
   enum : FlagType
   {
@@ -58,16 +65,16 @@ class ARCANE_CORE_EXPORT ItemFlags
     II_Detached = 1 << 16, //!< L'entité est détachée du maillage
     II_HasTrace = 1 << 17, //!< L'entité est marquée pour trace (pour débug)
 
-    II_Coarsen = 1 << 18, //!<  L'entité est marquée pour déraffinement
+    II_Coarsen = 1 << 18, //!<  L'entité est marquée pour dé-raffinement
     II_DoNothing = 1 << 19, //!<  L'entité est bloquée
     II_Refine = 1 << 20, //!<  L'entité est marquée pour raffinement
     II_JustRefined = 1 << 21, //!<  L'entité vient d'être raffinée
-    II_JustCoarsened = 1 << 22, //!<  L'entité vient d'être déraffiné
+    II_JustCoarsened = 1 << 22, //!<  L'entité vient d'être dé-raffiné
     II_Inactive = 1 << 23, //!<  L'entité est inactive //COARSEN_INACTIVE,
-    II_CoarsenInactive = 1 << 24, //!<  L'entité est inactive et a des enfants tagués pour déraffinement
+    II_CoarsenInactive = 1 << 24, //!< L'entité est inactive et a des enfants tagués pour dé-raffinement
 
-    II_UserMark1 = 1 << 25, //!< Marque utilisateur old_value 1<<24
-    II_UserMark2 = 1 << 26 //!< Marque utilisateur  old_value 1<<25
+    II_UserMark1 = 1 << 30, //!< Marque utilisateur
+    II_UserMark2 = 1 << 31 //!< Marque utilisateur
   };
 
   static const int II_InterfaceFlags = II_Boundary + II_HasFrontCell + II_HasBackCell +

--- a/arcane/src/arcane/core/ItemInternal.h
+++ b/arcane/src/arcane/core/ItemInternal.h
@@ -694,6 +694,9 @@ class ARCANE_CORE_EXPORT ItemBase
   ItemBase hChildBase(Int32 index) const { return _connectivity()->hChildBase(m_local_id, index, m_shared_info); }
   inline ItemBase parentBase(Int32 index) const;
 
+  //! Retourne si les flags \a flags sont positionnées pour l'entité
+  bool hasFlags(Int32 flags) const { return (this->flags() & flags); }
+
  public:
 
  /*!
@@ -832,7 +835,7 @@ class ARCANE_CORE_EXPORT MutableItemBase
   //! Positionne les flags de l'entité
   void setFlags(Int32 f) { m_shared_info->_setFlagsV2(m_local_id,f); }
 
-  //! Ajoute les flags \added_flags à ceux de l'entité
+  //! Ajoute les flags \a added_flags à ceux de l'entité
   void addFlags(Int32 added_flags)
   {
     Int32 f = this->flags();
@@ -840,7 +843,7 @@ class ARCANE_CORE_EXPORT MutableItemBase
     this->setFlags(f);
   }
 
-  //! Supprime les flags \added_flags de ceux de l'entité
+  //! Supprime les flags \a removed_flags de ceux de l'entité
   void removeFlags(Int32 removed_flags)
   {
     Int32 f = this->flags();

--- a/arcane/src/arcane/mesh/DynamicMesh.cc
+++ b/arcane/src/arcane/mesh/DynamicMesh.cc
@@ -2296,7 +2296,7 @@ _removeGhostChildItems2(Array<Int64>& cells_to_coarsen)
   cells_map.eachItem([&](Cell cell) {
     if (cell.owner() != sid)
       return;
-    if (cell.itemBase().flags() & ItemFlags::II_JustCoarsened) {
+    if (cell.hasFlags(ItemFlags::II_JustCoarsened)) {
       cells_to_coarsen.add(cell.uniqueId());
       for (Integer c = 0, cs = cell.nbHChildren(); c < cs; c++) {
         cells_to_remove.add(cell.hChild(c));

--- a/arcane/src/arcane/mesh/FaceFamily.cc
+++ b/arcane/src/arcane/mesh/FaceFamily.cc
@@ -387,7 +387,7 @@ addBackCellToFace(Face face,Cell new_cell)
   // par couches
   if (m_check_orientation){
     Cell current_cell = face.backCell();
-    if (face.itemBase().flags() & ItemFlags::II_HasBackCell){
+    if (face.hasFlags(ItemFlags::II_HasBackCell)){
       ARCANE_FATAL("Face already having a back cell."
                    " This is most probably due to the fact that the face"
                    " is connected to a reverse cell with a negative volume."
@@ -420,7 +420,7 @@ addFrontCellToFace(Face face,Cell new_cell)
   // par couches
   if (m_check_orientation){
     Cell current_cell = face.frontCell();
-    if (face.itemBase().flags() & ItemFlags::II_HasFrontCell){
+    if (face.hasFlags(ItemFlags::II_HasFrontCell)){
       ARCANE_FATAL("Face already having a front cell."
                    " This is most probably due to the fact that the face"
                    " is connected to a reverse cell with a negative volume."
@@ -473,13 +473,13 @@ addBackFrontCellsFromParentFace(Face subface,Face face)
 	Cell fcell= face.frontCell();
 	Cell bcell= face.backCell();
 
-	if (subface.itemBase().flags() & ItemFlags::II_HasBackCell){
+	if (subface.hasFlags(ItemFlags::II_HasBackCell)){
     if(fcell.isActive()) 
       addFrontCellToFace(subface,face.frontCell());
     else if(bcell.isActive())
       addFrontCellToFace(subface,face.backCell());
 	}
-	else if (subface.itemBase().flags() & ItemFlags::II_HasFrontCell){
+	else if (subface.hasFlags(ItemFlags::II_HasFrontCell)){
     if(bcell.isActive()) 
       addBackCellToFace(subface,face.backCell());
     else if (fcell.isActive())

--- a/arcane/src/arcane/mesh/GhostLayerBuilder.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* GhostLayerBuilder.cc                                        (C) 2000-2024 */
+/* GhostLayerBuilder.cc                                        (C) 2000-2025 */
 /*                                                                           */
 /* Construction des couches fantômes.                                        */
 /*---------------------------------------------------------------------------*/
@@ -212,7 +212,7 @@ _addOneGhostLayerV2()
       ostr() << '\n';
     }
     bool is_sub_domain_boundary_face = false;
-    if (face_base.flags() & ItemFlags::II_Boundary) {
+    if (face_base.hasFlags(ItemFlags::II_Boundary)) {
       is_sub_domain_boundary_face = true;
     }
     else{
@@ -264,10 +264,10 @@ _addOneGhostLayerV2()
     }
     //info() << " CHECK cell uid=" << cell->uniqueId() << " owner=" << cell->owner();
     //bool add_cell = false;
-    for( Node inode : cell.nodes() ){
+    for( Node node : cell.nodes() ){
       //info() << "** CHECK NODE node=" << i_node->uniqueId() << " cell=" << cell->uniqueId();
-      if (inode.itemBase().flags() & ItemFlags::II_Shared){
-        Int64 node_uid = inode.uniqueId();
+      if (node.hasFlags(ItemFlags::II_Shared)){
+        Int64 node_uid = node.uniqueId();
         //info() << "** ADD BOUNDARY CELL node=" << node_uid << " cell=" << cell->uniqueId();
         Int32 dest_rank = uid_to_subdomain_converter.uidToRank(node_uid);
         SharedArray<Int64> v = boundary_infos_to_send.lookupAdd(dest_rank)->value();
@@ -611,7 +611,7 @@ addGhostChildFromParent2(Array<Int64>& ghost_cell_to_refine)
     if (cell.owner() == sid)
       return;
     // cela suppose que les flags sont deja synchronises
-    if (cell.itemBase().flags() & ItemFlags::II_JustRefined) {
+    if (cell.hasFlags(ItemFlags::II_JustRefined)) {
       // cell to add
       ghost_cell_to_refine.add(cell.uniqueId());
       Int64Array& v = boundary_infos_to_send.lookupAdd(cell.owner())->value();

--- a/arcane/src/arcane/mesh/MeshExchange.cc
+++ b/arcane/src/arcane/mesh/MeshExchange.cc
@@ -1303,7 +1303,7 @@ _printItemToRemove(IItemFamily* family)
   // SDC DEBUG PRINT
   debug() << "= ITEM TO REMOVE FOR FAMILY " << family->name();
   ENUMERATE_ITEM(item, family->allItems()) {
-    if (item->itemBase().flags() & ItemFlags::II_NeedRemove)
+    if (item->hasFlags(ItemFlags::II_NeedRemove))
       debug() << "== TO REMOVE ITEM " << item->uniqueId()   << " kind " << item->kind();
   }
 }


### PR DESCRIPTION
This will remove the need to cast to `ItemBase` and to test with `operator&` which may be error prone.
Also change the value of `ItemFlags::II_UserMark1` and `ItemFlags::II_UserMark2` the be the two last bit of `Int32`.