### PR TITLE
Add support for CUDA 13

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.h
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.h
@@ -79,6 +79,38 @@ finalizeCudaMemoryAllocators(ITraceMng* tm);
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
+#define ARCANE_USING_CUDA13_OR_GREATER
+#endif
+
+// A partir de CUDA 13, il y a un nouveau type cudaMemLocation
+// pour les méthodes telles cudeMemAdvise ou cudaMemPrefetch
+#if defined(ARCANE_USING_CUDA13_OR_GREATER)
+inline cudaMemLocation
+_getMemoryLocation(int device_id)
+{
+  cudaMemLocation mem_location;
+  mem_location.type = cudaMemLocationTypeDevice;
+  mem_location.id = device_id;
+  if (device_id == cudaCpuDeviceId)
+    mem_location.type = cudaMemLocationTypeHost;
+  else {
+    mem_location.type = cudaMemLocationTypeDevice;
+    mem_location.id = device_id;
+  }
+  return mem_location;
+}
+#else
+inline int
+_getMemoryLocation(int device_id)
+{
+  return device_id;
+}
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // End namespace Arcane::accelerator::cuda
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -461,9 +461,15 @@ fillDevices(bool is_verbose)
   for (int i = 0; i < nb_device; ++i) {
     cudaDeviceProp dp;
     cudaGetDeviceProperties(&dp, i);
+    int runtime_version = 0;
+    cudaRuntimeGetVersion(&runtime_version);
+    int driver_version = 0;
+    cudaDriverGetVersion(&driver_version);
     OStringStream ostr;
     std::ostream& o = ostr.stream();
     o << "Device " << i << " name=" << dp.name << "\n";
+    o << " Driver version = " << (driver_version / 1000) << "." << (driver_version % 1000) << "\n";
+    o << " Runtime version = " << (runtime_version / 1000) << "." << (runtime_version % 1000) << "\n";
     o << " computeCapability = " << dp.major << "." << dp.minor << "\n";
     o << " totalGlobalMem = " << dp.totalGlobalMem << "\n";
     o << " sharedMemPerBlock = " << dp.sharedMemPerBlock << "\n";


### PR DESCRIPTION
CUDA 13 changes some prototypes of functions managed memory (like `cudaMemAdvise` or `cudaMemPrefetchAsysnc`) and add a new type `cudaMemoryLocation` to specify information for these functions.
