### PR TITLE
Add ItemType for `Line4` and `Triangle10` 1D and 2D cells in 3D mesh

### DIFF
--- a/arcane/src/arcane/core/ArcaneTypes.h
+++ b/arcane/src/arcane/core/ArcaneTypes.h
@@ -382,9 +382,15 @@ static const Int16 IT_Hexaedron27 = 47;
 static const Int16 IT_Line4 = 48;
 //! Triangle d'ordre 3. EXPERIMENTAL !
 static const Int16 IT_Triangle10 = 49;
+//! Ligen d'ordre 3. EXPERIMENTAL !
+static const Int16 IT_CellLine4 = 50;
+//! Ligen d'ordre 3. EXPERIMENTAL !
+static const Int16 IT_Cell3D_Line4 = 51;
+//! Triangle d'ordre 3 dans un maillage 3D. EXPERIMENTAL !
+static const Int16 IT_Cell3D_Triangle10 = 52;
 
 //! Nombre de types d'entités disponible par défaut
-static const Integer NB_BASIC_ITEM_TYPE = 50;
+static const Integer NB_BASIC_ITEM_TYPE = 53;
 
 //! Première valeur pour les type polygones génériques (EXPERIMENTAL)
 static const Int16 IT_GenericPolygon = 200;

--- a/arcane/src/arcane/core/ItemTypeId.h
+++ b/arcane/src/arcane/core/ItemTypeId.h
@@ -176,6 +176,13 @@ static constexpr ItemTypeId ITI_Hexaedron27(IT_Hexaedron27);
 static constexpr ItemTypeId ITI_Line4(IT_Line4);
 //! Triangle d'ordre 3. EXPERIMENTAL !
 static constexpr ItemTypeId ITI_Triangle10(IT_Triangle10);
+//! Ligne d'ordre 3. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_CellLine4(IT_CellLine4);
+//! Ligne d'ordre 3. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Line4(IT_Cell3D_Line4);
+
+//! Triangle d'ordre 3 dans un maillage 3D. EXPERIMENTAL !
+static constexpr ItemTypeId ITI_Cell3D_Triangle10(IT_Cell3D_Triangle10);
 
 //! Première valeur pour les type polygones génériques (EXPERIMENTAL)
 static constexpr ItemTypeId ITI_GenericPolygon(IT_GenericPolygon);

--- a/arcane/src/arcane/core/ItemTypeMng.cc
+++ b/arcane/src/arcane/core/ItemTypeMng.cc
@@ -270,6 +270,30 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->addEdge(2, 2, 0, 0, 1);
   }
 
+  // Cell3D_Triangle10
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Cell3D_Triangle10] = type;
+    Int32 nb_face = 3;
+    Int32 nb_edge = 0;
+    if (is_non_manifold)
+      std::swap(nb_face, nb_edge);
+
+    type->setInfos(this, IT_Cell3D_Triangle6, "Cell3D_Triangle10", Dimension::Dim2, 6, nb_edge, nb_face);
+    type->setOrder(2, ITI_Cell3D_Triangle3);
+
+    if (is_non_manifold) {
+      type->addEdge2D(0, 0, 1);
+      type->addEdge2D(1, 1, 2);
+      type->addEdge2D(2, 2, 0);
+    }
+    else {
+      type->addFaceLine4(0, 0, 1, 3, 4);
+      type->addFaceLine4(1, 1, 2, 5, 6);
+      type->addFaceLine4(2, 2, 0, 7, 8);
+    }
+  }
+
   // Quad4
   {
     _addPolygonType(IT_Quad4, 4, "Quad4");
@@ -926,6 +950,18 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->addFaceVertex(1, 1);
   }
 
+  // CellLine4 (maille d'ordre 3 pour les maillages 1D)
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_CellLine4] = type;
+    type->setOrder(3, ITI_CellLine2);
+
+    type->setInfos(this, IT_CellLine4, "CellLine4", Dimension::Dim1, 4, 0, 2);
+
+    type->addFaceVertex(0, 0);
+    type->addFaceVertex(1, 1);
+  }
+
   // Cell3D_Line3
   {
     ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
@@ -933,6 +969,15 @@ _buildTypes(IMesh* mesh, IParallelSuperMng* parallel_mng, ITraceMng* trace)
     type->setOrder(2, ITI_Cell3D_Line2);
 
     type->setInfos(this, IT_Cell3D_Line3, "Cell3D_Line3", Dimension::Dim1, 3, 0, 0);
+  }
+
+  // Cell3D_Line4
+  {
+    ItemTypeInfoBuilder* type = m_types_buffer->allocOne();
+    m_types[IT_Cell3D_Line4] = type;
+    type->setOrder(3, ITI_Cell3D_Line2);
+
+    type->setInfos(this, IT_Cell3D_Line4, "Cell3D_Line4", Dimension::Dim1, 4, 0, 0);
   }
 
   // Cell3D_Triangle3


### PR DESCRIPTION
At the moment only the id is used and there is no test because no mesh are available with theses types.