### PR TITLE
Add convenient methods for class `NumArray`

### DIFF
--- a/arcane/src/arcane/utils/tests/TestNumArray.cc
+++ b/arcane/src/arcane/utils/tests/TestNumArray.cc
@@ -221,6 +221,23 @@ TEST(NumArray3, Misc)
   v.resize(3, 2, 6);
   std::cout << "CAPACITY V4=" << v.capacity() << "\n";
 
+  ASSERT_EQ(v.data(), v.to1DSpan().data());
+
+  {
+    // Check iterators
+    NumArray<Int32, MDDim1> array1(4);
+    Int32 base = 2;
+    Int32 total = 0;
+    for( Int32& x : array1 ){
+      x = base;
+      ++base;
+    }
+    const auto&  const_array1 = array1;
+    for( Int32 x : const_array1 )
+      total += x;
+    ASSERT_EQ(total,14);
+  }
+
   // NOTE: temporarily disables the test until the method
   // resize() of 'NumArray' preserves values
 #if NUMARRAY_HAS_VALID_RESIZE

--- a/arccore/src/base/arccore/base/ArrayExtents.h
+++ b/arccore/src/base/arccore/base/ArrayExtents.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayExtents.h                                              (C) 2000-2025 */
+/* ArrayExtents.h                                              (C) 2000-2026 */
 /*                                                                           */
 /* Management of the number of elements per dimension for N-dimensional      */
 /* arrays.                                                                   */
@@ -212,6 +212,7 @@ class ArrayExtents<ExtentsV<SizeType_, X0>>
 
   using ExtentsType = ExtentsV<SizeType_, X0>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
+  using BaseClass::extent0;
   using BaseClass::totalNbElement;
   using DynamicDimsType = typename ExtentsType::DynamicDimsType;
 
@@ -247,6 +248,8 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
 
   using ExtentsType = ExtentsV<SizeType_, X0, X1>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
+  using BaseClass::extent0;
+  using BaseClass::extent1;
   using BaseClass::totalNbElement;
   using DynamicDimsType = typename ExtentsType::DynamicDimsType;
 
@@ -283,6 +286,9 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
 
   using ExtentsType = ExtentsV<SizeType_, X0, X1, X2>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
+  using BaseClass::extent0;
+  using BaseClass::extent1;
+  using BaseClass::extent2;
   using BaseClass::totalNbElement;
   using DynamicDimsType = typename BaseClass::DynamicDimsType;
 
@@ -320,6 +326,10 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
 
   using ExtentsType = ExtentsV<SizeType_, X0, X1, X2, X3>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
+  using BaseClass::extent0;
+  using BaseClass::extent1;
+  using BaseClass::extent2;
+  using BaseClass::extent3;
   using BaseClass::totalNbElement;
   using DynamicDimsType = typename BaseClass::DynamicDimsType;
 

--- a/arccore/src/base/tests/CMakeLists.txt
+++ b/arccore/src/base/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 ﻿arccore_add_component_test_executable(base
   FILES
+  TestArrayExtents.cc
   TestBasicDataType.cc
   TestException.cc
   TestGetIndices.cc

--- a/arccore/src/base/tests/TestArrayExtents.cc
+++ b/arccore/src/base/tests/TestArrayExtents.cc
@@ -1,0 +1,53 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+#include <gtest/gtest.h>
+
+#include "arccore/base/ArrayExtentsValue.h"
+#include "arccore/base/ArrayExtents.h"
+
+#include <iostream>
+
+using namespace Arcane;
+
+TEST(ArrayExtents, Misc)
+{
+  Int32 n1 = 150;
+  Int32 n2 = 120;
+  Int32 n3 = 50;
+  Int32 n4 = 200;
+
+  {
+    ArrayExtents<ExtentsV<Int32, DynExtent>> a(n1);
+    Int32 total_size = n1;
+    ASSERT_EQ(a.totalNbElement(), total_size);
+    ASSERT_EQ(a.extent0(), n1);
+  }
+  {
+    ArrayExtents<ExtentsV<Int32, DynExtent, DynExtent>> a(n1, n2);
+    Int32 total_size = n1 * n2;
+    ASSERT_EQ(a.totalNbElement(), total_size);
+    ASSERT_EQ(a.extent0(), n1);
+    ASSERT_EQ(a.extent1(), n2);
+  }
+  {
+    ArrayExtents<ExtentsV<Int32, DynExtent, DynExtent, DynExtent>> a(n1, n2, n3);
+    Int32 total_size = n1 * n2 * n3;
+    ASSERT_EQ(a.totalNbElement(), total_size);
+    ASSERT_EQ(a.extent0(), n1);
+    ASSERT_EQ(a.extent1(), n2);
+    ASSERT_EQ(a.extent2(), n3);
+  }
+  {
+    ArrayExtents<ExtentsV<Int32, DynExtent, DynExtent, DynExtent, DynExtent>> a(n1, n2, n3, n4);
+    Int32 total_size = n1 * n2 * n3 * n4;
+    ASSERT_EQ(a.totalNbElement(), total_size);
+    ASSERT_EQ(a.extent0(), n1);
+    ASSERT_EQ(a.extent1(), n2);
+    ASSERT_EQ(a.extent2(), n3);
+    ASSERT_EQ(a.extent3(), n4);
+  }
+}

--- a/arccore/src/common/arccore/common/NumArray.h
+++ b/arccore/src/common/arccore/common/NumArray.h
@@ -700,6 +700,37 @@ class NumArray
 
  public:
 
+  //! Base pointer of the array.
+  DataType* data() { return m_span._internalData(); }
+
+  //! Base pointer of the array.
+  const DataType* data() const { return m_span._internalData(); }
+
+ public:
+
+  //! Mutable iterator for the first element of the array
+  ArrayIterator<DataType*> begin() requires(Extents::rank() == 1)
+  {
+    return m_span.to1DSmallSpan().begin();
+  }
+  //! Mutable iterator following the last element of the array
+  ArrayIterator<DataType*> end() requires(Extents::rank() == 1)
+  {
+    return m_span.to1DSmallSpan().end();
+  }
+  //! Read-only iterator for the first element of the array
+  ArrayIterator<const DataType*> begin() const requires(Extents::rank() == 1)
+  {
+    return m_span.to1DSmallSpan().begin();
+  }
+  //! Read-only iterator following the last element of the array
+  ArrayIterator<const DataType*> end() const requires(Extents::rank() == 1)
+  {
+    return m_span.to1DSmallSpan().end();
+  }
+
+ public:
+
   //! \internal
   DataType* _internalData() { return m_span._internalData(); }
 


### PR DESCRIPTION
- Add methods `begin()` and `end()` on 1D `NumArray` to iterate over the array.
- Add method `data()` to get access to the first element of the `NumArray`.
- Make public the methods `extents*()` of `ArrayExtents`.
