### PR TITLE
Add a find package for ZLIB in the HDF5 find package

### DIFF
--- a/arccon/build-system/Modules/FindHDF5.cmake
+++ b/arccon/build-system/Modules/FindHDF5.cmake
@@ -13,6 +13,11 @@ arccon_return_if_package_found(HDF5)
 # Tente d'utiliser le module correspondant de CMake
 set(_SAVED_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
 unset(CMAKE_MODULE_PATH)
+# It seems CMake config file for HDF5 1.14
+# does not include ZLIB which leads to errors
+# when configuring (like 'ZLIB::ZLIB target not found').
+# To prevent that, we manually include this package
+find_package(ZLIB QUIET)
 find_package(HDF5 CONFIG QUIET)
 set(CMAKE_MODULE_PATH ${_SAVED_CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
This seems needed to make sure `ZLIB::ZLIB` is available when searching for HDF5, because the `hdf5-config.cmake` file does not do the `find_dependency` for ZLIB.