### PR TITLE
Generate a regex file to transforms headers to use `arcane/core` include directory

### DIFF
--- a/arcane/src/arcane/core/CMakeLists.txt
+++ b/arcane/src/arcane/core/CMakeLists.txt
@@ -17,6 +17,12 @@ target_include_directories(arcane_core PUBLIC $<BUILD_INTERFACE:${COMPAT_DIRECTO
 
 arcane_register_library(arcane_core)
 
+# Génère pour chaque include 'Toto.h' un fichier d'en-tête
+# 'arcane/Toto.h' qui inclue 'arcane/core/Toto.h'
+# Cela est nécessaire pour les codes utilisant les versions
+# d'Arcane pour lesquelles les fichiers d'en-tête n'étaient pas
+# dans 'core'.
+set(SED_REGEX)
 foreach(file ${ARCANE_ORIGINAL_SOURCES})
   if (${file} MATCHES "\.(h|H)$")
     string(TOUPPER ${file} upper_name1)
@@ -25,8 +31,13 @@ foreach(file ${ARCANE_ORIGINAL_SOURCES})
     get_filename_component(_file_dir "${file}" DIRECTORY [CACHE])
     configure_file(${Arcane_SOURCE_DIR}/cmake/IncludeCompat.h.in "${ARCANE_COMPATIBILITY_DIRECTORY}/arcane/${file}" @ONLY)
     install(FILES "${ARCANE_COMPATIBILITY_DIRECTORY}/arcane/${file}" DESTINATION "include/arcane/${_file_dir}")
+    set(SED_REGEX "${SED_REGEX}s-#include \\\"arcane/${file}\\\"-#include \\\"arcane/core/${file}\\\"-g\n")
   endif()
 endforeach()
+# Génère un fichier contenant des expressions régulières pour modifier
+# un fichier en remplacant les 'arcane/Toto.h' par 'arcane/core/Toto.h'
+file(WRITE ${CMAKE_BINARY_DIR}/share/change_core_header_sed_regex.txt ${SED_REGEX})
+file(WRITE ${CMAKE_BINARY_DIR}/share/do_change_core_header_sed_regex.sh "#!/bin/sh\nsed -i --file=\"${CMAKE_BINARY_DIR}/share/change_core_header_sed_regex.txt\" \"$@\"\n")
 
 if (GTEST_FOUND)
   add_subdirectory(tests)


### PR DESCRIPTION
Add a script and regex file to convert usage of header files to use `arcane/core` instead of `arcane`.
Each line containing `#include "arcane/Toto.h"` will be converted to use `#include "arcane/core/Toto.h"`.
