### PR TITLE
Add methods to create `Ref<ISerializeMessage>`

### DIFF
--- a/arcane/src/arcane/core/IParallelMng.h
+++ b/arcane/src/arcane/core/IParallelMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IParallelMng.h                                              (C) 2000-2024 */
+/* IParallelMng.h                                              (C) 2000-2025 */
 /*                                                                           */
 /* Interface du gestionnaire du parallélisme sur un sous-domaine.            */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/IParallelMng.h
+++ b/arcane/src/arcane/core/IParallelMng.h
@@ -745,6 +745,11 @@ class ARCANE_CORE_EXPORT IParallelMng
   virtual void processMessages(ConstArrayView<ISerializeMessage*> messages) =0;
 
   /*!
+   * \brief Exécute les opérations des messages \a messages
+   */
+  virtual void processMessages(ConstArrayView<Ref<ISerializeMessage>> messages) =0;
+
+  /*!
    * \brief Libère les requêtes.
    */
   virtual void freeRequests(ArrayView<Parallel::Request> requests) =0;

--- a/arcane/src/arcane/core/ParallelMngDispatcher.cc
+++ b/arcane/src/arcane/core/ParallelMngDispatcher.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelMngDispatcher.cc                                    (C) 2000-2025 */
+/* ParallelMngDispatcher.cc                                    (C) 2000-2024 */
 /*                                                                           */
 /* Redirection de la gestion des messages suivant le type des arguments.     */
 /*---------------------------------------------------------------------------*/
@@ -498,14 +498,25 @@ void ParallelMngDispatcher::
 processMessages(ConstArrayView<ISerializeMessage*> messages)
 {
   TimeMetricSentry tphase(Timer::phaseAction(timeStats(),TP_Communication));
-  ScopedPtrT<ISerializeMessageList> message_list(createSerializeMessageList());
+  Ref<ISerializeMessageList> message_list(createSerializeMessageListRef());
 
-  Integer nb_message = messages.size();
-  for( Integer i=0; i<nb_message; ++i ){
-    ISerializeMessage* m = messages[i];
+  for (ISerializeMessage* m : messages)
     message_list->addMessage(m);
-  }
-  message_list->processPendingMessages();
+
+  message_list->waitMessages(Parallel::WaitAll);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ParallelMngDispatcher::
+processMessages(ConstArrayView<Ref<ISerializeMessage>> messages)
+{
+  TimeMetricSentry tphase(Timer::phaseAction(timeStats(), TP_Communication));
+  Ref<ISerializeMessageList> message_list(createSerializeMessageListRef());
+
+  for (const Ref<ISerializeMessage>& v : messages)
+    message_list->addMessage(v.get());
 
   message_list->waitMessages(Parallel::WaitAll);
 }

--- a/arcane/src/arcane/core/ParallelMngDispatcher.cc
+++ b/arcane/src/arcane/core/ParallelMngDispatcher.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelMngDispatcher.cc                                    (C) 2000-2024 */
+/* ParallelMngDispatcher.cc                                    (C) 2000-2025 */
 /*                                                                           */
 /* Redirection de la gestion des messages suivant le type des arguments.     */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ParallelMngDispatcher.h
+++ b/arcane/src/arcane/core/ParallelMngDispatcher.h
@@ -268,6 +268,7 @@ class ARCANE_CORE_EXPORT ParallelMngDispatcher
   UniqueArray<Integer> waitSomeRequests(ArrayView<Request> requests) override;
   UniqueArray<Integer> testSomeRequests(ArrayView<Request> requests) override;
   void processMessages(ConstArrayView<ISerializeMessage*> messages) override;
+  void processMessages(ConstArrayView<Ref<ISerializeMessage>> messages) override;
   ISerializeMessageList* createSerializeMessageList() final;
   Ref<ISerializeMessageList> createSerializeMessageListRef() final;
   IParallelMng* createSubParallelMng(Int32ConstArrayView kept_ranks) final;

--- a/arcane/src/arcane/core/ParallelMngDispatcher.h
+++ b/arcane/src/arcane/core/ParallelMngDispatcher.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelMngDispatcher.h                                     (C) 2000-2024 */
+/* ParallelMngDispatcher.h                                     (C) 2000-2025 */
 /*                                                                           */
 /* Interface du gestionnaire du parallélisme sur un domaine.                 */
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/message_passing/arccore/message_passing/MessagePassingMng.h
+++ b/arccore/src/message_passing/arccore/message_passing/MessagePassingMng.h
@@ -60,8 +60,8 @@ class ARCCORE_MESSAGEPASSING_EXPORT MessagePassingMng
 
  private:
 
-  Int32 m_comm_rank;
-  Int32 m_comm_size;
+  Int32 m_comm_rank = A_NULL_RANK;
+  Int32 m_comm_size = A_NULL_RANK;
   IDispatchers* m_dispatchers = nullptr;
   ITimeMetricCollector* m_time_metric_collector = nullptr;
   Communicator m_communicator;

--- a/arccore/src/message_passing/arccore/message_passing/Messages.cc
+++ b/arccore/src/message_passing/arccore/message_passing/Messages.cc
@@ -20,6 +20,7 @@
 #include "arccore/serialize/BasicSerializer.h"
 #include "arccore/serialize/internal/BasicSerializerInternal.h"
 
+#include "arccore/message_passing/BasicSerializeMessage.h"
 #include "arccore/message_passing/ISerializeDispatcher.h"
 #include "arccore/message_passing/IControlDispatcher.h"
 #include "arccore/message_passing/MessageId.h"
@@ -134,7 +135,7 @@ doAllGather(MessagePassing::IMessagePassingMng* pm, const BasicSerializer* send_
   _doGatherOne(pm, send_float32, recv_p->getFloat32Buffer());
 }
 
-} // namespace Arccore
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -318,6 +319,34 @@ void mpAllGather(IMessagePassingMng* pm, const ISerializer* send_serializer, ISe
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
+Ref<ISerializeMessage>
+mpCreateSerializeMessage(IMessagePassingMng* pm, MessageRank target, ePointToPointMessageType type)
+{
+  return internal::BasicSerializeMessage::create(MessageRank(pm->commRank()), target, type);
+}
+
+Ref<ISerializeMessage>
+mpCreateSerializeMessage(IMessagePassingMng* pm, MessageId id)
+{
+  return internal::BasicSerializeMessage::create(MessageRank(pm->commRank()), id);
+}
+
+ARCCORE_MESSAGEPASSING_EXPORT Ref<ISerializeMessage>
+mpCreateSendSerializeMessage(IMessagePassingMng* pm, MessageRank destination)
+{
+  return mpCreateSerializeMessage(pm, destination, ePointToPointMessageType::MsgSend);
+}
+
+ARCCORE_MESSAGEPASSING_EXPORT Ref<ISerializeMessage>
+mpCreateReceiveSerializeMessage(IMessagePassingMng* pm, MessageRank source)
+{
+  return mpCreateSerializeMessage(pm, source, ePointToPointMessageType::MsgReceive);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 namespace
 {
   template <typename DataType> inline ITypeDispatcher<DataType>*

--- a/arccore/src/message_passing/arccore/message_passing/Messages.h
+++ b/arccore/src/message_passing/arccore/message_passing/Messages.h
@@ -265,6 +265,50 @@ mpAllGather(IMessagePassingMng* pm, const ISerializer* send_serializer, ISeriali
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Créé un message de sérialisation.
+ *
+ * \a type est le type de message et \a target la cible.
+ * Si le message est un envoi, \a target est la destination du message.
+ * Si le message est une réception, \a target est la source du message.
+ *
+ * \sa ISerializeMessageList
+ */
+ARCCORE_MESSAGEPASSING_EXPORT Ref<ISerializeMessage>
+mpCreateSerializeMessage(IMessagePassingMng* pm, MessageRank target, ePointToPointMessageType type);
+
+/*!
+ * \brief Créé un message de sérialisation correspondant à \a id.
+ *
+ * \sa ISerializeMessageList
+ */
+ARCCORE_MESSAGEPASSING_EXPORT Ref<ISerializeMessage>
+mpCreateSerializeMessage(IMessagePassingMng* pm, MessageId id);
+
+/*!
+ * \brief Créé un message de sérialisation en envoi.
+ *
+ * Cette méthode est équivalente à
+ * mpCreateSerializeMessage(pm, destination, ePointToPointMessageType::MsgSend).
+ *
+ * \sa ISerializeMessageList
+ */
+ARCCORE_MESSAGEPASSING_EXPORT Ref<ISerializeMessage>
+mpCreateSendSerializeMessage(IMessagePassingMng* pm, MessageRank destination);
+
+/*!
+ * \brief Créé un message de sérialisation en envoi.
+ *
+ * Cette méthode est équivalente à
+ * mpCreateSerializeMessage(pm, source, ePointToPointMessageType::MsgReceive).
+ *
+ * \sa ISerializeMessageList
+ */
+ARCCORE_MESSAGEPASSING_EXPORT Ref<ISerializeMessage>
+mpCreateReceiveSerializeMessage(IMessagePassingMng* pm, MessageRank source);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 ARCCORE_GENERATE_MESSAGEPASSING_PROTOTYPE(char)
 ARCCORE_GENERATE_MESSAGEPASSING_PROTOTYPE(signed char)
@@ -291,42 +335,44 @@ ARCCORE_GENERATE_MESSAGEPASSING_PROTOTYPE(Float16)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace Arccore::MessagePassing
+} // namespace Arcane::MessagePassing
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 namespace Arccore::MessagePassing
 {
-using Arcane::MessagePassing::mpSend;
-using Arcane::MessagePassing::mpReceive;
 using Arcane::MessagePassing::mpAllGather;
-using Arcane::MessagePassing::mpGather;
-using Arcane::MessagePassing::mpNonBlockingAllGather;
-using Arcane::MessagePassing::mpNonBlockingGather;
 using Arcane::MessagePassing::mpAllGatherVariable;
-using Arcane::MessagePassing::mpGatherVariable;
-using Arcane::MessagePassing::mpGather;
-using Arcane::MessagePassing::mpScatterVariable;
 using Arcane::MessagePassing::mpAllReduce;
-using Arcane::MessagePassing::mpNonBlockingAllReduce;
-using Arcane::MessagePassing::mpBroadcast;
-using Arcane::MessagePassing::mpNonBlockingBroadcast;
 using Arcane::MessagePassing::mpAllToAll;
-using Arcane::MessagePassing::mpNonBlockingAllToAll;
 using Arcane::MessagePassing::mpAllToAllVariable;
-using Arcane::MessagePassing::mpNonBlockingAllToAllVariable;
-using Arcane::MessagePassing::mpCreateRequestListRef;
-using Arcane::MessagePassing::mpWaitAll;
-using Arcane::MessagePassing::mpWait;
-using Arcane::MessagePassing::mpWaitSome;
-using Arcane::MessagePassing::mpTestSome;
-using Arcane::MessagePassing::mpProbe;
-using Arcane::MessagePassing::mpLegacyProbe;
-using Arcane::MessagePassing::mpSplit;
 using Arcane::MessagePassing::mpBarrier;
-using Arcane::MessagePassing::mpNonBlockingBarrier;
+using Arcane::MessagePassing::mpBroadcast;
+using Arcane::MessagePassing::mpCreateReceiveSerializeMessage;
+using Arcane::MessagePassing::mpCreateRequestListRef;
+using Arcane::MessagePassing::mpCreateSendSerializeMessage;
+using Arcane::MessagePassing::mpCreateSerializeMessage;
 using Arcane::MessagePassing::mpCreateSerializeMessageListRef;
+using Arcane::MessagePassing::mpGather;
+using Arcane::MessagePassing::mpGatherVariable;
+using Arcane::MessagePassing::mpLegacyProbe;
+using Arcane::MessagePassing::mpNonBlockingAllGather;
+using Arcane::MessagePassing::mpNonBlockingAllReduce;
+using Arcane::MessagePassing::mpNonBlockingAllToAll;
+using Arcane::MessagePassing::mpNonBlockingAllToAllVariable;
+using Arcane::MessagePassing::mpNonBlockingBarrier;
+using Arcane::MessagePassing::mpNonBlockingBroadcast;
+using Arcane::MessagePassing::mpNonBlockingGather;
+using Arcane::MessagePassing::mpProbe;
+using Arcane::MessagePassing::mpReceive;
+using Arcane::MessagePassing::mpScatterVariable;
+using Arcane::MessagePassing::mpSend;
+using Arcane::MessagePassing::mpSplit;
+using Arcane::MessagePassing::mpTestSome;
+using Arcane::MessagePassing::mpWait;
+using Arcane::MessagePassing::mpWaitAll;
+using Arcane::MessagePassing::mpWaitSome;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/message_passing/arccore/message_passing/SerializeMessageList.cc
+++ b/arccore/src/message_passing/arccore/message_passing/SerializeMessageList.cc
@@ -194,8 +194,7 @@ buildMessageInfo(ISerializeMessage* sm)
 Ref<ISerializeMessage> SerializeMessageList::
 createAndAddMessage(MessageRank destination,ePointToPointMessageType type)
 {
-  MessageRank source(m_message_passing_mng->commRank());
-  auto x = BasicSerializeMessage::create(source,destination,type);
+  auto x = mpCreateSerializeMessage(m_message_passing_mng, destination, type);
   addMessage(x.get());
   return x;
 }

--- a/arccore/src/message_passing/arccore/message_passing/SerializeMessageList.h
+++ b/arccore/src/message_passing/arccore/message_passing/SerializeMessageList.h
@@ -55,7 +55,7 @@ class ARCCORE_MESSAGEPASSING_EXPORT SerializeMessageList
 
  public:
 
-  SerializeMessageList(IMessagePassingMng* mpm);
+  explicit SerializeMessageList(IMessagePassingMng* mpm);
 
  public:
 


### PR DESCRIPTION
This will be used instead of plain `ISerializeMessage*` to automatically handle lifetime management of instances of `ISerializeMessage`.
