### PR TITLE
Neo: handle empty connectivity in the graph.

### DIFF
--- a/arctools/neo/src/neo/Items.h
+++ b/arctools/neo/src/neo/Items.h
@@ -249,6 +249,13 @@ struct FutureItemRange
     return std::move(new_items);
   }
 
+  ItemRange::size_type size() const {
+    if (is_data_released)
+      throw std::runtime_error(
+      "Impossible to call FutureItemRange.size(), data already released.");
+    return new_items.size();
+  }
+
  private:
   virtual ItemRange& _toItemRange() {
     return new_items;

--- a/arctools/neo/src/neo/Mesh.h
+++ b/arctools/neo/src/neo/Mesh.h
@@ -82,6 +82,14 @@ class Mesh
       if (nb_connected_elements.size() == 0) {return 0;}
       return *std::max_element(nb_connected_elements.begin(), nb_connected_elements.end());
     }
+
+    bool isEmpty() const {
+      return maxNbConnectedItems() == 0;
+    }
+
+    friend bool operator==(Connectivity const& lhs, Connectivity const& rhs) {
+      return (lhs.source_family == rhs.source_family) && (lhs.target_family == rhs.target_family) && lhs.name == rhs.name;
+    }
   };
 
   enum class ConnectivityOperation

--- a/arctools/neo/src/tests/NeoBaseTest.cpp
+++ b/arctools/neo/src/tests/NeoBaseTest.cpp
@@ -164,9 +164,11 @@ TEST(NeoTestItemRange, test_item_range) {
 
 TEST(NeoTestFutureItemRange, test_future_item_range) {
   Neo::FutureItemRange future_item_range{};
+  EXPECT_EQ(future_item_range.size(), 0);
   // Manually fill contained ItemRange
   std::vector<Neo::utils::Int32> lids{ 0, 2, 4, 6 };
   future_item_range.new_items = Neo::ItemRange{ Neo::ItemLocalIds{ lids } };
+  EXPECT_EQ(future_item_range.size(), lids.size());
   Neo::ItemRange& internal_range = future_item_range;
   EXPECT_EQ(&future_item_range.new_items, &internal_range);
   auto end_update = Neo::EndOfMeshUpdate{};
@@ -175,6 +177,7 @@ TEST(NeoTestFutureItemRange, test_future_item_range) {
     std::vector<int> filter{ 0, 1, 2 };
     auto filtered_future_range =
     Neo::make_future_range(future_item_range, filter);
+    EXPECT_EQ(filtered_future_range.size(), 0);
     // Get item_ranges
     auto filtered_range = filtered_future_range.get(end_update);
     auto item_range = future_item_range.get(end_update);

--- a/arctools/neo/src/tests/NeoMeshAPITest.cpp
+++ b/arctools/neo/src/tests/NeoMeshAPITest.cpp
@@ -238,6 +238,17 @@ TEST(NeoMeshApiTest, SetNodeCoordsTest) {
 
 /*---------------------------------------------------------------------------*/
 
+TEST(NeoMeshApiTest,EmptyMeshConnectivity) {
+  // Check empty connectivity
+  Neo::Family empty_family{Neo::ItemKind::IK_None, "EmptyFamily"};
+  Neo::Mesh::ConnectivityPropertyType empty_property{};
+  Neo::Mesh::Connectivity empty_connectivity{empty_family,empty_family,"empty_connectivity",
+    empty_property,empty_property};
+  EXPECT_TRUE(empty_connectivity.isEmpty());
+}
+
+/*---------------------------------------------------------------------------*/
+
 bool areEqual(Neo::Mesh::Connectivity const con1, Neo::Mesh::Connectivity const con2) {
   bool are_equal = con1.name == con2.name;
   are_equal &= &con1.source_family == &con2.source_family;
@@ -301,6 +312,10 @@ TEST(NeoMeshApiTest, AddItemConnectivity) {
   // check connectivities
   // check cell_to_nodes
   auto cell_to_nodes = mesh.getConnectivity(cell_family, node_family, cell_to_nodes_connectivity_name);
+  EXPECT_FALSE(cell_to_nodes.isEmpty());
+  // check operator ==
+  auto cell_to_nodes_copy{cell_to_nodes};
+  EXPECT_EQ(cell_to_nodes,cell_to_nodes_copy);
   EXPECT_EQ(cell_to_nodes_connectivity_name, cell_to_nodes.name);
   EXPECT_EQ(&cell_family, &cell_to_nodes.source_family);
   EXPECT_EQ(&node_family, &cell_to_nodes.target_family);


### PR DESCRIPTION
- Allow to add an existing connectivity if it was empty.