### PR TITLE
Make functions in `AcceleratorUtils.h` functions available without using accelerator compiler.

### DIFF
--- a/arccore/src/accelerator/arccore/accelerator/AcceleratorUtils.h
+++ b/arccore/src/accelerator/arccore/accelerator/AcceleratorUtils.h
@@ -16,13 +16,14 @@
 
 #include "arccore/accelerator/AcceleratorGlobal.h"
 
-#if defined(ARCCORE_COMPILING_HIP)
-#include <hip/hip_runtime.h>
+#if defined(ARCCORE_HAS_HIP)
+#include "arccore/accelerator_native/HipAccelerator.h"
 #endif
-#if defined(ARCCORE_COMPILING_CUDA)
+#if defined(ARCCORE_HAS_CUDA)
+#include "arccore/accelerator_native/CudaAccelerator.h"
 #endif
-#if defined(ARCCORE_COMPILING_SYCL)
-#include <sycl/sycl.hpp>
+#if defined(ARCCORE_HAS_SYCL)
+#include "arccore/accelerator_native/SyclAccelerator.h"
 #endif
 
 /*---------------------------------------------------------------------------*/
@@ -34,7 +35,7 @@ namespace Arcane::Accelerator::Impl
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#if defined(ARCCORE_COMPILING_CUDA)
+#if defined(ARCCORE_HAS_CUDA)
 class ARCCORE_ACCELERATOR_EXPORT CudaUtils
 {
  public:
@@ -48,7 +49,7 @@ class ARCCORE_ACCELERATOR_EXPORT CudaUtils
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#if defined(ARCCORE_COMPILING_HIP)
+#if defined(ARCCORE_HAS_HIP)
 class ARCCORE_ACCELERATOR_EXPORT HipUtils
 {
  public:
@@ -62,7 +63,7 @@ class ARCCORE_ACCELERATOR_EXPORT HipUtils
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#if defined(ARCCORE_COMPILING_SYCL)
+#if defined(ARCCORE_HAS_SYCL)
 class ARCCORE_ACCELERATOR_EXPORT SyclUtils
 {
  public:
@@ -87,7 +88,7 @@ namespace Arcane::Accelerator::AcceleratorUtils
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#if defined(ARCCORE_COMPILING_CUDA)
+#if defined(ARCCORE_HAS_CUDA)
 /*!
  * \brief Retourne l'instance de cudaStream_t associée à \q queue.
  *
@@ -100,7 +101,7 @@ toCudaNativeStream(const RunQueue& queue)
 }
 #endif
 
-#if defined(ARCCORE_COMPILING_HIP)
+#if defined(ARCCORE_HAS_HIP)
 /*!
  * \brief Retourne l'instance de hipStream_t associée à \q queue.
  *
@@ -113,7 +114,7 @@ toHipNativeStream(const RunQueue& queue)
 }
 #endif
 
-#if defined(ARCCORE_COMPILING_SYCL)
+#if defined(ARCCORE_HAS_SYCL)
 /*!
  * \brief Retourne l'instance de hipStream_t associée à \q queue.
  *

--- a/arccore/src/accelerator/arccore/accelerator/CommonUtils.h
+++ b/arccore/src/accelerator/arccore/accelerator/CommonUtils.h
@@ -19,16 +19,15 @@
 #include "arccore/common/accelerator/RunQueue.h"
 #include "arccore/common/Array.h"
 
+#include "arccore/accelerator/AcceleratorUtils.h"
+
 #if defined(ARCCORE_COMPILING_HIP)
-#include "arccore/accelerator_native/HipAccelerator.h"
 #include <rocprim/rocprim.hpp>
 #endif
 #if defined(ARCCORE_COMPILING_CUDA)
-#include "arccore/accelerator_native/CudaAccelerator.h"
 #include <cub/cub.cuh>
 #endif
 #if defined(ARCCORE_COMPILING_SYCL)
-#include "arccore/accelerator_native/SyclAccelerator.h"
 #if defined(ARCCORE_HAS_ONEDPL)
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
@@ -37,8 +36,6 @@
 #include <AdaptiveCpp/algorithms/algorithm.hpp>
 #endif
 #endif
-
-#include "arccore/accelerator/AcceleratorUtils.h"
 
 // A définir si on souhaite utiliser LambdaStorage
 // #ifdef ARCCORE_USE_LAMBDA_STORAGE


### PR DESCRIPTION
These functions only depend of the availability of the underlying accelerator headers (`cuda_runtime.h`, `hip_runtime.h` or `sycl.h`).