### PR TITLE
Fixing errors in HelloWorld and Poisson Tutorials

### DIFF
--- a/arcane/samples_build/samples/poisson/Poisson.axl
+++ b/arcane/samples_build/samples/poisson/Poisson.axl
@@ -30,7 +30,7 @@
   <options>
     <!-- - - - - - init-temperature - - - - -->
     <simple name="init-temperature" type="real" default="300">
-      <description>Température iitiale dans tout le maillage</description>
+      <description>Temperature initiale dans tout le maillage</description>
     </simple>
 
     <!-- - - - - - boundary-condition - - - - -->

--- a/arcane/tutorial/helloworld/CMakeLists.txt
+++ b/arcane/tutorial/helloworld/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+project(HelloWorld LANGUAGES C CXX)
+
+set(EXAMPLE_NAME HelloWorld)
+
+find_package(Arcane REQUIRED)
+
+add_executable(${EXAMPLE_NAME}
+  main.cc
+  HelloWorldModule.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/HelloWorld_axl.h
+)
+
+arcane_generate_axl(HelloWorld)
+
+arcane_add_arcane_libraries_to_target(${EXAMPLE_NAME})
+
+target_include_directories(${EXAMPLE_NAME} PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+configure_file(HelloWorld.config ${CMAKE_CURRENT_BINARY_DIR}/HelloWorld.config COPYONLY)
+configure_file(HelloWorld.arc    ${CMAKE_CURRENT_BINARY_DIR}/HelloWorld.arc    COPYONLY)
+
+enable_testing()
+add_test(NAME helloworld1 COMMAND ${EXAMPLE_NAME} HelloWorld.arc)
+

--- a/arcane/tutorial/helloworld/HelloWorld.axl
+++ b/arcane/tutorial/helloworld/HelloWorld.axl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!-- Compléter les attributs name et parent-name -->
-<module name="" parent-path="arcane" parent-name="">
+<module name="" version="1.0" parent-path="arcane" parent-name="">
 
 	<description>Descripteur du module Hello World</description>
 

--- a/arcane/tutorial/helloworld/Makefile
+++ b/arcane/tutorial/helloworld/Makefile
@@ -1,3 +1,0 @@
-EXAMPLE_NAME=HelloWorld
-
-include ../Makefile.samples

--- a/arcane/tutorial/poisson/CMakeLists.txt
+++ b/arcane/tutorial/poisson/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+project(Poisson LANGUAGES C CXX)
+
+set(EXAMPLE_NAME Poisson)
+
+find_package(Arcane REQUIRED)
+
+add_executable(${EXAMPLE_NAME}
+  main.cc
+  PoissonModule.cc
+  PoissonModule.h
+  ${CMAKE_CURRENT_BINARY_DIR}/Poisson_axl.h
+)
+
+arcane_generate_axl(Poisson)
+
+arcane_add_arcane_libraries_to_target(${EXAMPLE_NAME})
+
+target_include_directories(${EXAMPLE_NAME} PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+configure_file(Poisson.config ${CMAKE_CURRENT_BINARY_DIR}/Poisson.config COPYONLY)
+configure_file(Poisson.arc    ${CMAKE_CURRENT_BINARY_DIR}/Poisson.arc    COPYONLY)
+
+enable_testing()
+add_test(NAME poisson COMMAND ${EXAMPLE_NAME} Poisson.arc)
+

--- a/arcane/tutorial/poisson/Makefile
+++ b/arcane/tutorial/poisson/Makefile
@@ -1,3 +1,0 @@
-EXAMPLE_NAME=Poisson
-
-include ../Makefile.samples

--- a/arcane/tutorial/poisson/Poisson.axl
+++ b/arcane/tutorial/poisson/Poisson.axl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
-<module name="Poisson" parent-path="arcane" parent-name="BasicModule">
+<module name="Poisson" version="1.0" parent-path="arcane" parent-name="BasicModule">
 
 	<description>Descripteur du module Poisson</description>
 

--- a/arcane/tutorial/poisson/PoissonModule.h
+++ b/arcane/tutorial/poisson/PoissonModule.h
@@ -2,6 +2,7 @@
 #ifndef POISSONMODULE_H
 #define POISSONMODULE_H
 
+#include "TypesPoisson.h"
 #include "Poisson_axl.h"
 
 using namespace Arcane;


### PR DESCRIPTION
While following the tutorials, I faced some issues with the current implementation.
Here is a list of fixes that I propose :

1. Add of includes in `tutorial/poisson/PoissonModule.h`
2. Removing of outdated `MakeFile` and creation of `CMakeLists.txt` in both `tutorial/poisson` and `tutorial/helloworld`
3. Add module version information in `tutorial/poisson/Poisson.axl` and `tutorial/helloworld/HelloWorld.axl`
4. Fixing description in `samples_build/samples/poisson/Poisson.axl`