### PR TITLE
add missing target_link_libraries

### DIFF
--- a/arcane/src/arcane/aleph/petsc/CMakeLists.txt
+++ b/arcane/src/arcane/aleph/petsc/CMakeLists.txt
@@ -15,5 +15,6 @@ arcane_add_library(arcane_aleph_petsc
 
 arcane_add_arccon_packages(arcane_aleph_petsc PRIVATE ${PKGS})
 target_link_libraries(arcane_aleph_petsc PUBLIC arcane_core)
+target_link_libraries(arcane_aleph_petsc PRIVATE arcane_aleph)
 
 arcane_register_library(arcane_aleph_petsc OPTIONAL)


### PR DESCRIPTION
helps compile alephpetsc on MacOS