### PR TITLE
Let each accelerator runtime handle the choice of the memory allocator for data

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -24,6 +24,7 @@
 #include "arcane/utils/OStringStream.h"
 #include "arcane/utils/ValueConvert.h"
 #include "arcane/utils/CheckedConvert.h"
+#include "arcane/utils/internal/MemoryUtilsInternal.h"
 #include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
 
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
@@ -673,8 +674,8 @@ arcaneRegisterAcceleratorRuntimecuda(Arcane::Accelerator::RegisterRuntimeInfo& i
   Arcane::Accelerator::impl::setUsingCUDARuntime(true);
   Arcane::Accelerator::impl::setCUDARunQueueRuntime(&global_cuda_runtime);
   initializeCudaMemoryAllocators();
-  Arcane::platform::setAcceleratorHostMemoryAllocator(getCudaMemoryAllocator());
-  IMemoryRessourceMngInternal* mrm = platform::getDataMemoryRessourceMng()->_internal();
+  MemoryUtils::setAcceleratorHostMemoryAllocator(getCudaMemoryAllocator());
+  IMemoryRessourceMngInternal* mrm = MemoryUtils::getDataMemoryResourceMng()->_internal();
   mrm->setIsAccelerator(true);
   mrm->setAllocator(eMemoryRessource::UnifiedMemory, getCudaUnifiedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::HostPinned, getCudaHostPinnedMemoryAllocator());

--- a/arcane/src/arcane/accelerator/hip/runtime/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/hip/runtime/CMakeLists.txt
@@ -38,9 +38,7 @@ endif()
 
 add_library(arcane_accelerator_hip_testlib Test.cu.cc TestCpp.cc)
 set_source_files_properties(Test.cu.cc PROPERTIES LANGUAGE HIP)
-#set_target_properties(arcane_accelerator_hip_testlib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-target_link_libraries(arcane_accelerator_hip_testlib PUBLIC arcane_core)
-target_link_libraries(arcane_accelerator_hip_testlib PUBLIC arcane_core arcane_hip_compile_flags)
+target_link_libraries(arcane_accelerator_hip_testlib PUBLIC  arcane_accelerator arcane_core arcane_hip_compile_flags)
 
 add_executable(arcane_accelerator_hip_test TestMain.cc)
 target_link_libraries(arcane_accelerator_hip_test PUBLIC arcane_accelerator_hip_testlib arcane_accelerator_hip_runtime)

--- a/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/hip/runtime/HipAcceleratorRuntime.cc
@@ -20,6 +20,7 @@
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/IMemoryRessourceMng.h"
 #include "arcane/utils/OStringStream.h"
+#include "arcane/utils/internal/MemoryUtilsInternal.h"
 #include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
 
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
@@ -516,8 +517,9 @@ arcaneRegisterAcceleratorRuntimehip(Arcane::Accelerator::RegisterRuntimeInfo& in
   using namespace Arcane::Accelerator::Hip;
   Arcane::Accelerator::impl::setUsingHIPRuntime(true);
   Arcane::Accelerator::impl::setHIPRunQueueRuntime(&global_hip_runtime);
-  Arcane::platform::setAcceleratorHostMemoryAllocator(getHipMemoryAllocator());
-  IMemoryRessourceMngInternal* mrm = platform::getDataMemoryRessourceMng()->_internal();
+  MemoryUtils::setDefaultDataMemoryResource(eMemoryResource::UnifiedMemory);
+  MemoryUtils::setAcceleratorHostMemoryAllocator(getHipMemoryAllocator());
+  IMemoryRessourceMngInternal* mrm = MemoryUtils::getDataMemoryResourceMng()->_internal();
   mrm->setIsAccelerator(true);
   mrm->setAllocator(eMemoryRessource::UnifiedMemory, getHipUnifiedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::HostPinned, getHipHostPinnedMemoryAllocator());

--- a/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/sycl/runtime/SyclAcceleratorRuntime.cc
@@ -19,6 +19,7 @@
 #include "arcane/utils/NotImplementedException.h"
 #include "arcane/utils/FatalErrorException.h"
 #include "arcane/utils/IMemoryRessourceMng.h"
+#include "arcane/utils/internal/MemoryUtilsInternal.h"
 #include "arcane/utils/internal/IMemoryRessourceMngInternal.h"
 
 #include "arcane/accelerator/core/RunQueueBuildInfo.h"
@@ -311,7 +312,7 @@ class SyclRunnerRuntime
     _fillPointerAttribute(attribute, mem_type, device_id, ptr, device_ptr, host_ptr);
   }
 
-  DeviceMemoryInfo getDeviceMemoryInfo(DeviceId device_id) override
+  DeviceMemoryInfo getDeviceMemoryInfo([[maybe_unused]] DeviceId device_id) override
   {
     return {};
   }
@@ -451,8 +452,9 @@ arcaneRegisterAcceleratorRuntimesycl(Arcane::Accelerator::RegisterRuntimeInfo& i
   using namespace Arcane::Accelerator::Sycl;
   Arcane::Accelerator::impl::setUsingSYCLRuntime(true);
   Arcane::Accelerator::impl::setSYCLRunQueueRuntime(&global_sycl_runtime);
-  Arcane::platform::setAcceleratorHostMemoryAllocator(getSyclMemoryAllocator());
-  IMemoryRessourceMngInternal* mrm = platform::getDataMemoryRessourceMng()->_internal();
+  MemoryUtils::setAcceleratorHostMemoryAllocator(getSyclMemoryAllocator());
+  MemoryUtils::setDefaultDataMemoryResource(eMemoryResource::UnifiedMemory);
+  IMemoryRessourceMngInternal* mrm = MemoryUtils::getDataMemoryResourceMng()->_internal();
   mrm->setIsAccelerator(true);
   mrm->setAllocator(eMemoryRessource::UnifiedMemory, getSyclUnifiedMemoryAllocator());
   mrm->setAllocator(eMemoryRessource::HostPinned, getSyclHostPinnedMemoryAllocator());

--- a/arcane/src/arcane/accelerator/tests/TestCommon.cc
+++ b/arcane/src/arcane/accelerator/tests/TestCommon.cc
@@ -1,28 +1,29 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 
 #include "arcane/accelerator/AcceleratorGlobal.h"
+#include "arcane/accelerator/core/internal/RegisterRuntimeInfo.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #if defined(ARCANE_HAS_CUDA)
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimecuda();
+arcaneRegisterAcceleratorRuntimecuda(Arcane::Accelerator::RegisterRuntimeInfo& init_info);
 #endif
 
 #if defined(ARCANE_HAS_HIP)
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimehip();
+arcaneRegisterAcceleratorRuntimehip(Arcane::Accelerator::RegisterRuntimeInfo& init_info);
 #endif
 
 #if defined(ARCANE_HAS_SYCL)
 extern "C" ARCANE_EXPORT void
-arcaneRegisterAcceleratorRuntimesycl();
+arcaneRegisterAcceleratorRuntimesycl(Arcane::Accelerator::RegisterRuntimeInfo& init_info);
 #endif
 
 /*---------------------------------------------------------------------------*/
@@ -31,12 +32,14 @@ arcaneRegisterAcceleratorRuntimesycl();
 extern "C++" void
 arcaneRegisterDefaultAcceleratorRuntime()
 {
+  Arcane::Accelerator::RegisterRuntimeInfo init_info;
+  init_info.setVerbose(true);
 #ifdef ARCANE_HAS_CUDA
-  arcaneRegisterAcceleratorRuntimecuda();
+  arcaneRegisterAcceleratorRuntimecuda(init_info);
 #elif defined(ARCANE_HAS_HIP)
-  arcaneRegisterAcceleratorRuntimehip();
+  arcaneRegisterAcceleratorRuntimehip(init_info);
 #elif defined(ARCANE_HAS_SYCL)
-  arcaneRegisterAcceleratorRuntimesycl();
+  arcaneRegisterAcceleratorRuntimesycl(init_info);
 #endif
 }
 

--- a/arcane/src/arcane/impl/ArcaneMain.cc
+++ b/arcane/src/arcane/impl/ArcaneMain.cc
@@ -1179,10 +1179,6 @@ _checkAutoDetectAccelerator(bool& has_accelerator)
     if (!verbose_str.null())
       runtime_info.setVerbose(true);
 
-    // Par défaut utilise la mémoire unifiée pour les données.
-    // Le runtime accélérateur pourra changer cela.
-    MemoryUtils::setDefaultDataMemoryResource(eMemoryResource::UnifiedMemory);
-
     (*my_functor)(runtime_info);
     has_accelerator = true;
 


### PR DESCRIPTION
At the moment it is `UnifiedMemory` for all accelerator runtimes.