### PR TITLE
Begin support for iteration over a subset of constituent container

### DIFF
--- a/arcane/src/arcane/core/materials/ComponentItemVectorView.h
+++ b/arcane/src/arcane/core/materials/ComponentItemVectorView.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ComponentItemVectorView.h                                   (C) 2000-2024 */
+/* ComponentItemVectorView.h                                   (C) 2000-2026 */
 /*                                                                           */
 /* Vue sur un vecteur sur des entités de constituants.                       */
 /*---------------------------------------------------------------------------*/
@@ -63,6 +63,10 @@ class ARCANE_CORE_EXPORT ComponentItemVectorView
   friend class LambdaMatItemRangeFunctorT;
   template <typename DataType> friend class
   MaterialVariableArrayTraits;
+
+ public:
+
+ using ValueType = ComponentCell;
 
  public:
 
@@ -163,6 +167,10 @@ class ARCANE_CORE_EXPORT MatItemVectorView
 
  public:
 
+  using ValueType = MatCell;
+
+ public:
+
   MatItemVectorView() = default;
 
  private:
@@ -217,6 +225,10 @@ class ARCANE_CORE_EXPORT EnvItemVectorView
   friend class MeshEnvironment;
   template <typename ViewType, typename LambdaType>
   friend class LambdaMatItemRangeFunctorT;
+
+ public:
+
+  using ValueType = EnvCell;
 
  public:
 

--- a/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
+++ b/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
@@ -163,7 +163,6 @@ class ConstituentItemIndexedSelectionView
 
     ValueType operator*() const { return m_view->item(m_index); }
     Iterator& operator++() { ++m_index; return *this; };
-    Integer index() const { return index; }
     explicit(false) operator ComponentItemLocalId() const { return m_view->item(m_index); }
 
     friend bool operator!=(const Iterator& a, const Iterator& other)

--- a/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
+++ b/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
@@ -1,0 +1,291 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ConstituentItemIndexedSelectionView.h                       (C) 2000-2026 */
+/*                                                                           */
+/* Vue sur un sous ensemble d'un conteneur de ConstituentItem.               */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_CORE_MATERIALS_CONSTITUENTITEMINDEXEDSELECTIONVIEW_H
+#define ARCANE_CORE_MATERIALS_CONSTITUENTITEMINDEXEDSELECTIONVIEW_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/core/materials/MaterialsCoreGlobal.h"
+#include "arcane/core/materials/ComponentItemVectorView.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Materials::Impl
+{
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Caractéristiques pour le conteneur associé à
+ * ConstituentItemIndexedSelectionView.
+ *
+ * Cette classe doit être spécialisée. Elle l'est pour les conteneurs
+ * de type ComponentItemVectorView, MatCellVectorView, EnvCellVectorView
+ * ou SmallSpan<T>, avec T de type ComponentCell, MatCell ou EnvCell.
+ */
+template <typename ContainerType_>
+struct ConstituentItemIndexedSelectionViewTraits;
+
+template <typename ConstituentContainerType_>
+struct ConstituentItemIndexedSelectionViewTraitsBase
+{
+  using ThatContainer = ConstituentContainerType_;
+  using ValueType = ThatContainer::ValueType;
+  static constexpr bool IsSpan() { return false; }
+  static ARCCORE_HOST_DEVICE Int32 size(ThatContainer v)
+  {
+    return v.nbItem();
+  }
+};
+
+template <>
+struct ConstituentItemIndexedSelectionViewTraits<ComponentItemVectorView>
+: ConstituentItemIndexedSelectionViewTraitsBase<ComponentItemVectorView>
+{
+  static ARCCORE_HOST_DEVICE ComponentCell item(ComponentItemVectorView v, Int32 i)
+  {
+    return v.componentCell(i);
+  }
+};
+
+template <>
+struct ConstituentItemIndexedSelectionViewTraits<MatCellVectorView>
+: ConstituentItemIndexedSelectionViewTraitsBase<MatCellVectorView>
+{
+  static ARCCORE_HOST_DEVICE MatCell item(MatCellVectorView v, Int32 i)
+  {
+    return v.matCell(i);
+  }
+};
+
+template <>
+struct ConstituentItemIndexedSelectionViewTraits<EnvCellVectorView>
+: ConstituentItemIndexedSelectionViewTraitsBase<EnvCellVectorView>
+{
+  static ARCCORE_HOST_DEVICE EnvCell item(EnvCellVectorView v, Int32 i)
+  {
+    return v.envCell(i);
+  }
+};
+
+//! Spécialisation partielle pour un SmallSpan<T>
+template <typename ConstituentItemType_>
+class ConstituentItemIndexedSelectionViewTraitsSpanBase
+{
+  using ThatContainer = SmallSpan<const ConstituentItemType_>;
+  using ValueType = ConstituentItemType_;
+  static constexpr bool IsSpan() { return true; }
+  static ARCCORE_HOST_DEVICE Int32 size(ThatContainer v)
+  {
+    return v.size();
+  }
+  static ARCCORE_HOST_DEVICE ValueType item(ThatContainer v, Int32 i)
+  {
+    return v[i];
+  }
+};
+
+template <>
+struct ConstituentItemIndexedSelectionViewTraits<SmallSpan<const ConstituentItem>>
+: ConstituentItemIndexedSelectionViewTraitsSpanBase<ConstituentItem>
+{
+};
+template <>
+struct ConstituentItemIndexedSelectionViewTraits<SmallSpan<const MatCell>>
+: ConstituentItemIndexedSelectionViewTraitsSpanBase<MatCell>
+{
+};
+template <>
+struct ConstituentItemIndexedSelectionViewTraits<SmallSpan<const EnvCell>>
+: ConstituentItemIndexedSelectionViewTraitsSpanBase<EnvCell>
+{
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Materials::Impl
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Materials
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Vue sur un sous ensemble d'un conteneur de ConstituentItem.
+ *
+ * Le conteneur est l'argument template \a ContainerView_. Il peut
+ * s'agit d'un ComponentItemVectorView, MatCellVectorView, EnvCellVectorView
+ * ou juste d'un SmallSpan d'un ConstituentItem.
+ * La sélection des entités se fait par un tableau d'indices.
+ * Si ce tableau n'est pas fourni, la sélection est sur l'ensemble
+ * Classe générique d'adaptation pour une utilisation dans les boucles Arcane (RUNCOMMAND_ENUMERATE_*)
+ */
+template <typename ContainerView_>
+class ConstituentItemIndexedSelectionView
+{
+ public:
+
+  using ItemVecView = ContainerView_;
+  using ThatClass = ConstituentItemIndexedSelectionView;
+  using IndexArrayView = const SmallSpan<const Int32>;
+  using TraitsType = Impl::ConstituentItemIndexedSelectionViewTraits<ContainerView_>;
+  using ValueType = TraitsType::ValueType;
+  static constexpr bool IsSpanContainer() { return TraitsType::IsSpan(); }
+
+ public:
+
+  /*!
+   * Classe d'itérateur pour une utilisation dans les boucles Arcane non accélérées (ENUMERATE_ENVCELL et associées)
+   */
+  class Iterator
+  {
+   public:
+
+    Iterator(const ConstituentItemIndexedSelectionView* view, Int32 index)
+    : m_view(view)
+    , m_index(index)
+    {}
+
+   public:
+
+    ValueType operator*() const { return m_view->item(m_index); }
+    Iterator& operator++() { ++m_index; return *this; };
+    Integer index() const { return index; }
+    explicit(false) operator ComponentItemLocalId() const { return m_view->item(m_index); }
+
+    friend bool operator!=(const Iterator& a, const Iterator& other)
+    {
+      return &a.m_view != &(other.m_view) && a.m_index != other.m_index;
+    }
+
+   private:
+
+    const ConstituentItemIndexedSelectionView* m_view = nullptr;
+    Int32 m_index = 0;
+  };
+
+ public:
+
+  ConstituentItemIndexedSelectionView(ItemVecView ecv, IndexArrayView indices)
+  : m_container_view(ecv)
+  , m_selection_view(indices)
+  {
+  }
+
+  //! Construit une sélection contenant tous les éléments de \view
+  explicit ConstituentItemIndexedSelectionView(ItemVecView view)
+  requires(!IsSpanContainer())
+  : m_container_view(view)
+  , m_selection_view(nullptr, TraitsType::size(m_container_view))
+  , m_is_full_selection(true)
+  {
+  }
+
+  //! Constructeur à partir d'une vue de ConstituentCell, de MatCell ou EnvCell
+  explicit ConstituentItemIndexedSelectionView(IMeshComponent* constituent, SmallSpan<const ValueType> ecv)
+  requires(IsSpanContainer())
+  : m_container_view(ecv)
+  , m_selection_view(nullptr, TraitsType::size(m_container_view))
+  , m_is_full_selection(true)
+  {
+  }
+
+  //! indique si la selection est triviale ou pleine, c'est à dire que l'on a pas de liste d'indices et doit considerer toutes les EnvCell d'origine
+  constexpr bool isFullSelection() const { return m_is_full_selection; }
+
+  //! nombre de EnvCell sélectionnées
+  ARCCORE_HOST_DEVICE Int32 size() const { return m_selection_view.size(); }
+
+  // nombre total de mailles du milieu
+  ARCCORE_HOST_DEVICE Int32 sourceSize() const { return TraitsType::size(m_container_view); }
+
+  // vue sur le vecteur de EnvCell d'origine (toutes les mailles du milieu)
+  ItemVecView sourceView() const { return m_container_view; }
+
+  // le contenu de 'selectionView()' ne doit pas être utilisé quand la selection est dite 'pleine' (aka triviale) et que tous les EnvCell sont selectionnés
+  IndexArrayView selectionView() const
+  {
+    return isFullSelection() ? IndexArrayView{} : m_selection_view.constSmallView();
+  }
+
+  Iterator begin() const { return Iterator(this, 0); }
+  Iterator end() const { return Iterator(this, size()); }
+
+  ARCCORE_HOST_DEVICE ValueType operator[](Int32 i) const
+  {
+    return item(i);
+  }
+  ARCCORE_HOST_DEVICE ValueType item(Int32 i) const
+  {
+    ARCANE_CHECK_AT(i, size());
+    return TraitsType::item(m_container_view, m_is_full_selection ? i : m_selection_view[i]);
+  }
+
+ private:
+
+  //! Vue sur les éléments d'origine
+  ItemVecView m_container_view;
+
+  /*!
+   * \brief Sélection.
+   *
+   * Si ce champ est omis à la construction, le défaut sera une sélection 'pleine'
+   * (i.e. tous les éléments d'origine, dans le même ordre)
+   */
+  IndexArrayView m_selection_view = {};
+
+  //! Indique si la sélection est pleine.
+  const bool m_is_full_selection = false;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// types raccourcis pour des vues sur des selections de 'constituants' Arcane
+using EnvCellVectorSelectionView = ConstituentItemIndexedSelectionView<EnvCellVectorView>;
+using MatCellVectorSelectionView = ConstituentItemIndexedSelectionView<MatCellVectorView>;
+using ComponentCellVectorSelectionView = ConstituentItemIndexedSelectionView<ComponentCellVectorView>;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// permet de selectionner un "RunCommandTraits" qui sait parcourir une selection d'éléments Arcane
+template <typename ContainerViewT, typename ItemTypeT>
+struct GenericItemSelectionEnumeratorType
+{
+  using ContainerView = ContainerViewT;
+  using IndexArrayView = typename ConstituentItemIndexedSelectionView<ContainerViewT>::IndexArrayView;
+  using ItemType = ItemTypeT;
+};
+
+/*
+ * Raccourcis vers des types d'énumérateurs, utilisés dans les macros RUNCOMMAND_XXX_ENUMERATE comme premier argument
+ * si on utilise SelEnvCell, le type d'énumérateurs récupéré dans le foncteur sera toujours un EnvCell
+ * pour etre au maximum compatible avec du code existant.
+ */
+using SelEnvCell = GenericItemSelectionEnumeratorType<EnvCellVectorView, EnvCell>;
+using SelMatCell = GenericItemSelectionEnumeratorType<MatCellVectorView, MatCell>;
+using SelCompCell = GenericItemSelectionEnumeratorType<ComponentCellVectorView, ComponentCell>;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Materials
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/core/materials/MaterialsCoreGlobal.cc
+++ b/arcane/src/arcane/core/materials/MaterialsCoreGlobal.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2023 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MaterialsCoreGlobal.cc                                      (C) 2000-2023 */
+/* MaterialsCoreGlobal.cc                                      (C) 2000-2026 */
 /*                                                                           */
 /* Déclarations générales des matériaux de Arcane.                           */
 /*---------------------------------------------------------------------------*/
@@ -25,6 +25,7 @@
 // Pas utilisé directement mais nécessaire pour l'exportation des symboles.
 #include "arcane/core/materials/internal/IMeshComponentInternal.h"
 #include "arcane/core/materials/internal/IMeshMaterialMngInternal.h"
+#include "arcane/core/materials/ConstituentItemIndexedSelectionView.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
+++ b/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MaterialsCoreGlobal.h                                       (C) 2000-2025 */
+/* MaterialsCoreGlobal.h                                       (C) 2000-2026 */
 /*                                                                           */
 /* Déclarations générales des matériaux de Arcane.                           */
 /*---------------------------------------------------------------------------*/
@@ -116,6 +116,9 @@ class MeshEnvironment;
 class MeshComponentData;
 class EnvCellVector;
 class MatCellVector;
+
+template <typename ContainerView_>
+class ConstituentItemIndexedSelectionView;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/srcs.cmake
+++ b/arcane/src/arcane/core/srcs.cmake
@@ -35,6 +35,7 @@ set(ARCANE_MATERIALS_SOURCES
   materials/ComponentItemVectorView.h
   materials/ComponentPartItemVectorView.cc
   materials/ComponentPartItemVectorView.h
+  materials/ConstituentItemIndexedSelectionView.h
   materials/ConstituentItemVectorBuildInfo.h
   materials/ConstituentItemVectorBuildInfo.cc
   materials/ConstituentItemLocalIdList.cc

--- a/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/MeshMaterialAcceleratorUnitTest.cc
@@ -13,8 +13,6 @@
 
 #include "arcane/core/IMeshModifier.h"
 
-#include "arcane/utils/ScopedPtr.h"
-#include "arcane/utils/ArithmeticException.h"
 #include "arcane/utils/ValueChecker.h"
 #include "arcane/utils/IMemoryAllocator.h"
 #include "arcane/utils/MemoryUtils.h"
@@ -34,13 +32,8 @@
 #include "arcane/materials/MeshEnvironmentBuildInfo.h"
 #include "arcane/materials/MeshMaterialModifier.h"
 #include "arcane/materials/MatCellVector.h"
-#include "arcane/materials/EnvCellVector.h"
 #include "arcane/materials/MatItemEnumerator.h"
-#include "arcane/materials/MeshMaterialVariableRef.h"
-#include "arcane/materials/MeshEnvironmentVariableRef.h"
-#include "arcane/materials/MeshEnvironmentVariableRef.h"
 #include "arcane/materials/EnvItemVector.h"
-#include "arcane/materials/CellToAllEnvCellConverter.h"
 #include "arcane/materials/internal/AllCellToAllEnvCellContainer.h"
 
 #include "arcane/accelerator/core/Runner.h"
@@ -52,8 +45,100 @@
 #include "arcane/accelerator/RunCommandMaterialEnumerate.h"
 #include "arcane/accelerator/AsyncRunQueuePool.h"
 #include "arcane/accelerator/Reduce.h"
+#include "arcane/core/materials/ConstituentItemIndexedSelectionView.h"
 
 #include "arcane/accelerator/RunCommandEnumerate.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Materials
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// Variante ItemRunCommand (c.f. RunCommandEnumerate.h dans Arcane) permettant de parcourir une instance du template ConstituentItemIndexedSelectionView
+template <typename GenericEnumeratorT>
+struct GenericItemSelectionRunCommand
+{
+  using ThatClass = GenericItemSelectionRunCommand<GenericEnumeratorT>;
+  using CommandType = ThatClass;
+  using IteratorValueType = typename GenericEnumeratorT::ItemType;
+  using ContainerCreateViewType = ConstituentItemIndexedSelectionView<typename GenericEnumeratorT::ContainerView>;
+  using Container = ContainerCreateViewType;
+
+  static CommandType create(Accelerator::RunCommand& run_command, const Container& items)
+  {
+    return CommandType(run_command, items);
+  }
+
+  explicit GenericItemSelectionRunCommand(Accelerator::RunCommand& command, const Container& items)
+  : m_command(command)
+  , m_items(items)
+  {}
+
+  Accelerator::RunCommand& m_command;
+  Container m_items;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Materials
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// Spécialisation des implementations Arcane
+namespace Arcane::Accelerator::impl
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+// Base du RunCommandTraits qui fait le lien entre le type d'énumerateur d'élément et le type de vue sur le contenur et les valeurs associées
+template <typename GenericEnumeratorT>
+class RunCommandConstituentItemTraitsBaseT<::Arcane::Materials::GenericItemSelectionRunCommand<GenericEnumeratorT>>
+{
+ public:
+
+  using CommandType = ::Arcane::Materials::GenericItemSelectionRunCommand<GenericEnumeratorT>;
+  using IteratorValueType = CommandType::IteratorValueType;
+  using ContainerType = CommandType::Container;
+  using ContainerCreateViewType = CommandType::ContainerCreateViewType;
+
+ public:
+
+  static ContainerType createContainer(const ContainerCreateViewType& items)
+  {
+    return ContainerType{ items };
+  }
+};
+
+// Specialisation des classes d'implémentation Arcane pour pouvoir utiliser nos vues et énumerateurs customisés
+template <typename ContainerViewT, typename ItemTypeT>
+class RunCommandConstituentItemEnumeratorTraitsT<::Arcane::Materials::GenericItemSelectionEnumeratorType<ContainerViewT, ItemTypeT>>
+: public RunCommandConstituentItemTraitsBaseT<::Arcane::Materials::GenericItemSelectionRunCommand<::Arcane::Materials::GenericItemSelectionEnumeratorType<ContainerViewT, ItemTypeT>>>
+{
+ public:
+
+  using BaseClass = RunCommandConstituentItemTraitsBaseT<::Arcane::Materials::GenericItemSelectionRunCommand<::Arcane::Materials::GenericItemSelectionEnumeratorType<ContainerViewT, ItemTypeT>>>;
+  using BaseClass::createContainer;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Accelerator::impl
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#define ENUMERATE_SELENVCELL(EC, ECS) for (decltype((ECS).begin()) EC = (ECS).begin(), __##EC##_end = (ECS).end(); EC != __##EC##_end; ++EC)
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -131,6 +216,7 @@ class MeshMaterialAcceleratorUnitTest
   void _checkEnvValues1();
   void _checkMatValues1();
   void _checkEnvironmentValues();
+  void _testSelection();
 };
 
 /*---------------------------------------------------------------------------*/
@@ -364,6 +450,9 @@ executeTest()
                         });
     }
     _executeTest7(queue);
+  }
+  {
+    _testSelection();
   }
 }
 
@@ -1002,6 +1091,16 @@ _executeTest7(RunQueue& queue)
         ARCANE_FATAL("Bad mat cell lid={0}", mc.globalCellId());
     }
   }
+  {
+    // Teste sous vecteur vide
+    CellVector empty_cell_vector;
+    MatCellVector mat_vector(empty_cell_vector.view(), m_env1->materials()[1]);
+    MatCellVectorView sub_mat_view(mat_vector.view());
+    Int32 nb_sub_item = sub_mat_view.nbItem();
+    info() << "NB_SUB_ITEM (mat)=" << nb_sub_item;
+    if (nb_sub_item != 0)
+      ARCANE_FATAL("Bad value for number of sub items (v={0}). Should be zero", nb_sub_item);
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -1093,6 +1192,81 @@ _checkEnvironmentValues()
       _checkOneValue(m_env_c[iev], m_mat_c_ref[iev], "Test1_env_c");
     }
   }
+}
+
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Teste les commandes sur un sous-ensemble de ConstituenItem
+ */
+void MeshMaterialAcceleratorUnitTest::
+_testSelection()
+{
+  info() << "TestingSelection";
+
+  EnvCellVectorView env_cells(m_env1->envView());
+  Int32 nb_env_cell = env_cells.nbItem();
+
+  // Créé une sélection avec une entité sur 2
+  UniqueArray<Int32> selection_indices;
+  selection_indices.reserve((nb_env_cell / 2) + 1);
+  for (Int32 i = 0; i < nb_env_cell; ++i) {
+    if ((i % 2) == 0)
+      selection_indices.add(i);
+  }
+
+  // ... remplit une liste d'indices dans [ 0 ; env_cells.nbItems()-1 ]
+  EnvCellVectorSelectionView partial_env_cells{ env_cells, selection_indices.constSmallSpan() };
+
+  MaterialVariableCellInt32 test_var(VariableBuildInfo(mesh(), "SelectionTestVar"));
+
+  // phase de calcul
+  RunQueue queue = makeQueue(m_runner);
+
+  {
+    auto command = makeCommand(queue);
+    auto myVarView = viewInOut(command, test_var);
+    test_var.fill(0);
+    // premiere methode 1
+    command << RUNCOMMAND_MAT_ENUMERATE(SelEnvCell, evi, partial_env_cells)
+    {
+      myVarView[evi] += 1;
+    };
+  }
+
+  {
+    auto command = makeCommand(queue);
+    auto myVarView = viewInOut(command, test_var);
+    // ensuite, les boucles restent inchangées si on recoit en paramètre un EnvCellVectorSelectionView plutot qu'un EnvCellVectorView
+    command << RUNCOMMAND_MAT_ENUMERATE(SelEnvCell, evi, partial_env_cells)
+    {
+      myVarView[evi] += 1;
+    };
+  }
+
+  {
+    auto command = makeCommand(queue);
+    auto myVarView = viewInOut(command, test_var);
+    // troisieme possibilité
+    command << RUNCOMMAND_LOOP1(idx, partial_env_cells.size())
+    {
+      myVarView[partial_env_cells[idx]] += 1;
+    };
+  }
+
+  Int64 total = 0;
+  ENUMERATE_ENVCELL (ienvcell, env_cells) {
+    total += test_var[ienvcell];
+  }
+
+  ENUMERATE_SELENVCELL(ienvcell, partial_env_cells)
+  {
+    EnvCell x = *ienvcell;
+    total += test_var[x];
+  }
+
+  info() << "TOTAL=" << total;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR add a class `ConstituentItemIndexedSelectionView` which store a `SmallSpan<const Int32>` to filter selection over a container of constituent item.
This is a work in progress and is experimental at the moment.