### PR TITLE
Use `dependencies` version 1.11 to use `scriban` version 7.2

### DIFF
--- a/arcane/CMakeLists.txt
+++ b/arcane/CMakeLists.txt
@@ -199,7 +199,7 @@ include(LoadBuildSystem)
 # Cherche 'ArcDependencies'
 
 find_package(ArcDependencies REQUIRED)
-set(ARCANE_ArcDependencies_NEEDED_VERSION "1.10.0")
+set(ARCANE_ArcDependencies_NEEDED_VERSION "1.11.0")
 message(STATUS "ArcDependencies_VERSION = ${ArcDependencies_VERSION}")
 if (ArcDependencies_VERSION VERSION_LESS ARCANE_ArcDependencies_NEEDED_VERSION)
   message(FATAL_ERROR "ArcDependencies version '${ArcDependencies_VERSION}' is too old."

--- a/arcane/tools/Arcane.Templates/Arcane.Templates.csproj
+++ b/arcane/tools/Arcane.Templates/Arcane.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../CommonInternalDll.props" />
   <ItemGroup>
-    <PackageReference Include="Scriban" Version="7.0.6" />
+    <PackageReference Include="Scriban" Version="7.2.*" />
     <PackageReference Include="Mono.Options" Version="6.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The previous version of `scriban` in version 1.10 of dependencies has a CVE (see https://github.com/scriban/scriban/security/advisories).