### PR TITLE
Remove usage of deprecated type `IndexType` for MD-Array

### DIFF
--- a/arcane/src/arcane/utils/ArrayBounds.h
+++ b/arcane/src/arcane/utils/ArrayBounds.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayBounds.h                                               (C) 2000-2022 */
+/* ArrayBounds.h                                               (C) 2000-2025 */
 /*                                                                           */
 /* Gestion des itérations sur les tableaux N-dimensions                      */
 /*---------------------------------------------------------------------------*/
@@ -41,7 +41,8 @@ class ArrayBoundsBase
   using BaseClass::asStdArray;
   using BaseClass::constExtent;
   using BaseClass::getIndices;
-  using IndexType = typename BaseClass::IndexType;
+  using IndexType ARCANE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
+  using MDIndexType = typename BaseClass::MDIndexType;
   using ArrayExtentType = Arcane::ArrayExtents<Extents>;
 
  public:

--- a/arcane/src/arcane/utils/ArrayExtents.h
+++ b/arcane/src/arcane/utils/ArrayExtents.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayExtents.h                                              (C) 2000-2024 */
+/* ArrayExtents.h                                              (C) 2000-2025 */
 /*                                                                           */
 /* Gestion du nombre d'éléments par dimension pour les tableaux N-dimensions.*/
 /*---------------------------------------------------------------------------*/
@@ -359,8 +359,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
   using DynamicDimsType = typename BaseClass::DynamicDimsType;
   using MDIndexType = typename BaseClass::MDIndexType;
 
-  // TODO: Rendre obsolète mi-2024
-  using IndexType = typename BaseClass::IndexType;
+  using IndexType ARCANE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
 
  public:
 
@@ -379,7 +378,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
     BaseClass::_checkIndex(i);
     return i;
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(IndexType idx) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
   {
     BaseClass::_checkIndex(idx.id0());
     return idx.id0();
@@ -413,8 +412,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
   using DynamicDimsType = typename BaseClass::DynamicDimsType;
   using MDIndexType = typename BaseClass::MDIndexType;
 
-  // TODO: Rendre obsolète mi-2024
-  using IndexType = typename BaseClass::IndexType;
+  using IndexType ARCANE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
 
  public:
 
@@ -432,7 +430,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
   {
     return offset({ i, j });
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(IndexType idx) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
   {
     BaseClass::_checkIndex(idx);
     return Layout::offset(idx, this->template constExtent<Layout::LastExtent>());
@@ -467,8 +465,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
   using DynamicDimsType = typename BaseClass::DynamicDimsType;
   using MDIndexType = typename BaseClass::MDIndexType;
 
-  // TODO: Rendre obsolète mi-2024
-  using IndexType = typename BaseClass::IndexType;
+  using IndexType ARCANE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
 
  public:
 
@@ -488,7 +485,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
   {
     return offset({ i, j, k });
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(IndexType idx) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
   {
     this->_checkIndex(idx);
     return Layout::offset(idx, this->template constExtent<Layout::LastExtent>(), m_dim23_size);
@@ -536,8 +533,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
   using DynamicDimsType = typename BaseClass::DynamicDimsType;
   using MDIndexType = typename BaseClass::MDIndexType;
 
-  // TODO: Rendre obsolète mi-2024
-  using IndexType = typename BaseClass::IndexType;
+  using IndexType ARCANE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
 
  public:
 
@@ -557,7 +553,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
   {
     return offset({ i, j, k, l });
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(IndexType idx) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
   {
     this->_checkIndex(idx);
     return (m_dim234_size * idx.largeId0()) + m_dim34_size * idx.largeId1() + this->m_extent3.v * idx.largeId2() + idx.largeId3();

--- a/arcane/src/arcane/utils/ForLoopRanges.h
+++ b/arcane/src/arcane/utils/ForLoopRanges.h
@@ -88,8 +88,8 @@ class SimpleForLoopRanges
  public:
 
   using ArrayBoundsType = ArrayBounds<typename MDDimType<N>::DimType>;
-  using ArrayIndexType = typename ArrayBoundsType::IndexType;
-  using IndexType = ArrayIndexType;
+  using ArrayIndexType = typename ArrayBoundsType::MDIndexType;
+  using IndexType ARCANE_DEPRECATED_REASON("Use 'ArrayIndexType' instead") = ArrayIndexType;
 
  public:
 
@@ -128,8 +128,8 @@ class ComplexForLoopRanges
  public:
 
   using ArrayBoundsType = ArrayBounds<typename MDDimType<N>::DimType>;
-  using ArrayIndexType = typename ArrayBoundsType::IndexType;
-  using IndexType = ArrayIndexType;
+  using ArrayIndexType = typename ArrayBoundsType::MDIndexType;
+  using IndexType ARCANE_DEPRECATED_REASON("Use 'ArrayIndexType' instead") = ArrayIndexType;
 
  public:
 


### PR DESCRIPTION
This type is replaced by `MDIndexType`.

Also make deprecated other remaining usage of `IndexType` 

