### PR TITLE
Add support to automatically compute kernel arguments from computed occupancy

### DIFF
--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommandLaunchInfo.cc                                     (C) 2000-2024 */
+/* RunCommandLaunchInfo.cc                                     (C) 2000-2025 */
 /*                                                                           */
 /* Informations pour l'exécution d'une 'RunCommand'.                         */
 /*---------------------------------------------------------------------------*/
@@ -14,12 +14,11 @@
 #include "arcane/accelerator/core/RunCommandLaunchInfo.h"
 
 #include "arcane/utils/CheckedConvert.h"
-#include "arcane/utils/PlatformUtils.h"
 
-#include "arcane/accelerator/core/RunQueue.h"
-#include "arcane/accelerator/core/internal/IRunQueueStream.h"
+#include "arcane/accelerator/core/RunCommand.h"
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
 #include "arcane/accelerator/core/NativeStream.h"
+#include "arcane/accelerator/core/internal/IRunnerRuntime.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -167,11 +166,19 @@ _computeLoopRunInfo()
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
+/*!
+ * \brief Détermine la configuration du kernel.
+ *
+ * La configuration est dépendante du runtime sous-jacent. Pour CUDA et ROCM,
+ * il s'agit d'un nombre de blocs et de thread.
+ *
+ * Il est possible de calculer dynamiquement les valeurs optimales pour
+ * maximiser l'occupation.
+ */
 KernelLaunchArgs RunCommandLaunchInfo::
-_threadBlockInfo([[maybe_unused]] const void* func,[[maybe_unused]] Int64 shared_memory_size) const
+_threadBlockInfo(const void* func, Int32 shared_memory_size) const
 {
-  return m_kernel_launch_args;
+  return m_queue_impl->_internalRuntime()->computeKernalLaunchArgs(m_kernel_launch_args, func, totalLoopSize(), shared_memory_size);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* RunCommandLaunchInfo.h                                      (C) 2000-2024 */
+/* RunCommandLaunchInfo.h                                      (C) 2000-2025 */
 /*                                                                           */
 /* Informations pour l'exécution d'une 'RunCommand'.                         */
 /*---------------------------------------------------------------------------*/
@@ -15,7 +15,6 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/ConcurrencyUtils.h"
-#include "arcane/utils/Profiling.h"
 
 #include "arcane/accelerator/core/KernelLaunchArgs.h"
 
@@ -89,7 +88,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
   /*!
    * \brief Informations d'exécution de la boucle.
    *
-   * Ces informations ne sont valides si executionPolicy()==eExecutionPolicy::Thread
+   * Ces informations ne sont valides que si executionPolicy()==eExecutionPolicy::Thread
    * et si beginExecute() a été appelé.
    */
   const ForLoopRunInfo& loopRunInfo() const { return m_loop_run_info; }
@@ -110,13 +109,7 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
 
  private:
 
-  /*!
-   * \brief Informations dynamiques sur le nombre de block/thread/grille du noyau à lancer.
-   *
-   * Ces informations sont calculées à partir de méthodes fournies par le runtime accélérateur
-   * sous-jacent.
-   */
-  KernelLaunchArgs _threadBlockInfo(const void* func, Int64 shared_memory_size) const;
+  KernelLaunchArgs _threadBlockInfo(const void* func, Int32 shared_memory_size) const;
   NativeStream _internalNativeStream();
   void _doEndKernelLaunch();
   KernelLaunchArgs _computeKernelLaunchArgs() const;

--- a/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
+++ b/arcane/src/arcane/accelerator/core/RunQueueImpl.cc
@@ -13,7 +13,6 @@
 
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
 
-#include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/MemoryUtils.h"
 #include "arcane/utils/SmallArray.h"
 
@@ -23,9 +22,9 @@
 #include "arcane/accelerator/core/internal/RunnerImpl.h"
 #include "arcane/accelerator/core/internal/IRunQueueEventImpl.h"
 #include "arcane/accelerator/core/Runner.h"
-#include "arcane/accelerator/core/RunQueueBuildInfo.h"
 #include "arcane/accelerator/core/DeviceId.h"
 #include "arcane/accelerator/core/RunQueueEvent.h"
+#include "arcane/accelerator/core/KernelLaunchArgs.h"
 
 #include <unordered_set>
 

--- a/arcane/src/arcane/accelerator/core/Runner.cc
+++ b/arcane/src/arcane/accelerator/core/Runner.cc
@@ -13,7 +13,6 @@
 
 #include "arcane/accelerator/core/Runner.h"
 
-#include "arcane/utils/ITraceMng.h"
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/ArgumentException.h"
@@ -27,6 +26,7 @@
 #include "arcane/accelerator/core/DeviceMemoryInfo.h"
 #include "arcane/accelerator/core/IDeviceInfoList.h"
 #include "arcane/accelerator/core/PointerAttribute.h"
+#include "arcane/accelerator/core/KernelLaunchArgs.h"
 #include "arcane/accelerator/core/internal/IRunnerRuntime.h"
 #include "arcane/accelerator/core/internal/AcceleratorCoreGlobalInternal.h"
 #include "arcane/accelerator/core/internal/RunQueueImpl.h"
@@ -613,6 +613,18 @@ void impl::IRunnerRuntime::
 _fillPointerAttribute(PointerAttribute& attribute, const void* pointer)
 {
   attribute = PointerAttribute(pointer);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+impl::KernelLaunchArgs impl::IRunnerRuntime::
+computeKernalLaunchArgs(const KernelLaunchArgs& orig_args,
+                        [[maybe_unused]] const void* kernel_ptr,
+                        [[maybe_unused]] Int64 total_loop_size,
+                        [[maybe_unused]] Int32 wanted_shared_memory)
+{
+  return orig_args;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/internal/IRunnerRuntime.h
+++ b/arcane/src/arcane/accelerator/core/internal/IRunnerRuntime.h
@@ -59,6 +59,10 @@ class ARCANE_ACCELERATOR_CORE_EXPORT IRunnerRuntime
   virtual void pushProfilerRange([[maybe_unused]] const String& name, [[maybe_unused]] Int32 color_gdb) {}
   virtual void popProfilerRange() {}
   virtual void finalize(ITraceMng*) {}
+  virtual KernelLaunchArgs computeKernalLaunchArgs(const KernelLaunchArgs& orig_args,
+                                                   const void* kernel_ptr,
+                                                   Int64 total_loop_size,
+                                                   Int32 wanted_shared_memory);
 
  protected:
 


### PR DESCRIPTION
This PR add the implementation for CUDA.
This is done via a call to `cudaOccupancyMaxPotentialBlockSize()`.
This automatic computation is not active by default.