### PR TITLE
[CI] Use Arcane implementation for thread barriers with MacOs workflows

### DIFF
--- a/.github/workflows/MacOs-15-gnu-openmpi.yml
+++ b/.github/workflows/MacOs-15-gnu-openmpi.yml
@@ -32,6 +32,8 @@ jobs:
       CCACHE_MAXSIZE: 5G
       # To tell 'openmpi' we may use more cpu core than available
       OMPI_MCA_rmaps_base_oversubscribe : true
+      # To use passive wait for thread barriers
+      ARCANE_THREAD_IMPLEMENTATION : LegacyStd
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is to make sure we use a passive barrier which is needed when using oversubscribing.
In versions of LLVM up to 22 the `std::barrier` uses a active wait.
The problem seems to be fixed in recent versions of `libcxx`: https://github.com/llvm/llvm-project/pull/171041