### PR TITLE
Fix default memory allocator on CUDA

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
+++ b/arcane/src/arcane/accelerator/cuda/runtime/CudaAcceleratorRuntime.cc
@@ -674,7 +674,8 @@ arcaneRegisterAcceleratorRuntimecuda(Arcane::Accelerator::RegisterRuntimeInfo& i
   Arcane::Accelerator::impl::setUsingCUDARuntime(true);
   Arcane::Accelerator::impl::setCUDARunQueueRuntime(&global_cuda_runtime);
   initializeCudaMemoryAllocators();
-  MemoryUtils::setAcceleratorHostMemoryAllocator(getCudaMemoryAllocator());
+  MemoryUtils::setDefaultDataMemoryResource(eMemoryResource::UnifiedMemory);
+  MemoryUtils::setAcceleratorHostMemoryAllocator(getCudaUnifiedMemoryAllocator());
   IMemoryRessourceMngInternal* mrm = MemoryUtils::getDataMemoryResourceMng()->_internal();
   mrm->setIsAccelerator(true);
   mrm->setAllocator(eMemoryRessource::UnifiedMemory, getCudaUnifiedMemoryAllocator());


### PR DESCRIPTION
The right value should be `UnifiedMemory` but the PR #2221 has unintentionally changed that to use the default host allocator (which uses `malloc()/free()`.
