### PR TITLE
Add PInShMem property in AXL

### DIFF
--- a/arcane/doc/doc_user/chap_parallel/subchap_shmem/2_winvariable.md
+++ b/arcane/doc/doc_user/chap_parallel/subchap_shmem/2_winvariable.md
@@ -2,6 +2,13 @@
 
 [TOC]
 
+\warning Cette fonctionnalité est expérimentale. Si des variables avec support sont allouées en mémoire partagée, il
+peut y avoir des adaptations importantes à faire pour rendre les appels de redimensionnements collectifs (risque de
+deadlocks). Ces redimensionnements sont plus lents qu'en mémoire locale. Il est recommandé d'utiliser la mémoire
+partagée uniquement pour les variables sans support. Il n'est pas recommandé d'utiliser la mémoire partagée avec des
+variables sur les particules; les appels à `endUpdate()` sont plutôt fréquents et, avec la mémoire partagée, ils
+deviennent collectifs !
+
 ## Introduction {#arcanedoc_parallel_shmem_winvariable_intro}
 
 Les variables %Arcane utilisent habituellement l'allocateur par défaut pour allouer de la mémoire. Sans GPU, on utilise

--- a/arcane/doc/doc_user/chap_parallel/subchap_shmem/2_winvariable.md
+++ b/arcane/doc/doc_user/chap_parallel/subchap_shmem/2_winvariable.md
@@ -21,6 +21,10 @@ mémoire soit collectifs.
 Pour les variables redimensionnées par %Arcane, l'utilisateur n'a pas besoin de se préoccuper de ces appels collectifs,
 %Arcane s'en occupe. Exemple des variables au maillage, %Arcane s'occupe de les redimensionner si le maillage évolue.
 
+\warning Pour les variables avec support, au niveau des familles, l'utilisation des variables en mémoire partagée rend
+collectif les appels agissants sur ces variables. On peut notamment citer les méthodes
+`Arcane::IItemFamily::compactItems()` et `Arcane::IItemFamily::endUpdate()`.
+
 En revanche, pour les variables avec lesquelles une méthode `resize()` est disponible (ou `reshape()` pour les variables
 multi-dimensionnelles), il est nécessaire de s'assurer que tous les sous-domaines de la machine fassent un appel à cette
 méthode (quitte à faire `var.resize(var.size())` pour les sous-domaines ne nécessitant pas de redimensionnement).
@@ -29,7 +33,7 @@ Ces appels de redimensionnement mirent de côté, l'utilisation des variables en
 l'utilisation des variables en mémoire locale.
 
 Pour déclarer une variable en mémoire partagée, il suffit d'ajouter la propriété `IVariable::PInShMem` lors de sa
-création (pour l'instant, il n'est pas possible de le faire via l'AXL).
+création (dans les fichiers AXL, l'option correspondante est `in-shmem="true"`).
 
 ## Accès aux segments mémoire des autres sous-domaines {#arcanedoc_parallel_shmem_winvariable_shared}
 

--- a/arcane/src/arcane/core/Array2Variable.cc
+++ b/arcane/src/arcane/core/Array2Variable.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Array2Variable.cc                                           (C) 2000-2025 */
+/* Array2Variable.cc                                           (C) 2000-2026 */
 /*                                                                           */
 /* Variable tableau 2D.                                                      */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/Array2Variable.cc
+++ b/arcane/src/arcane/core/Array2Variable.cc
@@ -495,7 +495,11 @@ _internalResize(const VariableResizeArgs& resize_args)
 
   Integer dim2_size = data_values.dim2Size();
 
-  if (nb_additional_element!=0){
+  const bool is_collective_allocator = data_values.allocator()->isCollective();
+  if (is_collective_allocator) {
+    data_values.reserve(new_size+nb_additional_element*dim2_size);
+  }
+  else if (nb_additional_element != 0) {
     Integer capacity = data_values.capacity();
     if (new_size>capacity)
       data_values.reserve(new_size+nb_additional_element*dim2_size);

--- a/arcane/src/arcane/core/MeshMDVariableRef.h
+++ b/arcane/src/arcane/core/MeshMDVariableRef.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MeshMDVariableRef.h                                         (C) 2000-2025 */
+/* MeshMDVariableRef.h                                         (C) 2000-2026 */
 /*                                                                           */
 /* Classe gérant une variable multi-dimension sur une entité du maillage.    */
 /*---------------------------------------------------------------------------*/
@@ -105,7 +105,7 @@ class MeshMDVariableRefBaseT
  public:
 
   explicit MeshMDVariableRefBaseT(const VariableBuildInfo& b)
-  : MeshVariableRef()
+  : MeshVariableRef(b)
   , m_underlying_var(b)
   {
     _internalInit(m_underlying_var.variable());

--- a/arcane/src/arcane/core/VariableArray.cc
+++ b/arcane/src/arcane/core/VariableArray.cc
@@ -652,10 +652,12 @@ _internalResize(const VariableResizeArgs& resize_args)
 
   //const bool is_collective_allocator = value_internal->memoryAllocator().isCollectiveAllocator();
   const bool is_collective_allocator = value_internal->_internalDeprecatedValue().allocator()->isCollective();
-
-  if (nb_additional_element!=0){
+  if (is_collective_allocator) {
+    value_internal->reserve(new_size + nb_additional_element);
+  }
+  else if (nb_additional_element!=0){
     Integer capacity = value_internal->capacity();
-    if (new_size > capacity || is_collective_allocator)
+    if (new_size>capacity)
       value_internal->reserve(new_size+nb_additional_element);
   }
   eDataInitialisationPolicy init_policy = getGlobalDataInitialisationPolicy();

--- a/arcane/src/arcane/core/internal/IVariableMngInternal.h
+++ b/arcane/src/arcane/core/internal/IVariableMngInternal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IVariableMngInternal.h                                      (C) 2000-2024 */
+/* IVariableMngInternal.h                                      (C) 2000-2026 */
 /*                                                                           */
 /* Partie interne à Arcane de IVariableMng.                                  */
 /*---------------------------------------------------------------------------*/
@@ -61,6 +61,10 @@ class ARCANE_CORE_EXPORT IVariableMngInternal
 
   //! Supprime et détruit les variables gérées par ce gestionnaire
   virtual void removeAllVariables() = 0;
+
+  //! Supprime et détruit les variables ayant la propriété PInShMem, gérées
+  //! par ce gestionnaire.
+  virtual void removeAllShMemVariables() = 0;
 
   //! Détache les variables associées au maillage \a mesh.
   virtual void detachMeshVariables(IMesh* mesh) = 0;

--- a/arcane/src/arcane/core/internal/MachineShMemWinMemoryAllocator.h
+++ b/arcane/src/arcane/core/internal/MachineShMemWinMemoryAllocator.h
@@ -44,6 +44,7 @@ class ARCANE_CORE_EXPORT MachineShMemWinMemoryAllocator
 
  public:
 
+  bool hasRealloc(MemoryAllocationArgs) const override { return true; }
   AllocatedMemoryInfo allocate(MemoryAllocationArgs, Int64 new_size) override;
   AllocatedMemoryInfo reallocate(MemoryAllocationArgs, AllocatedMemoryInfo current_ptr, Int64 new_size) override;
   void deallocate(MemoryAllocationArgs, AllocatedMemoryInfo ptr) override;

--- a/arcane/src/arcane/impl/ArcaneMainBatch.cc
+++ b/arcane/src/arcane/impl/ArcaneMainBatch.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneMainBatch.cc                                          (C) 2000-2025 */
+/* ArcaneMainBatch.cc                                          (C) 2000-2026 */
 /*                                                                           */
 /* Gestion de l'exécution en mode Batch.                                     */
 /*---------------------------------------------------------------------------*/
@@ -40,28 +40,32 @@
 #include "arcane/impl/ArcaneMain.h"
 #include "arcane/impl/ParallelReplication.h"
 
-#include "arcane/IIOMng.h"
-#include "arcane/ICodeService.h"
-#include "arcane/ISession.h"
-#include "arcane/Timer.h"
-#include "arcane/ISubDomain.h"
-#include "arcane/IApplication.h"
-#include "arcane/ITimeLoopMng.h"
-#include "arcane/ITimeStats.h"
-#include "arcane/SequentialSection.h"
-#include "arcane/IParallelSuperMng.h"
-#include "arcane/ITimeHistoryMng.h"
-#include "arcane/IDirectExecution.h"
-#include "arcane/IDirectSubDomainExecuteFunctor.h"
-#include "arcane/ICaseMng.h"
-#include "arcane/ServiceFinder2.h"
-#include "arcane/SubDomainBuildInfo.h"
-#include "arcane/IParallelMng.h"
-#include "arcane/IMainFactory.h"
-#include "arcane/ApplicationBuildInfo.h"
-#include "arcane/CaseDatasetSource.h"
+#include "arcane/core/IIOMng.h"
+#include "arcane/core/ICodeService.h"
+#include "arcane/core/ISession.h"
+#include "arcane/core/Timer.h"
+#include "arcane/core/ISubDomain.h"
+#include "arcane/core/IApplication.h"
+#include "arcane/core/ITimeLoopMng.h"
+#include "arcane/core/ITimeStats.h"
+#include "arcane/core/SequentialSection.h"
+#include "arcane/core/IParallelSuperMng.h"
+#include "arcane/core/ITimeHistoryMng.h"
+#include "arcane/core/IDirectExecution.h"
+#include "arcane/core/IDirectSubDomainExecuteFunctor.h"
+#include "arcane/core/ICaseMng.h"
+#include "arcane/core/ServiceFinder2.h"
+#include "arcane/core/SubDomainBuildInfo.h"
+#include "arcane/core/IParallelMng.h"
+#include "arcane/core/IMainFactory.h"
+#include "arcane/core/ApplicationBuildInfo.h"
+#include "arcane/core/CaseDatasetSource.h"
 
-#include "arcane/ServiceUtils.h"
+#include "arcane/core/ServiceUtils.h"
+
+#include "arcane/core/IVariableMng.h"
+#include "arcane/core/VariableCollection.h"
+#include "arcane/core/internal/IVariableMngInternal.h"
 
 #include "arcane/impl/ExecutionStatsDumper.h"
 #include "arcane/impl/TimeLoopReader.h"
@@ -838,6 +842,14 @@ executeRank(Int32 local_rank)
       Accelerator::RunnerInternal::stopAllProfiling();
     pm->barrier();
     _printStats(sub_domain,trace,time_stat);
+
+    // On doit détruire les variables en mémoire partagée ici parce que leur
+    // destruction est effectuée collectivement.
+    // On ne peut pas détruire toutes les variables car certaines sont
+    // utilisées après (GlobalIteration par exemple).
+    // Si, un jour, on met certaines variables "Global" en mémoire partagée,
+    // cette partie va poser problème.
+    sub_domain->variableMng()->_internalApi()->removeAllShMemVariables();
   }
 
   //BaseForm[Hash["This is the end", "CRC32"], 16]

--- a/arcane/src/arcane/impl/VariableMng.cc
+++ b/arcane/src/arcane/impl/VariableMng.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableMng.cc                                              (C) 2000-2025 */
+/* VariableMng.cc                                              (C) 2000-2026 */
 /*                                                                           */
 /* Classe gérant l'ensemble des variables.                                   */
 /*---------------------------------------------------------------------------*/
@@ -982,6 +982,22 @@ dumpStatsJSON(JSONWriter& writer)
     }
   }
   writer.endArray();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void VariableMng::
+_removeAllShMemVariables()
+{
+  UniqueArray<IVariable*> shmem_vars;
+  for (const auto& [fst, snd] : m_full_name_variable_map) {
+    if (snd->property() & IVariable::PInShMem)
+      shmem_vars.add(snd);
+  }
+  for (IVariable* var : shmem_vars) {
+    removeVariable(var);
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/VariableMng.cc
+++ b/arcane/src/arcane/impl/VariableMng.cc
@@ -991,9 +991,16 @@ void VariableMng::
 _removeAllShMemVariables()
 {
   UniqueArray<IVariable*> shmem_vars;
-  for (const auto& [fst, snd] : m_full_name_variable_map) {
-    if (snd->property() & IVariable::PInShMem)
-      shmem_vars.add(snd);
+  for (const auto& [fst, var] : m_full_name_variable_map) {
+    if (var->property() & IVariable::PInShMem)
+      shmem_vars.add(var);
+  }
+  for (Integer i = 0; i < m_auto_create_variables.count(); ++i) {
+    VariableRef* var = m_auto_create_variables[i];
+    if (var->property() & IVariable::PInShMem) {
+      //La variable sera détruite juste après avec le removeVariable(var).
+      m_auto_create_variables.removeAt(i--);
+    }
   }
   for (IVariable* var : shmem_vars) {
     removeVariable(var);

--- a/arcane/src/arcane/impl/internal/VariableMng.h
+++ b/arcane/src/arcane/impl/internal/VariableMng.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableMng.h                                               (C) 2000-2024 */
+/* VariableMng.h                                               (C) 2000-2026 */
 /*                                                                           */
 /* Classe gérant la liste des maillages.                                     */
 /*---------------------------------------------------------------------------*/
@@ -128,6 +128,7 @@ class VariableMng
     void build() override { m_variable_mng->build(); }
     void initialize() override { m_variable_mng->initialize(); }
     void removeAllVariables() override { m_variable_mng->removeAllVariables(); }
+    void removeAllShMemVariables() override { m_variable_mng->_removeAllShMemVariables(); }
     void detachMeshVariables(IMesh* mesh) override { m_variable_mng->detachMeshVariables(mesh); }
     void addVariableRef(VariableRef* var) override { m_variable_mng->addVariableRef(var); }
     void removeVariableRef(VariableRef* var) override { m_variable_mng->removeVariableRef(var); }
@@ -271,6 +272,8 @@ class VariableMng
   static const char* _msgClassName() { return "Variable"; }
   VariableRef* _createVariableFromType(const String& full_type,
                                        const VariableBuildInfo& vbi);
+
+  void _removeAllShMemVariables();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/BasicParticleExchanger.axl
+++ b/arcane/src/arcane/mesh/BasicParticleExchanger.axl
@@ -31,6 +31,12 @@
         dans le cas d'un grand nombre de particules.
       </description>
     </simple>
+    <simple name="support-shmem-variables" type="bool" default="false">
+      <description>
+        Indique si l'on ajoute le support des variables particules en mémoire partagée.
+        Cette option peut augmenter la durée de l'échange de particules.
+      </description>
+    </simple>
   </options>
 
 </service>

--- a/arcane/src/arcane/mesh/BasicParticleExchanger.cc
+++ b/arcane/src/arcane/mesh/BasicParticleExchanger.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* BasicParticleExchanger.cc                                   (C) 2000-2025 */
+/* BasicParticleExchanger.cc                                   (C) 2000-2026 */
 /*                                                                           */
 /* Echangeur de particules.                                                  */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/BasicParticleExchanger.cc
+++ b/arcane/src/arcane/mesh/BasicParticleExchanger.cc
@@ -67,11 +67,14 @@ initialize(IItemFamily* item_family)
   m_rank = m_parallel_mng->commRank();
   m_timer = new Timer(m_parallel_mng->timerMng(),"BasicParticleExchanger",Timer::TimerReal);
 
-  if (options())
+  if (options()) {
     m_max_nb_message_without_reduce = options()->maxNbMessageWithoutReduce();
+    m_support_shmem_variables = options()->supportShmemVariables();
+  }
 
   info() << "Initialize BasicParticleExchanger family=" << item_family->name();
   info() << "-- MaxNbMessageWithoutReduce = " << m_max_nb_message_without_reduce;
+  info() << "-- SupportShmemVariables = " << m_support_shmem_variables;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -407,17 +410,32 @@ _waitMessages(ItemGroup item_group,Int32Array* new_particle_local_ids,IFunctor* 
   UniqueArray<ISerializeMessage*> current_messages(m_waiting_messages);
   m_waiting_messages.clear();
 
+  Int32 nb_end_update = 0;
+  Int32 max_nb_messages = 0;
+  if (m_support_shmem_variables) {
+    max_nb_messages = m_parallel_mng->reduce(MessagePassing::ReduceMax, current_messages.size());
+  }
+
   Int64UniqueArray items_to_create_unique_id;
   Int64UniqueArray items_to_create_cells_unique_id;
   Int32UniqueArray items_to_create_local_id;
   Int32UniqueArray items_to_create_cells_local_id;
-  for( ISerializeMessage* sm : current_messages ){
-    if (!sm->isSend())
+  for (ISerializeMessage* sm : current_messages) {
+    if (!sm->isSend()) {
       _deserializeMessage(sm,items_to_create_unique_id,items_to_create_cells_unique_id,
                           items_to_create_local_id,items_to_create_cells_local_id,
                           item_group,new_particle_local_ids);
+      nb_end_update++;
+    }
     delete sm;
   }
+
+  if (m_support_shmem_variables) {
+    for (; nb_end_update < max_nb_messages; ++nb_end_update) {
+      m_item_family->endUpdate();
+    }
+  }
+
   if (!m_waiting_messages.empty())
     ARCANE_FATAL("Pending messages n={0}",m_waiting_messages.size());
 }

--- a/arcane/src/arcane/mesh/BasicParticleExchanger.h
+++ b/arcane/src/arcane/mesh/BasicParticleExchanger.h
@@ -147,6 +147,8 @@ class BasicParticleExchanger
    */
   Int32 m_max_nb_message_without_reduce = 15;
 
+  bool m_support_shmem_variables = false;
+
  private:
 
   void _clearMessages();

--- a/arcane/src/arcane/mesh/BasicParticleExchanger.h
+++ b/arcane/src/arcane/mesh/BasicParticleExchanger.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* BasicParticleExchanger.h                                    (C) 2000-2025 */
+/* BasicParticleExchanger.h                                    (C) 2000-2026 */
 /*                                                                           */
 /*---------------------------------------------------------------------------*/
 #ifndef ARCANE_MESH_BASICPARTICLEEXCHANGER_H

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -151,7 +151,8 @@ class ItemFamily::InternalApi
   }
   void resizeVariables(bool force_resize) override
   {
-    return m_family->_resizeVariables(force_resize);
+    m_family->_resizeShMemVariables();
+    m_family->_resizeVariables(force_resize);
   }
 
  private:
@@ -274,6 +275,7 @@ ItemFamily(IMesh* mesh, eItemKind ik, const String& name)
 , m_common_item_shared_info(new ItemSharedInfo(this, m_item_internal_list, &m_item_connectivity_list))
 , m_item_shared_infos(new ItemSharedInfoList(this, m_common_item_shared_info))
 , m_used_variables(&_cmpIVariablePtr)
+, m_used_shmem_variables(&_cmpIVariablePtr)
 , m_properties(new Properties(*mesh->properties(), name))
 , m_sub_domain_id(mesh->meshPartInfo().partRank())
 {
@@ -733,6 +735,7 @@ _partialEndUpdate()
 void ItemFamily::
 _endUpdate(bool need_check_remove)
 {
+  _resizeShMemVariables();
   if (_partialEndUpdate())
     return;
 
@@ -835,6 +838,17 @@ _resizeVariables(bool force_resize)
     for (IVariable* var : m_used_variables) {
       _updateVariable(var);
     }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemFamily::
+_resizeShMemVariables()
+{
+  for (IVariable* var : m_used_shmem_variables) {
+    _updateVariable(var);
   }
 }
 
@@ -1608,6 +1622,9 @@ copyItemsValues(Int32ConstArrayView source, Int32ConstArrayView destination)
       //if (var->itemFamily()==this) {
       var->copyItemsValues(source, destination);
     }
+    for (IVariable* var : m_used_shmem_variables) {
+      var->copyItemsValues(source, destination);
+    }
   }
 }
 
@@ -1638,6 +1655,11 @@ copyItemsMeanValues(Int32ConstArrayView first_source,
         var->copyItemsMeanValues(first_source, second_source, destination);
       }
     }
+    for (IVariable* var : m_used_shmem_variables) {
+      if (!(var->property() & (IVariable::PTemporary | IVariable::PNoRestore))) {
+        var->copyItemsMeanValues(first_source, second_source, destination);
+      }
+    }
   }
 }
 
@@ -1657,6 +1679,10 @@ compactVariablesAndGroups(const ItemFamilyCompactInfos& compact_infos)
 
   for (IVariable* var : m_used_variables) {
     debug(Trace::High) << "Compact variable " << var->fullName();
+    var->compact(new_to_old_ids);
+  }
+  for (IVariable* var : m_used_shmem_variables) {
+    debug(Trace::High) << "Compact shmem variable " << var->fullName();
     var->compact(new_to_old_ids);
   }
 
@@ -2101,7 +2127,11 @@ _addVariable(IVariable* var)
   //info() << "Add var=" << var->fullName() << " to family=" << name();
   if (var->itemFamily()!=this)
     ARCANE_FATAL("Can not add a variable to a different family");
-  m_used_variables.insert(var);
+
+  if (var->property() & IVariable::PInShMem)
+    m_used_shmem_variables.insert(var);
+  else
+    m_used_variables.insert(var);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -2111,7 +2141,10 @@ void ItemFamily::
 _removeVariable(IVariable* var)
 {
   //info() << "Remove var=" << var->fullName() << " to family=" << name();
-  m_used_variables.erase(var);
+  if (var->property() & IVariable::PInShMem)
+    m_used_shmem_variables.erase(var);
+  else
+    m_used_variables.erase(var);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -2121,6 +2154,9 @@ void ItemFamily::
 usedVariables(VariableCollection collection)
 {
   for( IVariable* var : m_used_variables ){
+    collection.add(var);
+  }
+  for (IVariable* var : m_used_shmem_variables) {
     collection.add(var);
   }
 }

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemFamily.cc                                               (C) 2000-2025 */
+/* ItemFamily.cc                                               (C) 2000-2026 */
 /*                                                                           */
 /* Infos de maillage pour un genre d'entité donnée.                          */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemFamily.cc
+++ b/arcane/src/arcane/mesh/ItemFamily.cc
@@ -22,6 +22,7 @@
 #include "arcane/utils/PlatformUtils.h"
 #include "arcane/utils/OStringStream.h"
 #include "arcane/utils/ValueConvert.h"
+#include "arcane/utils/CStringUtils.h"
 
 #include "arcane/core/IParallelMng.h"
 #include "arcane/core/ISubDomain.h"
@@ -249,6 +250,15 @@ class ItemFamily::Variables
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+bool ItemFamily::
+_cmpIVariablePtr(const IVariable* a, const IVariable* b)
+{
+  return CStringUtils::isLess(a->name().localstr(), b->name().localstr());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -263,6 +273,7 @@ ItemFamily(IMesh* mesh, eItemKind ik, const String& name)
 , m_item_internal_list(mesh->meshItemInternalList())
 , m_common_item_shared_info(new ItemSharedInfo(this, m_item_internal_list, &m_item_connectivity_list))
 , m_item_shared_infos(new ItemSharedInfoList(this, m_common_item_shared_info))
+, m_used_variables(&_cmpIVariablePtr)
 , m_properties(new Properties(*mesh->properties(), name))
 , m_sub_domain_id(mesh->meshPartInfo().partRank())
 {

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -112,6 +112,12 @@ class ARCANE_MESH_EXPORT ItemFamily
   // TODO: à enlever mi 2025
   using AdjencyGroupMap = AdjacencyGroupMap;
 
+  /*!
+   * \brief Fonction permettant de comparer deux noms de variable (strcmp).
+   * \return True si le nom de a est lexicographiquement inférieur au nom de b.
+   */
+  static bool _cmpIVariablePtr(const IVariable* a, const IVariable* b);
+
  public:
 
   using ItemInternalMap = ::Arcane::mesh::ItemInternalMap;
@@ -347,7 +353,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   Ref<IVariableSynchronizer> m_variable_synchronizer;
   Integer m_current_variable_item_size = 0;
   IItemInternalSortFunction* m_item_sort_function = nullptr;
-  std::set<IVariable*> m_used_variables;
+  std::set<IVariable*, decltype(&_cmpIVariablePtr)> m_used_variables;
   UniqueArray<ItemFamily*> m_child_families;
   ItemConnectivityInfo* m_local_connectivity_info = nullptr;
   ItemConnectivityInfo* m_global_connectivity_info = nullptr;

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemFamily.h                                                (C) 2000-2025 */
+/* ItemFamily.h                                                (C) 2000-2026 */
 /*                                                                           */
 /* Famille d'entités.                                                        */
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/ItemFamily.h
+++ b/arcane/src/arcane/mesh/ItemFamily.h
@@ -354,6 +354,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   Integer m_current_variable_item_size = 0;
   IItemInternalSortFunction* m_item_sort_function = nullptr;
   std::set<IVariable*, decltype(&_cmpIVariablePtr)> m_used_variables;
+  std::set<IVariable*, decltype(&_cmpIVariablePtr)> m_used_shmem_variables;
   UniqueArray<ItemFamily*> m_child_families;
   ItemConnectivityInfo* m_local_connectivity_info = nullptr;
   ItemConnectivityInfo* m_global_connectivity_info = nullptr;
@@ -395,7 +396,11 @@ class ARCANE_MESH_EXPORT ItemFamily
  public:
 
   IItemFamilyTopologyModifier* _topologyModifier() override { return m_topology_modifier; }
-  void resizeVariables(bool force_resize) override { _resizeVariables(force_resize); }
+  void resizeVariables(bool force_resize) override
+  {
+    _resizeShMemVariables();
+    _resizeVariables(force_resize);
+  }
 
  private:
 
@@ -528,6 +533,7 @@ class ARCANE_MESH_EXPORT ItemFamily
   void _addVariable(IVariable* var);
   void _removeVariable(IVariable* var);
   void _resizeVariables(bool force_resize);
+  void _resizeShMemVariables();
   void _shrinkConnectivityAndPrintInfos();
   void _addOnSizeChangedObservable(VariableRef& var_ref);
 };

--- a/arccore/src/collections/arccore/collections/Array2.h
+++ b/arccore/src/collections/arccore/collections/Array2.h
@@ -367,7 +367,7 @@ class Array2
   void _resize(Int64 new_size,InitBehaviour rb)
   {
     Int64 old_size = m_md->dim1_size;
-    if (new_size==old_size)
+    if (new_size == old_size && !m_md->is_collective_allocator)
       return;
     _resize2(new_size,m_md->dim2_size,rb);
     m_md->dim1_size = new_size;

--- a/arccore/src/common/arccore/common/AbstractArray.h
+++ b/arccore/src/common/arccore/common/AbstractArray.h
@@ -431,8 +431,7 @@ class AbstractArray
    *
    * Si la nouvelle capacité est inférieure à l'ancienne, rien ne se passe.
    */
-  template <typename PodType>
-  void _internalRealloc(Int64 new_capacity, bool compute_capacity, PodType pod_type, RunQueue* queue = nullptr)
+  void _internalRealloc(Int64 new_capacity, bool compute_capacity, RunQueue* queue = nullptr)
   {
     // Remarque : Pour la mémoire partagée, si un des ptr est nullptr, alors
     // il l'est pour tous les processus.
@@ -454,48 +453,42 @@ class AbstractArray
     // (sauf pour un allocateur collectif).
     if (acapacity <= m_md->capacity) {
       if (m_meta_data.is_collective_allocator) {
-        _internalReallocate(m_md->capacity, pod_type, queue);
+        _internalReallocate(m_md->capacity, queue);
       }
       return;
     }
-    _internalReallocate(acapacity, pod_type, queue);
+    _internalReallocate(acapacity, queue);
   }
 
-  void _internalRealloc(Int64 new_capacity, bool compute_capacity)
+  void _internalReallocate(Int64 new_capacity, RunQueue* queue)
   {
-    _internalRealloc(new_capacity, compute_capacity, IsPODType());
-  }
-
-  //! Réallocation pour un type POD
-  void _internalReallocate(Int64 new_capacity, TrueType, RunQueue* queue)
-  {
-    T* old_ptr = m_ptr;
-    Int64 old_capacity = m_md->capacity;
-    _directReAllocate(new_capacity, queue);
-    bool update = (new_capacity < old_capacity) || (m_ptr != old_ptr);
-    if (update) {
-      _updateReferences();
-    }
-  }
-
-  //! Réallocation pour un type complexe (non POD)
-  void _internalReallocate(Int64 new_capacity, FalseType, RunQueue* queue)
-  {
-    T* old_ptr = m_ptr;
-    ArrayMetaData* old_md = m_md;
-    AllocatedMemoryInfo old_mem_info = _currentMemoryInfo();
-    Int64 old_size = m_md->size;
-    _directAllocate(new_capacity, queue);
-    if (m_ptr != old_ptr) {
-      for (Int64 i = 0; i < old_size; ++i) {
-        new (m_ptr + i) T(old_ptr[i]);
-        old_ptr[i].~T();
+    if constexpr (std::is_trivially_copyable_v<T>) {
+      T* old_ptr = m_ptr;
+      Int64 old_capacity = m_md->capacity;
+      _directReAllocate(new_capacity, queue);
+      bool update = (new_capacity < old_capacity) || (m_ptr != old_ptr);
+      if (update) {
+        _updateReferences();
       }
-      m_md->nb_ref = old_md->nb_ref;
-      m_md->_deallocate(old_mem_info, queue);
-      _updateReferences();
+    }
+    else {
+      T* old_ptr = m_ptr;
+      ArrayMetaData* old_md = m_md;
+      AllocatedMemoryInfo old_mem_info = _currentMemoryInfo();
+      Int64 old_size = m_md->size;
+      _directAllocate(new_capacity, queue);
+      if (m_ptr != old_ptr) {
+        for (Int64 i = 0; i < old_size; ++i) {
+          new (m_ptr + i) T(old_ptr[i]);
+          old_ptr[i].~T();
+        }
+        m_md->nb_ref = old_md->nb_ref;
+        m_md->_deallocate(old_mem_info, queue);
+        _updateReferences();
+      }
     }
   }
+
   // Libère la mémoire
   void _internalDeallocate(RunQueue* queue = nullptr)
   {
@@ -697,13 +690,13 @@ class AbstractArray
     if (s < 0)
       s = 0;
     if (s > m_md->size) {
-      this->_internalRealloc(s, false, pod_type, queue);
+      this->_internalRealloc(s, false, queue);
       this->_createRangeDefault(m_md->size, s, pod_type);
     }
     else {
       this->_destroyRange(s, m_md->size, pod_type);
       if (m_meta_data.is_collective_allocator) {
-        this->_internalRealloc(s, false, pod_type, queue);
+        this->_internalRealloc(s, false, queue);
       }
     }
     m_md->size = s;
@@ -838,7 +831,7 @@ class AbstractArray
       return;
     if (new_capacity < 4)
       new_capacity = 4;
-    _internalReallocate(new_capacity, IsPODType(), _nullRunQueue());
+    _internalReallocate(new_capacity, _nullRunQueue());
   }
 
   /*!

--- a/axlstar/Arcane.Axl.T4/Arcane.Axl/Axl.From.Xsd/VariableCode.cs
+++ b/axlstar/Arcane.Axl.T4/Arcane.Axl/Axl.From.Xsd/VariableCode.cs
@@ -23,6 +23,7 @@ namespace Arcane.Axl.Xsd
       NoExchange,
       Persistant,
       NoReplicaSync,
+      InShMem,
       Undefined
     }
     [XmlIgnore]
@@ -73,6 +74,8 @@ namespace Arcane.Axl.Xsd
       }
     }
 
+    public bool IsInShMem { get { return inshmemSpecified ? inshmem : false; } }
+
     public int NbProperty {
       get {
         return Convert.ToInt32(IsNoDump)
@@ -80,7 +83,8 @@ namespace Arcane.Axl.Xsd
           + Convert.ToInt32(IsExecutionDepend)
           + Convert.ToInt32(IsSubDomainDepend)
           + Convert.ToInt32(IsSubDomainPrivate)
-          + Convert.ToInt32(IsNoRestore);
+          + Convert.ToInt32(IsNoRestore)
+          + Convert.ToInt32(IsInShMem);
       }
     }
 
@@ -104,6 +108,8 @@ namespace Arcane.Axl.Xsd
           return Property.Persistant;
         if (IsNoReplicaSync)
           return Property.NoReplicaSync;
+        if (IsInShMem)
+          return Property.InShMem;
         return Property.Undefined;
       }
     }
@@ -129,6 +135,8 @@ namespace Arcane.Axl.Xsd
           properties.Add (Property.Persistant);
         if (IsNoReplicaSync)
           properties.Add (Property.NoReplicaSync);
+        if (IsInShMem)
+          properties.Add (Property.InShMem);
         properties.RemoveAt (0);
         return properties;
       }

--- a/axlstar/Arcane.Axl.T4/Arcane.Axl/Axl.From.Xsd/axl.cs
+++ b/axlstar/Arcane.Axl.T4/Arcane.Axl/Axl.From.Xsd/axl.cs
@@ -945,6 +945,10 @@ namespace Arcane.Axl.Xsd {
         
         private string extent1Field;
         
+        private bool inshmemField;
+
+        private bool inshmemFieldSpecified;
+
         public variablesVariable() {
             this.flowField = Flow.inout;
         }
@@ -1310,6 +1314,28 @@ namespace Arcane.Axl.Xsd {
             }
             set {
                 this.extent1Field = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute("in-shmem")]
+        public bool inshmem {
+            get {
+                return this.inshmemField;
+            }
+            set {
+                this.inshmemField = value;
+            }
+        }
+
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool inshmemSpecified {
+            get {
+                return this.inshmemFieldSpecified;
+            }
+            set {
+                this.inshmemFieldSpecified = value;
             }
         }
     }

--- a/axlstar/Arcane.Axl/Arcane.Axl.Generator.CSharp/CSharpCodeGenerator.cs
+++ b/axlstar/Arcane.Axl/Arcane.Axl.Generator.CSharp/CSharpCodeGenerator.cs
@@ -106,11 +106,13 @@ namespace Arcane.Axl
         _WriteVariableProperty(writer,variable_info.IsNoRestore,
                                "PNoRestore",ref is_first_attribute);
         _WriteVariableProperty(writer,variable_info.IsNoExchange,
-                               "PNoRestore",ref is_first_attribute);
+                               "PNoExchange",ref is_first_attribute);
         _WriteVariableProperty(writer,variable_info.IsPersistant,
                                "PPersistant",ref is_first_attribute);
         _WriteVariableProperty(writer,variable_info.IsNoReplicaSync,
                                "PNoReplicaSync",ref is_first_attribute);
+        _WriteVariableProperty(writer,variable_info.IsInShMem,
+                               "PInShMem",ref is_first_attribute);
         writer.Write("));\n");
       }
     }

--- a/axlstar/Arcane.Axl/Arcane.Axl.Generator.Cpp/CppCodeGenerator.cs
+++ b/axlstar/Arcane.Axl/Arcane.Axl.Generator.Cpp/CppCodeGenerator.cs
@@ -86,6 +86,8 @@ namespace Arcane.Axl
                                "PSubDomainPrivate",ref is_first_attribute);
         _WriteVariableProperty(writer,variable_info.IsNoRestore,
                                "PNoRestore",ref is_first_attribute);
+        _WriteVariableProperty(writer,variable_info.IsInShMem,
+                               "PInShMem",ref is_first_attribute);
         writer.Write("))\n");
       }
     }

--- a/axlstar/Arcane.Axl/Arcane.Axl/VariableInfo.cs
+++ b/axlstar/Arcane.Axl/Arcane.Axl/VariableInfo.cs
@@ -105,6 +105,10 @@ namespace Arcane.Axl
     //! Indique s'il s'agit d'une variable 'materiau'.
     public bool IsMaterial { get { return m_is_material; }}
 
+    readonly bool m_in_shmem;
+    //! Indique si la variable doit être allouée dans la mémoire partagée.
+    public bool IsInShMem { get { return m_in_shmem; } }
+
     public VariableInfo(XmlElement node)
     {
       m_dim = 0;
@@ -203,6 +207,7 @@ namespace Arcane.Axl
       m_no_replica_sync = _ReadProperty(node,"no-replica-sync");
       m_is_environment = _ReadProperty(node,"environment");
       m_is_material = _ReadProperty(node,"material");
+      m_in_shmem = _ReadProperty(node,"in-shmem");
     }
 
     bool _ReadProperty(XmlElement node,string name)

--- a/axlstar/Arcane.Axl/axl.xsd
+++ b/axlstar/Arcane.Axl/axl.xsd
@@ -411,6 +411,7 @@
             <xs:attribute name="shape-dim" type="ShapeDimension" use="optional" />
             <xs:attribute name="extent0" type="FixedExtent" use="optional" />
             <xs:attribute name="extent1" type="FixedExtent" use="optional" />
+            <xs:attribute name="in-shmem" type="xs:boolean" use="optional"/>
           </xs:complexType>
         </xs:element>
       </xs:sequence>


### PR DESCRIPTION
And :
- In `ItemFamily` class : 
  - Sort variables by name,
  - Add a set with all shmem variables.
- Add support for shmem variables in `BasicParticleExchanger`,
- Replace POD/non-POD `_internalReallocate()` methods with unique method using `std::is_trivially_copyable_v`.