### PR TITLE
Cleanup conversion between `String` and `std::wstring`

### DIFF
--- a/arcane/src/arcane/dotnet/coreclr/ArcaneCoreClr.cc
+++ b/arcane/src/arcane/dotnet/coreclr/ArcaneCoreClr.cc
@@ -9,6 +9,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#include "arccore/base/StringUtils.h"
+
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/String.h"
 #include "arcane/utils/CommandLineArguments.h"
@@ -42,16 +44,16 @@ using string_t = std::basic_string<char_t>;
 
 #ifdef _WINDOWS
 
-#include <Windows.h>
+#include <windows.h>
 
 #define STR(s) L##s
 #define CH(c) L##c
 
 namespace
 {
-  string_t _toString(const Arcane::String& s)
+  std::wstring _toString(const Arcane::String& s)
   {
-    return string_t((const char_t*)(s.utf16().data()));
+    return Arcane::StringUtils::convertToStdWString(s);
   }
   char_t* _duplicate(const char_t* x)
   {
@@ -59,12 +61,8 @@ namespace
   }
   Arcane::String _toArcaneString(const char_t* x)
   {
-    using namespace Arcane;
-    const UChar* ux = reinterpret_cast<const UChar*>(x);
-    size_t slen = wcslen(x);
-    Int32 len = CheckedConvert::toInt32(slen);
-    ConstArrayView<UChar> buf(len,ux);
-    return String(buf);
+    std::wstring_view wstr_view(x);
+    return Arcane::StringUtils::convertToArcaneString(wstr_view);
   }
 } // namespace
 
@@ -83,9 +81,7 @@ namespace
 {
   string_t _toString(const Arcane::String& s)
   {
-    if (s.null() || s.empty())
-      return string_t();
-    return string_t((const char_t*)(s.utf8().data()));
+    return std::string(s.toStdStringView());
   }
   char_t* _duplicate(const char_t* x)
   {

--- a/arcane/src/arcane/impl/Application.cc
+++ b/arcane/src/arcane/impl/Application.cc
@@ -11,6 +11,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arccore/base/StringUtils.h"
+
 #include "arcane/utils/Iostream.h"
 #include "arcane/utils/Iterator.h"
 #include "arcane/utils/List.h"
@@ -79,7 +81,6 @@
 
 #ifdef ARCANE_OS_WIN32
 #include <windows.h>
-#include <codecvt>
 #endif
 
 #include <vector>
@@ -348,10 +349,7 @@ build()
         // A vérifier si cela fonctionne lorsqu'on n'utilisera plus le chargeur
         // dynamique de la glib.
         m_trace->info(4) << "Adding '" << os_dir << "' to search library path";
-        // Convert en 'wchar_t' pour 'AddDllDirectory()'.
-        std::string std_utf8_str(os_dir.toStdStringView());
-        std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-        std::wstring wide_os_dir = converter.from_bytes(std_utf8_str);
+        std::wstring wide_os_dir = StringUtils::convertToStdWString(os_dir);
         SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
         AddDllDirectory(wide_os_dir.c_str());
       }
@@ -368,6 +366,7 @@ build()
 #ifdef ARCANE_OS_WIN32
     if (dynamic_library_loader){
       String os_dir(m_exe_info.dataOsDir());
+      // TODO: Ajouter le répertoire contenant 'arcane_impl' qui est connu dans ArcaneMain dans m_arcane_lib_path.
       String dyn_lib_names[5] = { "arcane_mpi", "arcane_std", "arcane_mesh",
                                   "arcane_thread", "arcane_mpithread",
                                 };

--- a/arcane/src/arcane/utils/PlatformUtils.cc
+++ b/arcane/src/arcane/utils/PlatformUtils.cc
@@ -28,6 +28,8 @@
 #include "arcane/utils/CheckedConvert.h"
 #include "arcane/utils/internal/MemoryUtilsInternal.h"
 
+#include "arccore/base/StringUtils.h"
+
 #include <chrono>
 
 #ifndef ARCANE_OS_WIN32
@@ -492,20 +494,6 @@ getLoadedSharedLibraryFullPath(const String& dll_name)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#if defined(ARCANE_OS_WIN32)
-namespace
-{
-  Arcane::String _toArcaneString(const wchar_t* x)
-  {
-    const UChar* ux = reinterpret_cast<const UChar*>(x);
-    size_t slen = std::wcslen(x);
-    Int32 len = CheckedConvert::toInt32(slen);
-    ConstArrayView<UChar> buf(len, ux);
-    return String(buf);
-  }
-} // namespace
-#endif
-
 extern "C++" void platform::
 fillCommandLineArguments(StringList& arg_list)
 {
@@ -549,7 +537,8 @@ fillCommandLineArguments(StringList& arg_list)
     ARCANE_FATAL("Can not get arguments from command line");
 
   for (int i = 0; i < nb_arg; i++) {
-    String str = _toArcaneString(w_arg_list[i]);
+    std::wstring_view wstr_view(w_arg_list[i]);
+    String str = StringUtils::convertToArcaneString(wstr_view);
     arg_list.add(str);
   }
 

--- a/arccore/src/base/arccore/base/String.cc
+++ b/arccore/src/base/arccore/base/String.cc
@@ -17,6 +17,7 @@
 #include "arccore/base/APReal.h"
 #include "arccore/base/TraceInfo.h"
 #include "arccore/base/FatalErrorException.h"
+#include "arccore/base/NotSupportedException.h"
 #include "arccore/base/StringView.h"
 #include "arccore/base/StringUtils.h"
 
@@ -1278,6 +1279,39 @@ std::vector<UChar> StringUtils::
 asUtf16BE(const String& str)
 {
   return StringUtilsImpl::toUtf16BE(str);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+std::wstring StringUtils::
+convertToStdWString(const String& str)
+{
+#ifdef ARCCORE_OS_WIN32
+  ConstArrayView<UChar> utf16 = str.utf16();
+  const wchar_t* wdata = reinterpret_cast<const wchar_t*>(utf16.data());
+  const size_t wlen = utf16.size();
+  std::wstring_view wstr_view(wdata,wlen);
+  return std::wstring(wstr_view);
+#else
+  ARCCORE_THROW(NotSupportedException,"This function is only supported on Win32");
+#endif
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+String StringUtils::
+convertToArcaneString(const std::wstring_view& wstr)
+{
+#ifdef ARCCORE_OS_WIN32
+  const UChar* ux = reinterpret_cast<const UChar*>(wstr.data());
+  Int32 len = arccoreCheckArraySize(wstr.length());
+  ConstArrayView<UChar> buf(len, ux);
+  return String(buf);
+#else
+  ARCCORE_THROW(NotSupportedException,"This function is only supported on Win32");
+#endif
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/StringUtils.h
+++ b/arccore/src/base/arccore/base/StringUtils.h
@@ -35,6 +35,22 @@ namespace Arcane::StringUtils
 extern "C++" ARCCORE_BASE_EXPORT std::vector<UChar>
 asUtf16BE(const String& str);
 
+/*!
+ * \brief Retourne la conversion de \a str en std::wstring.
+ *
+ * Cette fonction n'est supportée que pour la plateforme Win32.
+ */
+extern "C++" ARCCORE_BASE_EXPORT std::wstring
+convertToStdWString(const String& str);
+
+/*!
+ * \brief Convertie \a wstr en une String.
+ *
+ * Cette fonction n'est supportée que pour la plateforme Win32.
+ */
+extern "C++" ARCCORE_BASE_EXPORT String
+convertToArcaneString(const std::wstring_view& wstr);
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Add functions to do conversion between `Arcane::String` and `std::wstring`.
These functions are only valid for Win32 because they suppose a `wchar_t` is two bytes and is UTF-16 encoding.
