### PR TITLE
Fix missing specific copy implementation for element size greater than 24 bytes

### DIFF
--- a/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MemoryCopyUnitTest.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryCopyUnitTest.cc                                       (C) 2000-2025 */
+/* MemoryCopyUnitTest.cc                                       (C) 2000-2026 */
 /*                                                                           */
 /* Service de test des noyaux de recopie mémoire.                            */
 /*---------------------------------------------------------------------------*/
@@ -70,6 +70,7 @@ class MemoryCopyUnitTest
   void _executeCopy(eMemoryRessource mem_kind, bool use_queue);
   void _executeFill(eMemoryRessource mem_kind, bool use_queue, bool use_index);
   void _fillIndexes(Int32 n1, NumArray<Int32, MDDim1>& indexes);
+  void _executeSimpleFill();
 };
 
 /*---------------------------------------------------------------------------*/
@@ -134,6 +135,7 @@ _executeTest1(eMemoryRessource mem_kind, bool use_queue)
   _executeCopy(mem_kind, use_queue);
   _executeFill(mem_kind, use_queue, false);
   _executeFill(mem_kind, use_queue, true);
+  _executeSimpleFill();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -240,7 +242,7 @@ _executeCopy(eMemoryRessource mem_kind, bool use_queue)
     {
       MutableMemoryView t1_view(t1.to1DSpan());
       ConstMemoryView destination_view(destination_buffer.to1DSpan());
-      MemoryUtils::copyWithIndexedSource(t1_view, destination_view,indexes.to1DSpan().smallView(), queue_ptr);
+      MemoryUtils::copyWithIndexedSource(t1_view, destination_view, indexes.to1DSpan().smallView(), queue_ptr);
       // Teste copie vide
       MemoryUtils::copyWithIndexedSource(t1_view, destination_view, {}, queue_ptr);
     }
@@ -427,6 +429,31 @@ _executeFill(eMemoryRessource mem_kind, bool use_queue, bool use_index)
     }
   }
   info() << "End of test Rank1";
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void MemoryCopyUnitTest::
+_executeSimpleFill()
+{
+  info() << "Execute SimpleFill";
+
+  auto queue = makeQueue(m_runner);
+
+  constexpr int n1 = 2500;
+
+  Real3 x(1.0, 2.0, 3.0);
+  Real3 y(4.0, 5.0, 6.0);
+  Real3 z(-1.0, -2.0, -3.0);
+  Real3x3 wanted_value(x, y, z);
+  NumArray<Real3x3, MDDim1> values;
+  values.resize(n1);
+  values.fill(wanted_value, queue);
+
+  for (Int32 i = 0; i < n1; ++i)
+    if (values[i] != wanted_value)
+      ARCANE_FATAL("Bad value i={0} v={1} expected={2}", i, values[i], wanted_value);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/accelerator/arccore/accelerator/MemoryCopier.cc
+++ b/arccore/src/accelerator/arccore/accelerator/MemoryCopier.cc
@@ -40,6 +40,8 @@ AcceleratorSpecificMemoryCopyList()
   // explicites sont faites dans plusieurs fichiers.
   addExplicitTemplate1();
   addExplicitTemplate2();
+  addExplicitTemplate3();
+  addExplicitTemplate4();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl3.cc
+++ b/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl3.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryCopierTpl3.cc                                         (C) 2000-2025 */
+/* MemoryCopierTpl3.cc                                         (C) 2000-2026 */
 /*                                                                           */
 /* Fonctions de copie mémoire sur accélérateur.                              */
 /*---------------------------------------------------------------------------*/
@@ -13,7 +13,7 @@
 
 #include "arccore/accelerator/internal/AcceleratorMemoryCopier.h"
 
-namespace Arcane::Accelerator::impl
+namespace Arcane::Accelerator::Impl
 {
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl4.cc
+++ b/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl4.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MemoryCopierTpl4.cc                                         (C) 2000-2025 */
+/* MemoryCopierTpl4.cc                                         (C) 2000-2026 */
 /*                                                                           */
 /* Fonctions de copie mémoire sur accélérateur.                              */
 /*---------------------------------------------------------------------------*/
@@ -13,7 +13,7 @@
 
 #include "arccore/accelerator/internal/AcceleratorMemoryCopier.h"
 
-namespace Arcane::Accelerator::impl
+namespace Arcane::Accelerator::Impl
 {
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/accelerator/arccore/accelerator/srcs.cmake
+++ b/arccore/src/accelerator/arccore/accelerator/srcs.cmake
@@ -3,6 +3,8 @@ set(SOURCES
   MemoryCopier.cc
   MemoryCopierTpl1.cc
   MemoryCopierTpl2.cc
+  MemoryCopierTpl3.cc
+  MemoryCopierTpl4.cc
 
   AcceleratorGlobal.h
   AcceleratorGlobal.cc


### PR DESCRIPTION
When element size was greater than 12 we used the generic implementation as fallback. It was ok for copies but it did not work for filling because there is a limit of 24 bytes for the size of the type. So it did not work for type like `Real3x3` for example.