### PR TITLE
Enable C# wrapping on Win32 platform using `dotnet`

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -266,12 +266,8 @@ jobs:
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -V -R python_test
 
-      # NOTE: pour l'instant sous Win32 on ne peut pas exÃ©cuter les tests 'embedded'
-      # car il faut gÃ©rer le lancement de la compilation et aussi vÃ©rifier
-      # que la DLL 'arcane_dotnet_coreclr' est bien trouvÃ©e
       - name: Test .Net wrapper
         shell: bash
-        if: matrix.base_os != 'windows'
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R coreclr
 
@@ -290,7 +286,8 @@ jobs:
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R compare
 
-
+      # Comme ces tests sont un peu long on ne les exécute que sous Windows.
+      # Pour Linux, ils sont déjà lancés dans des CI dédiés.
       - name: Test Checkpoint
         shell: bash
         if: matrix.full_name == 'windows-2022-cxx20-intelmpi'

--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -1410,19 +1410,33 @@ endif()
 # TODO: pour 'libfabric.dll', plutôt modifier le package 'intel-mpi' de 'vcpkg' pour
 # indiquer explicitement où se trouve cette DLL.
 #
-if (ARCANE_ENABLE_TESTS)
+if (TARGET arcane_tests_exec)
   file(APPEND ${ARCANE_COPY_DLLS_CONFIG_FILE} "list(APPEND EXE_LIST \"$<TARGET_FILE:arcane_tests_exec>\")\n")
-  set(ARCANE_COPY_DLL_GENERATED_FILE ${CMAKE_CURRENT_BINARY_DIR}/copy_dlls_config.$<CONFIG>.cmake)
-  file(GENERATE OUTPUT ${ARCANE_COPY_DLL_GENERATED_FILE} INPUT ${ARCANE_COPY_DLLS_CONFIG_FILE})
-  add_custom_target(copy_dlls
-    COMMAND ${CMAKE_COMMAND} -D CONFIG_INCLUDE_FILE=${ARCANE_COPY_DLL_GENERATED_FILE} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ArcaneCopyDLLs.cmake )
 endif()
-
+# Pour copier 'nethost.dll' sous Windows.
+if (TARGET arcane_dotnet_coreclr)
+  file(APPEND ${ARCANE_COPY_DLLS_CONFIG_FILE} "list(APPEND EXE_LIST \"$<TARGET_FILE:arcane_dotnet_coreclr>\")\n")
+endif()
+foreach(pkg ${ARCANE_LIBRARIES})
+  if (TARGET ${pkg})
+    file(APPEND ${ARCANE_COPY_DLLS_CONFIG_FILE} "list(APPEND EXE_LIST \"$<TARGET_FILE:${pkg}>\")\n")
+  endif()
+endforeach()
+foreach(pkg ${ARCANE_OPTIONAL_LIBRARIES})
+  if (TARGET ${pkg})
+    file(APPEND ${ARCANE_COPY_DLLS_CONFIG_FILE} "list(APPEND EXE_LIST \"$<TARGET_FILE:${pkg}>\")\n")
+  endif()
+endforeach()
 find_path(INTEL_LIBFABRIC NAMES "libfabric.dll" PATH_SUFFIXES bin)
 if (INTEL_LIBFABRIC)
   message (STATUS "Found 'libfabric.dll' in = '${INTEL_LIBFABRIC}'")
   file(COPY ${INTEL_LIBFABRIC}/libfabric.dll DESTINATION "${LIBRARY_OUTPUT_PATH}")
 endif()
+
+set(ARCANE_COPY_DLL_GENERATED_FILE ${CMAKE_CURRENT_BINARY_DIR}/copy_dlls_config.$<CONFIG>.cmake)
+file(GENERATE OUTPUT ${ARCANE_COPY_DLL_GENERATED_FILE} INPUT ${ARCANE_COPY_DLLS_CONFIG_FILE})
+add_custom_target(copy_dlls
+  COMMAND ${CMAKE_COMMAND} -D CONFIG_INCLUDE_FILE=${ARCANE_COPY_DLL_GENERATED_FILE} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ArcaneCopyDLLs.cmake )
 
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------

--- a/arcane/src/arcane/dotnet/coreclr/ArcaneCoreClr.cc
+++ b/arcane/src/arcane/dotnet/coreclr/ArcaneCoreClr.cc
@@ -212,7 +212,15 @@ _execDirect(const CommandLineArguments& cmd_args,
   hostfxr_initialize_parameters params;
   params.size = sizeof(params);
   params.host_path = root_path1.c_str();
+#ifdef ARCANE_OS_WIN32
+  // Sous Windows, '.Net' est installé dans un chemin standard
+  // et il ne faut pas spécifier le chemin (cela provoque une erreur
+  // d'argument invalide (a vérifier si c'est parce que 'arcane_dotnet_root'
+  // n'est pas valide ou s'il ne faut rien spécifier).
+  params.dotnet_root = nullptr;
+#else
   params.dotnet_root = dotnet_root.c_str();
+#endif
   const_char_t* argv = new const_char_t[1];
   char_t* argv0_str = _duplicate((const char_t*)(orig_assembly_name1.c_str()));
   argv[0] = argv0_str;

--- a/arcane/src/arcane/dotnet/coreclr/ArcaneCoreClr.cc
+++ b/arcane/src/arcane/dotnet/coreclr/ArcaneCoreClr.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------

--- a/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.DotNetCompile/Compile.cs
+++ b/arcane/tools/Arcane.ExecDrivers/Arcane.ExecDrivers.DotNetCompile/Compile.cs
@@ -13,19 +13,26 @@ namespace Arcane.ExecDrivers.DotNetCompile
 {
   class Compile
   {
+    // NOTE: Il faut protéger les arguments en les entourant
+    // de guillements ('"') au cas où ils contiennent des espaces.
+    // NOTE: Avec '.Net Core', il y a dans ProcessStartInfo une propriété
+    // ArgumentList de type Collection<string> pour gérer les arguments.
+    // Il serait préférable d'utiliser cela pour éviter les problèmes
+    // comme les caractères blancs dans les noms d'arguments.
     class Helper
     {
       internal List<string> m_args = new List<string>();
 
       internal void AddReferenceLib(string path, string name)
       {
-        m_args.Add("/reference:" + Path.Combine(path, name));
+        m_args.Add("\"/reference:" + Path.Combine(path, name) + '"');
       }
       internal void AddArg(string name)
       {
-        m_args.Add(name);
+        m_args.Add('"'+name+'"');
       }
     }
+
     /*!
      * \brief Commande pour compiler les fichiers \a args.
      *
@@ -36,7 +43,6 @@ namespace Arcane.ExecDrivers.DotNetCompile
     {
       var helper = new Helper();
       string lib_dir = Utils.CodeLibPath;
-
       // Le répertoire de base de 'dotnet' est le répertoire dans lequel
       // il y a l'exécutable 'dotnet'
       string dotnet_command = Utils.DotnetCoreClrPath;
@@ -46,7 +52,6 @@ namespace Arcane.ExecDrivers.DotNetCompile
       string dotnet_sdk_path = Utils.DotnetCoreClrSdkPath;
 
       // Le compilateur est: ${dotnet_root}/sdk/${dotnet_full_version}/Roslyn/bincore/csc.dll
-      helper.AddArg(Utils.DotnetCoreClrPath);
       helper.AddArg("exec");
       helper.AddArg(Path.Combine(dotnet_sdk_path, "Roslyn", "bincore", "csc.dll"));
       helper.AddArg("/noconfig");
@@ -57,7 +62,7 @@ namespace Arcane.ExecDrivers.DotNetCompile
       helper.AddReferenceLib(Path.Combine(dotnet_sdk_path, "ref"), "netstandard.dll");
       helper.m_args.AddRange(args);
       string cmd = string.Join(" ", helper.m_args);
-      Utils.ExecShellCommand(cmd, null);
+      Utils.ExecCommand(Utils.DotnetCoreClrPath, cmd, null);
 
       return 0;
     }


### PR DESCRIPTION
The wrapping was previously available with `mono`.
For `dotnet`, we had to do the following modification:
- modify the search mechanism of DLLs to allow loading of DLLs in the build directory
- copy the `nethost.dll` in the build directory
- handling direct call to the roslyn compiler
- do not set `dotnet_root` when using embedded runtime.