### PR TITLE
[CI] Launch tests of IFPEN 2021 worklows in parallel with 4 jobs simultaneously.

### DIFF
--- a/.github/workflows/ifpen_el9_foss-2021b-cxx20.yml
+++ b/.github/workflows/ifpen_el9_foss-2021b-cxx20.yml
@@ -28,7 +28,7 @@ env:
   CM_BUILD_TYPE: Release
   CM_CCACHE_OPTS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
   # CTest
-  CT_OPTS: "--timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
+  CT_OPTS: "--parallel 4 --timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
   # OpenMPI
   OMPI_MCA_rmaps_base_oversubscribe : true
   # To remove test output directory to reduce disk usage

--- a/.github/workflows/ifpen_ubu2204_foss-2021b-cxx20.yml
+++ b/.github/workflows/ifpen_ubu2204_foss-2021b-cxx20.yml
@@ -28,7 +28,7 @@ env:
   CM_BUILD_TYPE: Release
   CM_CCACHE_OPTS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
   # CTest
-  CT_OPTS: "--timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
+  CT_OPTS: "--parallel --timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
   # OpenMPI
   OMPI_MCA_rmaps_base_oversubscribe : true
   # To remove test output directory to reduce disk usage

--- a/.github/workflows/ifpen_ubu2204_foss-2021b.yml
+++ b/.github/workflows/ifpen_ubu2204_foss-2021b.yml
@@ -28,7 +28,7 @@ env:
   CM_BUILD_TYPE: Release
   CM_CCACHE_OPTS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
   # CTest
-  CT_OPTS: "--timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
+  CT_OPTS: "--parallel 4 --timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
   # OpenMPI
   OMPI_MCA_rmaps_base_oversubscribe : true
   # To remove test output directory to reduce disk usage

--- a/.github/workflows/ifpen_ubu2204_gimkl-2021b-cxx20.yml
+++ b/.github/workflows/ifpen_ubu2204_gimkl-2021b-cxx20.yml
@@ -28,7 +28,7 @@ env:
   CM_BUILD_TYPE: RelWithDebInfo
   CM_CCACHE_OPTS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
   # CTest
-  CT_OPTS: "--timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
+  CT_OPTS: "--parallel 4 --timeout 60 --output-on-failure ${{ github.event.inputs.ctest_options }}"
   # For intel MPI to fix errors appearing in July 2023
   I_MPI_FABRICS: shm
   # For oversubscribe


### PR DESCRIPTION
The goal is to make tests run faster