### PR TITLE
Remove Eigen from runtime distributed direct solvers

### DIFF
--- a/arccore/src/alina/arccore/alina/DistributedDirectSolverRuntime.h
+++ b/arccore/src/alina/arccore/alina/DistributedDirectSolverRuntime.h
@@ -24,9 +24,8 @@
 /*---------------------------------------------------------------------------*/
 
 #include "arccore/alina/DistributedSkylineLUDirectSolver.h"
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-#include "arccore/alina/DistributedEigenSparseLUDirectSolver.h"
-#endif
+
+#include "arccore/base/NotSupportedException.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -39,10 +38,6 @@ namespace Arcane::Alina
 enum class eDistributedDirectSolverType
 {
   skyline_lu
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-  ,
-  eigen_splu
-#endif
 };
 
 /*---------------------------------------------------------------------------*/
@@ -53,10 +48,6 @@ inline std::ostream& operator<<(std::ostream& os, eDistributedDirectSolverType s
   switch (s) {
   case eDistributedDirectSolverType::skyline_lu:
     return os << "skyline_lu";
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-  case eDistributedDirectSolverType::eigen_splu:
-    return os << "eigen_splu";
-#endif
   default:
     return os << "???";
   }
@@ -72,18 +63,8 @@ inline std::istream& operator>>(std::istream& in, eDistributedDirectSolverType& 
 
   if (val == "skyline_lu")
     s = eDistributedDirectSolverType::skyline_lu;
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-  else if (val == "eigen_splu")
-    s = eDistributedDirectSolverType::eigen_splu;
-#endif
   else
-    throw std::invalid_argument("Invalid direct solver value. Valid choices are: "
-                                "skyline_lu"
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-                                ", eigen_splu"
-#endif
-                                ".");
-
+    ARCCORE_FATAL("Invalid direct solver value. Valid choices are: 'skyline_lu'");
   return in;
 }
 
@@ -111,14 +92,8 @@ class DistributedDirectSolverRuntime
       typedef DistributedSkylineLUDirectSolver<value_type> S;
       handle = static_cast<void*>(new S(comm, A, prm));
     } break;
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-    case eDistributedDirectSolverType::eigen_splu: {
-      typedef DistributedEigenSparseLUDirectSolver<value_type> S;
-      do_construct<S, value_type>(comm, A, prm);
-    } break;
-#endif
     default:
-      throw std::invalid_argument("Unsupported direct solver type");
+      ARCCORE_THROW(NotSupportedException, "Invalid solver type '{0}'", s);
     }
   }
 
@@ -135,14 +110,8 @@ class DistributedDirectSolverRuntime
       typedef DistributedSkylineLUDirectSolver<value_type> S;
       static_cast<const S*>(handle)->operator()(rhs, x);
     } break;
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-    case eDistributedDirectSolverType::eigen_splu: {
-      typedef DistributedEigenSparseLUDirectSolver<value_type> S;
-      do_solve<S, value_type>(rhs, x);
-    } break;
-#endif
     default:
-      throw std::invalid_argument("Unsupported direct solver type");
+      ARCCORE_THROW(NotSupportedException, "Invalid solver type '{0}'", s);
     }
   }
 
@@ -153,16 +122,14 @@ class DistributedDirectSolverRuntime
       typedef DistributedSkylineLUDirectSolver<value_type> S;
       delete static_cast<S*>(handle);
     } break;
-#ifdef ARCCORE_ALINA_HAVE_EIGEN
-    case eDistributedDirectSolverType::eigen_splu: {
-      typedef DistributedEigenSparseLUDirectSolver<value_type> S;
-      do_destruct<S, value_type>();
-    } break;
-#endif
     default:
       break;
     }
   }
+
+ public:
+
+  eDistributedDirectSolverType type() const { return s; }
 
  private:
 

--- a/arccore/src/alina/arccore/alina/Profiler.cc
+++ b/arccore/src/alina/arccore/alina/Profiler.cc
@@ -97,7 +97,7 @@ init()
 /*---------------------------------------------------------------------------*/
 
 void Profiler::
-print(std::ostream& out)
+print(std::ostream& out) const
 {
   if (stack.back() != &root)
     out << "Warning! Profile is incomplete." << std::endl;

--- a/arccore/src/alina/arccore/alina/Profiler.h
+++ b/arccore/src/alina/arccore/alina/Profiler.h
@@ -189,7 +189,7 @@ class ARCCORE_ALINA_EXPORT Profiler
 
   void init();
 
-  void print(std::ostream& out);
+  void print(std::ostream& out) const;
 
   /*!
    * \brief Sends formatted profiling data to an output stream.
@@ -197,7 +197,7 @@ class ARCCORE_ALINA_EXPORT Profiler
    * \param out  Output stream.
    * \param prof Profiler.
    */
-  friend std::ostream& operator<<(std::ostream& out, Profiler& prof)
+  friend std::ostream& operator<<(std::ostream& out, const Profiler& prof)
   {
     out << std::endl;
     prof.print(out);

--- a/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
@@ -16,61 +16,49 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <vector>
-#include <algorithm>
-#include <numeric>
-#include <cmath>
-
+#if defined(ARCCORE_ALINA_HAVE_EIGEN)
 // To remove warnings about deprecated Eigen usage.
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#include "arccore/alina/DistributedEigenSparseLUDirectSolver.h"
+#endif
 
-#include <boost/scope_exit.hpp>
-#include <boost/program_options.hpp>
+#include "arccore/trace/ITraceMng.h"
 
 #include "arccore/alina/DistributedDirectSolverRuntime.h"
 #include "arccore/alina/Profiler.h"
 
-namespace Arcane::Alina
-{
-Profiler prof;
-}
+#include "AlinaSamplesCommon.h"
+
+#include <boost/program_options.hpp>
 
 using namespace Arcane;
 
-int main(int argc, char* argv[])
+int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
 {
-  int provided;
-  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
-  BOOST_SCOPE_EXIT(void)
-  {
-    MPI_Finalize();
-  }
-  BOOST_SCOPE_EXIT_END
+  ITraceMng* tm = ctx.traceMng();
+
+  auto& prof = Alina::Profiler::globalProfiler();
 
   Alina::mpi_communicator comm(MPI_COMM_WORLD);
 
-  if (comm.rank == 0)
-    std::cout << "World size: " << comm.size << std::endl;
+  tm->info() << "World size: " << comm.size;
 
   namespace po = boost::program_options;
   po::options_description desc("Options");
 
-  desc.add_options()("help,h", "show help")(
-  "size,n",
-  po::value<int>()->default_value(128),
-  "domain size")("prm-file,P",
-                 po::value<std::string>(),
-                 "Parameter file in json format. ")(
-  "prm,p",
-  po::value<std::vector<std::string>>()->multitoken(),
-  "Parameters specified as name=value pairs. "
-  "May be provided multiple times. Examples:\n"
-  "  -p solver.tol=1e-3\n"
-  "  -p precond.coarse_enough=300");
+  desc.add_options()("help,h", "show help")("size,n",
+                                            po::value<int>()->default_value(128),
+                                            "domain size");
+  desc.add_options()("prm-file,P",
+                     po::value<std::string>(),
+                     "Parameter file in json format. ");
+  desc.add_options()("prm,p",
+                     po::value<std::vector<std::string>>()->multitoken(),
+                     "Parameters specified as name=value pairs. "
+                     "May be provided multiple times. Examples:\n"
+                     "  -p solver.tol=1e-3\n"
+                     "  -p precond.coarse_enough=300");
 
   po::variables_map vm;
   po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -95,8 +83,6 @@ int main(int argc, char* argv[])
 
   const int n = vm["size"].as<int>();
   const int n2 = n * n;
-
-  using Alina::prof;
 
   int chunk = (n2 + comm.size - 1) / comm.size;
   int chunk_start = comm.rank * chunk;
@@ -152,34 +138,59 @@ int main(int argc, char* argv[])
   A.setNbNonZero(A.ptr[chunk]);
   prof.toc("assemble");
 
-  prof.tic("setup");
-  Alina::DistributedDirectSolverRuntime<double> solve(comm, A, prm);
-  prof.toc("setup");
-
-  prof.tic("solve");
   std::vector<double> x(chunk);
-  solve(rhs, x);
-  solve(rhs, x);
-  prof.toc("solve");
 
-  prof.tic("save");
-  if (comm.rank == 0) {
-    std::vector<double> X(n2);
-    std::copy(x.begin(), x.end(), X.begin());
+  {
+    auto t = prof.scoped_tic("skyline");
 
-    for (int i = 1; i < comm.size; ++i)
-      MPI_Recv(&X[domain[i]], domain[i + 1] - domain[i], MPI_DOUBLE, i, 42, comm, MPI_STATUS_IGNORE);
+    prof.tic("setup");
+    Alina::DistributedDirectSolverRuntime<double> solve(comm, A, prm);
+    tm->info() << "Solver is = " << solve.type();
+    prof.toc("setup");
 
-    std::ofstream f("out.dat", std::ios::binary);
-    f.write((char*)&n2, sizeof(int));
-    f.write((char*)X.data(), n2 * sizeof(double));
+    prof.tic("solve1");
+    solve(rhs, x);
+    prof.toc("solve1");
   }
-  else {
-    MPI_Send(x.data(), chunk, MPI_DOUBLE, 0, 42, comm);
-  }
-  prof.toc("save");
 
-  if (comm.rank == 0) {
-    std::cout << prof << std::endl;
+#if defined(ARCCORE_ALINA_HAVE_EIGEN)
+  {
+    auto t = prof.scoped_tic("eigen");
+
+    prof.tic("setup");
+    Alina::DistributedEigenSparseLUDirectSolver<double> solve(comm, A, prm);
+    prof.toc("setup");
+
+    prof.tic("solve");
+    std::vector<double> x2(chunk);
+    solve(rhs, x2);
+    prof.toc("solve");
+    // Compare values between skyline and eigen
+    Int32 nb_error = 0;
+    for (Int32 i = 0; i < chunk; ++i) {
+      Real x_ref = x[i];
+      Real x_eigen = x2[i];
+      Real abs_sum = std::abs(x_ref);
+
+      Real diff = std::abs(x_eigen - x_ref);
+      if (abs_sum != 0.0)
+        diff /= abs_sum;
+
+      if (diff > 1.0e-12) {
+        tm->info() << "I=" << i << " compare skyline=" << x[i] << " eigen=" << x2[i] << " diff=" << diff;
+        ++nb_error;
+      }
+    }
+    if (nb_error != 0)
+      ARCCORE_FATAL("Error when comparing Eigen and SkylineLU nb_error={0}", nb_error);
   }
+#endif
+
+  tm->info() << prof;
+  return 0;
+}
+
+int main(int argc, char* argv[])
+{
+  return Arcane::Alina::SampleMainContext::execMain(main2, argc, argv);
 }


### PR DESCRIPTION
The solver is still available but has to be explicitly called.
This is needed to remove hard dependencies on Eigen.