### PR TITLE
Use a specific class instead of a typedef on template class for indexed selection on constituents

### DIFF
--- a/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
+++ b/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
@@ -285,22 +285,97 @@ class ConstituentItemIndexedSelectionEnumerator
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+/*!
+ * \brief Selection sur un ComponentCellVectorView.
+ */
+class ComponentCellVectorSelectionView
+: public ConstituentItemIndexedSelectionView<ComponentCellVectorView>
+{
+  using BaseClass = ConstituentItemIndexedSelectionView<ComponentCellVectorView>;
+
+ public:
+
+  ComponentCellVectorSelectionView(ComponentCellVectorView vector_view, SmallSpan<const Int32> indices)
+  : BaseClass(vector_view, indices)
+  {
+  }
+
+  //! Construit une sélection contenant tous les éléments de \view
+  explicit ComponentCellVectorSelectionView(ComponentCellVectorView vector_view)
+  : BaseClass(vector_view)
+  {
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Selection sur un EnvCellVectorView.
+ */
+class EnvCellVectorSelectionView
+: public ConstituentItemIndexedSelectionView<EnvCellVectorView>
+{
+  using BaseClass = ConstituentItemIndexedSelectionView<EnvCellVectorView>;
+
+ public:
+
+  EnvCellVectorSelectionView(EnvCellVectorView vector_view, SmallSpan<const Int32> indices)
+  : BaseClass(vector_view, indices)
+  {
+  }
+
+  //! Construit une sélection contenant tous les éléments de \view
+  explicit EnvCellVectorSelectionView(EnvCellVectorView vector_view)
+  : BaseClass(vector_view)
+  {
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Selection sur un MatCellVectorView.
+ */
+class MatCellVectorSelectionView
+: public ConstituentItemIndexedSelectionView<MatCellVectorView>
+{
+  using BaseClass = ConstituentItemIndexedSelectionView<MatCellVectorView>;
+
+ public:
+
+  MatCellVectorSelectionView(MatCellVectorView vector_view, SmallSpan<const Int32> indices)
+  : BaseClass(vector_view, indices)
+  {
+  }
+
+  //! Construit une sélection contenant tous les éléments de \view
+  explicit MatCellVectorSelectionView(MatCellVectorView vector_view)
+  : BaseClass(vector_view)
+  {
+  }
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 //! Enumérateur sur une sélection d'un constituant
 inline ConstituentItemIndexedSelectionEnumerator<ComponentCellVectorView>
-arcaneImplCreateConstituentEnumerator(ComponentCell, ConstituentItemIndexedSelectionView<ComponentCellVectorView> container)
+arcaneImplCreateConstituentEnumerator(ComponentCell, ComponentCellVectorSelectionView container)
 {
   return ConstituentItemIndexedSelectionEnumerator<ComponentCellVectorView>::create(container);
 }
+
 //! Enumérateur sur une sélection d'un constituant
 inline ConstituentItemIndexedSelectionEnumerator<ComponentCellVectorView>
-arcaneImplCreateConstituentEnumerator(ComponentCell, ConstituentItemIndexedSelectionView<EnvCellVectorView> container)
+arcaneImplCreateConstituentEnumerator(ComponentCell, EnvCellVectorSelectionView container)
 {
   ConstituentItemIndexedSelectionView<ComponentCellVectorView> c2(container.sourceView(), container.selectionView());
   return ConstituentItemIndexedSelectionEnumerator<ComponentCellVectorView>::create(c2);
 }
+
 //! Enumérateur sur une sélection d'un milieu
 inline ConstituentItemIndexedSelectionEnumerator<EnvCellVectorView>
-arcaneImplCreateConstituentEnumerator(EnvCell, ConstituentItemIndexedSelectionView<EnvCellVectorView> container)
+arcaneImplCreateConstituentEnumerator(EnvCell, EnvCellVectorSelectionView container)
 {
   return ConstituentItemIndexedSelectionEnumerator<EnvCellVectorView>::create(container);
 }

--- a/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
+++ b/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
@@ -187,14 +187,6 @@ class ConstituentItemIndexedSelectionView
   {
   }
 
-  //! Construit une sélection contenant tous les éléments de \view
-  explicit ConstituentItemIndexedSelectionView(ItemVecView view)
-  requires(!IsSpanContainer())
-  : ConstituentItemIndexedSelectionViewBase(view.component(), TraitsType::size(view))
-  , m_container_view(view)
-  {
-  }
-
   //! Constructeur à partir d'une vue de ConstituentCell, de MatCell ou EnvCell
   explicit ConstituentItemIndexedSelectionView(IMeshComponent* constituent, SmallSpan<const ValueType> ecv)
   requires(IsSpanContainer())
@@ -202,6 +194,17 @@ class ConstituentItemIndexedSelectionView
   , m_container_view(ecv)
   {
   }
+
+ protected:
+
+  //! Construit une sélection contenant tous les éléments de \view (qui doit dériver de ComponentCellVectorView)
+  explicit ConstituentItemIndexedSelectionView(ItemVecView view)
+  : ConstituentItemIndexedSelectionViewBase(view.component(), TraitsType::size(view))
+  , m_container_view(view)
+  {
+  }
+
+ public:
 
   // nombre total de mailles du milieu
   ARCCORE_HOST_DEVICE Int32 sourceSize() const { return TraitsType::size(m_container_view); }

--- a/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
+++ b/arcane/src/arcane/core/materials/MaterialsCoreGlobal.h
@@ -191,12 +191,17 @@ using EnvCellLocalId = EnvItemLocalId;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#if 0
 //! Selection sur un 'EvnCellVectorView'
 using EnvCellVectorSelectionView = ConstituentItemIndexedSelectionView<EnvCellVectorView>;
 //! Selection sur un 'MatCellVectorView'
 using MatCellVectorSelectionView = ConstituentItemIndexedSelectionView<MatCellVectorView>;
 //! Selection sur un 'ComponentCellVectorView'
 using ComponentCellVectorSelectionView = ConstituentItemIndexedSelectionView<ComponentCellVectorView>;
+#endif
+class EnvCellVectorSelectionView;
+class MatCellVectorSelectionView;
+class ComponentCellVectorSelectionView;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This is easier to read and allow us in the future to change implementation while keeping source compatibility.
