### PR TITLE
Remove CMake option `ARCANE_ADD_RPATH_TO_LIBS`

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -164,12 +164,6 @@ if(ARCANE_WANT_ARCCON_EXPORT_TARGET)
   endif()
 endif()
 
-# Indique si on ajoute automatiquement dans le rpath les chemins des bibliothèques
-# dynamiques. Ce mode existe historiquement pour contourner des problèmes avec
-# d'anciennes versions de CMake (pré 3.10) mais ne devrait plus être nécessaire.
-# Il faudrait donc le supprimer.
-option(ARCANE_ADD_RPATH_TO_LIBS "True if we automatically add rpath in target_link_libraries" OFF)
-
 # ----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------
 

--- a/arcane/cmake/Functions.cmake
+++ b/arcane/cmake/Functions.cmake
@@ -365,36 +365,8 @@ function(arcane_add_arccon_packages target visibility)
         list(APPEND ARCANE_PUBLIC_FOUND_PACKAGES ${package})
       endif()
       target_link_libraries(${target} ${visibility} ${_PKG})
-
-      # Récupère les bibliothèques définies dans le package.
-      # TODO: ne traiter que les répertoires correspondants aux bibliothèques
-      # dynamiques.
-      # NOTE: Ce mécanisme est obsolète (2023) et n'est actif que
-      # si ARCANE_ADD_RPATH_TO_LIBS est défini. Ce n'est normalement
-      # plus le cas. On le laisse temporairement pour des raisons
-      # de compatibilité
-      get_target_property(_LIB ${_PKG} INTERFACE_LINK_LIBRARIES)
-      foreach(lib ${_LIB})
-        #message(STATUS "LIB::${lib}")
-        get_filename_component(_LIB_PATH ${lib} DIRECTORY)
-        if (_LIB_PATH)
-          list(APPEND _RPATH_LIST ${_LIB_PATH})
-        endif()
-      endforeach()
     endif()
   endforeach()
-  # TODO: regarder plutôt sur quelles plateforme il faut le
-  # faire au lieu de juste retirer windows.
-  if (NOT WIN32 AND (_RPATH_LIST) AND ARCANE_ADD_RPATH_TO_LIBS)
-    list(REMOVE_DUPLICATES _RPATH_LIST)
-    # Les répertoires systèmes ne doivent pas être dans le rpath
-    set(_REMOVED_DIRS "/lib" "/lib64" "/usr/lib" "/usr/lib64")
-    list(REMOVE_ITEM _RPATH_LIST ${_REMOVED_DIRS})
-    foreach(path ${_RPATH_LIST})
-      #message(STATUS "Add rpath '${path}' to target '${target}'")
-      target_link_libraries(${target} PUBLIC "-Wl,-rpath,${path}")
-    endforeach()
-  endif()
   set(ARCANE_PUBLIC_FOUND_PACKAGES ${ARCANE_PUBLIC_FOUND_PACKAGES} CACHE STRING "List of public external packages founds" FORCE)
 endfunction()
 


### PR DESCRIPTION
This option is deprecated for several years and was only useful with old versions (previous 3.10) of CMake.