### PR TITLE
Remove compiler warnings about possible dangling reference

### DIFF
--- a/arcane/src/arcane/materials/MeshMaterialMng.cc
+++ b/arcane/src/arcane/materials/MeshMaterialMng.cc
@@ -435,8 +435,9 @@ createEnvironment(const MeshEnvironmentBuildInfo& infos)
 
   // Créé et ajoute les matériaux
   Integer nb_mat = infos.materials().size();
+  ConstArrayView<MeshEnvironmentBuildInfo::MatInfo> mat_build_infos = infos.materials();
   for( Integer i=0; i<nb_mat; ++i ){
-    const MeshEnvironmentBuildInfo::MatInfo& buildinfo = infos.materials()[i];
+    const MeshEnvironmentBuildInfo::MatInfo& buildinfo = mat_build_infos[i];
     const String& mat_name = buildinfo.m_name;
     String new_mat_name = env_name + "_" + mat_name;
     MeshMaterialInfo* mat_info = _findMaterialInfo(mat_name);

--- a/arcane/src/arcane/mesh/FaceFamily.cc
+++ b/arcane/src/arcane/mesh/FaceFamily.cc
@@ -974,7 +974,7 @@ applyTiedInterface(ITiedInterface* interface)
     Integer nb_slave = slave_tied_faces.size();
     slave_faces.clear();
     for( Integer zz=0; zz<nb_slave; ++zz ){
-      const TiedFace& tn = tied_faces[index][zz];
+      TiedFace tn = tied_faces[index][zz];
       Face slave_face = tn.face();
       slave_faces.add(slave_face.localId());
       _addMasterFaceToFace(slave_face,master_face);
@@ -997,7 +997,7 @@ removeTiedInterface(ITiedInterface* interface)
     ConstArrayView<TiedFace> slave_tied_faces(tied_faces[index]);
     Integer nb_slave = slave_tied_faces.size();
     for( Integer zz=0; zz<nb_slave; ++zz ){
-      const TiedFace& tn = tied_faces[index][zz];
+      TiedFace tn = tied_faces[index][zz];
       Face slave_face = tn.face();
       _removeMasterFaceToFace(slave_face);
     }

--- a/arcane/src/arcane/mesh/TiedInterface.cc
+++ b/arcane/src/arcane/mesh/TiedInterface.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* TiedInterface.cc                                            (C) 2000-2023 */
+/* TiedInterface.cc                                            (C) 2000-2025 */
 /*                                                                           */
 /* Informations sur les semi-conformitées du maillage.                       */
 /*---------------------------------------------------------------------------*/
@@ -2037,7 +2037,7 @@ _checkValid(bool is_print)
       for( Node inode : face.nodes()  )
         info() << "Master face node uid=" << inode.uniqueId();
     for( Integer zz=0, zs=tied_nodes[iface.index()].size(); zz<zs; ++zz ){
-      const TiedNode& tn = tied_nodes[iface.index()][zz];
+      TiedNode tn = tied_nodes[iface.index()][zz];
       nodes_in_master_face.insert(tn.node().uniqueId());
       if (is_print){
         info() << " node_uid=" << tn.node().uniqueId()
@@ -2063,7 +2063,7 @@ _checkValid(bool is_print)
       }
     }
     for( Integer zz=0, zs=tied_faces[iface.index()].size(); zz<zs; ++zz ){
-      const TiedFace& tf = tied_faces[iface.index()][zz];
+      TiedFace tf = tied_faces[iface.index()][zz];
       Face tied_slave_face = tf.face();
       if (!tied_slave_face.isSlaveFace()){
         ++nb_error;

--- a/arcane/src/arcane/tests/MeshUnitTest.cc
+++ b/arcane/src/arcane/tests/MeshUnitTest.cc
@@ -541,7 +541,7 @@ _dumpTiedInterfaces()
           info() << "Master face node uid=" << inode->uniqueId();
         }
         for( Integer zz=0, zs=tied_nodes[iface.index()].size(); zz<zs; ++zz ){
-          const TiedNode& tn = tied_nodes[iface.index()][zz];
+          TiedNode tn = tied_nodes[iface.index()][zz];
           nodes_in_master_face.insert(tn.node().uniqueId());
           if (zz<20){
             info() << " node_uid=" << tn.node().uniqueId()
@@ -563,7 +563,7 @@ _dumpTiedInterfaces()
             error() << "bad number of slave faces interne=" << slave_faces.size() << " struct=" << nb_tied;
         }
         for( Integer zz=0, zs=tied_faces[iface.index()].size(); zz<zs; ++zz ){
-          const TiedFace& tf = tied_faces[iface.index()][zz];
+          TiedFace tf = tied_faces[iface.index()][zz];
           Face tied_slave_face = tf.face();
           if (!tied_slave_face.isSlaveFace()){
             ++nb_error;


### PR DESCRIPTION
I think the warning is probably a false positive, but it costs nothing to delete it.