### PR TITLE
Add support for `pythonnet` 3.1

### DIFF
--- a/arcane/tools/wrapper/python/Arcane.Python.csproj.in
+++ b/arcane/tools/wrapper/python/Arcane.Python.csproj.in
@@ -20,7 +20,7 @@
     <ProjectReference Include="../Arcane.Services/Arcane.Services.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="pythonnet" Version="3.0.*" />
+    <PackageReference Include="pythonnet" Version="3.*" />
     <!-- Pas directement utile mais permet d'éviter un avertissement sur les versions des packages nuget -->
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>

--- a/arcane/tools/wrapper/python/csharp/BasicDotNetPythonExternalPlugin.cs
+++ b/arcane/tools/wrapper/python/csharp/BasicDotNetPythonExternalPlugin.cs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 using System;
+using System.Reflection;
 using Python.Runtime;
 using System.IO;
 
@@ -128,6 +129,9 @@ namespace Arcane.Python
       lock(m_init_lock){
         if (m_has_init)
           return;
+        Assembly pythonnet_assembly = Assembly.GetAssembly(typeof(PythonEngine));
+        if (pythonnet_assembly != null)
+          Console.WriteLine("Initializing PythonNet Version={0}",pythonnet_assembly.GetName().Version);
         PythonEngine.Initialize();
         m_has_init = true;
       }


### PR DESCRIPTION
This is needed to support version 3.14 of python for the wrapper.