### PR TITLE
Remove support for running without multi-threading implementation.

### DIFF
--- a/arcane/src/arcane/impl/Application.cc
+++ b/arcane/src/arcane/impl/Application.cc
@@ -438,7 +438,7 @@ build()
       }
     }
 
-    if (arcaneHasThread()){
+    {
       StringList names = build_info.threadImplementationServices();
       String found_name;
       auto sv = _tryCreateServiceUsingInjector<IThreadImplementationService>(names,&found_name, false);
@@ -449,9 +449,9 @@ build()
         m_thread_implementation->initialize();
         m_used_thread_service_name = found_name;
       }
-      else{
-        m_trace->info() << "Can not find thread implementation service "
-                        << "(names=" << _stringListToArray(names) << "). Threads are disabled.";
+      else {
+        ARCANE_FATAL("Can not find implementation for 'IThreadImplementation' (names='{0}').",
+                     _stringListToArray(names));
         arcaneSetHasThread(false);
       }
     }
@@ -461,7 +461,7 @@ build()
     m_trace->resetThreadStatus();
 
     // Recherche le service utilisé pour gérer les tâches
-    if (arcaneHasThread()){
+    {
       Integer nb_task_thread = build_info.nbTaskThread();
       if (nb_task_thread>=0){
 

--- a/arcane/src/arcane/utils/Misc.cc
+++ b/arcane/src/arcane/utils/Misc.cc
@@ -89,25 +89,17 @@ bool arcaneIsDebug()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-// Par défaut on a toujours le support des threads
-namespace
-{
-  bool global_arcane_has_thread = true;
-}
-
 extern "C++" ARCANE_UTILS_EXPORT
 bool arcaneHasThread()
 {
-  return global_arcane_has_thread;
+  return true;
 }
 
 extern "C++" ARCANE_UTILS_EXPORT
-void arcaneSetHasThread(bool v)
+void arcaneSetHasThread([[maybe_unused]] bool v)
 {
-  if (!v){
-    global_arcane_has_thread = v;
-    return;
-  }
+  if (!v)
+    std::cout << "WARNING: disabling thread via arcaneSetHasThread() is no longer available.\n";
 }
 
 /*---------------------------------------------------------------------------*/
@@ -116,11 +108,9 @@ void arcaneSetHasThread(bool v)
 extern "C++" ARCANE_UTILS_EXPORT
 Int64 arcaneCurrentThread()
 {
-  if (arcaneHasThread()){
-    IThreadImplementation* ti = platform::getThreadImplementationService();
-    if (ti)
-      return ti->currentThread();
-  }
+  IThreadImplementation* ti = platform::getThreadImplementationService();
+  if (ti)
+    return ti->currentThread();
   return 0;
 }
 
@@ -130,13 +120,13 @@ Int64 arcaneCurrentThread()
 extern "C++" ARCANE_UTILS_EXPORT void
 arcaneSetPauseOnError(bool v)
 {
-  Arccore::arccoreSetPauseOnError(v);
+  arccoreSetPauseOnError(v);
 }
 
 extern "C++" ARCANE_UTILS_EXPORT void
 arcaneDebugPause(const char* msg)
 {
-  Arccore::arccoreDebugPause(msg);
+  arccoreDebugPause(msg);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Now we are use STL thread implementation which is always available, we can force support for multi-threading.
