### PR TITLE
Add CMake properties `INSTALL_RPATH_USE_LINK_PATH` and `BUILD_RPATH_USE_ORIGIN` for Arccore libraries

### DIFF
--- a/arccore/cmake/Functions.cmake
+++ b/arccore/cmake/Functions.cmake
@@ -78,6 +78,12 @@ function(arccore_add_library target)
       RUNTIME_OUTPUT_DIRECTORY ${_libpath}
       )
   endif()
+  # Ajoute au RPATH celui des bibliothèques et utilise $ORIGIN
+  set_target_properties(${target}
+    PROPERTIES
+    INSTALL_RPATH_USE_LINK_PATH 1
+    BUILD_RPATH_USE_ORIGIN 1
+    )
 endfunction()
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This is used for Arcane libraries and it is needed for Arccore libraries to automatically find dependencies.