### PR TITLE
Add specific execution policy for `IMeshComponent`

### DIFF
--- a/arcane/src/arcane/core/materials/IMeshComponent.h
+++ b/arcane/src/arcane/core/materials/IMeshComponent.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IMeshComponent.h                                            (C) 2000-2023 */
+/* IMeshComponent.h                                            (C) 2000-2025 */
 /*                                                                           */
 /* Interface d'un composant (matériau ou milieu) d'un maillage.              */
 /*---------------------------------------------------------------------------*/
@@ -14,7 +14,9 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/ItemTypes.h"
+#include "arcane/accelerator/core/AcceleratorCoreGlobal.h"
+
+#include "arcane/core/ItemTypes.h"
 #include "arcane/core/materials/MaterialsCoreGlobal.h"
 
 /*---------------------------------------------------------------------------*/
@@ -115,6 +117,23 @@ class ARCANE_CORE_EXPORT IMeshComponent
    * Si isEnvironment()==false, retourne \a nullptr
    */
   virtual IMeshEnvironment* asEnvironment() =0;
+
+  /*!
+   * \brief Positionne une politique d'exécution pour ce constituant
+   *
+   * \warning Cette méthode est expérimentale. A ne pas utiliser en dehors d'Arcane.
+   *
+   * Si \a policy est différent de eExecutionPolicy::None, elle sera utilisée pour
+   * les opérations de création de EnvCellVector, MatCellVector ou ComponentItemVector
+   */
+  virtual void setSpecificExecutionPolicy(Accelerator::eExecutionPolicy policy) = 0;
+
+  /*!
+   * \brief Politique d'exécution spécifique.
+   *
+   * \sa setSpecificExecutionPolicy().
+   */
+  virtual Accelerator::eExecutionPolicy specificExecutionPolicy() const = 0;
 
  public:
 

--- a/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
+++ b/arcane/src/arcane/materials/ConstituentItemVectorImpl.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ConstituentItemVectorImpl.cc                                (C) 2000-2024 */
+/* ConstituentItemVectorImpl.cc                                (C) 2000-2025 */
 /*                                                                           */
 /* Implémentation de 'IConstituentItemVectorImpl'.                           */
 /*---------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ class ConstituentItemVectorImpl::SetItemHelper
 {
  public:
 
-  SetItemHelper(bool use_new_impl)
+  explicit SetItemHelper(bool use_new_impl)
   : m_use_new_impl(use_new_impl)
   {}
 
@@ -219,7 +219,8 @@ _setItems(SmallSpan<const Int32> local_ids)
 {
   const bool do_new_impl = m_material_mng->_internalApi()->isUseAcceleratorForConstituentItemVector();
 
-  RunQueue queue = m_material_mng->_internalApi()->runQueue();
+  Accelerator::eExecutionPolicy exec_policy = m_component->specificExecutionPolicy();
+  RunQueue queue = m_material_mng->_internalApi()->runQueue(exec_policy);
 
   if (do_new_impl)
     _computeNbPureAndImpure(local_ids, queue);
@@ -232,7 +233,7 @@ _setItems(SmallSpan<const Int32> local_ids)
 
   // Tableau qui contiendra les indices des mailles pures et partielles.
   // La première partie de 0 à nb_pure contiendra la partie pure.
-  // La seconde partie de nb_pure à (nb_pure+nb_impure) contiendra les mailles partielles
+  // La seconde partie de nb_pure à (nb_pure+nb_impure) contiendra les mailles partielles.
   // A noter que (nb_pure + nb_impure) peut être différent de local_ids.size()
   // si certaines mailles de \a local_ids n'ont pas le constituant.
   m_constituent_list->resize(total_nb_pure_and_impure);

--- a/arcane/src/arcane/materials/internal/MeshComponentData.h
+++ b/arcane/src/arcane/materials/internal/MeshComponentData.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshComponentData.h                                         (C) 2000-2024 */
+/* MeshComponentData.h                                         (C) 2000-2025 */
 /*                                                                           */
 /* Données d'un constituant (matériau ou milieu) d'un maillage.              */
 /*---------------------------------------------------------------------------*/
@@ -103,6 +103,16 @@ class MeshComponentData
     return m_component_id;
   }
 
+  void setSpecificExecutionPolicy(Accelerator::eExecutionPolicy policy)
+  {
+    m_specific_execution_policy = policy;
+  }
+
+  Accelerator::eExecutionPolicy specificExecutionPolicy() const
+  {
+    return m_specific_execution_policy;
+  }
+
  private:
 
   void _resizeItemsInternal(Int32 nb_item);
@@ -141,6 +151,9 @@ class MeshComponentData
 
   MeshComponentPartData* m_part_data = nullptr;
   FunctorT<MeshComponentData> m_recompute_part_data_functor;
+
+  //! Politique d'exécution spécifique
+  Accelerator::eExecutionPolicy m_specific_execution_policy = Accelerator::eExecutionPolicy::None;
 
  private:
 

--- a/arcane/src/arcane/materials/internal/MeshEnvironment.h
+++ b/arcane/src/arcane/materials/internal/MeshEnvironment.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshEnvironment.h                                           (C) 2000-2024 */
+/* MeshEnvironment.h                                           (C) 2000-2025 */
 /*                                                                           */
 /* Milieu d'un maillage.                                                     */
 /*---------------------------------------------------------------------------*/
@@ -136,6 +136,15 @@ class MeshEnvironment
 
   //! Indique si le milieu est mono-matériau
   bool isMonoMaterial() const;
+
+  void setSpecificExecutionPolicy(Accelerator::eExecutionPolicy policy) override
+  {
+    m_data.setSpecificExecutionPolicy(policy);
+  }
+  Accelerator::eExecutionPolicy specificExecutionPolicy() const override
+  {
+    return m_data.specificExecutionPolicy();
+  }
 
  public:
 

--- a/arcane/src/arcane/materials/internal/MeshMaterial.h
+++ b/arcane/src/arcane/materials/internal/MeshMaterial.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshMaterial.h                                              (C) 2000-2024 */
+/* MeshMaterial.h                                              (C) 2000-2025 */
 /*                                                                           */
 /* Matériau d'un maillage.                                                   */
 /*---------------------------------------------------------------------------*/
@@ -55,8 +55,13 @@ class MeshMaterial
   : public IMeshComponentInternal
   {
    public:
-    InternalApi(MeshMaterial* mat) : m_material(mat){}
+
+    explicit InternalApi(MeshMaterial* mat)
+    : m_material(mat)
+    {}
+
    public:
+
     MeshMaterialVariableIndexer* variableIndexer() const override
     {
       return m_material->variableIndexer();
@@ -70,7 +75,8 @@ class MeshMaterial
     Ref<IConstituentItemVectorImpl> createItemVectorImpl(ComponentItemVectorView rhs) const override;
 
    private:
-    MeshMaterial* m_material;
+
+    MeshMaterial* m_material = nullptr;
   };
 
  public:
@@ -124,6 +130,15 @@ class MeshMaterial
   MatImpurePartItemVectorView impureMatItems() const override;
   MatPartItemVectorView partMatItems(eMatPart part) const override;
 
+  void setSpecificExecutionPolicy(Accelerator::eExecutionPolicy policy) override
+  {
+    m_data.setSpecificExecutionPolicy(policy);
+  }
+  Accelerator::eExecutionPolicy specificExecutionPolicy() const override
+  {
+    return m_data.specificExecutionPolicy();
+  }
+
  public:
 
   IMeshComponentInternal* _internalApi() override { return &m_internal_api; }
@@ -149,12 +164,12 @@ class MeshMaterial
 
  private:
 
-  IMeshMaterialMng* m_material_mng;
-  MeshMaterialInfo* m_infos;
-  MeshEnvironment* m_environment;
-  IUserMeshMaterial* m_user_material;
+  IMeshMaterialMng* m_material_mng = nullptr;
+  MeshMaterialInfo* m_infos = nullptr;
+  MeshEnvironment* m_environment = nullptr;
+  IUserMeshMaterial* m_user_material = nullptr;
   MeshComponentData m_data;
-  MeshMaterial* m_non_const_this;
+  MeshMaterial* m_non_const_this = nullptr;
   InternalApi m_internal_api;
 };
 


### PR DESCRIPTION
This will be used to override the `RunQueue` used when building instances of `ComponentCellVector`, `MatCellVector` and `EnvCellVector`.