### PR TITLE
Use `Int64` instead of `size_t` for sizes in `IMemoryPool`

### DIFF
--- a/arcane/src/arcane/utils/tests/TestMemoryPool.cc
+++ b/arcane/src/arcane/utils/tests/TestMemoryPool.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -25,8 +25,8 @@ using namespace Arcane::Impl;
 class MyMemoryPoolAllocator
 : public IMemoryPoolAllocator
 {
-  void* allocateMemory(size_t size) override { return std::malloc(size); }
-  void freeMemory(void* address,size_t) override { std::free(address); }
+  void* allocateMemory(Int64 size) override { return std::malloc(size); }
+  void freeMemory(void* address,Int64) override { std::free(address); }
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/accelerator_native/arccore/accelerator_native/runtime/CudaAcceleratorRuntime.cc
+++ b/arccore/src/accelerator_native/arccore/accelerator_native/runtime/CudaAcceleratorRuntime.cc
@@ -115,13 +115,13 @@ class UnderlyingAllocator
 
  public:
 
-  void* allocateMemory(size_t size) final
+  void* allocateMemory(Int64 size) final
   {
     void* out = nullptr;
     ARCCORE_CHECK_CUDA(m_concrete_allocator._allocate(&out, size));
     return out;
   }
-  void freeMemory(void* ptr, [[maybe_unused]] size_t size) final
+  void freeMemory(void* ptr, [[maybe_unused]] Int64 size) final
   {
     ARCCORE_CHECK_CUDA_NOTHROW(m_concrete_allocator._deallocate(ptr));
   }

--- a/arccore/src/accelerator_native/arccore/accelerator_native/runtime/HipAcceleratorRuntime.cc
+++ b/arccore/src/accelerator_native/arccore/accelerator_native/runtime/HipAcceleratorRuntime.cc
@@ -74,13 +74,13 @@ class UnderlyingAllocator
 
  public:
 
-  void* allocateMemory(size_t size) final
+  void* allocateMemory(Int64 size) final
   {
     void* out = nullptr;
     ARCCORE_CHECK_HIP(m_concrete_allocator._allocate(&out, size));
     return out;
   }
-  void freeMemory(void* ptr, [[maybe_unused]] size_t size) final
+  void freeMemory(void* ptr, [[maybe_unused]] Int64 size) final
   {
     ARCCORE_CHECK_HIP_NOTHROW(m_concrete_allocator._deallocate(ptr));
   }

--- a/arccore/src/common/arccore/common/IMemoryPool.h
+++ b/arccore/src/common/arccore/common/IMemoryPool.h
@@ -48,10 +48,10 @@ class ARCCORE_COMMON_EXPORT IMemoryPool
   virtual void freeCachedMemory() = 0;
 
   //! Taille totale (en octet) allouée dans le pool mémoire
-  virtual size_t totalAllocated() const = 0;
+  virtual Int64 totalAllocated() const = 0;
 
   //! Taille totale (en octet) dans le cache
-  virtual size_t totalCached() const = 0;
+  virtual Int64 totalCached() const = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/common/arccore/common/MemoryPool.cc
+++ b/arccore/src/common/arccore/common/MemoryPool.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryPool.cc                                               (C) 2000-2025 */
+/* MemoryPool.cc                                               (C) 2000-2026 */
 /*                                                                           */
 /* Classe pour gérer une liste de zone allouées.                             */
 /*---------------------------------------------------------------------------*/
@@ -224,8 +224,8 @@ class MemoryPool::Impl
   AllocatedMap m_allocated_map;
   //! Liste des allocations libres dans le cache
   FreedMap m_free_map;
-  std::atomic<size_t> m_total_allocated = 0;
-  std::atomic<size_t> m_total_free = 0;
+  std::atomic<Int64> m_total_allocated = 0;
+  std::atomic<Int64> m_total_free = 0;
   std::atomic<Int32> m_nb_cached = 0;
   std::atomic<Int32> m_nb_no_cached = 0;
   size_t m_max_memory_size_to_pool = 1024 * 64 * 4 * 4;
@@ -361,11 +361,11 @@ MemoryPool::
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void* MemoryPool::allocateMemory(size_t size)
+void* MemoryPool::allocateMemory(Int64 size)
 {
   return m_p->allocateMemory(size);
 }
-void MemoryPool::freeMemory(void* ptr, size_t size)
+void MemoryPool::freeMemory(void* ptr, Int64 size)
 {
   m_p->freeMemory(ptr, size);
 }
@@ -392,12 +392,12 @@ freeCachedMemory()
 {
   m_p->freeCachedMemory();
 }
-size_t MemoryPool::
+Int64 MemoryPool::
 totalAllocated() const
 {
   return m_p->m_total_allocated;
 }
-size_t MemoryPool::
+Int64 MemoryPool::
 totalCached() const
 {
   return m_p->m_total_free;

--- a/arccore/src/common/arccore/common/internal/MemoryPool.h
+++ b/arccore/src/common/arccore/common/internal/MemoryPool.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryPool.h                                                (C) 2000-2025 */
+/* MemoryPool.h                                                (C) 2000-2026 */
 /*                                                                           */
 /* Classe pour gérer une liste de zone allouées.                             */
 /*---------------------------------------------------------------------------*/
@@ -44,9 +44,9 @@ class ARCCORE_COMMON_EXPORT IMemoryPoolAllocator
  public:
 
   //! Alloue un bloc pour \a size octets
-  virtual void* allocateMemory(size_t size) = 0;
+  virtual void* allocateMemory(Int64 size) = 0;
   //! Libère le bloc situé à l'adresse \a address contenant \a size octets
-  virtual void freeMemory(void* address, size_t size) = 0;
+  virtual void freeMemory(void* address, Int64 size) = 0;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -80,8 +80,8 @@ class ARCCORE_COMMON_EXPORT MemoryPool
 
  public:
 
-  void* allocateMemory(size_t size) override;
-  void freeMemory(void* ptr, size_t size) override;
+  void* allocateMemory(Int64 size) override;
+  void freeMemory(void* ptr, Int64 size) override;
   void dumpStats(std::ostream& ostr);
   void dumpFreeMap(std::ostream& ostr);
   String name() const;
@@ -90,8 +90,8 @@ class ARCCORE_COMMON_EXPORT MemoryPool
   //@{
   void setMaxCachedBlockSize(Int32 v) override;
   void freeCachedMemory() override;
-  size_t totalAllocated() const override;
-  size_t totalCached() const override;
+  Int64 totalAllocated() const override;
+  Int64 totalCached() const override;
   //@}
 
  private:


### PR DESCRIPTION
This is to be coherent with the other methods about memory.