### PR TITLE
Rework internal macro `A_ENUMERATE_COMPONENTCELL` to use free function to detect iterator type

### DIFF
--- a/arcane/src/arcane/core/materials/MatItemEnumerator.cc
+++ b/arcane/src/arcane/core/materials/MatItemEnumerator.cc
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MatItemEnumerator.cc                                        (C) 2000-2024 */
+/* MatItemEnumerator.cc                                        (C) 2000-2026 */
 /*                                                                           */
 /* Enumérateurs sur les mailles materiaux.                                   */
 /*---------------------------------------------------------------------------*/
@@ -424,6 +424,40 @@ EnvPartCellEnumerator EnvPartCellEnumerator::
 create(EnvPartItemVectorView v)
 {
   return EnvPartCellEnumerator(v);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ComponentCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentCell, ComponentItemVectorView v)
+{
+  return ComponentCellEnumerator::create(v);
+}
+MatCellEnumerator
+arcaneImplCreateConstituentEnumerator(MatCell, MatItemVectorView v)
+{
+  return MatCellEnumerator::create(v);
+}
+EnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(EnvCell, EnvItemVectorView v)
+{
+  return EnvCellEnumerator::create(v);
+}
+ComponentPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentPartCell, ComponentPartItemVectorView v)
+{
+  return ComponentPartCellEnumerator::create(v);
+}
+MatPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(MatPartCell, MatPartItemVectorView v)
+{
+  return MatPartCellEnumerator::create(v);
+}
+EnvPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(EnvPartCell, EnvPartItemVectorView v)
+{
+  return EnvPartCellEnumerator::create(v);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/core/materials/MatItemEnumerator.h
+++ b/arcane/src/arcane/core/materials/MatItemEnumerator.h
@@ -523,6 +523,111 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+inline AllEnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(AllEnvCell, AllEnvCellVectorView items)
+{
+  return AllEnvCellEnumerator::create(items);
+}
+inline AllEnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(AllEnvCell, IMeshMaterialMng* mng,const CellGroup& group)
+{
+  return AllEnvCellEnumerator::create(mng, group);
+}
+inline AllEnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(AllEnvCell, IMeshMaterialMng* mng,const CellVectorView& view)
+{
+  return AllEnvCellEnumerator::create(mng, view);
+}
+inline AllEnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(AllEnvCell, IMeshBlock* block)
+{
+  return AllEnvCellEnumerator::create(block);
+}
+
+inline ComponentCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentCell,IMeshComponent* component)
+{
+  return ComponentCellEnumerator::create(component);
+}
+inline ComponentCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentCell,const ComponentItemVector& v)
+{
+  return ComponentCellEnumerator::create(v);
+}
+ARCANE_CORE_EXPORT ComponentCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentCell, ComponentItemVectorView v);
+
+inline MatCellEnumerator
+arcaneImplCreateConstituentEnumerator(MatCell,IMeshMaterial* component)
+{
+  return MatCellEnumerator::create(component);
+}
+inline MatCellEnumerator
+arcaneImplCreateConstituentEnumerator(MatCell,const MatCellVector& v)
+{
+  return MatCellEnumerator::create(v);
+}
+ARCANE_CORE_EXPORT MatCellEnumerator
+arcaneImplCreateConstituentEnumerator(MatCell, MatItemVectorView v);
+
+inline EnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(EnvCell,IMeshEnvironment* component)
+{
+  return EnvCellEnumerator::create(component);
+}
+inline EnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(EnvCell,const EnvCellVector& v)
+{
+  return EnvCellEnumerator::create(v);
+}
+ARCANE_CORE_EXPORT EnvCellEnumerator
+arcaneImplCreateConstituentEnumerator(EnvCell, EnvItemVectorView v);
+
+ARCANE_CORE_EXPORT ComponentPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentPartCell, ComponentPartItemVectorView v);
+
+inline ComponentPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentPartCell, IMeshComponent* c,eMatPart part)
+{
+  return ComponentPartCellEnumerator::create(c, part);
+}
+ARCANE_CORE_EXPORT MatPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(MatPartCell, MatPartItemVectorView v);
+
+inline MatPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(MatPartCell, IMeshMaterial* c,eMatPart part)
+{
+  return MatPartCellEnumerator::create(c, part);
+}
+ARCANE_CORE_EXPORT EnvPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(EnvPartCell, EnvPartItemVectorView v);
+
+inline EnvPartCellEnumerator
+arcaneImplCreateConstituentEnumerator(EnvPartCell, IMeshEnvironment* c,eMatPart part)
+{
+  return EnvPartCellEnumerator::create(c, part);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Impl
+{
+
+template <typename ConstituentItemType, typename ConstituentItemContainerType, typename... RemainingArgs> auto
+makeConstituentItemEnumeratorLoop(ConstituentItemType x,
+                                  const ConstituentItemContainerType& container,
+                                  const RemainingArgs&... remaining_args)
+{
+  auto container_instance = arcaneImplCreateConstituentEnumerator(x, container, remaining_args...);
+  return container_instance;
+}
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 #if defined(ARCANE_TRACE_ENUMERATOR)
 #define A_TRACE_COMPONENT(_EnumeratorClassName) \
   ::Arcane::EnumeratorTraceWrapper< ::Arcane::Materials::_EnumeratorClassName, ::Arcane::Materials::IEnumeratorTracer >
@@ -535,10 +640,10 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
   _EnumeratorClassName
 #endif
 
-#define A_ENUMERATE_COMPONENTCELL(_EnumeratorClassName,iname,...) \
+#define A_ENUMERATE_COMPONENTCELL_OLD(_EnumeratorClassName,iname,...) \
   for( A_TRACE_COMPONENT(_EnumeratorClassName) iname(Arcane::Materials::_EnumeratorClassName::create(__VA_ARGS__) A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
 
-#define A_ENUMERATE_COMPONENT(_EnumeratorClassName,iname,container) \
+#define A_ENUMERATE_COMPONENT(_EnumeratorClassName,iname,container)     \
   for( A_TRACE_COMPONENT(_EnumeratorClassName) iname((::Arcane::Materials::_EnumeratorClassName)(container) A_TRACE_ENUMERATOR_WHERE); iname.hasNext(); ++iname )
 
 #define A_ENUMERATE_CELL_COMPONENTCELL(_EnumeratorClassName,iname,component_cell) \
@@ -546,6 +651,14 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
 
 #define A_ENUMERATEBUILDER_HELPER(ClassName_, ...) \
   ::Arcane::Materials::EnumeratorBuilder<::Arcane::Materials::ClassName_>::create(__VA_ARGS__)
+
+#define A_ENUMERATEBUILDER_HELPER2(ConstituentItemNameType, env_or_mat_container, ...) \
+  ::Arcane::Materials::Impl::makeConstituentItemEnumeratorLoop(ConstituentItemNameType(), env_or_mat_container __VA_OPT__(, __VA_ARGS__))
+
+#define A_ENUMERATE_COMPONENTCELL(ClassName_, iname, env_or_mat_container, ...) \
+  for (A_TRACE_COMPONENT_DIRECT_CLASS(decltype(A_ENUMERATEBUILDER_HELPER2(ClassName_, env_or_mat_container __VA_OPT__(, __VA_ARGS__)))) \
+       iname(A_ENUMERATEBUILDER_HELPER2(ClassName_, env_or_mat_container __VA_OPT__(, __VA_ARGS__)) A_TRACE_ENUMERATOR_WHERE); \
+       iname.hasNext(); ++iname)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -559,7 +672,7 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
  * la classe de l'énumérateur.
  */
 #define ENUMERATE_COMPONENTITEM(enumerator_class_name,iname,...)      \
-  A_ENUMERATE_COMPONENTCELL(ComponentItemEnumeratorTraitsT<enumerator_class_name>::EnumeratorType,iname,__VA_ARGS__)
+  A_ENUMERATE_COMPONENTCELL(enumerator_class_name, iname, __VA_ARGS__)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -584,7 +697,7 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
  * \param mat matériau, de type IMeshMaterial*
  */
 #define ENUMERATE_MATCELL(iname,mat) \
-  A_ENUMERATE_COMPONENTCELL(MatCellEnumerator,iname,mat)
+  A_ENUMERATE_COMPONENTCELL(Arcane::Materials::MatCell,iname,mat)
 
 /*!
  * \brief Macro pour itérer sur toutes les mailles d'un milieu.
@@ -593,7 +706,7 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
  * \param env milieu, de type IMeshEnvironment*
  */
 #define ENUMERATE_ENVCELL(iname,env) \
-  A_ENUMERATE_COMPONENTCELL(EnvCellEnumerator,iname,env)
+  A_ENUMERATE_COMPONENTCELL(Arcane::Materials::EnvCell,iname,env)
 
 /*!
  * \brief Macro pour itérer sur toutes les mailles d'un composant.
@@ -602,7 +715,7 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
  * \param component composant, de type IMeshComponent*
  */
 #define ENUMERATE_COMPONENTCELL(iname,component) \
-  A_ENUMERATE_COMPONENTCELL(ComponentCellEnumerator,iname,component)
+  A_ENUMERATE_COMPONENTCELL(Arcane::Materials::ComponentCell,iname,component)
 
 /*!
  * \brief Macro pour itérer sur une liste de composants
@@ -690,7 +803,7 @@ class ComponentItemEnumeratorTraitsT<ComponentPartSimdCell>
  * \param iname nom de la variable contenant l'itérateur
  * \param container conteneur sur lequel on souhaite itérer.
  *
- * Utiliser cette macro support qu'il existe une méthode dans la
+ * Utiliser cette macro suppose qu'il existe une dans la
  * classe Arcane::Materials::EnumeratorBuilder<ClassName_> une méthode
  * create() qui prenne en argument un objet de type \a container. Le type
  * de l'énumérateur sera le type de retour de cette méthode.

--- a/arcane/src/arcane/materials/ComponentSimd.h
+++ b/arcane/src/arcane/materials/ComponentSimd.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2022 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ComponentSimd.h                                             (C) 2000-2017 */
+/* ComponentSimd.h                                             (C) 2000-2026 */
 /*                                                                           */
 /* Support de la vectorisation pour les matériaux et milieux.                */
 /*---------------------------------------------------------------------------*/
@@ -20,8 +20,8 @@
  * vectorisation sur les composants (matériaux et milieux).
  */
 
-#include "arcane/ArcaneTypes.h"
-#include "arcane/SimdItem.h"
+#include "arcane/core/ArcaneTypes.h"
+#include "arcane/core/SimdItem.h"
 
 #include "arcane/materials/MatItem.h"
 #include "arcane/materials/MatItemEnumerator.h"
@@ -39,8 +39,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-MATERIALS_BEGIN_NAMESPACE
+namespace Arcane::Materials
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -107,11 +107,17 @@ class ARCANE_MATERIALS_EXPORT ComponentPartSimdCellEnumerator
   IMeshComponent* m_component;
 };
 
+inline ComponentPartSimdCellEnumerator
+arcaneImplCreateConstituentEnumerator(ComponentPartSimdCell, ComponentPartItemVectorView v)
+{
+  return ComponentPartSimdCellEnumerator::create(v);
+}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #define ENUMERATE_SIMD_COMPONENTCELL(iname,env) \
-  A_ENUMERATE_COMPONENTCELL(ComponentPartSimdCellEnumerator,iname,env)
+  A_ENUMERATE_COMPONENTCELL(ComponentPartSimdCell,iname,env)
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -138,7 +144,7 @@ class ARCANE_MATERIALS_EXPORT LoopFunctorEnvPartSimdCell
   typedef const SimdMatVarIndex& IterType;
  public:
   LoopFunctorEnvPartSimdCell(ComponentPartItemVectorView pure_items,
-                         ComponentPartItemVectorView impure_items)
+                             ComponentPartItemVectorView impure_items)
   : m_pure_items(pure_items), m_impure_items(impure_items){}
  public:
   static LoopFunctorEnvPartSimdCell create(const EnvCellVector& env);
@@ -366,8 +372,7 @@ viewOut(CellMaterialVariableScalarRef<DataType>& var)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-MATERIALS_END_NAMESPACE
-ARCANE_END_NAMESPACE
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/tests/material/MeshMaterialSimdUnitTest.cc
+++ b/arcane/src/arcane/tests/material/MeshMaterialSimdUnitTest.cc
@@ -74,8 +74,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANE_BEGIN_NAMESPACE
-MATERIALS_BEGIN_NAMESPACE
+namespace Arcane::Materials
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -171,18 +171,18 @@ class FullComponentPartCellEnumerator
 #define ENUMERATE_ENVCELL2(iname,env) \
   for( FullComponentPartCellEnumerator iname##_part(Arcane::Materials::FullComponentPartCellEnumerator::create(env)); iname##_part . hasNext(); ++ iname##_part ) \
     PRAGMA_IVDEP \
-    A_ENUMERATE_COMPONENTCELL(ComponentPartCellEnumerator,iname,*(iname##_part))
+    A_ENUMERATE_COMPONENTCELL(ComponentPartCell,iname,*(iname##_part))
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-MATERIALS_END_NAMESPACE
-ARCANE_END_NAMESPACE
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-ARCANETEST_BEGIN_NAMESPACE
+namespace ArcaneTest
+{
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -617,7 +617,7 @@ _executeDirect1(Integer nb_z)
   Real *c = new Real[TRUE_SIZE];
   Real *d = new Real[TRUE_SIZE];
   Real *e = new Real[TRUE_SIZE];
-#pragma omp parallel for
+  //#pragma omp parallel for
   for( Integer i=0, is=TRUE_SIZE; i<is; ++i ){
     Real z = (Real)i;
     a[i] = b[i] = c[i] = d[i] = e[i] = z;
@@ -695,7 +695,7 @@ _executeTest2(Integer nb_z)
     // ce pragma avec le compilateur intel. A noter que cela semble fonctionner
     // avec les versions 2021+ de Intel (icpc, icpx et DPC++).
 #ifndef __INTEL_COMPILER
-#pragma omp simd
+    //#pragma omp simd
 #endif
     ENUMERATE_ENVCELL(i,m_env1){
       a[i] = b[i] + c[i] * d[i] + e[i];
@@ -1416,10 +1416,7 @@ _computeEquationOfStateV4_noview()
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-ARCANETEST_END_NAMESPACE
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Use the overloaded free function `arcaneImplCreateConstituentEnumerator()` to choose the type of the iterator based on the constituent item type and the container type. This will allow us to use these macro with indexed selection.
Before that, the type of the enumerator was static. This