### PR TITLE
Remove ArcaneFeatureModel after open-sourcing Arcane

### DIFF
--- a/arcane/src/arcane/impl/FlexLMTools.cc
+++ b/arcane/src/arcane/impl/FlexLMTools.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* FlexLMTools.cc                                              (C) 2000-2025 */
+/* FlexLMTools.cc                                              (C) 2000-2026 */
 /*                                                                           */
 /* Implementation of an interface for FlexLM tools.                          */
 /*---------------------------------------------------------------------------*/
@@ -149,13 +149,6 @@ init(IParallelSuperMng* parallel_super_mng)
 
   // Marque l'initialisation effective; on peut maintenant utiliser le système de licence
   m_parallel_super_mng = parallel_super_mng;
-
-  FlexLMTools<ArcaneFeatureModel> license_tool;
-#ifndef ARCANE_TEST_RLM
-  license_tool.checkLicense(ArcaneFeatureModel::ArcaneCore, true); // do_fatal=true
-#else
-  license_tool.checkLicense(ArcaneFeatureModel::Arcane, true); // do_fatal=true
-#endif
 }
 
 /*---------------------------------------------------------------------------*/
@@ -307,17 +300,6 @@ featureInfo(const String name, const Real version) const
 
   return info;
 }
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-const String ArcaneFeatureModel::m_arcane_feature_name[] = {
-#ifndef ARCANE_TEST_RLM
-  "ArcaneCore",
-#else
-  "Arcane",
-#endif
-};
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/FlexLMTools.h
+++ b/arcane/src/arcane/impl/FlexLMTools.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* FlexLMTools.h                                               (C) 2000-2025 */
+/* FlexLMTools.h                                               (C) 2000-2026 */
 /*                                                                           */
 /* FlexLM Protection Management.                                             */
 /*---------------------------------------------------------------------------*/
@@ -190,39 +190,6 @@ class FlexLMTools
     const Real version = FeatureModel::getVersion(feature);
     return FlexLMMng::instance()->featureInfo(name, version);
   }
-};
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-class ArcaneFeatureModel
-{
- public:
-
-  typedef enum
-  {
-#ifndef ARCANE_TEST_RLM
-    ArcaneCore = 0, //<! Core feature (related to execution)
-#else
-    Arcane = 0, //<! Core feature (related to execution)
-#endif
-  } eFeature;
-
-  static String getName(eFeature feature)
-  {
-    return m_arcane_feature_name[feature];
-  }
-
-  static Real getVersion(eFeature feature)
-  {
-    ARCANE_UNUSED(feature);
-    // Writes a numerically comparable version; e.g., 1.0610 (instead of 1.6.1)
-    return (Real)ARCANE_VERSION_MAJOR + (Real)ARCANE_VERSION_MINOR / 100 + (Real)ARCANE_VERSION_RELEASE / 1000 + (Real)ARCANE_VERSION_BETA / 10000;
-  }
-
- private:
-
-  static const String m_arcane_feature_name[];
 };
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The `ArcaneFeatureModel` has been removed as Arcane is now open-source and no longer requires license protection under FlexLM.