### PR TITLE
Remove accelerator reduction implementation using atomics

### DIFF
--- a/arcane/src/arcane/accelerator/Reduce.h
+++ b/arcane/src/arcane/accelerator/Reduce.h
@@ -108,9 +108,6 @@ class ReduceDeviceInfo
    */
   unsigned int* m_device_count = nullptr;
 
-  //! Indique si on utilise la réduction par grille (sinon on utilise les atomiques)
-  bool m_use_grid_reduce = true;
-
   //! Taille d'un warp
   Int32 m_warp_size = 0;
 };
@@ -442,7 +439,6 @@ class HostDeviceReducerBase
     dvi.m_host_final_ptr = m_grid_memory_info.m_host_memory_for_reduced_value;
     dvi.m_current_value = m_local_value;
     dvi.m_identity = m_identity;
-    dvi.m_use_grid_reduce = m_grid_memory_info.m_reduce_policy != eDeviceReducePolicy::Atomic;
     dvi.m_warp_size = m_grid_memory_info.m_warp_size;
     ReduceFunctor::applyDevice(dvi); //grid_buffer,m_grid_device_count,m_host_or_device_memory_for_reduced_value,m_local_value,m_identity);
 #else

--- a/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
+++ b/arcane/src/arcane/accelerator/core/AcceleratorCoreGlobal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AcceleratorCoreGlobal.h                                     (C) 2000-2024 */
+/* AcceleratorCoreGlobal.h                                     (C) 2000-2025 */
 /*                                                                           */
 /* Déclarations générales pour le support des accélérateurs.                 */
 /*---------------------------------------------------------------------------*/
@@ -113,12 +113,21 @@ operator<<(std::ostream& o, eExecutionPolicy exec_policy);
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Politique des opératations de réduction sur les accélérateurs
+ * \brief Politique des opératations de réduction sur les accélérateurs.
+ *
+ * \note A partir de la version 3.15 de Arcane, seule la politique Grid
+ * est disponible.
  */
 enum class eDeviceReducePolicy
 {
-  //! Utilise des opérations atomiques entre les blocs
-  Atomic = 1,
+  /*!
+   * \brief Utilise des opérations atomiques entre les blocs.
+   *
+   * \deprecated Cette politique n'est plus disponible. Si on
+   * spécifie cette politique, elle se comportera comme
+   * eDeviceReducePolicy::Grid.
+   */
+  Atomic ARCANE_DEPRECATED_REASON("Y2025: Use eDeviceReducePolicy::Grid instead") = 1,
   //! Utilise un noyau de calcul avec une synchronisations entre les blocs.
   Grid = 2
 };

--- a/arcane/src/arcane/accelerator/core/IReduceMemoryImpl.h
+++ b/arcane/src/arcane/accelerator/core/IReduceMemoryImpl.h
@@ -42,8 +42,6 @@ class ARCANE_ACCELERATOR_CORE_EXPORT IReduceMemoryImpl
     MutableMemoryView m_grid_memory_values;
     //! Entier utilisé pour compter le nombre de blocs ayant déjà fait leur partie de la réduction
     unsigned int* m_grid_device_count = nullptr;
-    //! Politique de réduction
-    eDeviceReducePolicy m_reduce_policy = eDeviceReducePolicy::Grid;
     //! Pointeur vers la mémoire sur l'hôte contenant la valeur réduite.
     void* m_host_memory_for_reduced_value = nullptr;
     //! Taille d'un warp

--- a/arcane/src/arcane/accelerator/core/ReduceMemoryImpl.cc
+++ b/arcane/src/arcane/accelerator/core/ReduceMemoryImpl.cc
@@ -64,15 +64,6 @@ release()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void ReduceMemoryImpl::
-_setReducePolicy()
-{
-  m_grid_memory_info.m_reduce_policy = m_command->runner()->reducePolicy();
-}
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 void* ReduceMemoryImpl::
 allocateReduceDataMemory(ConstMemoryView identity_view)
 {

--- a/arcane/src/arcane/accelerator/core/internal/ReduceMemoryImpl.h
+++ b/arcane/src/arcane/accelerator/core/internal/ReduceMemoryImpl.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ReduceMemoryImpl.h                                          (C) 2000-2023 */
+/* ReduceMemoryImpl.h                                          (C) 2000-2025 */
 /*                                                                           */
 /* Gestion de la mémoire pour les réductions.                                */
 /*---------------------------------------------------------------------------*/
@@ -40,7 +40,6 @@ class ReduceMemoryImpl
   void setGridSizeAndAllocate(Int32 grid_size) override
   {
     m_grid_size = grid_size;
-    _setReducePolicy();
     _allocateGridDataMemory();
   }
   Int32 gridSize() const override { return m_grid_size; }


### PR DESCRIPTION
This implementation is no longer available in version 3.15.
The grid implementation is faster and is reproducible between runs