### PR TITLE
Update MacOS workflow

### DIFF
--- a/.github/workflows/MacOs-15-gnu-openmpi.yml
+++ b/.github/workflows/MacOs-15-gnu-openmpi.yml
@@ -48,6 +48,11 @@ jobs:
           echo "Display CPU information"
           sysctl -a | grep machdep.cpu
 
+      - name: Uninstall pre-installed dependencies
+        continue-on-error: true
+        run: |
+          brew uninstall cmake gcc open-mpi hdf5-mpi scotch dotnet petsc zstd ccache
+
       - name: Install dependencies
         run: |
           brew install cmake gcc open-mpi hdf5-mpi scotch dotnet petsc zstd ccache

--- a/.github/workflows/MacOs-15-gnu-openmpi.yml
+++ b/.github/workflows/MacOs-15-gnu-openmpi.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     env:
       CCACHE_BASEDIR: ${{github.workspace}}
       CCACHE_DIR: '${{ github.workspace }}/ccache'


### PR DESCRIPTION
- Use explicit `macos-15` runners
- uninstall pre-installed brew packages. This will allow to get rid of the following error:
```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.
```