### PR TITLE
Allow printing norm instead of real values in `VariableDiff`

### DIFF
--- a/arcane/src/arcane/core/Array2Variable.cc
+++ b/arcane/src/arcane/core/Array2Variable.cc
@@ -65,7 +65,6 @@ class Array2VariableDiff
   check(IVariable* var, ConstArray2View<DataType> ref, ConstArray2View<DataType> current,
         const VariableComparerArgs& compare_args)
   {
-    const int max_print = compare_args.maxPrint();
     const bool compare_ghost = compare_args.isCompareGhost();
     ItemGroup group = var->itemGroup();
     if (group.null())
@@ -125,7 +124,7 @@ class Array2VariableDiff
       }
     }
     if (nb_diff!=0)
-      this->_sortAndDump(var,pm,max_print);
+      this->_sortAndDump(var, pm, compare_args);
 
     return VariableComparerResults(nb_diff);
   }
@@ -156,7 +155,6 @@ class Array2VariableDiff
   _checkReplica2(IParallelMng* pm, IVariable* var, ConstArray2View<DataType> var_values,
                  const VariableComparerArgs& compare_args)
   {
-    const int max_print = compare_args.maxPrint();
     ITraceMng* msg = pm->traceMng();
     ItemGroup group = var->itemGroup();
     //TODO: traiter les variables qui ne sont pas sur des éléments du maillage.
@@ -221,7 +219,7 @@ class Array2VariableDiff
     }
 
     if (nb_diff!=0)
-      this->_sortAndDump(var,pm,max_print);
+      this->_sortAndDump(var, pm, compare_args);
 
     return VariableComparerResults(nb_diff);
   }

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -68,7 +68,6 @@ class ArrayVariableDiff
   check(IVariable* var, ConstArrayView<DataType> ref, ConstArrayView<DataType> current,
         const VariableComparerArgs& compare_args)
   {
-    const int max_print = compare_args.maxPrint();
     const bool compare_ghost = compare_args.isCompareGhost();
     if (var->itemKind() == IK_Unknown)
       return _checkAsArray(var, ref, current, compare_args);
@@ -155,7 +154,7 @@ class ArrayVariableDiff
                    << " for the variable " << var_name << " ref_size=" << ref_size;
     }
     if (nb_diff != 0)
-      this->_sortAndDump(var, pm, max_print);
+      this->_sortAndDump(var, pm, compare_args);
 
     return VariableComparerResults(nb_diff);
   }
@@ -186,7 +185,6 @@ class ArrayVariableDiff
   _checkAsArray(IVariable* var, ConstArrayView<DataType> ref, ConstArrayView<DataType> current,
                 const VariableComparerArgs& compare_args)
   {
-    const int max_print = compare_args.maxPrint();
     IParallelMng* pm = var->variableMng()->parallelMng();
     ITraceMng* msg = pm->traceMng();
 
@@ -243,7 +241,7 @@ class ArrayVariableDiff
         
     }
     if (nb_diff!=0)
-      this->_sortAndDump(var,pm,max_print);
+      this->_sortAndDump(var, pm, compare_args);
 
     return VariableComparerResults(nb_diff);
   }
@@ -252,7 +250,6 @@ class ArrayVariableDiff
   _checkReplica2(IParallelMng* pm, IVariable* var, ConstArrayView<DataType> var_values,
                  const VariableComparerArgs& compare_args)
   {
-    const int max_print = compare_args.maxPrint();
     ITraceMng* msg = pm->traceMng();
     Integer size = var_values.size();
     // Vérifie que tous les réplica ont le même nombre d'éléments pour la variable.
@@ -282,7 +279,7 @@ class ArrayVariableDiff
       }
     }
     if (nb_diff!=0)
-      this->_sortAndDump(var,pm,max_print);
+      this->_sortAndDump(var, pm, compare_args);
 
     return VariableComparerResults(nb_diff);
   }

--- a/arcane/src/arcane/core/VariableDiff.h
+++ b/arcane/src/arcane/core/VariableDiff.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableDiff.h                                              (C) 2000-2023 */
+/* VariableDiff.h                                              (C) 2000-2025 */
 /*                                                                           */
 /* Gestion des différences entre les variables                               */
 /*---------------------------------------------------------------------------*/
@@ -39,6 +39,7 @@ class VariableDiff
  public:
 
   using VarDataTypeTraits = VariableDataTypeTraitsT<DataType>;
+  static constexpr bool IsNumeric = std::is_same_v<typename VarDataTypeTraits::IsNumeric, TrueType>;
 
  public:
 
@@ -107,15 +108,15 @@ class VariableDiff
 
  protected:
 
-  void _sortAndDump(IVariable* var, IParallelMng* pm, int max_print)
+  void _sortAndDump(IVariable* var, IParallelMng* pm, const VariableComparerArgs& compare_args)
   {
     _sort();
-    dump(var, pm, max_print);
+    dump(var, pm, compare_args);
   }
 
-  void dump(IVariable* var, IParallelMng* pm, int max_print)
+  void dump(IVariable* var, IParallelMng* pm, const VariableComparerArgs& compare_args)
   {
-    DiffPrinter::dump(m_diffs_info, var, pm, max_print);
+    DiffPrinter::dump(m_diffs_info, var, pm, compare_args);
   }
   void _sort()
   {
@@ -128,8 +129,9 @@ class VariableDiff
   {
    public:
 
-    ARCANE_CORE_EXPORT static void dump(ConstArrayView<DiffInfo> diff_infos,
-                                        IVariable* var, IParallelMng* pm, int max_print);
+    ARCANE_CORE_EXPORT static void
+    dump(ConstArrayView<DiffInfo> diff_infos, IVariable* var, IParallelMng* pm,
+         const VariableComparerArgs& compare_args);
     ARCANE_CORE_EXPORT static void sort(ArrayView<DiffInfo> diff_infos);
   };
 };

--- a/arcane/src/arcane/core/VariableScalar.cc
+++ b/arcane/src/arcane/core/VariableScalar.cc
@@ -62,7 +62,6 @@ class ScalarVariableDiff
   check(IVariable* var,ConstArrayView<DataType> ref,ConstArrayView<DataType> current,
         const VariableComparerArgs& compare_args)
   {
-    const int max_print = compare_args.maxPrint();
     const bool compare_ghost = compare_args.isCompareGhost();
     ItemGroup group = var->itemGroup();
     if (group.null())
@@ -112,7 +111,7 @@ class ScalarVariableDiff
         
     }
     if (nb_diff!=0)
-      this->_sortAndDump(var,pm,max_print);
+      this->_sortAndDump(var, pm, compare_args);
 
     return VariableComparerResults(nb_diff);
   }


### PR DESCRIPTION
Implement a part of #2064 