### PR TITLE
Remove usage of services for `ITaskImplementation` and `IThreadImplementationService`

### DIFF
--- a/arcane/src/arcane/parallel/thread/GlibThreadImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/GlibThreadImplementation.cc
@@ -18,8 +18,6 @@
 #include "arcane/utils/UtilsTypes.h"
 #include "arcane/utils/IThreadImplementationService.h"
 
-#include "arcane/core/FactoryService.h"
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -53,7 +51,6 @@ class GlibThreadImplementationService
 {
  public:
 
-  explicit GlibThreadImplementationService(const ServiceBuildInfo&) {}
   GlibThreadImplementationService() = default;
 
  public:
@@ -70,11 +67,6 @@ class GlibThreadImplementationService
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-// TODO: a supprimer maintenant qu'on utilise 'DependencyInjection'
-ARCANE_REGISTER_APPLICATION_FACTORY(GlibThreadImplementationService,
-                                    IThreadImplementationService,
-                                    GlibThreadImplementationService);
 
 ARCANE_DI_REGISTER_PROVIDER(GlibThreadImplementationService,
                             DependencyInjection::ProviderProperty("GlibThreadImplementationService"),

--- a/arcane/src/arcane/parallel/thread/StdThreadImplementationService.cc
+++ b/arcane/src/arcane/parallel/thread/StdThreadImplementationService.cc
@@ -19,8 +19,6 @@
 #include "arcane/utils/UtilsTypes.h"
 #include "arcane/utils/IThreadImplementationService.h"
 
-#include "arcane/core/FactoryService.h"
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -35,7 +33,6 @@ class StdThreadImplementationService
 {
  public:
 
-  explicit StdThreadImplementationService(const ServiceBuildInfo&) {}
   StdThreadImplementationService() = default;
 
  public:
@@ -52,10 +49,6 @@ class StdThreadImplementationService
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-ARCANE_REGISTER_APPLICATION_FACTORY(StdThreadImplementationService,
-                                    IThreadImplementationService,
-                                    StdThreadImplementationService);
 
 ARCANE_DI_REGISTER_PROVIDER(StdThreadImplementationService,
                             DependencyInjection::ProviderProperty("StdThreadImplementationService"),

--- a/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBTaskImplementation.cc
@@ -22,10 +22,9 @@
 #include "arcane/utils/Profiling.h"
 #include "arcane/utils/MemoryAllocator.h"
 #include "arcane/utils/FixedArray.h"
+#include "arcane/utils/Array.h"
 #include "arccore/concurrency/internal/TaskFactoryInternal.h"
 #include "arccore/base/internal/DependencyInjection.h"
-
-#include "arcane/core/FactoryService.h"
 
 #include <new>
 #include <stack>
@@ -458,9 +457,6 @@ class TBBTaskImplementation
   };
 
  public:
-  TBBTaskImplementation(const ServiceBuildInfo& sbi)
-  {
-  }
   TBBTaskImplementation() = default;
   ~TBBTaskImplementation() override;
  public:
@@ -1429,10 +1425,6 @@ _createChildTask(ITaskFunctor* functor)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-// TODO: a supprimer maintenant qu'on utilise 'DependencyInjection'
-ARCANE_REGISTER_APPLICATION_FACTORY(TBBTaskImplementation,ITaskImplementation,
-                                    TBBTaskImplementation);
 
 ARCANE_DI_REGISTER_PROVIDER(TBBTaskImplementation,
                             DependencyInjection::ProviderProperty("TBBTaskImplementation"),

--- a/arcane/src/arcane/parallel/thread/TBBThreadImplementation.cc
+++ b/arcane/src/arcane/parallel/thread/TBBThreadImplementation.cc
@@ -19,9 +19,6 @@
 #include "arcane/utils/PlatformUtils.h"
 #include "arccore/base/internal/DependencyInjection.h"
 
-#include "arcane/FactoryService.h"
-#include "arcane/Concurrency.h"
-
 #include "arcane/parallel/thread/ArcaneThreadMisc.h"
 
 #include <tbb/tbb.h>
@@ -297,7 +294,6 @@ class TBBThreadImplementationService
 {
  public:
 
-  explicit TBBThreadImplementationService(const ServiceBuildInfo&) {}
   TBBThreadImplementationService() = default;
 
  public:
@@ -312,11 +308,6 @@ class TBBThreadImplementationService
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-// TODO: a supprimer maintenant qu'on utilise 'DependencyInjection'
-ARCANE_REGISTER_SERVICE(TBBThreadImplementationService,
-                        ServiceProperty("TBBThreadImplementationService",ST_Application),
-                        ARCANE_SERVICE_INTERFACE(IThreadImplementationService));
 
 ARCANE_DI_REGISTER_PROVIDER(TBBThreadImplementationService,
                             DependencyInjection::ProviderProperty("TBBThreadImplementationService"),


### PR DESCRIPTION
We only use dependency injection for these interfaces.