### PR TITLE
Add support for variables of non basic type in `VariableUtils::experimentalChangeAllocator()`

### DIFF
--- a/arcane/src/arcane/impl/ArrayData.inst.h
+++ b/arcane/src/arcane/impl/ArrayData.inst.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayData.inst.h                                            (C) 2000-2024 */
+/* ArrayData.inst.h                                            (C) 2000-2025 */
 /*                                                                           */
 /* Donnée du type 'Array'.                                                   */
 /*---------------------------------------------------------------------------*/
@@ -494,7 +494,11 @@ setAllocationInfo(const DataAllocationInfo& v)
 template <typename DataType> void ArrayDataT<DataType>::
 changeAllocator(const MemoryAllocationOptions& alloc_info)
 {
-  UniqueArray<DataType> new_value(alloc_info, m_value.size());
+  // Il faut utiliser par resizeNoInit() car si la mémoire demandée
+  // est le device on ne peut pas utiliser les constructeurs si le type
+  // n'est pas un type basique car l'opération est faite côté CPU.
+  UniqueArray<DataType> new_value(alloc_info);
+  new_value.resizeNoInit(m_value.size());
 
   // Copie \a m_value dans \a new_value
   // Tant qu'il n'y a pas l'API dans Arccore, il faut faire la copie à la


### PR DESCRIPTION
Non basic type is for example `Real2` or `Real3`.
