### PR TITLE
[CI] Update 'compile-all-workflow' with version 1.9.1 of `framework-ci` packages

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -42,6 +42,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
+            base_os: ubuntu
             full_name: 'ubuntu-22.04'
             package_name: 'ubuntu-22.04'
             triplet: x64-linux-dynamic
@@ -50,6 +51,7 @@ jobs:
             cmake_specific_args : '-DALIEN_BUILD_COMPONENT=all -DARCCORE_BUILD_MODE=Debug -DCMAKE_BUILD_TYPE=Debug'
             ctest_specific_args : '-I 1,200'
           - os: ubuntu-22.04
+            base_os: ubuntu
             full_name: 'ubuntu-cxx20-22.04'
             package_name: 'ubuntu-22.04'
             triplet: x64-linux-dynamic
@@ -58,6 +60,7 @@ jobs:
             cmake_specific_args : '-DALIEN_BUILD_COMPONENT=all -DARCCORE_BUILD_MODE=Debug -DCMAKE_BUILD_TYPE=Debug -DARCCORE_CXX_STANDARD=20 -DARCANE_ENABLE_DOTNET_PYTHON_WRAPPER=OFF'
             ctest_specific_args : '-I 1,210'
           - os: ubuntu-24.04
+            base_os: ubuntu
             full_name: 'ubuntu-cxx20-24.04'
             package_name: 'ubuntu-24.04'
             triplet: x64-linux-dynamic
@@ -66,6 +69,7 @@ jobs:
             cmake_specific_args : '-DALIEN_BUILD_COMPONENT=all -DARCCORE_BUILD_MODE=Debug -DCMAKE_BUILD_TYPE=Debug -DARCCORE_CXX_STANDARD=20 -DARCANE_ENABLE_DOTNET_PYTHON_WRAPPER=ON'
             ctest_specific_args : '-I 1,210'
           - os: 'windows-2022'
+            base_os: windows
             full_name: 'windows-2022-intelmpi'
             package_name: 'windows-2022-intelmpi'
             triplet: x64-windows
@@ -74,6 +78,7 @@ jobs:
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release'
             ctest_specific_args : '-I 1,160'
           - os: 'windows-2022'
+            base_os: windows
             full_name: 'windows-2022-cxx20-intelmpi'
             package_name: 'windows-2022-intelmpi'
             triplet: x64-windows
@@ -82,6 +87,7 @@ jobs:
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Release -DARCCORE_CXX_STANDARD=20'
             ctest_specific_args : '-I 1,160'
           - os: 'windows-2022'
+            base_os: windows
             full_name: 'windows-2022-cxx20-debug-intelmpi'
             package_name: 'windows-2022-intelmpi'
             triplet: x64-windows
@@ -212,7 +218,7 @@ jobs:
       - name: Configure build script
         shell: bash
         run: |
-          cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_VERBOSE_MAKEFILE=TRUE -DVCPKG_INSTALLED_DIR="${{ env.VCPKG_BUILD_DIR }}/installed" -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.cmake_specific_args }} -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" -GNinja
+          cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_VERBOSE_MAKEFILE=TRUE -DVCPKG_INSTALLED_DIR="${{ env.VCPKG_BUILD_DIR }}/installed" -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.cmake_specific_args }} -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" -GNinja -DARCANE_FORCE_NOASNEEDED=TRUE
 
       - name: Dump Some Generated files
         shell: bash
@@ -233,6 +239,14 @@ jobs:
         run: |
           find "${{ env.CMAKE_BUILD_DIR }}/lib"
 
+      - name: Print libraries path
+        if: matrix.base_os != 'windows'
+        shell: bash
+        run: |
+          ldd "${{ env.CMAKE_BUILD_DIR }}/lib/arcane_tests_exec"
+          ldd ${{ env.CMAKE_BUILD_DIR }}/lib/lib*.so
+          readelf -d ${{ env.CMAKE_BUILD_DIR }}/lib/lib*.so
+
       - name: Get 'ccache' status
         run: ccache -s -v
 
@@ -242,7 +256,7 @@ jobs:
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }}
 
       - name: Test Aleph kappa
-        if: matrix.os != 'windows-2022'
+        if: matrix.base_os != 'windows'
         shell: bash
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }} -R kappa
@@ -257,6 +271,6 @@ jobs:
       # que la DLL 'arcane_dotnet_coreclr' est bien trouvée
       - name: Test .Net wrapper
         shell: bash
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: matrix.base_os != 'windows'
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R coreclr

--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -88,9 +88,7 @@ jobs:
             vcpkg_os: windows-2022
             dotnet_version : "8.0.x"
             cmake_specific_args : '-DCMAKE_BUILD_TYPE=Debug -DARCCORE_CXX_STANDARD=20'
-            # Actuellement (juin 2024) les tests MPI plantent à la fin en erreur.
-            # C'est pourquoi on n'active que les tests de 1 à 40.
-            ctest_specific_args : '-I 1,40'
+            ctest_specific_args : '-I 1,160'
 
     env:
       # Indique pour IntelMPI de ne pas faire d'attente active
@@ -109,7 +107,7 @@ jobs:
       VCPKG_ROOT: '${{ github.workspace }}/../../build_base/framework-ci/vcpkg'
       VCPKG_BUILD_DIR: '${{ github.workspace }}/../../build_base/framework-ci/vcpkg'
       BUILD_COMMANDS_ROOT: '${{ github.workspace }}/../../build_base/framework-ci/_build'
-      VCPKG_INSTALL_HASH_PACKAGE_NAME: '1.7.3-${{ matrix.package_name }}-${{ matrix.triplet }}'
+      VCPKG_INSTALL_HASH_PACKAGE_NAME: '1.9.1-${{ matrix.package_name }}-${{ matrix.triplet }}'
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       FRAMEWORKCI_BRANCH: main

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -522,8 +522,17 @@ install(TARGETS arcane_full EXPORT ArcaneTargets)
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   # TODO: Vérifier que tous les compilateurs Linux (GCC,CLANG,Intel) supportent
   # cette option.
-  message(STATUS "Adding 'no-as-needed' to link option")
+  message(STATUS "Adding 'no-as-needed' to link option for 'arcane_full'")
   target_link_options(arcane_full INTERFACE "-Wl,--no-as-needed")
+  # Normalement ce n'est pas nécessaire par défaut mais cela peut permettre de
+  # contourner des problèmes de RPATH ou RUNPATH pour les bibliothèques
+  # pas directement utilisées par Arcane pour lequel le RPATH ou le RUNPATH
+  # n'est pas bien géré (cela peut-être du à un bug ou un fichier
+  # de configuration qui n'utilise pas cela)
+  if (ARCANE_FORCE_NOASNEEDED)
+    message(STATUS "Adding 'no-as-needed' to link option for 'arcane_build_compile_flags'")
+    target_link_options(arcane_build_compile_flags INTERFACE "-Wl,--no-as-needed")
+  endif()
 endif()
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This version use `vcpkg` version 2025.06.13 and `IntelMPI` version 2021.16.
