### PR TITLE
Automatically load library `arcane_cea.dll` on Win32 for tests

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -279,3 +279,9 @@ jobs:
         shell: bash
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R convert_mesh
+
+      - name: Test Checkpoint
+        shell: bash
+        if: matrix.full_name == 'windows-2022-cxx20-intelmpi'
+        run: |
+          cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R checkpoint

--- a/arcane/src/arcane/tests/ArcaneTestInit.cc
+++ b/arcane/src/arcane/tests/ArcaneTestInit.cc
@@ -4,6 +4,12 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ArcaneTestInit.cc                                           (C) 2000-2025 */
+/*                                                                           */
+/* Initialisation pour les tests.                                            */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/PlatformUtils.h"
 
@@ -43,6 +49,7 @@ arcaneTestSetApplicationInfo()
 #ifdef ARCANE_OS_WIN32
   app_build_info.addDynamicLibrary("PerfectGas");
   app_build_info.addDynamicLibrary("StiffenedGas");
+  app_build_info.addDynamicLibrary("arcane_cea");
   app_build_info.addDynamicLibrary("arcane_cea_tests");
   app_build_info.addDynamicLibrary("arcane_aleph_tests");
   app_build_info.addDynamicLibrary("arcane_aleph_hypre");


### PR DESCRIPTION
This library is not loaded because none of its symbols are directly used (it only contains plug-in).
Also add in Windows CI some case using this component.