### PR TITLE
Add basic Guix files

### DIFF
--- a/guix/channels.locked.scm
+++ b/guix/channels.locked.scm
@@ -1,0 +1,22 @@
+(list (channel
+        (name 'guix)
+        (url "https://codeberg.org/guix/guix")
+        (branch "master")
+        (commit
+          "56344729cd07c76d5133047f2866237bbb08dced")
+        (introduction
+          (make-channel-introduction
+            "9edb3f66fd807b096b48283debdcddccfea34bad"
+            (openpgp-fingerprint
+              "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
+      (channel
+        (name 'nonguix)
+        (url "https://gitlab.com/nonguix/nonguix")
+        (branch "master")
+        (commit
+          "94c750ad596f513d5659ce9909022ed09f864537")
+        (introduction
+          (make-channel-introduction
+            "897c1a470da759236cc11798f4e0a5f7d4d59fbc"
+            (openpgp-fingerprint
+              "2A39 3FFF 68F4 EF7A 3D29  12AF 6F51 20A0 22FB B2D5")))))

--- a/guix/channels.scm
+++ b/guix/channels.scm
@@ -1,0 +1,17 @@
+(list (channel
+        (name 'guix)
+        (url "https://codeberg.org/guix/guix")
+        (branch "master")
+        (introduction
+          (make-channel-introduction
+            "9edb3f66fd807b096b48283debdcddccfea34bad"
+            (openpgp-fingerprint
+              "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
+      (channel
+        (name 'nonguix)
+        (url "https://gitlab.com/nonguix/nonguix")
+        (introduction
+         (make-channel-introduction
+          "897c1a470da759236cc11798f4e0a5f7d4d59fbc"
+          (openpgp-fingerprint
+           "2A39 3FFF 68F4 EF7A 3D29  12AF 6F51 20A0 22FB B2D5")))))

--- a/guix/manifest.scm
+++ b/guix/manifest.scm
@@ -1,0 +1,23 @@
+(use-modules (guix build-system gnu)
+             (ice-9 match))
+
+(define stdenv
+  (map (lambda* (pkg)
+         (match pkg
+           ((_ value _ ...)
+            value)))
+       (standard-packages)))
+
+(concatenate-manifests (list (specifications->manifest (list "bash"
+                                                        "git"
+                                                        "cmake"
+                                                        "pkg-config"
+                                                        "googletest"
+                                                        "openmpi"
+                                                        "glib"
+                                                        "libxml2"
+                                                        "dotnet@8"
+                                                        "openblas"
+                                                        "boost"
+                                                        "gfortran-toolchain"))
+                             (packages->manifest stdenv)))


### PR DESCRIPTION
This PR adds files for using Guix to load dependencies in a shell. 

- `manifest.scm`: list of files to include.
- `channels.scm`: which Guix channels to use.
- `channels.locked.scm`, derived from the former, includes the commits for the channels.

To use the shell:

```
$ guix time-machine -C ./guix/channels.locked.scm -q -- shell -m ./guix/manifest.scm
$ cmake -B build ...
```

To update `channels.locked.scm`:


```
$ guix time-machine -C ./guix/channels.scm -q -- describe -f channels > guix/channels.locked.scm
``` 