### PR TITLE
Fix MSH reader when using Win32 end of line

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -274,3 +274,8 @@ jobs:
         if: matrix.base_os != 'windows'
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R coreclr
+
+      - name: Test Convert Mesh
+        shell: bash
+        run: |
+          cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R convert_mesh

--- a/arcane/src/arcane/std/MshParallelMeshReader.cc
+++ b/arcane/src/arcane/std/MshParallelMeshReader.cc
@@ -482,7 +482,7 @@ void MshParallelMeshReader::
 _goToNextLine()
 {
   if (m_ios_file.get())
-    m_ios_file->getNextLine();
+    m_ios_file->goToEndOfLine();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1734,7 +1734,7 @@ _readMeshFromFile()
         ARCANE_FATAL("Bad endianess for file. Read int as value '{0}' (expected=1)", int_value_one);
     }
 
-    ios_file->getNextLine(); // Skip current \n\r
+    _goToNextLine();
 
     // $EndMeshFormat
     if (!ios_file->lookForString("$EndMeshFormat"))

--- a/arcane/src/arcane/std/internal/IosFile.cc
+++ b/arcane/src/arcane/std/internal/IosFile.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IosFile.cc                                                  (C) 2000-2024 */
+/* IosFile.cc                                                  (C) 2000-2025 */
 /*                                                                           */
 /* Routines des Lecture/Ecriture d'un fichier.                               */
 /*---------------------------------------------------------------------------*/
@@ -83,6 +83,23 @@ getNextLine()
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Lit tous les caractères jusqu'à un caractère non blanc.
+ */
+void IosFile::
+goToEndOfLine()
+{
+  while (m_stream->good()) {
+    char c = m_stream->peek();
+    if (std::isspace(c))
+      m_stream->get();
+    else
+      break;
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 Real IosFile::
 getReal()
@@ -127,11 +144,11 @@ bool IosFile::
 lookForString(const String& str)
 {
   const char* bfr = getNextLine();
-  //	ITraceMng::info() << "[IosFile::getString] Looking for " << str;
+  std::cout << "[IosFile::getString] Looking for '" << str << "' len=" << str.length() << "\n";
   std::istringstream iline(bfr);
   std::string got;
   iline >> got;
-  //	info() << "[IosFile::getString] got=" << got;
+  std::cout << "[IosFile::getString] got='" << got << "' len=" << got.length() << "\n";
   return isEqualString(got, str);
 }
 

--- a/arcane/src/arcane/std/internal/IosFile.h
+++ b/arcane/src/arcane/std/internal/IosFile.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IosFile.h                                                   (C) 2000-2024 */
+/* IosFile.h                                                   (C) 2000-2025 */
 /*                                                                           */
 /* Routines des Lecture/Ecriture d'un fichier.                               */
 /*---------------------------------------------------------------------------*/
@@ -42,6 +42,7 @@ class IosFile
   {}
   const char* getNextLine(const char*);
   const char* getNextLine(void);
+  void goToEndOfLine(void);
   Real getReal(void);
   Integer getInteger(void);
   Int64 getInt64(void);
@@ -59,7 +60,7 @@ class IosFile
 
  private:
 
-  std::istream* m_stream;
+  std::istream* m_stream = nullptr;
   char m_buf[IOS_BFR_SZE];
 };
 


### PR DESCRIPTION
Win32 may be using CR LF for end of line and in this case `std::istream::getline()`has an `\r` at the end of the readed string.