### PR TITLE
Add connectivities for several order 2 cell type

### DIFF
--- a/arcane/src/arcane/core/ArcaneTypes.h
+++ b/arcane/src/arcane/core/ArcaneTypes.h
@@ -342,7 +342,14 @@ static const Int16 IT_Quad8 = 33;
 static const Int16 IT_Tetraedron10 = 34;
 //! Hexaèdre d'ordre 2
 static const Int16 IT_Hexaedron20 = 35;
+//! Pyramide d'ordre 2
+static const Int16 IT_Pyramid13 = 36;
+//! Prisme d'ordre 2
+static const Int16 IT_Pentaedron15 = 37;
 //@}
+
+//! Maille Line3. EXPERIMENTAL !
+static const Int16 IT_CellLine3 = 38;
 
 /*!
  * \brief Mailles 2D dans un maillage 3D.
@@ -351,15 +358,28 @@ static const Int16 IT_Hexaedron20 = 35;
  */
 //@{
 //! Maille Line2 dans un maillage 3D. EXPERIMENTAL !
-static const Int16 IT_Cell3D_Line2 = 36;
+static const Int16 IT_Cell3D_Line2 = 39;
 //! Maille Triangulaire à 3 noeuds dans un maillage 3D. EXPERIMENTAL !
-static const Int16 IT_Cell3D_Triangle3 = 37;
-//! Maille Quadrangulaire à 5 noeuds dans un maillage 3D. EXPERIMENTAL !
-static const Int16 IT_Cell3D_Quad4 = 38;
+static const Int16 IT_Cell3D_Triangle3 = 40;
+//! Maille Quadrangulaire à 4 noeuds dans un maillage 3D. EXPERIMENTAL !
+static const Int16 IT_Cell3D_Quad4 = 41;
+//! Maille Line3 dans un maillage 3D. EXPERIMENTAL !
+static const Int16 IT_Cell3D_Line3 = 42;
+//! Maille Triangulaire à 6 noeuds dans un maillage 3D. EXPERIMENTAL !
+static const Int16 IT_Cell3D_Triangle6 = 43;
+//! Maille Quadrangulaire à 8 noeuds dans un maillage 3D. EXPERIMENTAL !
+static const Int16 IT_Cell3D_Quad8 = 44;
+//! Maille Quadrangulaire à 9 noeuds dans un maillage 3D. EXPERIMENTAL !
+static const Int16 IT_Cell3D_Quad9 = 45;
 //@}
 
+//! Quadrangle d'ordre 2 (avec 4 noeuds sur les faces et 1 noeud au centre). EXPERIMENTAL !
+static const Int16 IT_Quad9 = 46;
+//! Hexaèdre d'ordre 2 (avec 12 noeuds sur les arêtes, 6 sur les faces et un noeud centre. EXPERIMENTAL !
+static const Int16 IT_Hexaedron27 = 47;
+
 //! Nombre de types d'entités disponible par défaut
-static const Integer NB_BASIC_ITEM_TYPE = 39;
+static const Integer NB_BASIC_ITEM_TYPE = 48;
 
 extern "C++" ARCANE_CORE_EXPORT eItemKind
 dualItemKind(Integer type);

--- a/arcane/src/arcane/core/ItemTypeId.h
+++ b/arcane/src/arcane/core/ItemTypeId.h
@@ -136,7 +136,14 @@ static constexpr ItemTypeId ITI_Quad8(IT_Quad8);
 static constexpr ItemTypeId ITI_Tetraedron10(IT_Tetraedron10);
 //! Hexaèdre d'ordre 2
 static constexpr ItemTypeId ITI_Hexaedron20(IT_Hexaedron20);
+//! Hexaèdre d'ordre 2
+static constexpr ItemTypeId ITI_Pentaedron15(IT_Pentaedron15);
+//! Pyramide d'ordre 2
+static constexpr ItemTypeId ITI_Pyramid13(IT_Pyramid13);
 //@}
+
+//! Maille Line3. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_CellLine3(IT_CellLine3);
 
 /*!
  * \brief Mailles 2D dans un maillage 3D.
@@ -148,9 +155,22 @@ static constexpr ItemTypeId ITI_Hexaedron20(IT_Hexaedron20);
 static constexpr ItemTypeId ITI_Cell3D_Line2(IT_Cell3D_Line2);
 //! Maille Triangulaire à 3 noeuds dans un maillage 3D. EXPERIMENTAL !
 static constexpr ItemTypeId ITI_Cell3D_Triangle3(IT_Cell3D_Triangle3);
-//! Maille Quadrangulaire à 5 noeuds dans un maillage 3D. EXPERIMENTAL !
+//! Maille Quadrangulaire à 4 noeuds dans un maillage 3D. EXPERIMENTAL !
 static constexpr ItemTypeId ITI_Cell3D_Quad4(IT_Cell3D_Quad4);
+//! Maille Line3 dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Line3(IT_Cell3D_Line3);
+//! Maille Triangulaire à 6 noeuds dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Triangle6(IT_Cell3D_Triangle6);
+//! Maille Quadrangulaire à 8 noeuds dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Quad8(IT_Cell3D_Quad8);
+//! Maille Quadrangulaire à 9 noeuds dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Quad9(IT_Cell3D_Quad9);
 //@}
+
+//! Quadrangle d'ordre 2 (avec 4 noeuds sur les faces et 1 noeud au centre). EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Quad9(IT_Quad9);
+//! Hexaèdre d'ordre 2 (avec 12 noeuds sur les arêtes, 6 sur les faces et un noeud centre. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Hexaedron27(IT_Hexaedron27);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemTypeInfo.h
+++ b/arcane/src/arcane/core/ItemTypeInfo.h
@@ -52,7 +52,7 @@ class ItemTypeInfo
   {
    public:
 
-    LocalFace(Integer* index)
+    explicit LocalFace(Integer* index)
     : m_index(index)
     {}
 
@@ -84,7 +84,7 @@ class ItemTypeInfo
   {
    public:
 
-    LocalEdge(Integer* index)
+    explicit LocalEdge(Integer* index)
     : m_index(index)
     {}
 
@@ -135,6 +135,8 @@ class ItemTypeInfo
   ItemTypeId linearItemTypeId() const { return m_linear_type_id; }
   //! Type de l'élément linéaire correspondant
   const ItemTypeInfo* linearTypeInfo() const { return m_mng->typeFromId(m_linear_type_id); }
+  //! Indique si le type a un noeud au centre
+  bool hasCenterNode() const { return m_has_center_node; }
 
  public:
 
@@ -163,6 +165,8 @@ class ItemTypeInfo
   Int16 m_dimension = (-1);
   //! Indique si le type est valide pour une maille.
   bool m_is_valid_for_cell = true;
+  //! Indique si le type a un nœud au centre (pour les faces ou les mailles)
+  bool m_has_center_node = false;
   Integer m_nb_node = 0;
   Integer m_nb_edge = 0;
   Integer m_nb_face = 0;

--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
@@ -276,6 +276,32 @@ addFaceQuad8(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
 /*---------------------------------------------------------------------------*/
 
 void ItemTypeInfoBuilder::
+addFaceQuad9(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
+             Integer n4, Integer n5, Integer n6, Integer n7, Integer n8)
+{
+  _checkDimension(3);
+  Array<Integer>& buf = m_mng->m_ids_buffer;
+  buf[m_first_item_index + m_nb_edge + face_index] = buf.size();
+  buf.add(IT_Quad9);
+  buf.add(9);
+  buf.add(n0);
+  buf.add(n1);
+  buf.add(n2);
+  buf.add(n3);
+  buf.add(n4);
+  buf.add(n5);
+  buf.add(n6);
+  buf.add(n7);
+  buf.add(n8);
+  buf.add(4);
+  for (Integer i = 0; i < 4; ++i)
+    buf.add(-1); // undef value, filled by ItemTypeInfoBuilder::computeFaceEdgeInfos
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemTypeInfoBuilder::
 addFacePentagon(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3, Integer n4)
 {
   _checkDimension(3);

--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.h
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.h
@@ -32,7 +32,7 @@ namespace Arcane
  * \brief Construction des infos d'un type d'entité du maillage.
  *
  * Pour des raisons de performances, on essaie de stocker ces informations
- * de manière contigue en mémoire car elles seront accédées très souvent.
+ * de manière contigue en mémoire, car elles seront accédées très souvent.
  * Pour cela, on utilise un Buffer dans ItemTypeMng.
  *
  * La méthode setInfos() permet d'indiquer le type et le nombre de noeuds, d'arêtes
@@ -43,7 +43,7 @@ namespace Arcane
  * Pour un numéro de type donné, il n'existe qu'une instance de ItemTypeInfo et cette
  * instance reste valide tant que le gestionnaire de type (ItemTypeMng) n'est pas détruit.
  * Par conséquent, il est possible de stocker le pointeur sur l'instance et
- * de comparer deux types uniquement en comparant les pointeurs
+ * de comparer deux types uniquement en comparant les pointeurs.
  */
 class ItemTypeInfoBuilder
 : public ItemTypeInfo
@@ -124,7 +124,7 @@ class ItemTypeInfoBuilder
                           std::array<Int16, 2> left_and_right_face);
 
   /*!
-   * \brief Ajoute une arête pour une maille 2D.
+   * \brief Ajoute une arête pour une maille 2D d'un maillage en 3D.
    *
    * \a n0 noeud origine
    * \a n1 noeud extrémité
@@ -154,6 +154,10 @@ class ItemTypeInfoBuilder
   void addFaceQuad8(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
                     Integer n4, Integer n5, Integer n6, Integer n7);
 
+  //! Ajoute un quadrilatère quadratique à la liste des faces
+  void addFaceQuad9(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3,
+                    Integer n4, Integer n5, Integer n6, Integer n7, Integer n8);
+
   //! Ajoute un pentagone à la liste des faces
   void addFacePentagon(Integer face_index, Integer n0, Integer n1, Integer n2, Integer n3, Integer n4);
 
@@ -175,9 +179,16 @@ class ItemTypeInfoBuilder
   //! Calcule les relations face->arêtes
   void computeFaceEdgeInfos();
 
+  //! Positionne l'information indiquant si le type est valide pour une maille
   void setIsValidForCell(bool is_valid)
   {
     m_is_valid_for_cell = is_valid;
+  }
+
+  //! Positionne l'information indiquant si le type a un nœud au centre
+  void setHasCenterNode(bool has_center_node)
+  {
+    m_has_center_node = has_center_node;
   }
 
  private:

--- a/arcane/src/arcane/core/ItemTypeMng.cc
+++ b/arcane/src/arcane/core/ItemTypeMng.cc
@@ -13,6 +13,7 @@
 
 #include "arcane/core/ItemTypeMng.h"
 
+#include "ItemTypeId.h"
 #include "arcane/utils/Iostream.h"
 #include "arcane/utils/String.h"
 #include "arcane/utils/PlatformUtils.h"
@@ -251,12 +252,32 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
 
   // Quad8
   {
-    // TODO: Pour l'instant comme quad4
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
     m_types[IT_Quad8] = type;
 
     type->setInfos(this, IT_Quad8, "Quad8", Dimension::Dim2, 8, 4, 4);
     type->setOrder(2, ITI_Quad4);
+
+    type->addFaceLine3(0, 0, 1, 4);
+    type->addFaceLine3(1, 1, 2, 5);
+    type->addFaceLine3(2, 2, 3, 6);
+    type->addFaceLine3(3, 3, 0, 7);
+
+    type->addEdge(0, 0, 1, 3, 1);
+    type->addEdge(1, 1, 2, 0, 2);
+    type->addEdge(2, 2, 3, 1, 3);
+    type->addEdge(3, 3, 0, 2, 0);
+  }
+
+  // Quad9
+  {
+    // Comme Quad8 mais avec un noeud en plus au milieu du quadrangle
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Quad9] = type;
+
+    type->setInfos(this, IT_Quad9, "Quad9", Dimension::Dim2, 9, 4, 4);
+    type->setOrder(2, ITI_Quad4);
+    type->setHasCenterNode(true);
 
     type->addFaceLine3(0, 0, 1, 4);
     type->addFaceLine3(1, 1, 2, 5);
@@ -369,6 +390,37 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->addEdge(11, 7, 4, 3, 1);
   }
 
+  // Hexaedron27
+  {
+    // Pour l'instant comme Hexaedron8
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Hexaedron27] = type;
+
+    type->setInfos(this, IT_Hexaedron27, "Hexaedron27", Dimension::Dim3, 27, 12, 6);
+    type->setOrder(2, ITI_Hexaedron8);
+    type->setHasCenterNode(true);
+
+    type->addFaceQuad9(0, 0, 3, 2, 1, 11, 10, 9, 8, 24);
+    type->addFaceQuad9(1, 0, 4, 7, 3, 16, 15, 19, 11, 20);
+    type->addFaceQuad9(2, 0, 1, 5, 4, 8, 17, 12, 16, 22);
+    type->addFaceQuad9(3, 4, 5, 6, 7, 12, 13, 14, 15, 25);
+    type->addFaceQuad9(4, 1, 2, 6, 5, 9, 18, 13, 17, 21);
+    type->addFaceQuad9(5, 2, 3, 7, 6, 10, 19, 14, 18, 23);
+
+    type->addEdge(0, 0, 1, 2, 0);
+    type->addEdge(1, 1, 2, 4, 0);
+    type->addEdge(2, 2, 3, 5, 0);
+    type->addEdge(3, 3, 0, 1, 0);
+    type->addEdge(4, 0, 4, 1, 2);
+    type->addEdge(5, 1, 5, 2, 4);
+    type->addEdge(6, 2, 6, 4, 5);
+    type->addEdge(7, 3, 7, 5, 1);
+    type->addEdge(8, 4, 5, 3, 2);
+    type->addEdge(9, 5, 6, 3, 4);
+    type->addEdge(10, 6, 7, 3, 5);
+    type->addEdge(11, 7, 4, 3, 1);
+  }
+
   // Pyramid5
   {
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
@@ -392,6 +444,29 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->addEdge(7, 3, 4, 4, 1);
   }
 
+  // Pyramid13
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Pyramid13] = type;
+    type->setOrder(2, ITI_Pyramid5);
+    type->setInfos(this, IT_Pyramid13, "Pyramid13", Dimension::Dim3, 13, 8, 5);
+
+    type->addFaceQuad8(0, 0, 3, 2, 1, 5, 6, 7, 8);
+    type->addFaceTriangle6(1, 0, 4, 3, 9, 12, 8);
+    type->addFaceTriangle6(2, 0, 1, 4, 5, 10, 9);
+    type->addFaceTriangle6(3, 1, 2, 4, 6, 11, 10);
+    type->addFaceTriangle6(4, 2, 3, 4, 7, 12, 11);
+
+    type->addEdge(0, 0, 1, 2, 0);
+    type->addEdge(1, 1, 2, 3, 0);
+    type->addEdge(2, 2, 3, 4, 0);
+    type->addEdge(3, 3, 0, 1, 0);
+    type->addEdge(4, 0, 4, 1, 2);
+    type->addEdge(5, 1, 4, 2, 3);
+    type->addEdge(6, 2, 4, 3, 4);
+    type->addEdge(7, 3, 4, 4, 1);
+  }
+
   // Pentaedron6
   {
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
@@ -404,6 +479,31 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->addFaceQuad(2, 0, 1, 4, 3);
     type->addFaceTriangle(3, 3, 4, 5);
     type->addFaceQuad(4, 1, 2, 5, 4);
+
+    type->addEdge(0, 0, 1, 2, 0);
+    type->addEdge(1, 1, 2, 4, 0);
+    type->addEdge(2, 2, 0, 1, 0);
+    type->addEdge(3, 0, 3, 1, 2);
+    type->addEdge(4, 1, 4, 2, 4);
+    type->addEdge(5, 2, 5, 4, 1);
+    type->addEdge(6, 3, 4, 3, 2);
+    type->addEdge(7, 4, 5, 3, 4);
+    type->addEdge(8, 5, 3, 3, 1);
+  }
+
+  // Pentaedron15
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Pentaedron15] = type;
+    type->setOrder(2, ITI_Pentaedron15);
+
+    type->setInfos(this, IT_Pentaedron15, "Pentaedron15", Dimension::Dim3, 15, 9, 5);
+
+    type->addFaceTriangle6(0, 0, 2, 1, 6, 7, 8);
+    type->addFaceQuad8(1, 0, 3, 5, 2, 12, 11, 14, 8);
+    type->addFaceQuad8(2, 0, 1, 4, 3, 6, 13, 9, 3);
+    type->addFaceTriangle6(3, 3, 4, 5, 9, 10, 11);
+    type->addFaceQuad8(4, 1, 2, 5, 4, 7, 14, 10, 13);
 
     type->addEdge(0, 0, 1, 2, 0);
     type->addEdge(1, 1, 2, 4, 0);
@@ -844,6 +944,27 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->setInfos(this, IT_Cell3D_Line2, "Cell3D_Line2", Dimension::Dim1, 2, 0, 0);
   }
 
+  // CellLine3 (maille d'ordre 2 pour les maillages 1D)
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_CellLine3] = type;
+    type->setOrder(2, ITI_CellLine2);
+
+    type->setInfos(this, IT_CellLine3, "CellLine3", Dimension::Dim1, 3, 0, 2);
+
+    type->addFaceVertex(0, 0);
+    type->addFaceVertex(1, 1);
+  }
+
+  // Cell3D_Line3
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Cell3D_Line3] = type;
+    type->setOrder(2, ITI_Cell3D_Line2);
+
+    type->setInfos(this, IT_Cell3D_Line3, "Cell3D_Line3", Dimension::Dim1, 3, 0, 0);
+  }
+
   // Cell3D_Triangle3
   {
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
@@ -864,6 +985,30 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
       type->addFaceLine(0, 0, 1);
       type->addFaceLine(1, 1, 2);
       type->addFaceLine(2, 2, 0);
+    }
+  }
+
+  // Cell3D_Triangle6
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Cell3D_Triangle6] = type;
+    Int32 nb_face = 3;
+    Int32 nb_edge = 0;
+    if (is_non_manifold)
+      std::swap(nb_face, nb_edge);
+
+    type->setInfos(this, IT_Cell3D_Triangle6, "Cell3D_Triangle6", Dimension::Dim2, 6, nb_edge, nb_face);
+    type->setOrder(2, ITI_Cell3D_Triangle3);
+
+    if (is_non_manifold) {
+      type->addEdge2D(0, 0, 1);
+      type->addEdge2D(1, 1, 2);
+      type->addEdge2D(2, 2, 0);
+    }
+    else {
+      type->addFaceLine3(0, 0, 1, 3);
+      type->addFaceLine3(1, 1, 2, 4);
+      type->addFaceLine3(2, 2, 0, 5);
     }
   }
 
@@ -888,6 +1033,60 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
       type->addFaceLine(1, 1, 2);
       type->addFaceLine(2, 2, 3);
       type->addFaceLine(3, 3, 0);
+    }
+  }
+
+  // Cell3D_Quad8
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Cell3D_Quad8] = type;
+
+    Int32 nb_face = 4;
+    Int32 nb_edge = 0;
+    if (is_non_manifold)
+      std::swap(nb_face, nb_edge);
+
+    type->setInfos(this, IT_Cell3D_Quad8, "Cell3D_Quad8", Dimension::Dim2, 8, nb_edge, nb_face);
+    type->setOrder(2, ITI_Cell3D_Quad4);
+
+    if (is_non_manifold) {
+      type->addEdge2D(0, 0, 1);
+      type->addEdge2D(1, 1, 2);
+      type->addEdge2D(2, 2, 3);
+      type->addEdge2D(3, 3, 0);
+    }
+    else {
+      type->addFaceLine3(0, 0, 1, 4);
+      type->addFaceLine3(1, 1, 2, 5);
+      type->addFaceLine3(2, 2, 3, 6);
+      type->addFaceLine3(3, 3, 0, 7);
+    }
+  }
+
+  // Cell3D_Quad9
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Cell3D_Quad9] = type;
+
+    Int32 nb_face = 4;
+    Int32 nb_edge = 0;
+    if (is_non_manifold)
+      std::swap(nb_face, nb_edge);
+
+    type->setInfos(this, IT_Cell3D_Quad9, "Cell3D_Quad9", Dimension::Dim2, 9, nb_edge, nb_face);
+    type->setOrder(2, ITI_Cell3D_Quad4);
+
+    if (is_non_manifold) {
+      type->addEdge2D(0, 0, 1);
+      type->addEdge2D(1, 1, 2);
+      type->addEdge2D(2, 2, 3);
+      type->addEdge2D(3, 3, 0);
+    }
+    else {
+      type->addFaceLine3(0, 0, 1, 4);
+      type->addFaceLine3(1, 1, 2, 5);
+      type->addFaceLine3(2, 2, 3, 6);
+      type->addFaceLine3(3, 3, 0, 7);
     }
   }
 


### PR DESCRIPTION
Add connectivity for  `IT_Quad9`, `IT_Hexaedron27`, `IT_Pyramid13`, `IT_Pentaedron15` and `IT_CellLine3`.