### PR TITLE
Add support to use `cudaLaunchKernel` and `cudaLaunchCooperativeKernel`

### DIFF
--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.cc
@@ -180,7 +180,10 @@ _computeLoopRunInfo()
 KernelLaunchArgs RunCommandLaunchInfo::
 _threadBlockInfo(const void* func, Int32 shared_memory_size) const
 {
-  return m_queue_impl->_internalRuntime()->computeKernalLaunchArgs(m_kernel_launch_args, func, totalLoopSize(), shared_memory_size);
+  IRunnerRuntime* r = m_queue_impl->_internalRuntime();
+
+  return r->computeKernalLaunchArgs(m_kernel_launch_args, func,
+                                    totalLoopSize(), shared_memory_size);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -199,6 +202,25 @@ Int32 RunCommandLaunchInfo::
 _sharedMemorySize() const
 {
   return m_command._sharedMemory();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool RunCommandLaunchInfo::
+_isUseCooperativeLaunch() const
+{
+  // Indique si on utilise cudaLaunchCooperativeKernel()
+  return false;
+}
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool RunCommandLaunchInfo::
+_isUseCudaLaunchKernel() const
+{
+  // Indique si on utilise cudaLaunchKernel() au lieu de kernel<<<...>>>.
+  return true;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
+++ b/arcane/src/arcane/accelerator/core/RunCommandLaunchInfo.h
@@ -116,6 +116,10 @@ class ARCANE_ACCELERATOR_CORE_EXPORT RunCommandLaunchInfo
   void _doEndKernelLaunch();
   KernelLaunchArgs _computeKernelLaunchArgs() const;
 
+  // Pour test uniquement avec CUDA
+  bool _isUseCooperativeLaunch() const;
+  bool _isUseCudaLaunchKernel() const;
+
  private:
 
   void _computeLoopRunInfo();


### PR DESCRIPTION
This is experimental and not used at the moment.
This will be used to test usage of `cooperative_groups`.