### PR TITLE
Add more information in DeviceInfo for CUDA backend

### DIFF
--- a/arccore/src/accelerator_native/arccore/accelerator_native/runtime/CudaAcceleratorRuntime.cc
+++ b/arccore/src/accelerator_native/arccore/accelerator_native/runtime/CudaAcceleratorRuntime.cc
@@ -941,6 +941,7 @@ fillDevices(bool is_verbose)
       << " " << dp.maxThreadsDim[2] << "\n";
     o << " maxGridSize = " << dp.maxGridSize[0] << " " << dp.maxGridSize[1]
       << " " << dp.maxGridSize[2] << "\n";
+    o << " pciInfo = " << dp.pciDomainID << " " << dp.pciBusID << " " << dp.pciDeviceID << "\n";
 #if !defined(ARCCORE_USING_CUDA13_OR_GREATER)
     o << " clockRate = " << dp.clockRate << "\n";
     o << " deviceOverlap = " << dp.deviceOverlap << "\n";
@@ -954,13 +955,15 @@ fillDevices(bool is_verbose)
       ARCCORE_CHECK_CUDA(cudaDeviceGetStreamPriorityRange(&least_val, &greatest_val));
       o << " leastPriority = " << least_val << " greatestPriority = " << greatest_val << "\n";
     }
+    std::ostringstream device_uuid_ostr;
     {
       CUdevice device;
       ARCCORE_CHECK_CUDA(cuDeviceGet(&device, i));
       CUuuid device_uuid;
       ARCCORE_CHECK_CUDA(cuDeviceGetUuid(&device_uuid, device));
       o << " deviceUuid=";
-      impl::printUUID(o, device_uuid.bytes);
+      impl::printUUID(device_uuid_ostr, device_uuid.bytes);
+      o << device_uuid_ostr.str();
       o << "\n";
     }
     String description(ostr.str());
@@ -972,9 +975,14 @@ fillDevices(bool is_verbose)
     device_info.setDeviceId(DeviceId(i));
     device_info.setName(dp.name);
     device_info.setWarpSize(dp.warpSize);
+    device_info.setUUIDAsString(device_uuid_ostr.str());
     device_info.setSharedMemoryPerBlock(static_cast<Int32>(dp.sharedMemPerBlock));
     device_info.setSharedMemoryPerMultiprocessor(static_cast<Int32>(dp.sharedMemPerMultiprocessor));
     device_info.setSharedMemoryPerBlockOptin(static_cast<Int32>(dp.sharedMemPerBlockOptin));
+    device_info.setTotalConstMemory(static_cast<Int32>(dp.totalConstMem));
+    device_info.setPCIDomainID(dp.pciDomainID);
+    device_info.setPCIBusID(dp.pciBusID);
+    device_info.setPCIDeviceID(dp.pciDeviceID);
     m_device_info_list.addDevice(device_info);
   }
 

--- a/arccore/src/common/arccore/common/accelerator/DeviceInfo.h
+++ b/arccore/src/common/arccore/common/accelerator/DeviceInfo.h
@@ -7,7 +7,7 @@
 /*---------------------------------------------------------------------------*/
 /* DeviceInfo.h                                                (C) 2000-2025 */
 /*                                                                           */
-/* Information sur un device.                                                */
+/* Information sur un accélérateur.                                          */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCCORE_COMMON_ACCELERATOR_DEVICEINFO_H
 #define ARCCORE_COMMON_ACCELERATOR_DEVICEINFO_H
@@ -26,7 +26,7 @@ namespace Arcane::Accelerator
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Information sur un device.
+ * \brief Information sur un accélérateur.
  */
 class ARCCORE_COMMON_EXPORT DeviceInfo
 {
@@ -47,12 +47,20 @@ class ARCCORE_COMMON_EXPORT DeviceInfo
   //! Taille d'un warp
   Int32 warpSize() const { return m_warp_size; }
 
-  //! Mémoire locale par bloc
+  //! Mémoire locale (en octet) par bloc
   Int32 sharedMemoryPerBlock() const { return m_shared_memory_per_block; }
-  //! Mémoire locale par SM
+  //! Mémoire locale (en octet) par SM
   Int32 sharedMemoryPerMultiprocessor() const { return m_shared_memory_per_multiprocessor; }
-  //! Mémoire locale par bloc qui peut s'activer sur option
+  //! Mémoire locale (en octet) par bloc qui peut s'activer sur option
   Int32 sharedMemoryPerBlockOptin() const { return m_shared_memory_per_block_optin; }
+  //! Mémoire constante (en octet)
+  Int32 totalConstMemory() const { return m_total_const_memory; }
+  //! Identifiant du domaine PCI (-1 si inconnu)
+  int pciDomainID() const { return m_pci_domain_id; }
+  //! Identifiant du bus PCI (-1 si inconnu)
+  int pciBusID() const { return m_pci_bus_id; }
+  //! Identifiant PCI de l'accélérateur (-1 si inconnu)
+  int pciDeviceID() const { return m_pci_device_id; }
 
  public:
 
@@ -64,6 +72,10 @@ class ARCCORE_COMMON_EXPORT DeviceInfo
   void setSharedMemoryPerBlock(Int32 v) { m_shared_memory_per_block = v; }
   void setSharedMemoryPerMultiprocessor(Int32 v) { m_shared_memory_per_multiprocessor = v; }
   void setSharedMemoryPerBlockOptin(Int32 v) { m_shared_memory_per_block_optin = v; }
+  void setTotalConstMemory(Int32 v) { m_total_const_memory = v; }
+  void setPCIDomainID(int v) { m_pci_domain_id = v; }
+  void setPCIBusID(int v) { m_pci_bus_id = v; }
+  void setPCIDeviceID(int v ){ m_pci_device_id = v; }
 
  private:
 
@@ -75,6 +87,10 @@ class ARCCORE_COMMON_EXPORT DeviceInfo
   Int32 m_shared_memory_per_block = 0;
   Int32 m_shared_memory_per_multiprocessor = 0;
   Int32 m_shared_memory_per_block_optin = 0;
+  Int32 m_total_const_memory = 0;
+  int m_pci_domain_id = -1;
+  int m_pci_bus_id = -1;
+  int m_pci_device_id = -1;
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Add information about PCI port and available constant memory.
This may be used to detect which CPU cores are near or far a device.