### PR TITLE
Clone the collection used in 'IPostProcessorWriter::setGroups()'.

### DIFF
--- a/arcane/src/arcane/core/IPostProcessorWriter.h
+++ b/arcane/src/arcane/core/IPostProcessorWriter.h
@@ -118,7 +118,11 @@ class ARCANE_CORE_EXPORT IPostProcessorWriter
   //! Liste des variables à sauver
   virtual VariableCollection variables() = 0;
 
-  //! Positionne la liste des groupes à sortir
+  /*!
+   * \brief Positionne la liste des groupes à sortir.
+   *
+   * La collection passée en argument est clonée.
+   */
   virtual void setGroups(ItemGroupCollection groups) = 0;
 
   //! Liste des groupes à sauver

--- a/arcane/src/arcane/core/PostProcessorWriterBase.cc
+++ b/arcane/src/arcane/core/PostProcessorWriterBase.cc
@@ -1,32 +1,32 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* PostProcessorWriterBase.cc                                  (C) 2000-2014 */
+/* PostProcessorWriterBase.cc                                  (C) 2000-2025 */
 /*                                                                           */
 /* Classe de base d'un écrivain pour les informations de post-traitement.    */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include "arcane/utils/ArcanePrecomp.h"
-
 #include "arcane/utils/Array.h"
 #include "arcane/utils/Collection.h"
 #include "arcane/utils/String.h"
+#include "arcane/utils/List.h"
 
-#include "arcane/ArcaneTypes.h"
-#include "arcane/PostProcessorWriterBase.h"
-#include "arcane/ISubDomain.h"
-#include "arcane/ItemGroup.h"
-#include "arcane/VariableCollection.h"
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/PostProcessorWriterBase.h"
+#include "arcane/core/ISubDomain.h"
+#include "arcane/core/ItemGroup.h"
+#include "arcane/core/VariableCollection.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
+namespace Arcane
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -34,12 +34,15 @@ ARCANE_BEGIN_NAMESPACE
 class PostProcessorWriterBasePrivate
 {
  public:
+
   PostProcessorWriterBasePrivate();
+
  public:
+
   String m_base_dirname;
   String m_base_filename;
   VariableCollection m_variables;
-  ItemGroupCollection m_groups;
+  ItemGroupList m_groups;
   SharedArray<Real> m_times;
 };
 
@@ -134,7 +137,7 @@ setVariables(VariableCollection variables)
 void PostProcessorWriterBase::
 setGroups(ItemGroupCollection groups)
 {
-  m_p->m_groups = groups;
+  m_p->m_groups.clone(groups);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -167,8 +170,7 @@ groups()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_END_NAMESPACE
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-


### PR DESCRIPTION
This is to make sure any change done after to the collection does not impact the writer. Also this make sure the value returned by `IPostProcessorWriter::groups()` is always valid even if `setGroups()` has not be called.