### PR TITLE
Add Sycl support for RUNCOMMAND_LAUNCH without additional args

### DIFF
--- a/arcane/src/arcane/accelerator/AcceleratorGlobal.h
+++ b/arcane/src/arcane/accelerator/AcceleratorGlobal.h
@@ -19,6 +19,7 @@
 #include "arcane/accelerator/core/AcceleratorCoreGlobal.h"
 
 #include <iosfwd>
+#include <type_traits>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -38,12 +39,24 @@ namespace Impl
 {
   class CudaHipKernelRemainingArgsHelper;
   class SyclKernelRemainingArgsHelper;
-}
+  /*!
+ * \brief Template pour savoir si un type utilisé comme boucle dans les
+ * kernels nécessite toujours sycl::nb_item comme argument.
+ *
+ * Si c'est le cas, il faut spécialiser cette template en la faisant
+ * dériver de std::true_type. C'est le cas par exemple pour WorkGroupLoopRange.
+ */
+  template <typename T>
+  class IsAlwaysUseSyclNdItem
+  : public std::false_type
+  {
+  };
+} // namespace Impl
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template<typename T, Int32 Extent = DynExtent> class LocalMemory;
+template <typename T, Int32 Extent = DynExtent> class LocalMemory;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -90,7 +103,7 @@ getBadPolicyMessage(eExecutionPolicy policy);
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-}
+} // namespace Arcane::Accelerator::impl
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -110,4 +123,4 @@ getBadPolicyMessage(eExecutionPolicy policy);
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#endif  
+#endif

--- a/arcane/src/arcane/accelerator/KernelLauncher.h
+++ b/arcane/src/arcane/accelerator/KernelLauncher.h
@@ -382,7 +382,7 @@ void _applyKernelSYCL(RunCommandLaunchInfo& launch_info, SyclKernel kernel, Lamb
 #if defined(ARCANE_COMPILING_SYCL)
   sycl::queue s = SyclUtils::toNativeStream(launch_info._internalNativeStream());
   sycl::event event;
-  if constexpr (sizeof...(RemainingArgs) > 0) {
+  if constexpr (IsAlwaysUseSyclNdItem<LambdaArgs>::value || sizeof...(RemainingArgs) > 0) {
     auto tbi = launch_info.kernelLaunchArgs();
     Int32 b = tbi.nbBlockPerGrid();
     Int32 t = tbi.nbThreadPerBlock();

--- a/arcane/src/arcane/accelerator/RunCommandLoop.h
+++ b/arcane/src/arcane/accelerator/RunCommandLoop.h
@@ -56,6 +56,20 @@ arcaneGetLoopIndexSycl(const ComplexForLoopRanges<N, IndexType_>& bounds, sycl::
   return bounds.getIndices(static_cast<Int32>(x.get_global_id(0)));
 }
 
+template <int N, typename IndexType_>
+SimpleForLoopRanges<N, IndexType_>::LoopIndexType
+arcaneGetLoopIndexSycl(const SimpleForLoopRanges<N, IndexType_>& bounds, sycl::id<1> x)
+{
+  return bounds.getIndices(static_cast<Int32>(x));
+}
+
+template <int N, typename IndexType_>
+ComplexForLoopRanges<N, IndexType_>::LoopIndexType
+arcaneGetLoopIndexSycl(const ComplexForLoopRanges<N, IndexType_>& bounds, sycl::id<1> x)
+{
+  return bounds.getIndices(static_cast<Int32>(x));
+}
+
 #endif
 
 /*---------------------------------------------------------------------------*/
@@ -127,7 +141,7 @@ class DoDirectSYCLLambdaArrayBounds
 
     Int32 i = static_cast<Int32>(x);
     if (i < bounds.nbElement()) {
-      body(bounds.getIndices(i));
+      body(arcaneGetLoopIndexSycl(bounds, i));
     }
   }
 };

--- a/arcane/src/arcane/accelerator/WorkGroupLoopRange.h
+++ b/arcane/src/arcane/accelerator/WorkGroupLoopRange.h
@@ -429,6 +429,17 @@ arcaneGetLoopIndexCudaHip([[maybe_unused]] const WorkGroupLoopRange& loop_range,
 
 #if defined(ARCANE_COMPILING_SYCL)
 
+namespace Impl
+{
+  // Pour indiquer qu'il faut toujours utiliser sycl::nd_item (et jamais sycl::id)
+  // comme argument avec 'WorkGroupLoopRange.
+  template <>
+  class IsAlwaysUseSyclNdItem<WorkGroupLoopRange>
+  : public std::true_type
+  {
+  };
+} // namespace Impl
+
 inline SyclWorkGroupLoopContext
 arcaneGetLoopIndexSycl([[maybe_unused]] const WorkGroupLoopRange& loop_range,
                        sycl::nd_item<1> id)


### PR DESCRIPTION
The corresponding support for CUDA and ROCM was added in #2313.