### PR TITLE
Add barrier when using `GenericScanner` and `GenericSorter` with a synchronized queue.

### DIFF
--- a/arcane/src/arcane/accelerator/GenericFilterer.h
+++ b/arcane/src/arcane/accelerator/GenericFilterer.h
@@ -593,7 +593,11 @@ class GenericFilterer
     gf.apply<false>(*base_ptr, nb_value, input_iter, out, select_lambda, trace_info);
   }
 
-  //! Nombre d'éléments en sortie.
+  /*!
+   * \brief Nombre d'éléments en sortie.
+   *
+   * \brief Cette méthode effectue une barrière avant de récupérer la valeur.
+   */
   Int32 nbOutputElement()
   {
     return _nbOutputElement();

--- a/arcane/src/arcane/accelerator/GenericSorter.h
+++ b/arcane/src/arcane/accelerator/GenericSorter.h
@@ -55,6 +55,16 @@ class ARCANE_ACCELERATOR_EXPORT GenericSorterBase
 
   RunQueue m_queue;
   GenericDeviceStorage m_algo_storage;
+
+ protected:
+
+  void _checkBarrier()
+  {
+    // Les fonctions cub ou rocprim pour le scan sont asynchrones par défaut.
+    // Si on a une RunQueue synchrone, alors on fait une barrière.
+    if (!m_queue.isAsync())
+      m_queue.barrier();
+  }
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The underlying algorithms use `cub` or `rocprim` and they asynchronous so we need to do a barrier if the used `RunQueue` is not async.