### PR TITLE
Use `VtkLegacy` as mesh writer for MED polygonal test

### DIFF
--- a/arcane/tests/testMesh-med-polygonal.arc
+++ b/arcane/tests/testMesh-med-polygonal.arc
@@ -13,6 +13,7 @@
  <module-test-unitaire>
    <test name="MeshUnitTest">
      <test-adjacence>0</test-adjacence>
+     <write-mesh-service-name>VtkLegacy</write-mesh-service-name>
    </test>
  </module-test-unitaire>
 


### PR DESCRIPTION
The default writing service is `Lima` library but it does not support polygonal meshes.