### PR TITLE
Use a backend instead of a value type for distributed direct solver classes.

### DIFF
--- a/arccore/src/alina/arccore/alina/AlinaLib.cc
+++ b/arccore/src/alina/arccore/alina/AlinaLib.cc
@@ -30,6 +30,7 @@ using namespace Arcane;
 /*---------------------------------------------------------------------------*/
 
 using Backend = Alina::BuiltinBackend<double>;
+//using Backend = Alina::BuiltinBackend<double,Int32,Int32>;
 using PreconditionerType = Alina::AMG<Backend, Alina::CoarseningRuntime, Alina::RelaxationRuntime>;
 using SequentialSolverType = Alina::PreconditionedSolver<PreconditionerType, Alina::SolverRuntime<Backend>>;
 typedef Alina::PropertyTree Params;
@@ -38,7 +39,7 @@ typedef Alina::PropertyTree Params;
 
 using DistributedSolverType = Alina::DistributedSubDomainDeflation<PreconditionerType,
                                                                    Alina::DistributedSolverRuntime<Backend>,
-                                                                   Alina::DistributedDirectSolverRuntime<double>>;
+                                                                   Alina::DistributedDirectSolverRuntime<Backend>>;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -239,6 +240,11 @@ solver_create(int n, const int* ptr,
     solver = new SequentialSolverType(A, prm->m_properties);
   else
     solver = new SequentialSolverType(A);
+  std::cout << "Printing solver infos\n";
+  std::cout << (*solver) << std::endl;
+  Alina::PropertyTree ptree;
+  solver->prm.get(ptree);
+  std::cout << "SOLVER_PARAMS: " << ptree << "\n";
   return new AlinaSequentialSolver(solver);
 }
 

--- a/arccore/src/alina/arccore/alina/DistributedAMG.h
+++ b/arccore/src/alina/arccore/alina/DistributedAMG.h
@@ -46,7 +46,7 @@ namespace Arcane::Alina
 template <class Backend,
           class Coarsening,
           class Relaxation,
-          class DirectSolver = DistributedSkylineLUDirectSolver<typename Backend::value_type>,
+          class DirectSolver = DistributedSkylineLUDirectSolver<Backend>,
           class Repartition = SimpleMatrixPartitioner<Backend>>
 class DistributedAMG
 {

--- a/arccore/src/alina/arccore/alina/DistributedDirectSolverBase.h
+++ b/arccore/src/alina/arccore/alina/DistributedDirectSolverBase.h
@@ -37,14 +37,18 @@ namespace Arcane::Alina
 /*!
  * \brief Base class for distributed direct solver.
  */
-template <class value_type, class Solver>
+template <typename Backend, class Solver>
 class DistributedDirectSolverBase
 {
  public:
 
+  typedef typename Backend::value_type value_type;
   typedef typename math::scalar_of<value_type>::type scalar_type;
   typedef typename math::rhs_of<value_type>::type rhs_type;
-  typedef CSRMatrix<value_type> build_matrix;
+  //typedef Backend::matrix build_matrix;
+  using col_type = Backend::col_type;
+  using ptr_type = Backend::ptr_type;
+  typedef CSRMatrix<value_type, col_type, ptr_type> build_matrix;
 
   DistributedDirectSolverBase() {}
 

--- a/arccore/src/alina/arccore/alina/DistributedDirectSolverRuntime.h
+++ b/arccore/src/alina/arccore/alina/DistributedDirectSolverRuntime.h
@@ -73,12 +73,14 @@ inline std::istream& operator>>(std::istream& in, eDistributedDirectSolverType& 
 /*!
  * \brief Runtime wrapper for distributed direct solvers.
  */
-template <class value_type>
+template <typename Backend>
 class DistributedDirectSolverRuntime
 {
  public:
 
+  typedef typename Backend::value_type value_type;
   typedef Alina::PropertyTree params;
+  using SkylineSolverType = DistributedSkylineLUDirectSolver<Backend>;
 
   template <class Matrix>
   DistributedDirectSolverRuntime(Alina::mpi_communicator comm, const Matrix& A, params prm = params())
@@ -89,8 +91,7 @@ class DistributedDirectSolverRuntime
 
     switch (s) {
     case eDistributedDirectSolverType::skyline_lu: {
-      typedef DistributedSkylineLUDirectSolver<value_type> S;
-      handle = static_cast<void*>(new S(comm, A, prm));
+      handle = static_cast<void*>(new SkylineSolverType(comm, A, prm));
     } break;
     default:
       ARCCORE_THROW(NotSupportedException, "Invalid solver type '{0}'", s);
@@ -107,8 +108,7 @@ class DistributedDirectSolverRuntime
   {
     switch (s) {
     case eDistributedDirectSolverType::skyline_lu: {
-      typedef DistributedSkylineLUDirectSolver<value_type> S;
-      static_cast<const S*>(handle)->operator()(rhs, x);
+      static_cast<const SkylineSolverType*>(handle)->operator()(rhs, x);
     } break;
     default:
       ARCCORE_THROW(NotSupportedException, "Invalid solver type '{0}'", s);
@@ -119,8 +119,7 @@ class DistributedDirectSolverRuntime
   {
     switch (s) {
     case eDistributedDirectSolverType::skyline_lu: {
-      typedef DistributedSkylineLUDirectSolver<value_type> S;
-      delete static_cast<S*>(handle);
+      delete static_cast<SkylineSolverType*>(handle);
     } break;
     default:
       break;

--- a/arccore/src/alina/arccore/alina/DistributedEigenSparseLUDirectSolver.h
+++ b/arccore/src/alina/arccore/alina/DistributedEigenSparseLUDirectSolver.h
@@ -44,12 +44,15 @@ namespace Arcane::Alina
  * This is a wrapper around Eigen SparseLU solver that provides a
  * distributed direct solver interface but always works sequentially.
  */
-template <typename value_type>
+template <typename Backend>
 class DistributedEigenSparseLUDirectSolver
-: public DistributedDirectSolverBase<value_type, DistributedEigenSparseLUDirectSolver<value_type>>
+: public DistributedDirectSolverBase<Backend, DistributedEigenSparseLUDirectSolver<Backend>>
 {
+  using Base = DistributedDirectSolverBase<Backend, DistributedEigenSparseLUDirectSolver<Backend>>;
+
  public:
 
+  using value_type = Backend::value_type;
   using EigenMatrix = Eigen::SparseMatrix<value_type, Eigen::ColMajor, int>;
   using Solver = EigenSolver<Eigen::SparseLU<EigenMatrix>>;
   typedef typename Solver::params params;
@@ -93,7 +96,6 @@ class DistributedEigenSparseLUDirectSolver
 
  private:
 
-  typedef DistributedDirectSolverBase<value_type, DistributedEigenSparseLUDirectSolver<value_type>> Base;
   params prm;
   std::shared_ptr<Solver> S;
 };

--- a/arccore/src/alina/arccore/alina/DistributedPreconditioner.h
+++ b/arccore/src/alina/arccore/alina/DistributedPreconditioner.h
@@ -99,7 +99,7 @@ class DistributedPreconditioner
   using AMGPrecondType = DistributedAMG<Backend,
                                         DistributedCoarseningRuntime<Backend>,
                                         DistributedRelaxationRuntime<Backend>,
-                                        DistributedDirectSolverRuntime<value_type>,
+                                        DistributedDirectSolverRuntime<Backend>,
                                         MatrixPartitionerRuntime<Backend>>;
 
   template <class Matrix>

--- a/arccore/src/alina/arccore/alina/DistributedSkylineLUDirectSolver.h
+++ b/arccore/src/alina/arccore/alina/DistributedSkylineLUDirectSolver.h
@@ -42,15 +42,18 @@ namespace Arcane::Alina
  * This is a wrapper around Skyline LU factorization solver that provides a
  * distributed direct solver interface but always works sequentially.
  */
-template <typename value_type>
+template <typename Backend>
 class DistributedSkylineLUDirectSolver
-: public DistributedDirectSolverBase<value_type, DistributedSkylineLUDirectSolver<value_type>>
+: public DistributedDirectSolverBase<Backend, DistributedSkylineLUDirectSolver<Backend>>
 {
+  using Base = DistributedDirectSolverBase<Backend, DistributedSkylineLUDirectSolver<Backend>>;
+
  public:
 
+  typedef typename Backend::value_type value_type;
   typedef Alina::solver::SkylineLUSolver<value_type> Solver;
   typedef typename Solver::params params;
-  typedef CSRMatrix<value_type> build_matrix;
+  typedef Backend::matrix build_matrix;
 
   /// Constructor.
   template <class Matrix>
@@ -90,7 +93,6 @@ class DistributedSkylineLUDirectSolver
 
  private:
 
-  typedef DistributedDirectSolverBase<value_type, DistributedSkylineLUDirectSolver<value_type>> Base;
   params prm;
   std::shared_ptr<Solver> S;
 };

--- a/arccore/src/alina/arccore/alina/DistributedSubDomainDeflation.h
+++ b/arccore/src/alina/arccore/alina/DistributedSubDomainDeflation.h
@@ -125,7 +125,7 @@ sdd_projected_matrix<SDD, Matrix> make_sdd_projected_matrix(const SDD& S, const 
  */
 template <class LocalPrecond,
           class IterativeSolver,
-          class DirectSolver = DistributedSkylineLUDirectSolver<typename LocalPrecond::backend_type::value_type>>
+          class DirectSolver = DistributedSkylineLUDirectSolver<typename LocalPrecond::backend_type>>
 class DistributedSubDomainDeflation
 {
  public:

--- a/arccore/src/alina/arccore/alina/samples/BasicSolver.cc
+++ b/arccore/src/alina/arccore/alina/samples/BasicSolver.cc
@@ -101,7 +101,11 @@ solve(const Alina::PropertyTree& prm,
     Solver solve(std::tie(rows, ptr, col, val), prm, bprm);
     prof.toc("setup");
 
+    std::cout << "Printing solver infos\n";
     std::cout << solve << std::endl;
+    Alina::PropertyTree ptree;
+    solve.prm.get(ptree);
+    std::cout << "SOLVER PARAMS: " << ptree << "\n";
 
     auto f_b = Backend::copy_vector(rhs, bprm);
     auto x_b = Backend::copy_vector(x, bprm);
@@ -201,6 +205,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
     _doHypreSolver(rows, ptr, col, val, rhs, x, argc, argv);
   }
   else {
+
     solver_result = solve(prm, rows, ptr, col, val, rhs, x);
 
     if (vm.count("output")) {

--- a/arccore/src/alina/arccore/alina/samples/DistributedBasicSolver.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedBasicSolver.cc
@@ -190,7 +190,7 @@ void solve_scalar(Alina::mpi_communicator comm,
   //using RelaxationType = Alina::DistributedRelaxationRuntime<Backend>,
 
   using AMGPrecondType = Alina::DistributedAMG<Backend, CoarseningType, RelaxationType,
-                                               Alina::DistributedDirectSolverRuntime<BackendValueType>,
+                                               Alina::DistributedDirectSolverRuntime<Backend>,
                                                Alina::MatrixPartitionerRuntime<Backend>>;
 
   using Solver = Alina::DistributedPreconditionedSolver<AMGPrecondType, Alina::DistributedSolverRuntime<Backend>>;

--- a/arccore/src/alina/arccore/alina/samples/DistributedCPR.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedCPR.cc
@@ -260,7 +260,7 @@ int main(int argc, char* argv[])
   using AMG = DistributedAMG<Backend,
                              DistributedCoarseningRuntime<Backend>,
                              DistributedRelaxationRuntime<Backend>,
-                             DistributedDirectSolverRuntime<double>,
+                             DistributedDirectSolverRuntime<Backend>,
                              MatrixPartitionerRuntime<Backend>>;
 
   typedef DistributedPreconditionedSolver<

--- a/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
@@ -21,6 +21,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #pragma GCC diagnostic ignored "-Wint-in-bool-context"
 #include "arccore/alina/DistributedEigenSparseLUDirectSolver.h"
+#include "arccore/alina/EigenBackend.h"
 #endif
 
 #include "arccore/trace/ITraceMng.h"
@@ -144,7 +145,8 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
     auto t = prof.scoped_tic("skyline");
 
     prof.tic("setup");
-    Alina::DistributedDirectSolverRuntime<double> solve(comm, A, prm);
+    using Backend = Alina::BuiltinBackend<double>;
+    Alina::DistributedDirectSolverRuntime<Backend> solve(comm, A, prm);
     tm->info() << "Solver is = " << solve.type();
     prof.toc("setup");
 
@@ -158,7 +160,8 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
     auto t = prof.scoped_tic("eigen");
 
     prof.tic("setup");
-    Alina::DistributedEigenSparseLUDirectSolver<double> solve(comm, A, prm);
+    using Backend = Alina::backend::EigenBackend<double>;
+    Alina::DistributedEigenSparseLUDirectSolver<Backend> solve(comm, A, prm);
     prof.toc("setup");
 
     prof.tic("solve");

--- a/arccore/src/alina/arccore/alina/samples/DistributedMatrixMarketSolver.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedMatrixMarketSolver.cc
@@ -316,12 +316,13 @@ int main(int argc, char* argv[])
   prof.toc("read problem");
 
   prof.tic("setup");
+  using Backend = BuiltinBackend<double>;
   using SDD = DistributedSubDomainDeflation<AMG<
-                                            BuiltinBackend<double>,
+                                            Backend,
                                             CoarseningRuntime,
                                             RelaxationRuntime>,
-                                            DistributedSolverRuntime<BuiltinBackend<double>>,
-                                            DistributedDirectSolverRuntime<double>>;
+                                            DistributedSolverRuntime<Backend>,
+                                            DistributedDirectSolverRuntime<Backend>>;
 
   std::function<double(ptrdiff_t, unsigned)> dv = Alina::constant_deflation(block_size);
   prm.put("num_def_vec", block_size);

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD.cc
@@ -738,7 +738,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
   prof.tic("setup");
   using SDD = Alina::DistributedSubDomainDeflation<Alina::PreconditionerRuntime<Backend>,
                                                    Alina::DistributedSolverRuntime<Backend>,
-                                                   Alina::DistributedDirectSolverRuntime<double>>;
+                                                   Alina::DistributedDirectSolverRuntime<Backend>>;
 
   SDD solve(world, std::tie(chunk, ptr, col, val), prm, bprm);
   prof.toc("setup");

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD3D.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD3D.cc
@@ -330,7 +330,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
     prof.tic("setup");
     using SDD = DistributedSubDomainDeflation<RelaxationAsPreconditioner<Backend, RelaxationRuntime>,
                                               DistributedSolverRuntime<Backend>,
-                                              DistributedDirectSolverRuntime<double>>;
+                                              DistributedDirectSolverRuntime<Backend>>;
 
     SDD solve(world, std::tie(chunk, ptr, col, val), prm, bprm);
     prof.toc("setup");
@@ -346,7 +346,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
     prof.tic("setup");
     using SDD = DistributedSubDomainDeflation<AMG<Backend, CoarseningRuntime, RelaxationRuntime>,
                                               DistributedSolverRuntime<Backend>,
-                                              DistributedDirectSolverRuntime<double>>;
+                                              DistributedDirectSolverRuntime<Backend>>;
 
     SDD solve(world, std::tie(chunk, ptr, col, val), prm, bprm);
     prof.toc("setup");

--- a/arccore/src/alina/arccore/alina/samples/DistributedSCHUR.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedSCHUR.cc
@@ -304,7 +304,7 @@ int main(int argc, char* argv[])
       DistributedSubDomainDeflation<
         AMG<Backend, CoarseningRuntime, RelaxationRuntime>,
         DistributedSolverRuntime<Backend>,
-        DistributedDirectSolverRuntime<double>>>,
+        DistributedDirectSolverRuntime<Backend>>>,
     DistributedSolverRuntime<Backend>>
   Solver;
 


### PR DESCRIPTION
This will allow us to use a backend other than the default backend for these direct solvers.