### PR TITLE
Fix device reduction with empty loops

### DIFF
--- a/arccore/src/accelerator/arccore/accelerator/Reduce.h
+++ b/arccore/src/accelerator/arccore/accelerator/Reduce.h
@@ -323,6 +323,10 @@ class HostDeviceReducerBase
     if (m_memory_impl) {
       m_memory_impl->allocateReduceDataMemory(sizeof(DataType));
       m_grid_memory_info = m_memory_impl->gridMemoryInfo();
+      // Initialise la valeur finale pour le cas où la réduction ne sera pas
+      // effectuée (par exemple si la RunCommand n'est jamais lancée)
+      DataType* ptr = _getHostPinnedMemoryForReducedValue();
+      *ptr = m_local_value;
     }
   }
 
@@ -400,7 +404,7 @@ class HostDeviceReducerBase
 
     DataType* final_ptr = m_host_memory_for_reduced_value;
     if (m_memory_impl) {
-      final_ptr = reinterpret_cast<DataType*>(m_grid_memory_info.m_host_memory_for_reduced_value);
+      final_ptr = _getHostPinnedMemoryForReducedValue();
       m_memory_impl->release();
       m_memory_impl = nullptr;
     }
@@ -436,7 +440,7 @@ class HostDeviceReducerBase
     Impl::ReduceDeviceInfo<DataType> dvi;
     dvi.m_grid_buffer = grid_buffer;
     dvi.m_device_count = m_grid_memory_info.m_grid_device_count;
-    dvi.m_host_pinned_final_ptr = reinterpret_cast<DataType*>(m_grid_memory_info.m_host_memory_for_reduced_value);
+    dvi.m_host_pinned_final_ptr = _getHostPinnedMemoryForReducedValue();
     dvi.m_current_value = m_local_value;
 #if defined(ARCCORE_COMPILING_CUDA_OR_HIP)
     ReduceFunctor::applyDevice(dvi); //grid_buffer,m_grid_device_count,m_host_or_device_memory_for_reduced_value,m_local_value,m_identity);
@@ -453,6 +457,17 @@ class HostDeviceReducerBase
 
     //printf("Destroy host %p %p\n",m_host_or_device_memory_for_reduced_value,this);
 #endif
+  }
+
+ private:
+
+  /*!
+   * \brief Zone mémoire qui contiendra le résultat de la réduction si cette
+   * dernière est réalisée sur le Device.
+   */
+  ARCCORE_HOST_DEVICE DataType* _getHostPinnedMemoryForReducedValue()
+  {
+    return reinterpret_cast<DataType*>(m_grid_memory_info.m_host_memory_for_reduced_value);
   }
 };
 

--- a/arccore/src/accelerator/tests/TestReduce1.cc
+++ b/arccore/src/accelerator/tests/TestReduce1.cc
@@ -36,6 +36,9 @@ extern "C++" Int64
 _testReduceGridStride(RunQueue queue, SmallSpan<const Int64> c, Int32 nb_thread,
                       Int32 nb_value, Int32 nb_part, Int32 nb_loop, bool is_async);
 
+extern "C++" Int64
+_testReduceEmpty(RunQueue queue, SmallSpan<const Int64> c);
+
 void _doTestReduceDirect(bool use_accelerator, Int32 max_allowed_thread)
 {
   Accelerator::Initializer x(use_accelerator, max_allowed_thread);
@@ -106,6 +109,11 @@ void _doTestReduceDirect(bool use_accelerator, Int32 max_allowed_thread)
       ASSERT_EQ(v2, expected_value);
     }
     nb_part *= 2;
+  }
+  // Teste la réduction avec un tableau vide (dans ce cas le kernel n'est pas lancé)
+  {
+    Int64 v = _testReduceEmpty(queue, {});
+    ASSERT_EQ(v, 0);
   }
 }
 

--- a/arccore/src/accelerator/tests/TestReduce_Accelerator.cc
+++ b/arccore/src/accelerator/tests/TestReduce_Accelerator.cc
@@ -1,6 +1,6 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
@@ -62,6 +62,29 @@ _testReduceDirect(RunQueue queue, SmallSpan<const Int64> c, Int32 nb_thread,
             << " nb_part=" << nb_part << " nb_value=" << nb_value
             << " nb_thread=" << nb_thread
             << " GB/s=" << nb_giga_byte_second << " time=" << diff << "\n";
+  return total_x;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+extern "C++" Int64
+_testReduceEmpty(RunQueue queue, SmallSpan<const Int64> c)
+{
+  Int64 total_x = 0;
+  {
+    SmallSpan<const Int64> c_view(c);
+    auto command = makeCommand(queue);
+    ReducerSum2<Int64> reducer(command);
+    command << RUNCOMMAND_LOOP1(iter, c.size(), reducer)
+    {
+      Int32 i = iter;
+      reducer.combine(iter);
+    };
+    Int64 tx = reducer.reducedValue();
+    total_x += tx;
+  }
+  std::cout << "** TotalReduceEmpty=" << total_x << "\n";
   return total_x;
 }
 


### PR DESCRIPTION
Force initialization of reduced value to identity in constructor of `HostDeviceReducerBase`.
    
This is needed to make sure the reduced value is always initialized even if the associated `RunCommand` is never launched (which is the case for example when kernel has zero blocks).
