### PR TITLE
Add support to directly call lambda and mutable lambda with accelerator API

### DIFF
--- a/arccore/src/accelerator/arccore/accelerator/RunCommandLoop.h
+++ b/arccore/src/accelerator/arccore/accelerator/RunCommandLoop.h
@@ -375,6 +375,26 @@ run(RunCommand& command, ComplexForLoopRanges<N, Int32> bounds, const Lambda& fu
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+//! Applies the lambda \a func on the iteration range given by \a bounds
+template <int N, typename Lambda> void
+launchRunCommand(RunCommand& command, SimpleForLoopRanges<N, Int32> bounds, Lambda func)
+{
+  Impl::_applyGenericLoop(command, bounds, func);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+//! Applies the lambda \a func on the iteration range given by \a bounds
+template <int N, typename Lambda> void
+launchRunCommand(RunCommand& command, ComplexForLoopRanges<N, Int32> bounds, const Lambda& func)
+{
+  Impl::_applyGenericLoop(command, bounds, func);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 template <typename ExtentType> auto
 operator<<(RunCommand& command, const ArrayBounds<ExtentType>& bounds)
 -> Impl::ArrayBoundRunCommand<SimpleForLoopRanges<ExtentType::rank(), Int32>>

--- a/arccore/src/accelerator/tests/CMakeLists.txt
+++ b/arccore/src/accelerator/tests/CMakeLists.txt
@@ -6,6 +6,7 @@
   TestReduce1.cc
   TestLoop1.cc
   TestMemoryBandwidth.cc
+  TestLambda.cc
 )
 
 set(ACCELERATOR_FILES
@@ -15,6 +16,7 @@ set(ACCELERATOR_FILES
   TestCooperativeLaunch_GridSync.cc
   TestCooperativeLaunch_Accelerator.cc
   TestCooperativeLaunch_Accelerator2.cc
+  TestLambda_Accelerator.cc
 )
 
 arccore_add_component_test_executable(accelerator

--- a/arccore/src/accelerator/tests/TestLambda.cc
+++ b/arccore/src/accelerator/tests/TestLambda.cc
@@ -1,0 +1,46 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "arccore/base/PlatformUtils.h"
+
+#include "arccore/common/accelerator/Runner.h"
+#include "arccore/common/accelerator/RunQueue.h"
+#include "arccore/common/NumArray.h"
+
+#include "arccore/accelerator/NumArrayViews.h"
+#include "arccore/accelerator/RunCommandLoop.h"
+#include "arccore/accelerator/Reduce.h"
+#include "arccore/accelerator/internal/Initializer.h"
+
+#include "./TestCommon.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+using namespace Arcane;
+using namespace Arcane::Accelerator;
+
+extern "C++" void
+_doTestLambda(RunQueue queue);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void _doLambda(bool use_accelerator, Int32 max_allowed_thread)
+{
+  Accelerator::Initializer x(use_accelerator, max_allowed_thread);
+  Runner runner(x.executionPolicy());
+  RunQueue queue(makeQueue(runner));
+  _doTestLambda(queue);
+}
+
+ARCCORE_TEST_DO_TEST_ACCELERATOR(ArccoreAccelerator, TestLambda, _doLambda);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arccore/src/accelerator/tests/TestLambda_Accelerator.cc
+++ b/arccore/src/accelerator/tests/TestLambda_Accelerator.cc
@@ -1,0 +1,91 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "arccore/base/MDIndex.h"
+
+#include "arccore/common/accelerator/RunQueue.h"
+#include "arccore/common/NumArray.h"
+
+#include "arccore/accelerator/RunCommandLoop.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+using namespace Arcane;
+using namespace Arcane::Accelerator;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void
+_fillArray(NumArray<Int64, MDDim1>& num_array, Int64 base_value)
+{
+  Int32 nb_value = num_array.extent0();
+  for (Int32 i = 0; i < nb_value; ++i) {
+    num_array(i) = (i + base_value);
+  }
+}
+
+extern "C++" void
+_doTestLambda(RunQueue queue)
+{
+  Int32 nb_value = 50000;
+
+  std::cout << "Using accelerator policy name=" << queue.executionPolicy() << "\n";
+  std::cout << " nb_value=" << nb_value << "\n";
+
+  NumArray<Int64, MDDim1> a(nb_value);
+  _fillArray(a, 3);
+
+  NumArray<Int64, MDDim1> b(nb_value);
+
+  // Test direct lambda launch
+  {
+    SmallSpan<const Int64> a_view(a.to1DSmallSpan());
+    SmallSpan<Int64> b_view(a.to1DSmallSpan());
+    auto lambda1 = [=] ARCCORE_HOST_DEVICE(Int32 index) {
+      b_view[index] = a_view[index];
+    };
+
+    {
+      std::cout << "Test lambda direct\n";
+      RunCommand command = makeCommand(queue);
+      auto range = makeLoopRanges(nb_value);
+      Arcane::Accelerator::run(command, range, lambda1);
+    }
+
+    for (Int32 k = 0; k < nb_value; ++k) {
+      ASSERT_EQ(a_view[k], b_view[k]) << " Index1=" << k;
+    }
+  }
+
+  {
+    _fillArray(a, 5);
+
+    ConstArrayView<Int64> a_view(nb_value, a.data());
+    ArrayView<Int64> b_view(nb_value, b.data());
+    auto mutable_lambda1 = [=] ARCCORE_HOST_DEVICE(Int32 index) mutable {
+      b_view[index] = a_view[index];
+    };
+
+    {
+      std::cout << "Test mutable lambda direct\n";
+      RunCommand command = makeCommand(queue);
+      auto range = makeLoopRanges(nb_value);
+      Arcane::Accelerator::launchRunCommand(command, range, mutable_lambda1);
+    }
+
+    for (Int32 k = 0; k < nb_value; ++k) {
+      ASSERT_EQ(a_view[k], b_view[k]) << " Index2=" << k;
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arccore/src/common/arccore/common/SequentialFor.h
+++ b/arccore/src/common/arccore/common/SequentialFor.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* SequentialFor.h                                             (C) 2000-2025 */
+/* SequentialFor.h                                             (C) 2000-2026 */
 /*                                                                           */
 /* Handling of sequential for loops.                                         */
 /*---------------------------------------------------------------------------*/
@@ -29,7 +29,7 @@ namespace Arcane
 //! Applies the functor \a func over a 1D loop.
 template <typename IndexType, template <int T, typename> class LoopBoundType,
           typename Lambda, typename... RemainingArgs>
-void arccoreSequentialFor(LoopBoundType<1, IndexType> bounds, const Lambda& func,
+void arccoreSequentialFor(LoopBoundType<1, IndexType> bounds, Lambda func,
                           RemainingArgs... remaining_args)
 {
   Impl::HostKernelRemainingArgsHelper::applyAtBegin(remaining_args...);
@@ -43,7 +43,7 @@ void arccoreSequentialFor(LoopBoundType<1, IndexType> bounds, const Lambda& func
 
 //! Applies the functor \a func over a 2D loop.
 template <typename IndexType, template <int T, typename> class LoopBoundType, typename Lambda> void
-arccoreSequentialFor(LoopBoundType<2, IndexType> bounds, const Lambda& func)
+arccoreSequentialFor(LoopBoundType<2, IndexType> bounds, Lambda func)
 {
   for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
     for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
@@ -55,7 +55,7 @@ arccoreSequentialFor(LoopBoundType<2, IndexType> bounds, const Lambda& func)
 
 //! Applies the functor \a func over a 3D loop.
 template <typename IndexType, template <int T, typename> class LoopBoundType, typename Lambda> void
-arccoreSequentialFor(LoopBoundType<3, IndexType> bounds, const Lambda& func)
+arccoreSequentialFor(LoopBoundType<3, IndexType> bounds, Lambda func)
 {
   for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
     for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
@@ -68,7 +68,7 @@ arccoreSequentialFor(LoopBoundType<3, IndexType> bounds, const Lambda& func)
 
 //! Applies the functor \a func over a 4D loop.
 template <typename IndexType, template <int, typename> class LoopBoundType, typename Lambda> void
-arccoreSequentialFor(LoopBoundType<4, IndexType> bounds, const Lambda& func)
+arccoreSequentialFor(LoopBoundType<4, IndexType> bounds, Lambda func)
 {
   for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
     for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)


### PR DESCRIPTION
The function `Arcane::Accelerator::launchRunCommand()` is the one to call to directly call a lambda