### PR TITLE
Use by default memory pool for accelerator related allocations

### DIFF
--- a/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
+++ b/arcane/src/arcane/accelerator/cuda/CudaAccelerator.cc
@@ -203,7 +203,7 @@ class UnifiedMemoryCudaMemoryAllocator
 
   void initialize()
   {
-    _doInitializeUVM();
+    _doInitializeUVM(true);
   }
 
  public:
@@ -296,7 +296,7 @@ class HostPinnedCudaMemoryAllocator
 
   void initialize()
   {
-    _doInitializeHostPinned();
+    _doInitializeHostPinned(true);
   }
 };
 
@@ -362,7 +362,7 @@ class DeviceCudaMemoryAllocator
 
   void initialize()
   {
-    _doInitializeDevice();
+    _doInitializeDevice(true);
   }
 };
 

--- a/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
+++ b/arcane/src/arcane/accelerator/hip/HipAccelerator.cc
@@ -143,7 +143,7 @@ class UnifiedMemoryHipMemoryAllocator
 
   void initialize()
   {
-    _doInitializeUVM();
+    _doInitializeUVM(true);
   }
 };
 
@@ -184,7 +184,7 @@ class HostPinnedHipMemoryAllocator
 
   void initialize()
   {
-    _doInitializeHostPinned();
+    _doInitializeHostPinned(true);
   }
 };
 
@@ -231,7 +231,7 @@ class DeviceHipMemoryAllocator
 
   void initialize()
   {
-    _doInitializeDevice();
+    _doInitializeDevice(true);
   }
 };
 

--- a/arcane/src/arcane/materials/MeshEnvironment.cc
+++ b/arcane/src/arcane/materials/MeshEnvironment.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshEnvironment.cc                                          (C) 2000-2024 */
+/* MeshEnvironment.cc                                          (C) 2000-2025 */
 /*                                                                           */
 /* Milieu d'un maillage.                                                     */
 /*---------------------------------------------------------------------------*/
@@ -296,7 +296,7 @@ _computeMaterialIndexes(ComponentItemInternalData* item_internal_data, RunQueue&
       const MeshMaterialVariableIndexer* var_indexer = mat->variableIndexer();
       CellGroup mat_cells = mat->cells();
       info(4) << "COMPUTE (V2) mat_cells mat=" << mat->name() << " nb_cell=" << mat_cells.size()
-              << " mat_id=" << mat_id << " index=" << var_indexer->index();
+              << " mat_id=" << mat_id << " index=" << var_indexer->index() << " is_async=" << queue.isAsync();
 
       mat->resizeItemsInternal(var_indexer->nbItem());
 
@@ -329,6 +329,9 @@ _computeMaterialIndexes(ComponentItemInternalData* item_internal_data, RunQueue&
       mat_cells._internalApi()->notifySimdPaddingDone();
     }
   }
+  // La RunQueue est asynchrone. Cette barrière est nécessaire pour éviter une
+  // erreur si on utilise le pool mémoire.
+  queue.barrier();
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This is still possible to disable it using environment variable `ARCANE_ACCELERATOR_MEMORY_POOL`.
Using memory pool remove the implicit synchronization with `RunQueue` so some errors may occur when using asynchronous `RunQueue` with missing barriers.