### PR TITLE
Make thread-safe the buffer management in VariableSynchronizerMng

### DIFF
--- a/arcane/src/arcane/impl/internal/VariableSynchronizerMng.h
+++ b/arcane/src/arcane/impl/internal/VariableSynchronizerMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableSynchronizerMng.h                                   (C) 2000-2023 */
+/* VariableSynchronizerMng.h                                   (C) 2000-2025 */
 /*                                                                           */
 /* Gestionnaire des synchroniseurs de variables.                             */
 /*---------------------------------------------------------------------------*/
@@ -20,6 +20,8 @@
 
 #include "arcane/core/IVariableSynchronizerMng.h"
 #include "arcane/core/internal/IVariableSynchronizerMngInternal.h"
+
+#include <memory>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -67,7 +69,7 @@ class ARCANE_IMPL_EXPORT VariableSynchronizerMng
    private:
 
     VariableSynchronizerMng* m_synchronizer_mng = nullptr;
-    BufferList* m_buffer_list = nullptr;
+    std::unique_ptr<BufferList> m_buffer_list;
   };
 
  public:


### PR DESCRIPTION
This way the synchronization on variables may be used from different threads.
 