### PR TITLE
Use `std::mutex` instead of `Arcane::Mutex` in `TraceMng`

### DIFF
--- a/arccore/src/trace/arccore/trace/CMakeLists.txt
+++ b/arccore/src/trace/arccore/trace/CMakeLists.txt
@@ -5,7 +5,6 @@ arccore_add_component_library(trace
 )
 
 target_link_libraries(arccore_trace PUBLIC arccore_base)
-target_link_libraries(arccore_trace PRIVATE arccore_concurrency)
 
 # ----------------------------------------------------------------------------
 # Local Variables:


### PR DESCRIPTION
This way `arccore_trace` does not need to depend of `arccore_concurrency`.