### PR TITLE
Prefetch variables only if they are allocated using Unified Memory

### DIFF
--- a/arcane/src/arcane/core/VariableUtils.cc
+++ b/arcane/src/arcane/core/VariableUtils.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableUtils.cc                                            (C) 2000-2024 */
+/* VariableUtils.cc                                            (C) 2000-2025 */
 /*                                                                           */
 /* Fonctions utilitaires diverses sur les variables.                         */
 /*---------------------------------------------------------------------------*/
@@ -14,6 +14,7 @@
 #include "arcane/core/VariableUtils.h"
 
 #include "arcane/utils/MemoryUtils.h"
+#include "arcane/utils/IMemoryAllocator.h"
 
 #include "arcane/accelerator/core/RunQueue.h"
 #include "arcane/accelerator/core/Memory.h"
@@ -55,6 +56,11 @@ prefetchVariableAsync(IVariable* var, const RunQueue* queue_or_null)
   IData* d = var->data();
   INumericDataInternal* nd = d->_commonInternal()->numericData();
   if (!nd)
+    return;
+  // On ne pré-charge que si la variable est en mémoire unifiée.
+  // Cela n'est utile que dans ce cas et de plus avec CUDA cela provoque
+  // une erreur si la mémoire n'est pas u
+  if (nd->memoryAllocator()->memoryResource() != eMemoryResource::UnifiedMemory)
     return;
   ConstMemoryView mem_view = nd->memoryView();
   queue_or_null->prefetchMemory(MemoryPrefetchArgs(mem_view).addAsync());

--- a/arcane/src/arcane/core/internal/IDataInternal.h
+++ b/arcane/src/arcane/core/internal/IDataInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IDataInternal.h                                             (C) 2000-2024 */
+/* IDataInternal.h                                             (C) 2000-2025 */
 /*                                                                           */
 /* Partie interne à Arcane de IData.                                         */
 /*---------------------------------------------------------------------------*/
@@ -160,6 +160,11 @@ class ARCANE_CORE_EXPORT INumericDataInternal
    * \warning For experimental use only.
    */
   virtual void changeAllocator(const MemoryAllocationOptions& alloc_info) = 0;
+
+  /*!
+   * \brief Allocateur utilisé pour la donnée.
+   */
+  virtual IMemoryAllocator* memoryAllocator() const = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/Array2Data.h
+++ b/arcane/src/arcane/impl/internal/Array2Data.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Array2Data.h                                                (C) 2000-2024 */
+/* Array2Data.h                                                (C) 2000-2025 */
 /*                                                                           */
 /* Donnée du type 'Array2'.                                                  */
 /*---------------------------------------------------------------------------*/
@@ -240,10 +240,11 @@ class Array2DataT<DataType>::Impl
   {
     m_p->computeHash(hash_info);
   }
+  IMemoryAllocator* memoryAllocator() const override { return m_p->m_value.allocator(); }
 
  private:
 
-  Array2DataT<DataType>* m_p;
+  Array2DataT<DataType>* m_p = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/internal/ArrayData.h
+++ b/arcane/src/arcane/impl/internal/ArrayData.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayData.h                                                 (C) 2000-2024 */
+/* ArrayData.h                                                 (C) 2000-2025 */
 /*                                                                           */
 /* Donnée du type 'Array'.                                                   */
 /*---------------------------------------------------------------------------*/
@@ -208,10 +208,11 @@ class ArrayDataT<DataType>::Impl
   {
     m_p->computeHash(hash_info);
   }
+  IMemoryAllocator* memoryAllocator() const override { return m_p->m_value.allocator(); }
 
  private:
 
-  ArrayDataT<DataType>* m_p;
+  ArrayDataT<DataType>* m_p = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Using CUDA, it is an error to call `cudaMemPrefetchAsync()` with a pointer which is not using Unified Memory (if `cudaDevAttrPageableMemoryAccess` is false).
