### PR TITLE
Always create boundary groups  when using cartesian mesh generators.

### DIFF
--- a/arcane/src/arcane/std/CartesianMeshGenerator.cc
+++ b/arcane/src/arcane/std/CartesianMeshGenerator.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* CartesianMeshGenerator.cc                                   (C) 2000-2023 */
+/* CartesianMeshGenerator.cc                                   (C) 2000-2025 */
 /*                                                                           */
 /* Service de génération de maillage cartésien.                              */
 /*---------------------------------------------------------------------------*/
@@ -892,7 +892,9 @@ generateMesh()
   }
   nodes_coord_var.synchronize();
 
-  if (m_build_info.m_is_generate_sod_groups){
+  // Créé les groupes correspondants aux bords du maillage
+  // Si demandé, on créé aussi les groupes pour tester un tube à choc de Sod.
+  {
     SodStandardGroupsBuilder groups_builder(traceMng());
     Real3 origin = m_build_info.m_origine;
     Real3 length(m_l.x,m_l.y,m_l.z);
@@ -901,9 +903,10 @@ generateMesh()
     // le milieu à partir de la position de la maille d'offset le milieu
     // et pas à partir des coordonnées
     // Calculer middle_x comme position du milieu
+    bool do_zg_and_zd = m_build_info.m_is_generate_sod_groups;
     Real middle_x = (origin.x + max_pos.x) / 2.0;
     Real middle_height = (origin.y + max_pos.y) / 2.0;
-    groups_builder.generateGroups(mesh,origin,origin+length,middle_x,middle_height);
+    groups_builder.generateGroups(mesh, origin, origin + length, middle_x, middle_height, do_zg_and_zd);
   }
 
   return false; // false == ok

--- a/arcane/src/arcane/std/SodMeshGenerator.cc
+++ b/arcane/src/arcane/std/SodMeshGenerator.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SodMeshGenerator.cc                                         (C) 2000-2024 */
+/* SodMeshGenerator.cc                                         (C) 2000-2025 */
 /*                                                                           */
 /* Service de génération d'un maillage à-la 'sod'.                           */
 /*---------------------------------------------------------------------------*/
@@ -567,7 +567,7 @@ generateMesh(IPrimaryMesh* mesh)
       info()<< "[SodMeshGenerator::generateMesh]  max_y=" << max_y;
     }
     const Real max_z = zdelta * Convert::toReal(total_para_cell_z);
-    groups_builder.generateGroups(mesh,Real3::null(),Real3(max_x,max_y,max_z),middle_x,middle_height);
+    groups_builder.generateGroups(mesh, Real3::null(), Real3(max_x, max_y, max_z), middle_x, middle_height, true);
   }
 
   bool is_random = !math::isNearlyZero(m_random_coef);

--- a/arcane/src/arcane/std/internal/SodStandardGroupsBuilder.cc
+++ b/arcane/src/arcane/std/internal/SodStandardGroupsBuilder.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SodStandardGroupsBuilder.cc                                 (C) 2000-2023 */
+/* SodStandardGroupsBuilder.cc                                 (C) 2000-2025 */
 /*                                                                           */
 /* Création des groupes pour les cas test de tube à choc de Sod.             */
 /*---------------------------------------------------------------------------*/
@@ -57,7 +57,7 @@ _createFaceGroup(IMesh* mesh,const String& name, Int32ConstArrayView faces_lid)
 /*---------------------------------------------------------------------------*/
 
 void SodStandardGroupsBuilder::
-generateGroups(IMesh* mesh,Real3 min_pos,Real3 max_pos,Real middle_x,Real middle_height)
+generateGroups(IMesh* mesh, Real3 min_pos, Real3 max_pos, Real middle_x, Real middle_height, bool do_zg_and_zd)
 {
   VariableNodeReal3& nodes_coord_var(mesh->nodesCoordinates());
   Int32 mesh_dimension = mesh->dimension();
@@ -74,16 +74,16 @@ generateGroups(IMesh* mesh,Real3 min_pos,Real3 max_pos,Real middle_x,Real middle
          << " middle_x=" << middle_x << " middle_height=" << middle_height;
 
   {
-    Int32UniqueArray xmin_surface_lid;
-    Int32UniqueArray xmax_surface_lid;
-    Int32UniqueArray ymin_surface_lid;
-    Int32UniqueArray ymax_surface_lid;
-    Int32UniqueArray zmin_surface_lid;
-    Int32UniqueArray zmax_surface_lid;
+    UniqueArray<Int32> xmin_surface_lid;
+    UniqueArray<Int32> xmax_surface_lid;
+    UniqueArray<Int32> ymin_surface_lid;
+    UniqueArray<Int32> ymax_surface_lid;
+    UniqueArray<Int32> zmin_surface_lid;
+    UniqueArray<Int32> zmax_surface_lid;
 
-    ENUMERATE_FACE(iface,mesh->allFaces()){
+    ENUMERATE_ (Face, iface, mesh->allFaces()) {
       Face face = *iface;
-      Integer face_local_id = face.localId();
+      Int32 face_local_id = face.localId();
       bool is_xmin = true;
       bool is_xmax = true;
       bool is_ymin = true;
@@ -135,12 +135,11 @@ generateGroups(IMesh* mesh,Real3 min_pos,Real3 max_pos,Real middle_x,Real middle
   }
 
   // Détermine les couches ZG et ZD
-  {
-    Int32UniqueArray zg_lid;
-    Int32UniqueArray zd_lid;
+  if (do_zg_and_zd) {
+    UniqueArray<Int32> zg_lid;
+    UniqueArray<Int32> zd_lid;
     const Real xlimit = middle_x; // Position séparant les deux zones ZG et ZD
-    ENUMERATE_CELL(icell,mesh->allCells()){
-      //Real xpos = 0.;
+    ENUMERATE_ (Cell, icell, mesh->allCells()) {
       bool is_in_zd = false;
       bool is_in_zg = false;
       const Cell& cell = *icell;
@@ -191,12 +190,12 @@ generateGroups(IMesh* mesh,Real3 min_pos,Real3 max_pos,Real middle_x,Real middle
   }
   
   // Détermine les groupes ZD_HAUT et ZD_BAS
-  {
+  if (do_zg_and_zd) {
     ItemGroup zdGroup = cell_family->findGroup("ZD");
     if (zdGroup.null())
-      fatal()<<"zdGroup has not been found!";
-    Int32UniqueArray zd_bas_lid;
-    Int32UniqueArray zd_haut_lid;
+      ARCANE_FATAL("Group 'ZD' has not been found!");
+    UniqueArray<Int32> zd_bas_lid;
+    UniqueArray<Int32> zd_haut_lid;
     const Real height_limit = middle_height; // Position séparant les deux zones HAUT et BAS
     ENUMERATE_CELL(icell, zdGroup){
       bool is_in_zd_bas = false;

--- a/arcane/src/arcane/std/internal/SodStandardGroupsBuilder.h
+++ b/arcane/src/arcane/std/internal/SodStandardGroupsBuilder.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SodStandardGroupsBuilder.h                                  (C) 2000-2020 */
+/* SodStandardGroupsBuilder.h                                  (C) 2000-2025 */
 /*                                                                           */
 /* Création des groupes pour les cas test de tube à choc de Sod.             */
 /*---------------------------------------------------------------------------*/
@@ -15,7 +15,7 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arcane/utils/TraceAccessor.h"
-#include "arcane/ArcaneTypes.h"
+#include "arcane/core/ArcaneTypes.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -31,7 +31,7 @@ namespace Arcane
  * Les groupes créés sont les groupes de faces correspondants aux côtés du
  * maillages (XMIN,XMAX,YMIN,YMAX,ZMIN,ZMAX), les groupes de mailles à gauche (ZG)
  * et à droite (ZD) le long de l'axe des X et pour le groupe de droite
- *  la partie en haut (ZD_HAUT) et en bas (ZD_BAS).
+ * la partie en haut (ZD_HAUT) et en bas (ZD_BAS).
  *
  * \sa SodMeshGenerator
  */
@@ -39,12 +39,26 @@ class SodStandardGroupsBuilder
 : public TraceAccessor
 {
  public:
+
   explicit SodStandardGroupsBuilder(ITraceMng* tm)
-  : TraceAccessor(tm){}
+  : TraceAccessor(tm)
+  {}
+
  public:
-  void generateGroups(IMesh* mesh,Real3 min_pos,Real3 max_pos,Real middle_x,Real middle_height);
+
+  /*!
+   * \brief Créé les groupes pour un initialiser un tube à choc de sod.
+   *
+   * Les groupes correspondant aux frontières ((X|Y|Z)(MIN|MAX) sont toujours créés.
+   * Les autres groupes correspondant aux zones gauches et droites pour
+   * un tube à choc de Sod sont créés si \a do_zg_and_zd est vrai.
+   */
+  void generateGroups(IMesh* mesh, Real3 min_pos, Real3 max_pos,
+                      Real middle_x, Real middle_height, bool do_zg_and_zd);
+
  private:
-  void _createFaceGroup(IMesh* mesh,const String& name,Int32ConstArrayView faces_lid);
+
+  void _createFaceGroup(IMesh* mesh, const String& name, Int32ConstArrayView faces_lid);
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
These groups are `XMIN`, `XMAX`, `YMIN`, `YMAX`, `ZMIN` and `ZMAX`.
Only groups specific to Sod test cases are optionals.