### PR TITLE
[alien,core] Remove include of internal file `BasicSerializer.h`

### DIFF
--- a/alien/standalone/src/core/alien/utils/Precomp.h
+++ b/alien/standalone/src/core/alien/utils/Precomp.h
@@ -50,7 +50,6 @@
 #include <arccore/message_passing/Request.h>
 #include <arccore/message_passing/ISerializeMessage.h>
 #include <arccore/message_passing/ISerializeMessageList.h>
-#include <arccore/serialize/BasicSerializer.h>
 #include <arccore/serialize/ISerializer.h>
 
 #include <arccore/trace/ITraceMng.h>


### PR DESCRIPTION
This file is internal to Arccore and should not be used in user code.