### PR TITLE
Move copy methods from `MemoryView` classes in `MemoryUtils` namespace

### DIFF
--- a/arcane/src/arcane/accelerator/core/RunQueueRuntime.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueRuntime.cc
@@ -13,6 +13,7 @@
 
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/MemoryView.h"
+#include "arcane/utils/MemoryUtils.h"
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/FatalErrorException.h"
 
@@ -51,7 +52,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT HostRunQueueStream
   void barrier() override { return m_runtime->barrier(); }
   void copyMemory(const MemoryCopyArgs& args) override
   {
-    args.destination().copyHost(args.source());
+    MemoryUtils::copyHost(args.destination(), args.source());
   }
   void prefetchMemory(const MemoryPrefetchArgs&) override {}
   NativeStream nativeStream() override { return {}; }

--- a/arcane/src/arcane/core/Data.cc
+++ b/arcane/src/arcane/core/Data.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Data.cc                                                     (C) 2000-2024 */
+/* Data.cc                                                     (C) 2000-2025 */
 /*                                                                           */
 /* Types liés aux 'IData'.                                                   */
 /*---------------------------------------------------------------------------*/
@@ -118,7 +118,7 @@ fillContiguousDataGeneric(IData* data, const void* fill_address,
     destination_buf = makeMutableMemoryView(destination_buf.data(), datatype_size, nb_element * total_dim);
   }
 
-  destination_buf.fill(fill_value_view, &queue);
+  MemoryUtils::fill(destination_buf, fill_value_view, &queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/IBufferCopier.h
+++ b/arcane/src/arcane/impl/internal/IBufferCopier.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IBufferCopier.h                                             (C) 2000-2024 */
+/* IBufferCopier.h                                             (C) 2000-2025 */
 /*                                                                           */
 /* Interface pour la copie de buffer.                                        */
 /*---------------------------------------------------------------------------*/
@@ -16,6 +16,7 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/MemoryView.h"
+#include "arcane/utils/MemoryUtils.h"
 
 #include "arcane/core/GroupIndexTable.h"
 #include "arcane/accelerator/core/RunQueue.h"
@@ -76,7 +77,7 @@ class DirectBufferCopier
                            MutableMemoryView var_value) override
   {
     RunQueue* q = (m_queue.isNull()) ? nullptr : &m_queue;
-    buffer.copyToIndexes(var_value, indexes, q);
+    MemoryUtils::copyToIndexes(var_value, buffer, indexes, q);
   }
 
   void copyToBufferAsync(Int32ConstArrayView indexes,

--- a/arcane/src/arcane/impl/internal/IBufferCopier.h
+++ b/arcane/src/arcane/impl/internal/IBufferCopier.h
@@ -85,7 +85,7 @@ class DirectBufferCopier
                          ConstMemoryView var_value) override
   {
     RunQueue* q = (m_queue.isNull()) ? nullptr : &m_queue;
-    buffer.copyFromIndexes(var_value, indexes, q);
+    MemoryUtils::copyFromIndexes(buffer, var_value, indexes, q);
   }
 
   void barrier() override;

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -490,7 +490,7 @@ _copyToBuffer(SmallSpan<const MatVarIndex> matvar_indexes,
   const Int32 nb_item = matvar_indexes.size();
   MutableMemoryView destination_buffer(makeMutableMemoryView(bytes.data(),one_data_size,nb_item));
   ConstMultiMemoryView source_view(m_views_as_bytes.view(),one_data_size);
-  source_view.copyToIndexes(destination_buffer,indexes,queue);
+  MemoryUtils::copyToIndexes(destination_buffer,source_view,indexes,queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -505,7 +505,7 @@ _copyFromBuffer(SmallSpan<const MatVarIndex> matvar_indexes,
   const Int32 nb_item = matvar_indexes.size();
   MutableMultiMemoryView destination_view(m_views_as_bytes.view(),one_data_size);
   ConstMemoryView source_buffer(makeConstMemoryView(bytes.data(),one_data_size,nb_item));
-  destination_view.copyFromIndexes(source_buffer,indexes,queue);
+  MemoryUtils::copyFromIndexes(destination_view, source_buffer,indexes,queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/materials/MeshMaterialVariable.cc
+++ b/arcane/src/arcane/materials/MeshMaterialVariable.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshMaterialVariable.cc                                     (C) 2000-2024 */
+/* MeshMaterialVariable.cc                                     (C) 2000-2025 */
 /*                                                                           */
 /* Variable sur un matériau du maillage.                                     */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/parallel/thread/SharedMemoryParallelDispatch.cc
+++ b/arcane/src/arcane/parallel/thread/SharedMemoryParallelDispatch.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SharedMemoryParallelDispatch.cc                             (C) 2000-2024 */
+/* SharedMemoryParallelDispatch.cc                             (C) 2000-2025 */
 /*                                                                           */
 /* Implémentation des messages en mémoire partagée.                          */
 /*---------------------------------------------------------------------------*/
@@ -17,13 +17,11 @@
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/String.h"
 #include "arcane/utils/ITraceMng.h"
-#include "arcane/utils/Real2.h"
-#include "arcane/utils/Real3.h"
-#include "arcane/utils/Real2x2.h"
-#include "arcane/utils/Real3x3.h"
+#include "arcane/utils/NumericTypes.h"
 #include "arcane/utils/APReal.h"
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/MemoryView.h"
+#include "arcane/utils/MemoryUtils.h"
 
 #include "arcane/MeshVariable.h"
 #include "arcane/IParallelMng.h"
@@ -139,7 +137,7 @@ _genericAllToAllVariable(ConstMemoryView send_buf,
     ConstMemoryView view(ainfo.send_buf);
     Integer index = ainfo.send_index[my_rank];
     Integer count = ainfo.send_count[my_rank];
-    recv_mem_buf.subView(global_index,count).copyHost(view.subView(index,count));
+    MemoryUtils::copyHost(recv_mem_buf.subView(global_index,count), view.subView(index,count));
     global_index += count;
   }
   _collectiveBarrier();
@@ -158,7 +156,7 @@ _genericAllGather(ConstMemoryView send_buf,MutableMemoryView recv_buf)
   for( Int32 i=0; i<m_nb_rank; ++i ){
     ConstMemoryView view(m_all_dispatchs_base[i]->m_const_view);
     Int64 size = view.nbElement();
-    recv_mem_view.subView(index,size).copyHost(view);
+    MemoryUtils::copyHost(recv_mem_view.subView(index,size), view);
     index += size;
   }
   _collectiveBarrier();
@@ -182,7 +180,7 @@ _genericAllGatherVariable(ConstMemoryView send_buf,IResizableArray* recv_buf)
   for( Integer i=0; i<m_nb_rank; ++i ){
     ConstMemoryView view(m_all_dispatchs_base[i]->m_const_view);
     Int64 size = view.nbElement();
-    recv_mem_view.subView(index,size).copyHost(view);
+    MemoryUtils::copyHost(recv_mem_view.subView(index,size), view);
     index += size;
   }
   _collectiveBarrier();
@@ -203,7 +201,7 @@ _genericScatterVariable(ConstMemoryView send_buf,MutableMemoryView recv_buf,Int3
     for( Integer i=0; i<m_nb_rank; ++i ){
       MutableMemoryView view(m_all_dispatchs_base[i]->m_recv_view);
       Int64 size = view.nbElement();
-      view.copyHost(const_view.subView(index,size));
+      MemoryUtils::copyHost(view, const_view.subView(index,size));
       index += size;
     }
   }
@@ -260,7 +258,7 @@ _genericBroadcast(MutableMemoryView send_buf,Int32 rank)
 {
   m_broadcast_view = send_buf;
   _collectiveBarrier();
-  m_broadcast_view.copyHost(m_all_dispatchs_base[rank]->m_broadcast_view);
+  MemoryUtils::copyHost(m_broadcast_view, m_all_dispatchs_base[rank]->m_broadcast_view);
   _collectiveBarrier();
 }
 

--- a/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryCopyUnitTest.cc                                       (C) 2000-2024 */
+/* MemoryCopyUnitTest.cc                                       (C) 2000-2025 */
 /*                                                                           */
 /* Service de test des noyaux de recopie mémoire.                            */
 /*---------------------------------------------------------------------------*/
@@ -14,6 +14,7 @@
 #include "arcane/utils/NumArray.h"
 #include "arcane/utils/ValueChecker.h"
 #include "arcane/utils/MemoryView.h"
+#include "arcane/utils/MemoryUtils.h"
 
 #include "arcane/BasicUnitTest.h"
 #include "arcane/ServiceFactory.h"
@@ -239,9 +240,9 @@ _executeCopy(eMemoryRessource mem_kind, bool use_queue)
     {
       MutableMemoryView t1_view(t1.to1DSpan());
       ConstMemoryView destination_view(destination_buffer.to1DSpan());
-      destination_view.copyToIndexes(t1_view, indexes.to1DSpan().smallView(), queue_ptr);
+      MemoryUtils::copyToIndexes(t1_view, destination_view,indexes.to1DSpan().smallView(), queue_ptr);
       // Teste copie vide
-      destination_view.copyToIndexes(t1_view, {}, queue_ptr);
+      MemoryUtils::copyToIndexes(t1_view, destination_view, {}, queue_ptr);
     }
 
     // Vérifie la validité
@@ -316,10 +317,10 @@ _executeCopy(eMemoryRessource mem_kind, bool use_queue)
 
     {
       MutableMemoryView t1_view(t1.to1DSpan(), n2);
-      ConstMemoryView destination_view(destination_buffer.to1DSpan(), n2);
-      destination_view.copyToIndexes(t1_view, indexes.to1DSpan().smallView(), queue_ptr);
+      ConstMemoryView source_view(destination_buffer.to1DSpan(), n2);
+      MemoryUtils::copyToIndexes(t1_view, source_view, indexes.to1DSpan().smallView(), queue_ptr);
       // Teste copie vide
-      destination_view.copyToIndexes(t1_view, {}, queue_ptr);
+      MemoryUtils::copyToIndexes(t1_view, source_view, {}, queue_ptr);
     }
 
     {

--- a/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
@@ -206,9 +206,9 @@ _executeCopy(eMemoryRessource mem_kind, bool use_queue)
     {
       ConstMemoryView source(t1.to1DSpan());
       MutableMemoryView destination(destination_buffer.to1DSpan());
-      destination.copyFromIndexes(source, indexes.to1DSpan().smallView(), queue_ptr);
+      MemoryUtils::copyFromIndexes(destination, source, indexes.to1DSpan().smallView(), queue_ptr);
       // Teste copie vide
-      destination.copyFromIndexes(source, {}, queue_ptr);
+      MemoryUtils::copyFromIndexes(destination, source, {}, queue_ptr);
     }
 
     NumArray<double, MDDim1> host_destination(eMemoryRessource::Host);
@@ -282,9 +282,9 @@ _executeCopy(eMemoryRessource mem_kind, bool use_queue)
     {
       ConstMemoryView source(t1.to1DSpan(), n2);
       MutableMemoryView destination(destination_buffer.to1DSpan(), n2);
-      destination.copyFromIndexes(source, indexes.to1DSpan().smallView(), queue_ptr);
+      MemoryUtils::copyFromIndexes(destination, source, indexes.to1DSpan().smallView(), queue_ptr);
       // Teste copie vide
-      destination.copyFromIndexes(source, {}, queue_ptr);
+      MemoryUtils::copyFromIndexes(destination, source, {}, queue_ptr);
     }
 
     NumArray<double, MDDim2> host_destination(eMemoryRessource::Host);

--- a/arcane/src/arcane/tests/accelerator/MultiMemoryCopyUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MultiMemoryCopyUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MultiMemoryCopyUnitTest.cc                                  (C) 2000-2023 */
+/* MultiMemoryCopyUnitTest.cc                                  (C) 2000-2025 */
 /*                                                                           */
 /* Service de test des noyaux de recopie mémoire.                            */
 /*---------------------------------------------------------------------------*/
@@ -14,6 +14,7 @@
 #include "arcane/utils/NumArray.h"
 #include "arcane/utils/ValueChecker.h"
 #include "arcane/utils/MemoryView.h"
+#include "arcane/utils/MemoryUtils.h"
 #include "arcane/utils/PlatformUtils.h"
 
 #include "arcane/BasicUnitTest.h"
@@ -239,9 +240,9 @@ _executeCopy1Rank1(eMemoryRessource mem_kind, bool use_queue)
   {
     ConstMultiMemoryView source_memory_view(memories_as_bytes.constView(), sizeof(double));
     MutableMemoryView destination(buffer.to1DSpan());
-    source_memory_view.copyToIndexes(destination, indexes.to1DSpan().smallView(), queue_ptr);
+    MemoryUtils::copyToIndexes(destination, source_memory_view, indexes.to1DSpan().smallView(), queue_ptr);
     // Teste copie vide
-    source_memory_view.copyToIndexes(destination, {}, queue_ptr);
+    MemoryUtils::copyToIndexes(destination, source_memory_view, {}, queue_ptr);
   }
 
   UniqueArray<NumArray<double, MDDim1>> host_memories;
@@ -359,9 +360,9 @@ _executeCopy1Rank2(eMemoryRessource mem_kind, bool use_queue)
   {
     ConstMultiMemoryView source_memory_view(memories_as_bytes.constView(), sizeof(double) * n2);
     MutableMemoryView destination(buffer.to1DSpan(), n2);
-    source_memory_view.copyToIndexes(destination, indexes.to1DSpan().smallView(), queue_ptr);
+    MemoryUtils::copyToIndexes(destination, source_memory_view, indexes.to1DSpan().smallView(), queue_ptr);
     // Teste copie vide
-    source_memory_view.copyToIndexes(destination, {}, queue_ptr);
+    MemoryUtils::copyToIndexes(destination, source_memory_view, {}, queue_ptr);
   }
 
   UniqueArray<NumArray<double, MDDim2>> host_memories;

--- a/arcane/src/arcane/tests/accelerator/MultiMemoryCopyUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MultiMemoryCopyUnitTest.cc
@@ -281,11 +281,11 @@ _executeCopy1Rank1(eMemoryRessource mem_kind, bool use_queue)
 
   // Effectue la copie depuis le buffer
   {
-    MutableMultiMemoryView source_memory_view(memories_as_bytes.view(), sizeof(double));
+    MutableMultiMemoryView destination_memory_view(memories_as_bytes.view(), sizeof(double));
     ConstMemoryView source(buffer.to1DSpan());
-    source_memory_view.copyFromIndexes(source, indexes.to1DSpan().smallView(), queue_ptr);
+    MemoryUtils::copyFromIndexes(destination_memory_view, source, indexes.to1DSpan().smallView(), queue_ptr);
     // Teste copie vide
-    source_memory_view.copyFromIndexes(source, {}, queue_ptr);
+    MemoryUtils::copyFromIndexes(destination_memory_view, source, {}, queue_ptr);
   }
 
   // Vérifie le résultat
@@ -403,11 +403,11 @@ _executeCopy1Rank2(eMemoryRessource mem_kind, bool use_queue)
 
   // Effectue la copie depuis le buffer
   {
-    MutableMultiMemoryView source_memory_view(memories_as_bytes.view(), sizeof(double) * n2);
+    MutableMultiMemoryView destination_memory_view(memories_as_bytes.view(), sizeof(double) * n2);
     ConstMemoryView source(buffer.to1DSpan(), n2);
-    source_memory_view.copyFromIndexes(source, indexes.to1DSpan().smallView(), queue_ptr);
+    MemoryUtils::copyFromIndexes(destination_memory_view, source, indexes.to1DSpan().smallView(), queue_ptr);
     // Teste copie vide
-    source_memory_view.copyFromIndexes(source, {}, queue_ptr);
+    MemoryUtils::copyFromIndexes(destination_memory_view, source, {}, queue_ptr);
   }
 
   // Vérifie le résultat
@@ -483,9 +483,9 @@ _executeFill1Rank1(eMemoryRessource mem_kind, bool use_queue, bool use_index)
     MutableMultiMemoryView destination_memory_view(memories_as_bytes.view(), sizeof(double));
     ConstMemoryView source_memory_view(fill_buffer.constSpan());
     if (use_index)
-      destination_memory_view.fillIndexes(source_memory_view, indexes, queue_ptr);
+      MemoryUtils::fillIndexes(destination_memory_view, source_memory_view, indexes, queue_ptr);
     else
-      destination_memory_view.fill(source_memory_view, queue_ptr);
+      MemoryUtils::fill(destination_memory_view, source_memory_view, queue_ptr);
   }
 
   // Recopie dans la mémoire hôte

--- a/arcane/src/arcane/utils/MemoryResourceMng.cc
+++ b/arcane/src/arcane/utils/MemoryResourceMng.cc
@@ -67,7 +67,7 @@ class DefaultHostMemoryCopier
       ARCANE_FATAL("Destination buffer is not accessible from host and no copier provided (location={0})",
                    to_mem);
 
-    to.copyHost(from);
+    MemoryUtils::copyHost(to, from);
   }
 };
 

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -402,6 +402,34 @@ fill(MutableMemoryView destination, ConstMemoryView source,
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie dans \a destination les données de \a source indexées.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int32 n = indexes.size();
+ * for( Int32 i=0; i<n; ++i ){
+ *   Int32 index0 = indexes[ (i*2)   ];
+ *   Int32 index1 = indexes[ (i*2)+1 ];
+ *   destination[i] = source[index0][index1];
+ * }
+ * \endcode
+ *
+ * Le tableau des indexes doit avoir une taille multiple de 2. Les valeurs
+ * paires servent à indexer le premier tableau et les valeurs impaires le 2ème.
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ * \pre desination.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copyToIndexes(MutableMemoryView destination, ConstMultiMemoryView source,
+              SmallSpan<const Int32> indexes, RunQueue* run_queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 } // namespace Arcane::MemoryUtils
 

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryUtils.h                                               (C) 2000-2024 */
+/* MemoryUtils.h                                               (C) 2000-2025 */
 /*                                                                           */
 /* Fonctions utilitaires de gestion mémoire.                                 */
 /*---------------------------------------------------------------------------*/
@@ -229,19 +229,71 @@ copy(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queu
 
 //! Copie de \a source vers \a destination en utilisant la file \a queue.
 template <typename DataType> inline void
-copy(Span<DataType> destination, Span<const DataType> source, const RunQueue* queue = nullptr)
+copy(Span<DataType> destination, Span<const DataType> source,
+     const RunQueue* queue = nullptr)
 {
   ConstMemoryView input(asBytes(source));
   MutableMemoryView output(asWritableBytes(destination));
   copy(output, input, queue);
 }
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 //! Copie de \a source vers \a destination en utilisant la file \a queue.
 template <typename DataType> inline void
-copy(SmallSpan<DataType> destination, SmallSpan<const DataType> source, const RunQueue* queue = nullptr)
+copy(SmallSpan<DataType> destination, SmallSpan<const DataType> source,
+     const RunQueue* queue = nullptr)
 {
   copy(Span<DataType>(destination), Span<const DataType>(source), queue);
 }
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie sur l'hôte des données avec indirection.
+ *
+ * Copie dans \a destination les données de \a source
+ * indexées par \a indexes
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int64 n = indexes.size();
+ * for( Int64 i=0; i<n; ++i )
+ *   destination[i] = source[indexes[i]];
+ * \endcode
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ * \pre source.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copyToIndexesHost(MutableMemoryView destination, ConstMemoryView source,
+                  Span<const Int32> indexes);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie sur l'hôte des données avec indirection.
+ *
+ * Copie dans \a destination les données de \a source
+ * indexées par \a indexes
+ *
+ * \code
+ * Int32 n = indexes.size();
+ * for( Int32 i=0; i<n; ++i )
+ *   destinationv[i] = source[indexes[i]];
+ * \endcode
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ * \pre source.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copyToIndexes(MutableMemoryView destination, ConstMemoryView source,
+              SmallSpan<const Int32> indexes,
+              RunQueue* run_queue = nullptr);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -430,6 +430,88 @@ copyToIndexes(MutableMemoryView destination, ConstMultiMemoryView source,
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie les éléments indéxés de \a destination avec les données de \a source.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int32 n = indexes.size();
+ * for( Int32 i=0; i<n; ++i ){
+ *   Int32 index0 = indexes[ (i*2)   ];
+ *   Int32 index1 = indexes[ (i*2)+1 ];
+ *   destination[index0][index1] = source[i];
+ * }
+ * \endcode
+ *
+ * Le tableau des indexes doit avoir une taille multiple de 2. Les valeurs
+ * paires servent à indexer le premier tableau et les valeurs impaires le 2ème.
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == v.datatypeSize();
+ * \pre source.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copyFromIndexes(MutableMultiMemoryView destination, ConstMemoryView source,
+                SmallSpan<const Int32> indexes, RunQueue* run_queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Remplit les éléments indéxés de \a destination avec la donnée \a source.
+ *
+ * \a source doit avoir une seule valeur. Cette valeur sera utilisée
+ * pour remplir les valeur de l'instance aux indices spécifiés par
+ * \a indexes. Elle doit être accessible depuis l'hôte.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int32 n = indexes.size();
+ * for( Int32 i=0; i<n; ++i ){
+ *   Int32 index0 = indexes[ (i*2)   ];
+ *   Int32 index1 = indexes[ (i*2)+1 ];
+ *   destination[index0][index1] = source[0];
+ * }
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ * \pre destination.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+fillIndexes(MutableMultiMemoryView destination, ConstMemoryView source,
+            SmallSpan<const Int32> indexes, RunQueue* run_queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Remplit les éléments de \a destination avec la valeur \a source.
+ *
+ * \a source doit avoir une seule valeur. Elle doit être accessible depuis l'hôte.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int32 n = nbElement();
+ * for( Int32 i=0; i<n; ++i ){
+ *   Int32 index0 = (i*2);
+ *   Int32 index1 = (i*2)+1;
+ *   destination[index0][index1] = source[0];
+ * }
+ * \endcode
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+fill(MutableMultiMemoryView destination, ConstMemoryView source,
+     RunQueue* run_queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 } // namespace Arcane::MemoryUtils
 

--- a/arcane/src/arcane/utils/MemoryUtils.h
+++ b/arcane/src/arcane/utils/MemoryUtils.h
@@ -297,6 +297,111 @@ copyToIndexes(MutableMemoryView destination, ConstMemoryView source,
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie dans \a destination les données de \a source.
+ *
+ * Utilise std::memmove pour la copie.
+ *
+ * \pre source.bytes.size() >= destination.bytes.size()
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copyHost(MutableMemoryView destination, ConstMemoryView source);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie dans l'instance les données indexées de \a v.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int64 n = indexes.size();
+ * for( Int64 i=0; i<n; ++i )
+ *   destination[indexes[i]] = source[i];
+ * \endcode
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ * \pre destination.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copyFromIndexesHost(MutableMemoryView destination, ConstMemoryView source,
+                    Span<const Int32> indexes);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Copie dans l'instance les données indexées de \a v.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int32 n = indexes.size();
+ * for( Int32 i=0; i<n; ++i )
+ *   destination[indexes[i]] = source[i];
+ * \endcode
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ * \pre destination.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+copyFromIndexes(MutableMemoryView destination, ConstMemoryView source,
+                SmallSpan<const Int32> indexes, RunQueue* run_queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Remplit une zone mémoire indexée avec une valeur.
+ *
+ * Remplit les indices \a indexes de la zone mémoire \a destination avec
+ * la valeur de la zone mémoire \a source. \a source doit avoir une seule valeur.
+ * La zone mémoire \a source être accessible depuis l'hôte.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int32 n = indexes.size();
+ * for( Int32 i=0; i<n; ++i )
+ *   destination[indexes[i]] = source[0];
+ * \endcode
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ * \pre destination.nbElement() >= indexes.size();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+fillIndexes(MutableMemoryView destination, ConstMemoryView source,
+            SmallSpan<const Int32> indexes, const RunQueue* run_queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Remplit une zone mémoire avec une valeur.
+ *
+ * Remplit les valeurs de la zone mémoire \a destination avec
+ * la valeur de la zone mémoire \a source. \a source doit avoir une seule valeur.
+ * La zone mémoire \a source être accessible depuis l'hôte.
+ *
+ * L'opération est équivalente au pseudo-code suivant:
+ *
+ * \code
+ * Int32 n = nbElement();
+ * for( Int32 i=0; i<n; ++i )
+ *   destination[i] = source[0];
+ * \endcode
+ *
+ * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
+ *
+ * \pre destination.datatypeSize() == source.datatypeSize();
+ */
+extern "C++" ARCANE_UTILS_EXPORT void
+fill(MutableMemoryView destination, ConstMemoryView source,
+     const RunQueue* run_queue = nullptr);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 } // namespace Arcane::MemoryUtils
 

--- a/arcane/src/arcane/utils/MemoryView.cc
+++ b/arcane/src/arcane/utils/MemoryView.cc
@@ -224,43 +224,44 @@ makeConstMemoryView(const void* ptr, Int32 datatype_size, Int64 nb_element)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MutableMultiMemoryView::
-copyFromIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes,
-                RunQueue* queue)
+void MemoryUtils::
+copyFromIndexes(MutableMultiMemoryView destination, ConstMemoryView source,
+                SmallSpan<const Int32> indexes, RunQueue* queue)
 {
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, destination.datatypeSize(), source.datatypeSize());
 
   Int64 nb_index = indexes.size();
   if (nb_index == 0)
     return;
 
-  _getDefaultCopyList(queue)->copyFrom(one_data_size, { indexes, m_views, v.bytes(), queue });
+  _getDefaultCopyList(queue)->copyFrom(one_data_size, { indexes, destination.views(), source.bytes(), queue });
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MutableMultiMemoryView::
-fillIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes, RunQueue* queue)
+void MemoryUtils::
+fillIndexes(MutableMultiMemoryView destination, ConstMemoryView source,
+            SmallSpan<const Int32> indexes, RunQueue* queue)
 {
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, destination.datatypeSize(), source.datatypeSize());
 
   Int64 nb_index = indexes.size();
   if (nb_index == 0)
     return;
 
-  _getDefaultCopyList(queue)->fill(one_data_size, { indexes, m_views, v.bytes(), queue });
+  _getDefaultCopyList(queue)->fill(one_data_size, { indexes, destination.views(), source.bytes(), queue });
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MutableMultiMemoryView::
-fill(ConstMemoryView v, RunQueue* queue)
+void MemoryUtils::
+fill(MutableMultiMemoryView destination, ConstMemoryView source, RunQueue* queue)
 {
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, destination.datatypeSize(), source.datatypeSize());
 
-  _getDefaultCopyList(queue)->fill(one_data_size, { {}, m_views, v.bytes(), queue });
+  _getDefaultCopyList(queue)->fill(one_data_size, { {}, destination.views(), source.bytes(), queue });
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryView.cc
+++ b/arcane/src/arcane/utils/MemoryView.cc
@@ -86,82 +86,86 @@ setDefaultCopyListIfNotSet(ISpecificMemoryCopyList* ptr)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MutableMemoryView::
-copyHost(ConstMemoryView v) const
+void MemoryUtils::
+copyHost(MutableMemoryView destination, ConstMemoryView source)
 {
-  auto source = v.bytes();
-  auto destination = bytes();
-  Int64 source_size = source.size();
+  auto b_source = source.bytes();
+  auto b_destination = destination.bytes();
+  Int64 source_size = b_source.size();
   if (source_size == 0)
     return;
-  Int64 destination_size = destination.size();
+  Int64 destination_size = b_destination.size();
   if (source_size > destination_size)
     ARCANE_FATAL("Destination is too small source_size={0} destination_size={1}",
                  source_size, destination_size);
-  auto* dest_data = destination.data();
-  auto* source_data = source.data();
-  ARCANE_CHECK_POINTER(dest_data);
+  auto* destination_data = b_destination.data();
+  auto* source_data = b_source.data();
+  ARCANE_CHECK_POINTER(destination_data);
   ARCANE_CHECK_POINTER(source_data);
-  std::memmove(destination.data(), source.data(), source_size);
+  std::memmove(destination_data, source_data, source_size);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MutableMemoryView::
-copyFromIndexesHost(ConstMemoryView v, Span<const Int32> indexes) const
+void MemoryUtils::
+copyFromIndexesHost(MutableMemoryView destination, ConstMemoryView source,
+                    Span<const Int32> indexes)
 {
-  copyFromIndexes(v, indexes.smallView(), nullptr);
+  copyFromIndexes(destination, source, indexes.smallView(), nullptr);
 }
 
-void MutableMemoryView::
-copyFromIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes,
-                RunQueue* queue) const
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MemoryUtils::
+copyFromIndexes(MutableMemoryView destination, ConstMemoryView source,
+                SmallSpan<const Int32> indexes, RunQueue* queue)
 {
 
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, destination.datatypeSize(), source.datatypeSize());
 
   Int64 nb_index = indexes.size();
   if (nb_index == 0)
     return;
 
-  auto source = v.bytes();
-  auto destination = bytes();
+  auto b_source = source.bytes();
+  auto b_destination = destination.bytes();
 
-  _getDefaultCopyList(queue)->copyFrom(one_data_size, { indexes, source, destination, queue });
+  _getDefaultCopyList(queue)->copyFrom(one_data_size, { indexes, b_source, b_destination, queue });
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MutableMemoryView::
-fillIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes,
-            const RunQueue* queue) const
+void MemoryUtils::
+fillIndexes(MutableMemoryView destination, ConstMemoryView source,
+            SmallSpan<const Int32> indexes, const RunQueue* queue)
 {
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, destination.datatypeSize(), source.datatypeSize());
 
   Int64 nb_index = indexes.size();
   if (nb_index == 0)
     return;
 
-  auto source = v.bytes();
-  auto destination = bytes();
+  auto b_source = source.bytes();
+  auto b_destination = destination.bytes();
 
-  _getDefaultCopyList(queue)->fill(one_data_size, { indexes, source, destination, queue });
+  _getDefaultCopyList(queue)->fill(one_data_size, { indexes, b_source, b_destination, queue });
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void MutableMemoryView::
-fill(ConstMemoryView v, const RunQueue* queue) const
+void MemoryUtils::
+fill(MutableMemoryView destination, ConstMemoryView source, const RunQueue* queue)
 {
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, destination.datatypeSize(), source.datatypeSize());
 
-  auto source = v.bytes();
-  auto destination = bytes();
+  auto b_source = source.bytes();
+  auto b_destination = destination.bytes();
 
-  _getDefaultCopyList(queue)->fill(one_data_size, { {}, source, destination, queue });
+  _getDefaultCopyList(queue)->fill(one_data_size, { {}, b_source, b_destination, queue });
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryView.cc
+++ b/arcane/src/arcane/utils/MemoryView.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryView.cc                                               (C) 2000-2024 */
+/* MemoryView.cc                                               (C) 2000-2025 */
 /*                                                                           */
 /* Vues constantes ou modifiables sur une zone mémoire.                      */
 /*---------------------------------------------------------------------------*/
@@ -14,6 +14,7 @@
 #include "arcane/utils/MemoryView.h"
 
 #include "arcane/utils/FatalErrorException.h"
+#include "arcane/utils/MemoryUtils.h"
 #include "arcane/utils/internal/SpecificMemoryCopyList.h"
 
 #include <cstring>
@@ -166,26 +167,31 @@ fill(ConstMemoryView v, const RunQueue* queue) const
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ConstMemoryView::
-copyToIndexesHost(MutableMemoryView v, Span<const Int32> indexes) const
+void MemoryUtils::
+copyToIndexesHost(MutableMemoryView destination, ConstMemoryView source,
+                  Span<const Int32> indexes)
 {
-  copyToIndexes(v, indexes.smallView(), nullptr);
+  copyToIndexes(destination, source, indexes.smallView(), nullptr);
 }
 
-void ConstMemoryView::
-copyToIndexes(MutableMemoryView v, SmallSpan<const Int32> indexes,
-              RunQueue* queue) const
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MemoryUtils::
+copyToIndexes(MutableMemoryView destination, ConstMemoryView source,
+              SmallSpan<const Int32> indexes,
+              RunQueue* queue)
 {
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, source.datatypeSize(), destination.datatypeSize());
 
   Int64 nb_index = indexes.size();
   if (nb_index == 0)
     return;
 
-  auto source = bytes();
-  auto destination = v.bytes();
+  auto b_source = source.bytes();
+  auto b_destination = destination.bytes();
 
-  _getDefaultCopyList(queue)->copyTo(one_data_size, { indexes, source, destination, queue });
+  _getDefaultCopyList(queue)->copyTo(one_data_size, { indexes, b_source, b_destination, queue });
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryView.cc
+++ b/arcane/src/arcane/utils/MemoryView.cc
@@ -266,17 +266,17 @@ fill(ConstMemoryView v, RunQueue* queue)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ConstMultiMemoryView::
-copyToIndexes(MutableMemoryView v, SmallSpan<const Int32> indexes,
-              RunQueue* queue)
+void MemoryUtils::
+copyToIndexes(MutableMemoryView destination, ConstMultiMemoryView source,
+              SmallSpan<const Int32> indexes, RunQueue* queue)
 {
-  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, m_datatype_size, v.datatypeSize());
+  Int32 one_data_size = _checkDataTypeSize(A_FUNCINFO, destination.datatypeSize(), source.datatypeSize());
 
   Int64 nb_index = indexes.size();
   if (nb_index == 0)
     return;
 
-  _getDefaultCopyList(queue)->copyTo(one_data_size, { indexes, m_views, v.bytes(), queue });
+  _getDefaultCopyList(queue)->copyTo(one_data_size, { indexes, source.views(), destination.bytes(), queue });
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/MemoryView.h
+++ b/arcane/src/arcane/utils/MemoryView.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryView.h                                                (C) 2000-2024 */
+/* MemoryView.h                                                (C) 2000-2025 */
 /*                                                                           */
 /* Vues constantes ou modifiables sur une zone mémoire.                      */
 /*---------------------------------------------------------------------------*/
@@ -230,94 +230,6 @@ class ARCANE_UTILS_EXPORT MutableMemoryView
     auto sub_bytes = m_bytes.subspan(byte_offset, nb_element * m_datatype_size);
     return { sub_bytes, m_datatype_size, nb_element };
   }
-
- public:
-
-  /*!
-   * \brief Copie dans l'instance les données de \a v.
-   *
-   * Utilise std::memmove pour la copie.
-   *
-   * \pre v.bytes.size() >= bytes.size()
-   */
-  void copyHost(ConstMemoryView v) const;
-
-  /*!
-   * \brief Copie dans l'instance les données indexées de \a v.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int64 n = indexes.size();
-   * for( Int64 i=0; i<n; ++i )
-   *   this[indexes[i]] = v[i];
-   * \endcode
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre this.nbElement() >= indexes.size();
-   */
-  void copyFromIndexesHost(ConstMemoryView v, Span<const Int32> indexes) const;
-
-  /*!
-   * \brief Copie dans l'instance les données indexées de \a v.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = indexes.size();
-   * for( Int32 i=0; i<n; ++i )
-   *   this[indexes[i]] = v[i];
-   * \endcode
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre this.nbElement() >= indexes.size();
-   */
-  void copyFromIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes,
-                       RunQueue* run_queue = nullptr) const;
-
-  /*!
-   * \brief Remplit dans l'instance les données de \a v.
-   *
-   * \a v doit avoir une seule valeur. Cette valeur sera utilisée
-   * pour remplir les valeur de l'instance aux indices spécifiés par
-   * \a indexes. Elle doit être accessible depuis l'hôte.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = indexes.size();
-   * for( Int32 i=0; i<n; ++i )
-   *   this[indexes[i]] = v[0];
-   * \endcode
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre this.nbElement() >= indexes.size();
-   */
-  void fillIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes,
-                   const RunQueue* run_queue = nullptr) const;
-
-  /*!
-   * \brief Remplit les éléments de l'instance avec la valeur \a v.
-   *
-   * \a v doit avoir une seule valeur. Elle doit être accessible depuis l'hôte.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = nbElement();
-   * for( Int32 i=0; i<n; ++i )
-   *   this[i] = v[0];
-   * \endcode
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   */
-  void fill(ConstMemoryView v, const RunQueue* run_queue = nullptr) const;
 
  public:
 

--- a/arcane/src/arcane/utils/MemoryView.h
+++ b/arcane/src/arcane/utils/MemoryView.h
@@ -302,76 +302,11 @@ class ARCANE_UTILS_EXPORT MutableMultiMemoryView
 
  public:
 
-  /*!
-   * \brief Copie dans l'instance indexée les données de \a v.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = indexes.size();
-   * for( Int32 i=0; i<n; ++i ){
-   *   Int32 index0 = indexes[ (i*2)   ];
-   *   Int32 index1 = indexes[ (i*2)+1 ];
-   *   this[index0][index1] = v[i];
-   * }
-   * \endcode
-   *
-   * Le tableau des indexes doit avoir une taille multiple de 2. Les valeurs
-   * paires servent à indexer le premier tableau et les valeurs impaires le 2ème.
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre v.nbElement() >= indexes.size();
-   */
-  void copyFromIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes,
-                       RunQueue* run_queue = nullptr);
+  //! Vues en octets sur la zone mémoire
+  constexpr SmallSpan<Span<std::byte>> views() const { return m_views; }
 
-  /*!
-   * \brief Remplit dans l'instance les données de \a v.
-   *
-   * \a v doit avoir une seule valeur. Cette valeur sera utilisée
-   * pour remplir les valeur de l'instance aux indices spécifiés par
-   * \a indexes. Elle doit être accessible depuis l'hôte.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = indexes.size();
-   * for( Int32 i=0; i<n; ++i ){
-   *   Int32 index0 = indexes[ (i*2)   ];
-   *   Int32 index1 = indexes[ (i*2)+1 ];
-   *   this[index0][index1] = v[0];
-   * }
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre this.nbElement() >= indexes.size();
-   */
-  void fillIndexes(ConstMemoryView v, SmallSpan<const Int32> indexes,
-                   RunQueue* run_queue = nullptr);
-
-  /*!
-   * \brief Remplit les éléments de l'instance avec la valeur \a v.
-   *
-   * \a v doit avoir une seule valeur. Elle doit être accessible depuis l'hôte.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = nbElement();
-   * for( Int32 i=0; i<n; ++i ){
-   *   Int32 index0 = (i*2);
-   *   Int32 index1 = (i*2)+1;
-   *   this[index0][index1] = v[0];
-   * }
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   */
-  void fill(ConstMemoryView v, RunQueue* run_queue = nullptr);
+  //! Taille du type de donnée associé (1 par défaut)
+  constexpr Int32 datatypeSize() const { return m_datatype_size; }
 
  private:
 

--- a/arcane/src/arcane/utils/MemoryView.h
+++ b/arcane/src/arcane/utils/MemoryView.h
@@ -125,43 +125,6 @@ class ARCANE_UTILS_EXPORT ConstMemoryView
 
  public:
 
-  /*!
-   * \brief Copie dans l'instance indexée les données de \a v.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int64 n = indexes.size();
-   * for( Int64 i=0; i<n; ++i )
-   *   v[i] = this[indexes[i]];
-   * \endcode
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre v.nbElement() >= indexes.size();
-   */
-  void copyToIndexesHost(MutableMemoryView v, Span<const Int32> indexes) const;
-
-  /*!
-   * \brief Copie dans l'instance indexée les données de \a v.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = indexes.size();
-   * for( Int32 i=0; i<n; ++i )
-   *   v[i] = this[indexes[i]];
-   * \endcode
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre v.nbElement() >= indexes.size();
-   */
-  void copyToIndexes(MutableMemoryView v, SmallSpan<const Int32> indexes,
-                     RunQueue* run_queue = nullptr) const;
-
- public:
-
   //! Vue convertie en un Span
   ARCANE_DEPRECATED_REASON("Use bytes() instead")
   SpanType span() const { return m_bytes; }

--- a/arcane/src/arcane/utils/MemoryView.h
+++ b/arcane/src/arcane/utils/MemoryView.h
@@ -270,32 +270,11 @@ class ARCANE_UTILS_EXPORT ConstMultiMemoryView
     m_views = { ptr, views.size() };
   }
 
- public:
+  //! Vues en octets sur la zone mémoire
+  constexpr SmallSpan<const Span<const std::byte>> views() const { return m_views; }
 
-  /*!
-   * \brief Copie dans l'instance indexée les données de \a v.
-   *
-   * L'opération est équivalente au pseudo-code suivant:
-   *
-   * \code
-   * Int32 n = indexes.size();
-   * for( Int32 i=0; i<n; ++i ){
-   *   Int32 index0 = indexes[ (i*2)   ];
-   *   Int32 index1 = indexes[ (i*2)+1 ];
-   *   v[i] = this[index0][index1];
-   * }
-   * \endcode
-   *
-   * Le tableau des indexes doit avoir une taille multiple de 2. Les valeurs
-   * paires servent à indexer le premier tableau et les valeurs impaires le 2ème.
-   *
-   * Si \a run_queue n'est pas nul, elle sera utilisée pour la copie.
-   *
-   * \pre this.datatypeSize() == v.datatypeSize();
-   * \pre v.nbElement() >= indexes.size();
-   */
-  void copyToIndexes(MutableMemoryView v, SmallSpan<const Int32> indexes,
-                     RunQueue* run_queue = nullptr);
+  //! Taille du type de donnée associé (1 par défaut)
+  constexpr Int32 datatypeSize() const { return m_datatype_size; }
 
  private:
 

--- a/arcane/src/arcane/utils/NumArray.cc
+++ b/arcane/src/arcane/utils/NumArray.cc
@@ -71,7 +71,7 @@ _memoryAwareFill(Span<std::byte> to, Int64 nb_element, const void* fill_address,
 {
   ConstMemoryView fill_value_view(makeConstMemoryView(fill_address, datatype_size, 1));
   MutableMemoryView destination(makeMutableMemoryView(to.data(), datatype_size, nb_element));
-  destination.fillIndexes(fill_value_view, indexes, queue);
+  MemoryUtils::fillIndexes(destination, fill_value_view, indexes, queue);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ _memoryAwareFill(Span<std::byte> to, Int64 nb_element, const void* fill_address,
 {
   ConstMemoryView fill_value_view(makeConstMemoryView(fill_address, datatype_size, 1));
   MutableMemoryView destination(makeMutableMemoryView(to.data(), datatype_size, nb_element));
-  destination.fill(fill_value_view, queue);
+  MemoryUtils::fill(destination, fill_value_view, queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/TestMemory.cc
+++ b/arcane/src/arcane/utils/tests/TestMemory.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -90,7 +90,7 @@ class MemoryTester
       UniqueArray<DataType> array2(nb_value);
       MutableMemoryView to(array2.span());
       ConstMemoryView from(array1.span());
-      to.copyHost(from);
+      MemoryUtils::copyHost(to, from);
       ASSERT_EQ(array1, array2);
     }
 
@@ -120,7 +120,7 @@ class MemoryTester
       UniqueArray<DataType> array3(nb_index);
       MutableMemoryView to(array3.span());
       ConstMemoryView from(array1.span());
-      to.copyFromIndexesHost(from, copy_indexes);
+      MemoryUtils::copyFromIndexesHost(to, from, copy_indexes);
       ASSERT_EQ(array2, array3);
       ConstMemoryView view2(array1.view());
       ASSERT_EQ(view2.bytes(), asBytes(array1));

--- a/arcane/src/arcane/utils/tests/TestMemory.cc
+++ b/arcane/src/arcane/utils/tests/TestMemory.cc
@@ -146,7 +146,7 @@ class MemoryTester
 
       MutableMemoryView to(array3.span());
       ConstMemoryView from(array1.span());
-      from.copyToIndexesHost(to, copy_indexes);
+      MemoryUtils::copyToIndexesHost(to, from,copy_indexes);
       ASSERT_EQ(array2, array3);
     }
   }


### PR DESCRIPTION
This makes them easier to detect, and calls more consistent.
It will also make `MemoryView` classes independent of the accelerator API.