### PR TITLE
Add a way to choose the entry sort mode in Alien BasicIndexManager.

### DIFF
--- a/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/IIndexManager.h
+++ b/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/IIndexManager.h
@@ -1,9 +1,14 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
+/* IIndexMng                                                 (C) 2000-2026   */
+/*                                                                           */
+/* Interface for Alien IndexMng                                              */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 #ifndef ALIEN_IINDEX_MANAGER_H
 #define ALIEN_IINDEX_MANAGER_H
 
@@ -329,6 +334,13 @@ namespace ArcaneTools {
     /*! Uniquement valide après \a prepare */
     virtual Arccore::Integer localSize() const = 0;
 
+    //! Mode de tri pour les entrées
+    enum class EntrySortMode
+    {
+      KindUidsCreationIndex, //!< Tri par type, puis par UID, puis par index de création
+      KindCreationIndex      //!< Tri par type, puis par index de création
+    };
+
     //! Construction d'un enumerateur sur les \a Entry
     virtual EntryEnumerator enumerateEntry() const = 0;
 
@@ -363,17 +375,33 @@ namespace ArcaneTools {
     // virtual VectorIndexSet buildVectorIndexSet(const String name, const
     // Arcane::ItemGroup
     // & itemGroup, const Integer n) = 0;
-    //! Construit une nouvelle entrée vectoriellesur un ensemble d'entités abstraites
+    //! Construit une nouvelle entrée vectorielle sur un ensemble d'entités abstraites
     /*! L'implémentation actuelle considére le multi-scalaire comme du vectoriel */
     virtual VectorIndexSet buildVectorIndexSet(const Arccore::String name,
         const Arccore::ConstArrayView<Arccore::Integer> localIds,
         const IAbstractFamily& family, const Arccore::Integer n) = 0;
 
-    //! Construit une nouvelle entrée scalaire sur l'ensemble des entités d'une familles
-    //! abstraite
+    //! Construit une nouvelle entrée vectorielle sur un ensemble d'entités abstraites
+    /*! L'implémentation actuelle considére le multi-scalaire comme du vectoriel
+     *  \param sort mode de tri des entrées
+     */
+    virtual VectorIndexSet buildVectorIndexSet(const Arccore::String name,
+        const Arccore::ConstArrayView<Arccore::Integer> localIds,
+        const IAbstractFamily& family, const Arccore::Integer n,
+        const EntrySortMode sort) = 0;
+
+    //! Construit une nouvelle entrée vectorielle sur l'ensemble des entités d'une famille abstraite
     /*! L'implémentation actuelle considére le multi-scalaire comme du vectoriel */
     virtual VectorIndexSet buildVectorIndexSet(const Arccore::String name,
         const IAbstractFamily& family, const Arccore::Integer n) = 0;
+
+    //! Construit une nouvelle entrée vectorielle sur l'ensemble des entités d'une famille abstraite
+    /*! L'implémentation actuelle considére le multi-scalaire comme du vectoriel
+     *  \param sort mode de tri des entrées
+     */
+    virtual VectorIndexSet buildVectorIndexSet(const Arccore::String name,
+        const IAbstractFamily& family, const Arccore::Integer n,
+        const EntrySortMode sort) = 0;
 
     //! Demande de dé-indexation d'une partie d'une entrée
     /*! Utilisable uniquement avant prepare */

--- a/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.cc
+++ b/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.cc
@@ -1,17 +1,19 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2025 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* BasicIndexManager                                           (C) 2000-2025 */
+/* BasicIndexManager                                           (C) 2000-2026 */
 /*                                                                           */
 /* Basic indexing between algebra and mesh worlds. Depends on Arcane         */
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 #include "alien/arcane_tools/indexManager/BasicIndexManager.h"
+
+#include "alien/arcane_tools/IIndexManager.h"
 
 #include <list>
 #include <vector>
@@ -611,7 +613,7 @@ namespace ArcaneTools {
       entry->freeDefinedLids();
     }
 
-    std::sort(entry_index.begin(), entry_index.end(), EntryIndexComparator());
+    std::sort(entry_index.begin(), entry_index.end(), EntryIndexComparator(m_sort_mode));
 
     ALIEN_ASSERT(
         ((Integer)entry_index.size() == m_local_entry_count + m_global_entry_count),
@@ -1214,11 +1216,10 @@ namespace ArcaneTools {
     const MyEntryImpl* bEntry = b.m_entry;
     if (a.m_kind != b.m_kind)
       return a.m_kind < b.m_kind;
-    else if (a.m_uid != b.m_uid)
+    else if (m_sort == IIndexManager::EntrySortMode::KindUidsCreationIndex && a.m_uid != b.m_uid)
       return a.m_uid < b.m_uid;
     else
       return aEntry->getCreationIndex() < bEntry->getCreationIndex();
-    // return a.m_creation_index < b.m_creation_index;
   }
 
   /*---------------------------------------------------------------------------*/
@@ -1279,6 +1280,26 @@ namespace ArcaneTools {
   IIndexManager::VectorIndexSet BasicIndexManager::buildVectorIndexSet(
       const String name, const Arcane::ItemGroup& itemGroup, const Integer n)
   {
+    m_sort_mode = IIndexManager::EntrySortMode::KindUidsCreationIndex;
+    VectorIndexSet ens(n);
+    const ConstArrayView<Integer> localIds = itemGroup.view().localIds();
+    Arcane::IItemFamily* item_family = itemGroup.itemFamily();
+    Integer kind = kindFromItemFamily(item_family);
+    std::shared_ptr<IAbstractFamily>& family = m_abstract_families[kind];
+    if (!family)
+      family.reset(new ItemAbstractFamily(item_family));
+    for (Integer i = 0; i < n; ++i) {
+      ens[i] = buildEntry(
+          String::format("{0}[{1}]", name, i), family.get(), kind);
+      defineIndex(ens[i], localIds);
+    }
+    return ens;
+  }
+
+  IIndexManager::VectorIndexSet BasicIndexManager::buildVectorIndexSet(
+      const String name, const Arcane::ItemGroup& itemGroup, const Integer n, const EntrySortMode sort)
+  {
+    m_sort_mode = sort;
     VectorIndexSet ens(n);
     const ConstArrayView<Integer> localIds = itemGroup.view().localIds();
     Arcane::IItemFamily* item_family = itemGroup.itemFamily();
@@ -1300,6 +1321,21 @@ namespace ArcaneTools {
       const ConstArrayView<Integer> localIds, const IAbstractFamily& family,
       const Integer n)
   {
+    m_sort_mode = IIndexManager::EntrySortMode::KindUidsCreationIndex;
+    VectorIndexSet ens(n);
+    for (Integer i = 0; i < n; ++i) {
+      ens[i] = buildEntry(
+          String::format("{0}[{1}]", name, i), &family, addNewAbstractFamily(&family));
+      defineIndex(ens[i], localIds);
+    }
+    return ens;
+  }
+
+  IIndexManager::VectorIndexSet BasicIndexManager::buildVectorIndexSet(const String name,
+      const ConstArrayView<Integer> localIds, const IAbstractFamily& family,
+      const Integer n, const EntrySortMode sort)
+  {
+    m_sort_mode = sort;
     VectorIndexSet ens(n);
     for (Integer i = 0; i < n; ++i) {
       ens[i] = buildEntry(
@@ -1314,6 +1350,22 @@ namespace ArcaneTools {
   IIndexManager::VectorIndexSet BasicIndexManager::buildVectorIndexSet(
       const String name, const IAbstractFamily& family, const Integer n)
   {
+    m_sort_mode = IIndexManager::EntrySortMode::KindUidsCreationIndex;
+    UniqueArray<Int32> localIds = family.allLocalIds();
+
+    VectorIndexSet ens(n);
+    for (Integer i = 0; i < n; ++i) {
+      ens[i] = buildEntry(
+          String::format("{0}[{1}]", name, i), &family, addNewAbstractFamily(&family));
+      defineIndex(ens[i], localIds.view());
+    }
+    return ens;
+  }
+
+  IIndexManager::VectorIndexSet BasicIndexManager::buildVectorIndexSet(
+      const String name, const IAbstractFamily& family, const Integer n, const EntrySortMode sort)
+  {
+    m_sort_mode = sort;
     UniqueArray<Int32> localIds = family.allLocalIds();
 
     VectorIndexSet ens(n);

--- a/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.h
+++ b/alien/ArcaneInterface/modules/arcane_tools/src/alien/arcane_tools/indexManager/BasicIndexManager.h
@@ -1,11 +1,11 @@
 ﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
 //-----------------------------------------------------------------------------
-// Copyright 2000-2024 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* BasicIndexManager                                         (C) 2000-2024   */
+/* BasicIndexManager                                         (C) 2000-2026   */
 /*                                                                           */
 /* Basic indexing between algebra and mesh worlds. Depends on Arcane         */
 /*---------------------------------------------------------------------------*/
@@ -128,18 +128,28 @@ namespace ArcaneTools {
     /*! L'implémentation actuelle considére le multi-scalaire comme du vectoriel */
     VectorIndexSet buildVectorIndexSet(const Arccore::String name,
         const Arcane::ItemGroup& itemGroup, const Arccore::Integer n);
+    VectorIndexSet buildVectorIndexSet(const Arccore::String name,
+        const Arcane::ItemGroup& itemGroup, const Arccore::Integer n,
+        const EntrySortMode sort);
 
     //! Construit une nouvelle entrée vectoriellesur un ensemble d'entités abstraites
     /*! L'implémentation actuelle considére le multi-scalaire comme du vectoriel */
     VectorIndexSet buildVectorIndexSet(const Arccore::String name,
         const Arccore::IntegerConstArrayView localIds, const IAbstractFamily& family,
         const Arccore::Integer n);
+    VectorIndexSet buildVectorIndexSet(const Arccore::String name,
+        const Arccore::IntegerConstArrayView localIds, const IAbstractFamily& family,
+        const Arccore::Integer n,
+        const EntrySortMode sort);
 
     //! Construit une nouvelle entrée scalaire sur l'ensemble des entités d'une familles
     //! abstraite
     /*! L'implémentation actuelle considére le multi-scalaire comme du vectoriel */
     VectorIndexSet buildVectorIndexSet(const Arccore::String name,
         const IAbstractFamily& family, const Arccore::Integer n);
+    VectorIndexSet buildVectorIndexSet(const Arccore::String name,
+        const IAbstractFamily& family, const Arccore::Integer n,
+        const EntrySortMode sort);
 
     //! Demande de dé-indexation d'une partie d'une entrée
     /*! Utilisable uniquement avant prepare */
@@ -236,8 +246,10 @@ namespace ArcaneTools {
 
     struct EntryIndexComparator
     {
-      inline bool operator()(
-          const InternalEntryIndex& a, const InternalEntryIndex& b) const;
+      IIndexManager::EntrySortMode m_sort = IIndexManager::EntrySortMode::KindUidsCreationIndex;
+      EntryIndexComparator(IIndexManager::EntrySortMode sort) : m_sort(sort) {}
+      explicit EntryIndexComparator() = default;
+      inline bool operator()(const InternalEntryIndex& a, const InternalEntryIndex& b) const;
     };
 
     //! Table des Entry connues localement
@@ -246,6 +258,7 @@ namespace ArcaneTools {
 
     //! Index de creation des entrées
     Arccore::Integer m_creation_index = 0;
+    IIndexManager::EntrySortMode m_sort_mode = IIndexManager::EntrySortMode::KindUidsCreationIndex;
 
     //! Famille des familles abstraites associées aux familles du maillage
 


### PR DESCRIPTION
- The idea is to control order of entries when using several families of same kind (and not to rely on uids but on the adding order)
- Default is unchanged: first kind, then uids, then adding order
- A new IIndexMng::buildVectorIndexSet is added with EntrySortMode enum as an extra parameter. 