### PR TITLE
Always set `RUNTIME_OUTPUT_DIRECTORY` and `LIBRARY_OUTPUT_DIRECTORY` for Arcane targets

### DIFF
--- a/arcane/cmake/Functions.cmake
+++ b/arcane/cmake/Functions.cmake
@@ -213,6 +213,8 @@ function(arcane_target_set_standard_path target)
   message(STATUS "arcane_target_set_standard_path target='${target}'")
   set_target_properties(${target}
     PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${_libpath}
+    LIBRARY_OUTPUT_DIRECTORY ${_libpath}
     LIBRARY_OUTPUT_DIRECTORY_DEBUG ${_libpath}
     RUNTIME_OUTPUT_DIRECTORY_DEBUG ${_libpath}
     LIBRARY_OUTPUT_DIRECTORY_RELEASE ${_libpath}


### PR DESCRIPTION
Normally this is not necessary as the versions associated with the possible values of CMAKE_BUILD_TYPE are set (Debug, Release, ...) but if CMAKE_BUILD_TYPE is empty or does not contain one of the predefined values then the libraries will not be installed in the right place.