### PR TITLE
Improve support for polygon types in standard mesh

### DIFF
--- a/arcane/src/arcane/core/ItemTypeInfo.h
+++ b/arcane/src/arcane/core/ItemTypeInfo.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemTypeInfo.h                                              (C) 2000-2025 */
+/* ItemTypeInfo.h                                              (C) 2000-2026 */
 /*                                                                           */
 /* Informations sur un type d'entité du maillage.                            */
 /*---------------------------------------------------------------------------*/
@@ -137,6 +137,12 @@ class ItemTypeInfo
   const ItemTypeInfo* linearTypeInfo() const { return m_mng->typeFromId(m_linear_type_id); }
   //! Indique si le type a un noeud au centre
   bool hasCenterNode() const { return m_has_center_node; }
+  /*!
+   * \brief Indique si le type est un polygone.
+   *
+   * Un polygone est un élément 2D d'ordre 1 contenant au moins 5 noeuds.
+   */
+  bool isPolygon() const { return m_is_polygon; }
 
  public:
 
@@ -167,6 +173,8 @@ class ItemTypeInfo
   bool m_is_valid_for_cell = true;
   //! Indique si le type a un nœud au centre (pour les faces ou les mailles)
   bool m_has_center_node = false;
+  //! Indique si le type est un polygone
+  bool m_is_polygon = false;
   Integer m_nb_node = 0;
   Integer m_nb_edge = 0;
   Integer m_nb_face = 0;

--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemTypeInfoBuilder.cc                                      (C) 2000-2025 */
+/* ItemTypeInfoBuilder.cc                                      (C) 2000-2026 */
 /*                                                                           */
 /* Constructeur de type d'entité de maillage.                                */
 /*---------------------------------------------------------------------------*/
@@ -52,6 +52,7 @@ setInfos(ItemTypeMng* mng, ItemTypeId type_id, String type_name,
   m_nb_node = nb_node;
   m_type_name = type_name;
   _setNbEdgeAndFace(nb_edge, nb_face);
+  _checkSetIsPolygon();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -92,6 +93,7 @@ setOrder(Int16 order, ItemTypeId linear_type_id)
 {
   m_order = order;
   m_linear_type_id = linear_type_id;
+  _checkSetIsPolygon();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -483,6 +485,15 @@ _setNbEdgeAndFace(Integer nb_edge, Integer nb_face)
     m_first_item_index = buf.size();
     buf.resize(m_first_item_index + total);
   }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void ItemTypeInfoBuilder::
+_checkSetIsPolygon()
+{
+  m_is_polygon = (m_order == 1 && m_dimension == 2 && m_nb_node > 4);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemTypeInfoBuilder.h
+++ b/arcane/src/arcane/core/ItemTypeInfoBuilder.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ItemTypeInfoBuilder.h                                       (C) 2000-2025 */
+/* ItemTypeInfoBuilder.h                                       (C) 2000-2026 */
 /*                                                                           */
 /* Construction d'un type d'entité du maillage.                              */
 /*---------------------------------------------------------------------------*/
@@ -26,7 +26,6 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \internal
  * \brief Construction des infos d'un type d'entité du maillage.
@@ -198,6 +197,7 @@ class ItemTypeInfoBuilder
 
   void _setNbEdgeAndFace(Integer nb_edge,Integer nb_face);
   void _checkDimension(Int16 dim);
+  void _checkSetIsPolygon();
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemTypeMng.cc
+++ b/arcane/src/arcane/core/ItemTypeMng.cc
@@ -42,6 +42,12 @@
 
 namespace Arcane
 {
+namespace
+{
+  // Nombre de noeuds pour les types polygones additionnels.
+  // Les types jusqu'à ITI_Octogon8 existent toujours.
+  Int16 global_polygon_begin_nb_node = 9;
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -208,10 +214,10 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->addFaceVertex(1, 1);
   }
 
-  /**
-   * SDP: Pour les polygones les faces et les arêtes sont identiques.
+  /*
+   * Pour les polygones les faces et les arêtes sont identiques.
    *
-   * @note lors des declarations des arêtes, on donne pour faces les
+   * \note lors des declarations des arêtes, on donne pour faces les
    * arêtes qui sont jointes a l'arête courante
    */
 
@@ -266,15 +272,7 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
 
   // Quad4
   {
-    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
-    m_types[IT_Quad4] = type;
-
-    type->setInfos(this, IT_Quad4, "Quad4", Dimension::Dim2, 4, 4, 4);
-
-    type->addEdgeAndFaceLine(0, { 0, 1 }, { 3, 1 });
-    type->addEdgeAndFaceLine(1, { 1, 2 }, { 0, 2 });
-    type->addEdgeAndFaceLine(2, { 2, 3 }, { 1, 3 });
-    type->addEdgeAndFaceLine(3, { 3, 0 }, { 2, 0 });
+    _addPolygonType(IT_Quad4, 4, "Quad4");
   }
 
   // Quad8
@@ -319,46 +317,12 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
 
   // Pentagon5
   {
-    _addPolygonType(IT_Pentagon5,5, "Pentagon5");
-    // ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
-    // m_types[IT_Pentagon5] = type;
-
-    // type->setInfos(this, IT_Pentagon5, "Pentagon5", Dimension::Dim2, 5, 5, 5);
-
-    // type->addFaceLine(0, 0, 1);
-    // type->addFaceLine(1, 1, 2);
-    // type->addFaceLine(2, 2, 3);
-    // type->addFaceLine(3, 3, 4);
-    // type->addFaceLine(4, 4, 0);
-
-    // type->addEdge(0, 0, 1, 4, 1);
-    // type->addEdge(1, 1, 2, 0, 2);
-    // type->addEdge(2, 2, 3, 1, 3);
-    // type->addEdge(3, 3, 4, 2, 4);
-    // type->addEdge(4, 4, 0, 3, 0);
+    _addPolygonType(IT_Pentagon5, 5, "Pentagon5");
   }
 
   // Hexagon6
   {
-    _addPolygonType(IT_Hexagon6,6, "Hexagon6");
-    // ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
-    // m_types[IT_Hexagon6] = type;
-
-    // type->setInfos(this, IT_Hexagon6, "Hexagon6", Dimension::Dim2, 6, 6, 6);
-
-    // type->addFaceLine(0, 0, 1);
-    // type->addFaceLine(1, 1, 2);
-    // type->addFaceLine(2, 2, 3);
-    // type->addFaceLine(3, 3, 4);
-    // type->addFaceLine(4, 4, 5);
-    // type->addFaceLine(5, 5, 0);
-
-    // type->addEdge(0, 0, 1, 5, 1);
-    // type->addEdge(1, 1, 2, 0, 2);
-    // type->addEdge(2, 2, 3, 1, 3);
-    // type->addEdge(3, 3, 4, 2, 4);
-    // type->addEdge(4, 4, 5, 3, 5);
-    // type->addEdge(5, 5, 0, 4, 0);
+    _addPolygonType(IT_Hexagon6, 6, "Hexagon6");
   }
 
   // Hexaedron8
@@ -934,35 +898,12 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
 
   // Heptagon7
   {
-    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
-    m_types[IT_Heptagon7] = type;
-
-    type->setInfos(this, IT_Heptagon7, "Heptagon7", Dimension::Dim2, 7, 7, 7);
-
-    type->addEdgeAndFaceLine(0, { 0, 1 }, { 6, 1 });
-    type->addEdgeAndFaceLine(1, { 1, 2 }, { 0, 2 });
-    type->addEdgeAndFaceLine(2, { 2, 3 }, { 1, 3 });
-    type->addEdgeAndFaceLine(3, { 3, 4 }, { 2, 4 });
-    type->addEdgeAndFaceLine(4, { 4, 5 }, { 3, 5 });
-    type->addEdgeAndFaceLine(5, { 5, 6 }, { 4, 6 });
-    type->addEdgeAndFaceLine(6, { 6, 0 }, { 5, 0 });
+    _addPolygonType(IT_Heptagon7, 7, "Heptagon7");
   }
 
   // Octogon8
   {
-    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
-    m_types[IT_Octogon8] = type;
-
-    type->setInfos(this, IT_Octogon8, "Octogon8", Dimension::Dim2, 8, 8, 8);
-
-    type->addEdgeAndFaceLine(0, { 0, 1 }, { 7, 1 });
-    type->addEdgeAndFaceLine(1, { 1, 2 }, { 0, 2 });
-    type->addEdgeAndFaceLine(2, { 2, 3 }, { 1, 3 });
-    type->addEdgeAndFaceLine(3, { 3, 4 }, { 2, 4 });
-    type->addEdgeAndFaceLine(4, { 4, 5 }, { 3, 5 });
-    type->addEdgeAndFaceLine(5, { 5, 6 }, { 4, 6 });
-    type->addEdgeAndFaceLine(6, { 6, 7 }, { 5, 7 });
-    type->addEdgeAndFaceLine(7, { 7, 0 }, { 6, 0 });
+    _addPolygonType(IT_Octogon8, 8, "Octogon8");
   }
 
   // Cell3D_Line2
@@ -1119,7 +1060,6 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     }
   }
 
-
   { // Polygon & Polyhedron: generic item types
     String arcane_item_type_file = platform::getEnvironmentVariable("ARCANE_ITEM_TYPE_FILE");
     if (!arcane_item_type_file.null()) {
@@ -1148,8 +1088,8 @@ buildPolygonTypes()
     return;
   m_has_polygon_type = true;
   // Ajoute les types polygones génériques
-  // Ils commencent à 7 noeuds.
-  Int16 begin_nb_node = 7;
+  // Ils commencent à 9 noeuds.
+  const Int16 begin_nb_node = global_polygon_begin_nb_node;
   Int16 max_nb_node = 21;
   Int16 max_type = IT_GenericPolygon + max_nb_node - begin_nb_node;
   ItemTypeInfo* null_type = typeFromId(IT_NullType);
@@ -1173,7 +1113,6 @@ buildPolygonTypes()
 void ItemTypeMng::
 _addPolygonType(Int16 type_id, Int32 nb_node, const String& type_name)
 {
-  m_trace->info() << "AddPolygonType type_id=" << type_id << " nb_node=" << nb_node << " name=" << type_name;
   ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
   m_types[type_id] = type;
   type->setInfos(this, type_id, type_name, ItemTypeInfoBuilder::Dimension::Dim2, nb_node, nb_node, nb_node);
@@ -1520,6 +1459,35 @@ setMeshWithGeneralCells(IMesh* mesh) noexcept
 {
   ARCANE_ASSERT(mesh, ("Trying to indicate a null mesh contains general cells."));
   m_mesh_with_general_cells.insert(mesh);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ItemTypeId ItemTypeMng::
+getPolygonType(Int16 nb_node) const
+{
+  ItemTypeId polygon_type;
+  if (nb_node == 3)
+    polygon_type = ITI_Triangle3;
+  else if (nb_node == 4)
+    polygon_type = ITI_Quad4;
+  else if (nb_node == 5)
+    polygon_type = ITI_Pentagon5;
+  else if (nb_node == 6)
+    polygon_type = ITI_Hexagon6;
+  else if (nb_node == 7)
+    polygon_type = ITI_Heptagon7;
+  else if (nb_node == 8)
+    polygon_type = ITI_Octogon8;
+  else if (nb_node > 8 && nb_node < 20) {
+    if (!m_has_polygon_type)
+      ARCANE_THROW(NotSupportedException, "extended polygon requested (nb_node={0}) but ItemTypeMng::buildPolygonTypes() has not been called", nb_node);
+    polygon_type = ItemTypeId(ITI_GenericPolygon.typeId() + nb_node - 9);
+  }
+  else
+    ARCANE_THROW(NotSupportedException, "polygon with nb_node={0} (3<=nb_node<=20)", nb_node);
+  return polygon_type;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/ItemTypeMng.h
+++ b/arcane/src/arcane/core/ItemTypeMng.h
@@ -169,6 +169,18 @@ class ARCANE_CORE_EXPORT ItemTypeMng
    */
   void buildPolygonTypes();
 
+  /*!
+   * \brief Retourne le type pour un polygone ayant \a nb_node.
+   *
+   * Si \a nb_node est comprise entre 3 et 8 inclus, retourne le type
+   * interne correspondant (ITI_Triangle3, ITI_Quad4, ..., ITI_Octogon8).
+   * Sinon, retourne le type additionnel à condition que buildPolygonTypes()
+   * ait été appelé avant.
+   *
+   * Lève une exception NotSupportedException si aucun type ne correspond.
+   */
+  ItemTypeId getPolygonType(Int16 nb_node) const;
+
   //! nombre de types disponibles
   static Integer nbBasicItemType();
 

--- a/arcane/src/arcane/core/VtkCellTypes.cc
+++ b/arcane/src/arcane/core/VtkCellTypes.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VtkCellTypes.cc                                             (C) 2000-2025 */
+/* VtkCellTypes.cc                                             (C) 2000-2026 */
 /*                                                                           */
 /* Définitions des types de maille de VTK.                                   */
 /*---------------------------------------------------------------------------*/
@@ -58,6 +58,10 @@ vtkToArcaneCellType(int vtk_type, Int32 nb_node)
       return IT_Pentagon5;
     if (nb_node == 6)
       return IT_Hexagon6;
+    if (nb_node == 7)
+      return IT_Heptagon7;
+    if (nb_node == 8)
+      return IT_Octogon8;
     ARCANE_THROW(IOException, "Unsupported VtkCellType VTK_POLYGON with nb_node={0}", nb_node);
   case VTK_TETRA:
     return IT_Tetraedron4;
@@ -123,11 +127,10 @@ arcaneToVtkCellTypeNoThrow(Int16 arcane_type)
   case IT_Cell3D_Quad9:
     return VTK_BIQUADRATIC_QUAD;
   case IT_Pentagon5:
-    return VTK_POLYGON;
-    // VTK_POLYGON (a tester...)
   case IT_Hexagon6:
+  case IT_Heptagon7:
+  case IT_Octogon8:
     return VTK_POLYGON;
-    // VTK_POLYGON (a tester ...)
   case IT_Tetraedron4:
     return VTK_TETRA;
   case IT_Tetraedron10:

--- a/arcane/src/arcane/hdf5/MEDMeshReaderService.cc
+++ b/arcane/src/arcane/hdf5/MEDMeshReaderService.cc
@@ -532,6 +532,7 @@ _readAndCreateCells(IPrimaryMesh* mesh, Int32 mesh_dimension, med_idt fid, const
   UniqueArray<med_int> med_connectivity;
   UniqueArray<med_int> med_family_values;
 
+  ItemTypeMng* itm = mesh->itemTypeMng();
   // Alloue les mailles types par type.
   // Parcours les types disponibles et traite ceux qui correspondent à la dimension
   // du maillage.
@@ -572,21 +573,7 @@ _readAndCreateCells(IPrimaryMesh* mesh, Int32 mesh_dimension, med_idt fid, const
       ++cell_unique_id;
       if (is_polygon) {
         nb_item_node = polygon_nb_nodes[i];
-        // En dessous de 7 noeuds, le type est un type interne.
-        // Sinon c'est un polygone.
-        if (nb_item_node == 3)
-          arcane_type = ITI_Triangle3;
-        else if (nb_item_node == 4)
-          arcane_type = ITI_Quad4;
-        else if (nb_item_node == 5)
-          arcane_type = ITI_Pentagon5;
-        else if (nb_item_node == 6)
-          arcane_type = ITI_Hexagon6;
-        else if (nb_item_node > 6 && nb_item_node < 20)
-          arcane_type = ItemTypeId(ITI_GenericPolygon.typeId() + nb_item_node - 7);
-        else
-          ARCANE_THROW(NotSupportedException, "polygon with nb_node={0} (3<=nb_node<=20)", nb_item_node);
-
+        arcane_type = itm->getPolygonType(static_cast<Int16>(nb_item_node));
         cells_infos[cells_infos_index] = arcane_type;
         ++cells_infos_index;
         cells_infos[cells_infos_index] = current_cell_unique_id;

--- a/arcane/src/arcane/std/VtkMeshIOService.cc
+++ b/arcane/src/arcane/std/VtkMeshIOService.cc
@@ -1940,7 +1940,13 @@ _writeMeshToFile(IMesh* mesh, const String& file_name, eItemKind cell_kind)
     // Le type doit être coherent avec celui de vtkCellType.h
     ofile << "CELL_TYPES " << nb_cell_kind << "\n";
     ENUMERATE_ (ItemWithNodes, iitem, cell_kind_family->allItems()) {
-      int type = arcaneToVtkCellType(iitem->typeInfo());
+      const ItemTypeInfo* iti = iitem->typeInfo();
+      // Regarde si le type est un polygone pour VTK (dimension 2 et plus de 4 noeuds)
+      int type = VTK_BAD_ARCANE_TYPE;
+      if (iti->isPolygon())
+        type = VTK_POLYGON;
+      else
+        type = arcaneToVtkCellType(iti);
       ofile << type << '\n';
     }
   }

--- a/arcane/src/arcane/tests/CMakeLists.txt
+++ b/arcane/src/arcane/tests/CMakeLists.txt
@@ -835,6 +835,9 @@ endif()
 if(${VTK_PACKAGE_PREFIX}IOXML_FOUND)
   arcane_add_test_sequential(ios_vtu testIos-vtu.arc)
 endif()
+if(MEDFile_FOUND)
+  arcane_add_test_sequential(ios_med_polygon testIos-med-polygon.arc)
+endif()
 
 ###############
 # HYODA TESTS #
@@ -1404,6 +1407,9 @@ if (SLOOP_FOUND)
 endif ()
 
 arcane_add_test(simple_heat_3d testSimpleHeat3D.arc)
+if(MEDFile_FOUND)
+  arcane_add_test(simple_heat_med_polygon testSimpleHeat-med-polygon.arc)
+endif()
 
 # ----------------------------------------------------------------------------
 

--- a/arcane/tests/testIos-med-polygon.arc
+++ b/arcane/tests/testIos-med-polygon.arc
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<case codename="ArcaneTest" xml:lang="en" codeversion="1.0">
+  <arcane>
+    <titre>Test IO Reader/Writer for MED and VTK with polygons</titre>
+    <description>Test IO Reader/Writer for MED and VTK with polygons</description>
+    <timeloop>UnitTest</timeloop>
+  </arcane>
+
+ <mesh>
+   <file internal-partition="true">circle_cut-poly.med</file>
+   
+ </mesh>
+ 
+  <unit-test-module>
+    <test name="IosUnitTest">
+      <write-vtu>false</write-vtu>
+      <write-xmf>false</write-xmf>
+      <write-msh>false</write-msh>
+      <write-vtk-legacy>true</write-vtk-legacy>
+    </test>
+  </unit-test-module>
+</case>

--- a/arcane/tests/testSimpleHeat-med-polygon.arc
+++ b/arcane/tests/testSimpleHeat-med-polygon.arc
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<case codename="ArcaneTest" xml:lang="en" codeversion="1.0">
+  <arcane>
+    <title>Sample</title>
+    <timeloop>SimpleHeatTestLoop</timeloop>
+  </arcane>
+
+  <meshes>
+    <mesh>
+      <filename>circle_cut-poly.med</filename>
+    </mesh>
+  </meshes>
+
+  <arcane-post-processing>
+    <output-period>10</output-period>
+    <output>
+      <variable>CellTemperature</variable>
+      <variable>NodeTemperature</variable>
+    </output>
+  </arcane-post-processing>
+  <simple-heat>
+    <nb-iteration>50</nb-iteration>
+  </simple-heat>
+</case>


### PR DESCRIPTION
- Use existing types `IT_Heptagon7` and `IT_Octogon8` pour polygon with 7 and 8 nodes
- Add `ItemTypeInfo::isPolygon()` to know if a type is a polygon
- Add `ItemTypeMng::getPolygonType()` to get the polygon type for a given number of nodes
- Add support to write polygonal mesh in VTKLegacy writer
- Add support to read polygon mesh with up to 8 nodes for a polygon in VTKLegacy reader