### PR TITLE
Improve support for type other than `Int32` for array extents

### DIFF
--- a/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl1.cc
+++ b/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl1.cc
@@ -22,7 +22,7 @@ namespace Arcane::Accelerator::Impl
 void AcceleratorSpecificMemoryCopyList::
 addExplicitTemplate1()
 {
-  using namespace Arcane::impl;
+  using namespace Arcane::Impl;
 
   //! Adds specific implementations for the first common sizes
   addCopier<SpecificType<std::byte, ExtentValue<1>>>(); // 1

--- a/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl2.cc
+++ b/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl2.cc
@@ -25,7 +25,7 @@ namespace Arcane::Accelerator::Impl
 void AcceleratorSpecificMemoryCopyList::
 addExplicitTemplate2()
 {
-  using namespace Arcane::impl;
+  using namespace Arcane::Impl;
 
   //! Adds specific implementations for the first common sizes
   addCopier<SpecificType<Int16, ExtentValue<3>>>(); // 6

--- a/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl3.cc
+++ b/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl3.cc
@@ -22,7 +22,7 @@ namespace Arcane::Accelerator::Impl
 void AcceleratorSpecificMemoryCopyList::
 addExplicitTemplate3()
 {
-  using namespace Arcane::impl;
+  using namespace Arcane::Impl;
 
   //! Adds specific implementations for the first common sizes
   addCopier<SpecificType<Int64, ExtentValue<2>>>(); // 16

--- a/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl4.cc
+++ b/arccore/src/accelerator/arccore/accelerator/MemoryCopierTpl4.cc
@@ -22,7 +22,7 @@ namespace Arcane::Accelerator::Impl
 void AcceleratorSpecificMemoryCopyList::
 addExplicitTemplate4()
 {
-  using namespace Arcane::impl;
+  using namespace Arcane::Impl;
 
   //! Adds specific implementations for the first common sizes
   addCopier<SpecificType<Int64, ExtentValue<6>>>(); // 48

--- a/arccore/src/base/arccore/base/ArrayBounds.h
+++ b/arccore/src/base/arccore/base/ArrayBounds.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayBounds.h                                               (C) 2000-2025 */
+/* ArrayBounds.h                                               (C) 2000-2026 */
 /*                                                                           */
 /* Handling of iterations on N-dimensional arrays                            */
 /*---------------------------------------------------------------------------*/
@@ -24,7 +24,9 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
+/*!
+ * \brief Base class for bounds of multidimensional array.
+ */
 template <typename Extents>
 class ArrayBoundsBase
 : private ArrayExtents<Extents>
@@ -35,11 +37,12 @@ class ArrayBoundsBase
   using BaseClass::asStdArray;
   using BaseClass::constExtent;
   using BaseClass::getIndices;
-  using MDIndexType = typename BaseClass::MDIndexType;
-  using LoopIndexType = typename BaseClass::LoopIndexType;
-  using ArrayExtentType = Arcane::ArrayExtents<Extents>;
+  using MDIndexType = BaseClass::MDIndexType;
+  using LoopIndexType = BaseClass::LoopIndexType;
+  using ExtentIndexType = Extents::ExtentIndexType;
+  using ArrayExtentType = ArrayExtents<Extents>;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'LoopIndexType' or 'MDIndexType' instead") = LoopIndexType;
+  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = LoopIndexType;
 
  public:
 
@@ -49,7 +52,7 @@ class ArrayBoundsBase
   {
   }
 
-  constexpr explicit ArrayBoundsBase(const std::array<Int32, Extents::nb_dynamic>& v)
+  constexpr explicit ArrayBoundsBase(const std::array<ExtentIndexType, Extents::nb_dynamic>& v)
   : BaseClass(v)
   {
   }
@@ -61,7 +64,9 @@ class ArrayBoundsBase
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
+/*!
+ * \brief Represents the bounds of a multidimensional array.
+ */
 template <typename Extents>
 class ArrayBounds
 : public ArrayBoundsBase<Extents>
@@ -69,31 +74,31 @@ class ArrayBounds
  public:
 
   using ExtentsType = Extents;
+  using ExtentIndexType = Extents::ExtentIndexType;
   using BaseClass = ArrayBoundsBase<ExtentsType>;
   using ArrayExtentsType = ArrayExtents<ExtentsType>;
+  using LoopIndexType = BaseClass::LoopIndexType;
 
  public:
 
-  template <typename X = Extents, typename = std::enable_if_t<X::nb_dynamic == 4, void>>
-  constexpr ArrayBounds(Int32 dim1, Int32 dim2, Int32 dim3, Int32 dim4)
+  constexpr ArrayBounds(ExtentIndexType dim1, ExtentIndexType dim2,
+                        ExtentIndexType dim3, ExtentIndexType dim4) requires(Extents::nb_dynamic == 4)
   : BaseClass(ArrayExtentsType(dim1, dim2, dim3, dim4))
   {
   }
 
-  template <typename X = Extents, typename = std::enable_if_t<X::nb_dynamic == 3, void>>
-  constexpr ArrayBounds(Int32 dim1, Int32 dim2, Int32 dim3)
+  constexpr ArrayBounds(ExtentIndexType dim1, ExtentIndexType dim2,
+                        ExtentIndexType dim3) requires(Extents::nb_dynamic == 3)
   : BaseClass(ArrayExtentsType(dim1, dim2, dim3))
   {
   }
 
-  template <typename X = Extents, typename = std::enable_if_t<X::nb_dynamic == 2, void>>
-  constexpr ArrayBounds(Int32 dim1, Int32 dim2)
+  constexpr ArrayBounds(ExtentIndexType dim1, ExtentIndexType dim2) requires(Extents::nb_dynamic == 2)
   : BaseClass(ArrayExtentsType(dim1, dim2))
   {
   }
 
-  template <typename X = Extents, typename = std::enable_if_t<X::nb_dynamic == 1, void>>
-  constexpr ArrayBounds(Int32 dim1)
+  constexpr ArrayBounds(ExtentIndexType dim1) requires(Extents::nb_dynamic == 1)
   : BaseClass(ArrayExtentsType(dim1))
   {
   }
@@ -103,7 +108,7 @@ class ArrayBounds
   {
   }
 
-  constexpr explicit ArrayBounds(std::array<Int32, Extents::nb_dynamic>& v)
+  constexpr explicit ArrayBounds(std::array<ExtentIndexType, Extents::nb_dynamic>& v)
   : BaseClass(v)
   {
   }

--- a/arccore/src/base/arccore/base/ArrayExtents.h
+++ b/arccore/src/base/arccore/base/ArrayExtents.h
@@ -30,7 +30,6 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization of ArrayStrideBase for 0-dimensional arrays (scalars)
  */
@@ -108,7 +107,6 @@ class ArrayStridesBase
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization of ArrayExtentsBase for 0-dimensional arrays (scalars)
  */
@@ -131,7 +129,6 @@ class ArrayExtentsBase<ExtentsV<>>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Class to maintain the number of elements in each dimension.
  */
@@ -141,9 +138,10 @@ class ArrayExtentsBase
 {
  protected:
 
-  using BaseClass = typename Extents::ArrayExtentsValueType;
+  using BaseClass = Extents::ArrayExtentsValueType;
+  using ExtentIndexType = Extents::ExtentIndexType;
   using ArrayExtentsPreviousRank = ArrayExtentsBase<typename Extents::RemovedFirstExtentsType>;
-  using DynamicDimsType = typename Extents::DynamicDimsType;
+  using DynamicDimsType = Extents::DynamicDimsType;
 
  public:
 
@@ -161,7 +159,7 @@ class ArrayExtentsBase
 
  protected:
 
-  explicit constexpr ARCCORE_HOST_DEVICE ArrayExtentsBase(SmallSpan<const Int32> extents)
+  explicit constexpr ARCCORE_HOST_DEVICE ArrayExtentsBase(SmallSpan<const ExtentIndexType> extents)
   : BaseClass(extents)
   {
   }
@@ -174,7 +172,7 @@ class ArrayExtentsBase
  public:
 
   //! TEMPORARY: Sets the number of elements of dimension 0 to \a v.
-  ARCCORE_HOST_DEVICE void setExtent0(Int32 v) { this->m_extent0.v = v; }
+  ARCCORE_HOST_DEVICE void setExtent0(ExtentIndexType v) { this->m_extent0.v = v; }
 
   // Instance containing dimensions after the first
   ARCCORE_HOST_DEVICE ArrayExtentsPreviousRank removeFirstExtent() const
@@ -192,19 +190,18 @@ class ArrayExtentsBase
   /*!
    * \brief Constructs an instance from the values given in \a extents.
    */
-  ARCCORE_HOST_DEVICE static ArrayExtentsBase<Extents> fromSpan(SmallSpan<const Int32> extents)
+  ARCCORE_HOST_DEVICE static ArrayExtentsBase fromSpan(SmallSpan<const ExtentIndexType> extents)
   {
-    return ArrayExtentsBase<Extents>(extents);
+    return ArrayExtentsBase(extents);
   }
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent for 1-dimensional arrays.
  */
-template <typename SizeType_, int X0>
+template <typename SizeType_, Int32 X0>
 class ArrayExtents<ExtentsV<SizeType_, X0>>
 : public ArrayExtentsBase<ExtentsV<SizeType_, X0>>
 {
@@ -214,7 +211,9 @@ class ArrayExtents<ExtentsV<SizeType_, X0>>
   using BaseClass = ArrayExtentsBase<ExtentsType>;
   using BaseClass::extent0;
   using BaseClass::totalNbElement;
-  using DynamicDimsType = typename ExtentsType::DynamicDimsType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
  public:
 
@@ -227,7 +226,7 @@ class ArrayExtents<ExtentsV<SizeType_, X0>>
   {
   }
   // TODO: To be removed
-  constexpr ARCCORE_HOST_DEVICE explicit ArrayExtents(Int32 dim1_size)
+  constexpr ARCCORE_HOST_DEVICE explicit ArrayExtents(ExtentIndexType dim1_size)
   {
     static_assert(ExtentsType::nb_dynamic == 1, "This method is only allowed for full dynamic extents");
     this->m_extent0.v = dim1_size;
@@ -236,11 +235,10 @@ class ArrayExtents<ExtentsV<SizeType_, X0>>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent for 2-dimensional arrays.
  */
-template <typename SizeType_, int X0, int X1>
+template <typename SizeType_, Int32 X0, Int32 X1>
 class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
 : public ArrayExtentsBase<ExtentsV<SizeType_, X0, X1>>
 {
@@ -251,7 +249,9 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
   using BaseClass::extent0;
   using BaseClass::extent1;
   using BaseClass::totalNbElement;
-  using DynamicDimsType = typename ExtentsType::DynamicDimsType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
  public:
 
@@ -264,7 +264,7 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
   {
   }
   // TODO: To be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(Int32 dim1_size, Int32 dim2_size)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtents(ExtentIndexType dim1_size, ExtentIndexType dim2_size)
   {
     static_assert(ExtentsType::nb_dynamic == 2, "This method is only allowed for full dynamic extents");
     this->m_extent0.v = dim1_size;
@@ -274,11 +274,10 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent for 3-dimensional arrays.
  */
-template <typename SizeType_, int X0, int X1, int X2>
+template <typename SizeType_, Int32 X0, Int32 X1, Int32 X2>
 class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
 : public ArrayExtentsBase<ExtentsV<SizeType_, X0, X1, X2>>
 {
@@ -290,7 +289,9 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
   using BaseClass::extent1;
   using BaseClass::extent2;
   using BaseClass::totalNbElement;
-  using DynamicDimsType = typename BaseClass::DynamicDimsType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
  public:
 
@@ -303,7 +304,7 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
   {
   }
   // TODO: To be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtents(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size)
   {
     static_assert(ExtentsType::nb_dynamic == 3, "This method is only allowed for full dynamic extents");
     this->m_extent0.v = dim1_size;
@@ -314,11 +315,10 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent for 4-dimensional arrays.
  */
-template <typename SizeType_, int X0, int X1, int X2, int X3>
+template <typename SizeType_, Int32 X0, Int32 X1, Int32 X2, Int32 X3>
 class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
 : public ArrayExtentsBase<ExtentsV<SizeType_, X0, X1, X2, X3>>
 {
@@ -331,7 +331,9 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
   using BaseClass::extent2;
   using BaseClass::extent3;
   using BaseClass::totalNbElement;
-  using DynamicDimsType = typename BaseClass::DynamicDimsType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
  public:
 
@@ -344,7 +346,7 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
   {
   }
   // TODO: To be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, Int32 dim4_size)
+  constexpr ARCCORE_HOST_DEVICE ArrayExtents(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size, ExtentIndexType dim4_size)
   {
     static_assert(ExtentsType::nb_dynamic == 4, "This method is only allowed for full dynamic extents");
     this->m_extent0.v = dim1_size;
@@ -359,11 +361,10 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent and Offset for 1-dimensional arrays.
  */
-template <typename SizeType_, int X0, typename LayoutType>
+template <typename SizeType_, SizeType_ X0, typename LayoutType>
 class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
 : private ArrayExtents<ExtentsV<SizeType_, X0>>
 {
@@ -376,11 +377,11 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
   using BaseClass::getIndices;
   using BaseClass::totalNbElement;
   using Layout = typename LayoutType::Layout1Type;
-  using DynamicDimsType = typename BaseClass::DynamicDimsType;
-  using MDIndexType = typename BaseClass::MDIndexType;
-  using LoopIndexType = typename BaseClass::LoopIndexType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 
  public:
 
@@ -394,7 +395,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
   : BaseClass(rhs)
   {
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(ExtentIndexType i) const
   {
     BaseClass::_checkIndex(i);
     return i;
@@ -413,11 +414,10 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent and Offset for 2-dimensional arrays.
  */
-template <typename SizeType_, int X0, int X1, typename LayoutType>
+template <typename SizeType_, SizeType_ X0, SizeType_ X1, typename LayoutType>
 class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
 : private ArrayExtents<ExtentsV<SizeType_, X0, X1>>
 {
@@ -431,10 +431,11 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
   using BaseClass::getIndices;
   using BaseClass::totalNbElement;
   using Layout = typename LayoutType::Layout2Type;
-  using DynamicDimsType = typename BaseClass::DynamicDimsType;
-  using MDIndexType = typename BaseClass::MDIndexType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 
  public:
 
@@ -448,7 +449,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
   : BaseClass(rhs)
   {
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(ExtentIndexType i, ExtentIndexType j) const
   {
     return offset({ i, j });
   }
@@ -470,7 +471,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
 /*!
  * \brief Extent and Offset for 3-dimensional arrays.
  */
-template <typename SizeType_, int X0, int X1, int X2, typename LayoutType>
+template <typename SizeType_, SizeType_ X0, SizeType_ X1, SizeType_ X2, typename LayoutType>
 class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
 : private ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
 {
@@ -485,8 +486,9 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
   using BaseClass::getIndices;
   using BaseClass::totalNbElement;
   using Layout = typename LayoutType::Layout3Type;
-  using DynamicDimsType = typename BaseClass::DynamicDimsType;
-  using MDIndexType = typename BaseClass::MDIndexType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
   using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
 
@@ -504,7 +506,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
   {
     _computeOffsets();
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j, Int32 k) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k) const
   {
     return offset({ i, j, k });
   }
@@ -534,11 +536,10 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent and Offset for 4-dimensional arrays.
  */
-template <typename SizeType_, int X0, int X1, int X2, int X3, typename LayoutType>
+template <typename SizeType_, SizeType_ X0, SizeType_ X1, SizeType_ X2, SizeType_ X3, typename LayoutType>
 class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
 : private ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
 {
@@ -554,8 +555,9 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
   using BaseClass::getIndices;
   using BaseClass::totalNbElement;
   using Layout = typename LayoutType::Layout4Type;
-  using DynamicDimsType = typename BaseClass::DynamicDimsType;
-  using MDIndexType = typename BaseClass::MDIndexType;
+  using DynamicDimsType = BaseClass::DynamicDimsType;
+  using MDIndexType = BaseClass::MDIndexType;
+  using ExtentIndexType = BaseClass::ExtentIndexType;
 
   using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = typename BaseClass::MDIndexType;
 
@@ -573,7 +575,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
   {
     _computeOffsets();
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j, Int32 k, Int32 l) const
+  constexpr ARCCORE_HOST_DEVICE Int64 offset(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k, ExtentIndexType l) const
   {
     return offset({ i, j, k, l });
   }

--- a/arccore/src/base/arccore/base/ArrayExtentsValue.h
+++ b/arccore/src/base/arccore/base/ArrayExtentsValue.h
@@ -23,19 +23,20 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-namespace Arcane::impl
+namespace Arcane::Impl
 {
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template <class T> constexpr ARCCORE_HOST_DEVICE
-T
+template <class T> constexpr ARCCORE_HOST_DEVICE T
 fastmod(T a, T b)
 {
   return a < b ? a : a - b * (a / b);
 }
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \brief Information for a fixed dimension known at compile time.
  *
@@ -46,10 +47,14 @@ class ExtentValue
 {
  public:
 
+  using ExtentIndexType = IndexType_;
+
   static constexpr Int64 size() { return Size; };
-  static constexpr Int32 v = Size;
+  static constexpr ExtentIndexType v = Size;
 };
 
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 /*!
  * \brief Specialization for a dynamic dimension.
  *
@@ -60,16 +65,19 @@ class ExtentValue<DynExtent, IndexType_>
 {
  public:
 
+  using ExtentIndexType = IndexType_;
+
+ public:
+
   constexpr Int64 size() const { return v; }
 
  public:
 
-  IndexType_ v = 0;
+  ExtentIndexType v = 0;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization to hold the dimensions of a 1-dimensional array.
  */
@@ -78,24 +86,25 @@ class ArrayExtentsValue<IndexType_, X0>
 {
  public:
 
+  using ExtentIndexType = IndexType_;
   using ExtentsType = ExtentsV<IndexType_, X0>;
   using DynamicDimsType = typename ExtentsType::DynamicDimsType;
-  using MDIndexType = MDIndex<1>;
-  using LoopIndexType = MDIndex<1>;
+  using MDIndexType = MDIndex<1, IndexType_>;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'LoopIndexType' or 'MDIndexType' instead") = LoopIndexType;
+  using LoopIndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = MDIndexType;
+  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = MDIndexType;
 
   ArrayExtentsValue() = default;
 
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE Int32 constExtent() const
+  template <Int32 I> constexpr ARCCORE_HOST_DEVICE ExtentIndexType constExtent() const
   {
     static_assert(I == 0, "Invalid value for i (i==0)");
     return m_extent0.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE std::array<Int32, 1> asStdArray() const
+  constexpr ARCCORE_HOST_DEVICE std::array<ExtentIndexType, 1> asStdArray() const
   {
-    return std::array<Int32, 1>{ m_extent0.v };
+    return std::array<ExtentIndexType, 1>{ m_extent0.v };
   }
 
   constexpr ARCCORE_HOST_DEVICE Int64 totalNbElement() const
@@ -103,17 +112,17 @@ class ArrayExtentsValue<IndexType_, X0>
     return m_extent0.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(Int32 i) const
+  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
   {
     return { i };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int32 extent0() const { return m_extent0.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const
   {
-    std::array<Int32, ExtentsType::nb_dynamic> x = {};
+    std::array<ExtentIndexType, ExtentsType::nb_dynamic> x = {};
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       x[i++] = m_extent0.v;
@@ -122,7 +131,7 @@ class ArrayExtentsValue<IndexType_, X0>
 
  protected:
 
-  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const Int32> extents)
+  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const ExtentIndexType> extents)
   {
     if constexpr (X0 == DynExtent)
       m_extent0.v = extents[0];
@@ -136,7 +145,7 @@ class ArrayExtentsValue<IndexType_, X0>
       m_extent0.v = dims[i++];
   }
 
-  constexpr std::array<Int32, 0> _removeFirstExtent() const
+  constexpr std::array<ExtentIndexType, 0> _removeFirstExtent() const
   {
     return {};
   }
@@ -148,12 +157,11 @@ class ArrayExtentsValue<IndexType_, X0>
 
  protected:
 
-  impl::ExtentValue<X0> m_extent0;
+  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization to hold the dimensions of a 2-dimensional array.
  */
@@ -162,12 +170,13 @@ class ArrayExtentsValue<IndexType_, X0, X1>
 {
  public:
 
+  using ExtentIndexType = IndexType_;
   using ExtentsType = ExtentsV<IndexType_, X0, X1>;
-  using MDIndexType = MDIndex<2>;
-  using LoopIndexType = MDIndex<2>;
-  using DynamicDimsType = typename ExtentsType::DynamicDimsType;
+  using MDIndexType = MDIndex<2, IndexType_>;
+  using DynamicDimsType = ExtentsType::DynamicDimsType;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'LoopIndexType' or 'MDIndexType' instead") = LoopIndexType;
+  using LoopIndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = MDIndexType;
+  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = LoopIndexType;
 
  public:
 
@@ -175,7 +184,7 @@ class ArrayExtentsValue<IndexType_, X0, X1>
 
  public:
 
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE Int32 constExtent() const
+  template <Int32 I> constexpr ARCCORE_HOST_DEVICE ExtentIndexType constExtent() const
   {
     static_assert(I >= 0 && I < 2, "Invalid value for I (0<=I<2)");
     if (I == 0)
@@ -183,7 +192,7 @@ class ArrayExtentsValue<IndexType_, X0, X1>
     return m_extent1.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE std::array<Int32, 2> asStdArray() const
+  constexpr ARCCORE_HOST_DEVICE std::array<ExtentIndexType, 2> asStdArray() const
   {
     return { m_extent0.v, m_extent1.v };
   }
@@ -193,20 +202,20 @@ class ArrayExtentsValue<IndexType_, X0, X1>
     return m_extent0.size() * m_extent1.size();
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(Int32 i) const
+  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
   {
-    Int32 i0 = i / m_extent1.v;
-    Int32 i1 = i % m_extent1.v;
+    ExtentIndexType i0 = i / m_extent1.v;
+    ExtentIndexType i1 = i % m_extent1.v;
     return { i0, i1 };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int32 extent0() const { return m_extent0.v; };
-  constexpr ARCCORE_HOST_DEVICE Int32 extent1() const { return m_extent1.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent1() const { return m_extent1.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const
   {
-    std::array<Int32, ExtentsType::nb_dynamic> x = {};
+    std::array<ExtentIndexType, ExtentsType::nb_dynamic> x = {};
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       x[i++] = m_extent0.v;
@@ -217,7 +226,7 @@ class ArrayExtentsValue<IndexType_, X0, X1>
 
  protected:
 
-  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const Int32> extents)
+  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const ExtentIndexType> extents)
   {
     if constexpr (X0 == DynExtent)
       m_extent0.v = extents[0];
@@ -235,9 +244,9 @@ class ArrayExtentsValue<IndexType_, X0, X1>
       m_extent1.v = dims[i++];
   }
 
-  constexpr std::array<Int32, 1> _removeFirstExtent() const
+  constexpr std::array<ExtentIndexType, 1> _removeFirstExtent() const
   {
-    return std::array<Int32, 1>{ m_extent1.v };
+    return std::array<ExtentIndexType, 1>{ m_extent1.v };
   }
 
   ARCCORE_HOST_DEVICE void _checkIndex([[maybe_unused]] MDIndexType idx) const
@@ -248,13 +257,12 @@ class ArrayExtentsValue<IndexType_, X0, X1>
 
  protected:
 
-  impl::ExtentValue<X0> m_extent0;
-  impl::ExtentValue<X1> m_extent1;
+  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
+  Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization to hold the dimensions of a 3-dimensional array.
  */
@@ -263,12 +271,13 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
 {
  public:
 
+  using ExtentIndexType = IndexType_;
   using ExtentsType = ExtentsV<IndexType_, X0, X1, X2>;
-  using MDIndexType = MDIndex<3>;
-  using LoopIndexType = MDIndex<3>;
+  using MDIndexType = MDIndex<3, IndexType_>;
   using DynamicDimsType = typename ExtentsType::DynamicDimsType;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'LoopIndexType' or 'MDIndexType' instead") = LoopIndexType;
+  using LoopIndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = MDIndexType;
+  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = LoopIndexType;
 
  public:
 
@@ -276,7 +285,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
 
  public:
 
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE Int32 constExtent() const
+  template <Int32 I> constexpr ARCCORE_HOST_DEVICE ExtentIndexType constExtent() const
   {
     static_assert(I >= 0 && I < 3, "Invalid value for I (0<=I<3)");
     if (I == 0)
@@ -286,7 +295,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
     return m_extent2.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE std::array<Int32, 3> asStdArray() const
+  constexpr ARCCORE_HOST_DEVICE std::array<ExtentIndexType, 3> asStdArray() const
   {
     return { m_extent0.v, m_extent1.v, m_extent2.v };
   }
@@ -296,23 +305,23 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
     return m_extent0.size() * m_extent1.size() * m_extent2.size();
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(Int32 i) const
+  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
   {
-    Int32 i0 = i / (m_extent1.v * m_extent2.v);
+    ExtentIndexType i0 = i / (m_extent1.v * m_extent2.v);
     i %= (m_extent1.v * m_extent2.v);
-    Int32 i1 = i / m_extent2.v;
-    Int32 i2 = i % m_extent2.v;
+    ExtentIndexType i1 = i / m_extent2.v;
+    ExtentIndexType i2 = i % m_extent2.v;
     return { i0, i1, i2 };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int32 extent0() const { return m_extent0.v; };
-  constexpr ARCCORE_HOST_DEVICE Int32 extent1() const { return m_extent1.v; };
-  constexpr ARCCORE_HOST_DEVICE Int32 extent2() const { return m_extent2.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent1() const { return m_extent1.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent2() const { return m_extent2.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const
   {
-    std::array<Int32, ExtentsType::nb_dynamic> x = {};
+    std::array<ExtentIndexType, ExtentsType::nb_dynamic> x = {};
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       x[i++] = m_extent0.v;
@@ -325,7 +334,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
 
  protected:
 
-  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const Int32> extents)
+  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const ExtentIndexType> extents)
   {
     if constexpr (X0 == DynExtent)
       m_extent0.v = extents[0];
@@ -347,7 +356,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
       m_extent2.v = dims[i++];
   }
 
-  constexpr std::array<Int32, 2> _removeFirstExtent() const
+  constexpr std::array<ExtentIndexType, 2> _removeFirstExtent() const
   {
     return { m_extent1.v, m_extent2.v };
   }
@@ -361,9 +370,9 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
 
  protected:
 
-  impl::ExtentValue<X0> m_extent0;
-  impl::ExtentValue<X1> m_extent1;
-  impl::ExtentValue<X2> m_extent2;
+  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
+  Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
+  Impl::ExtentValue<X2, ExtentIndexType> m_extent2;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -377,12 +386,13 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
 {
  public:
 
+  using ExtentIndexType = IndexType_;
   using ExtentsType = ExtentsV<IndexType_, X0, X1, X2, X3>;
-  using MDIndexType = MDIndex<4>;
-  using LoopIndexType = MDIndex<4>;
+  using MDIndexType = MDIndex<4, IndexType_>;
   using DynamicDimsType = typename ExtentsType::DynamicDimsType;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'LoopIndexType' or 'MDIndexType' instead") = LoopIndexType;
+  using LoopIndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = MDIndexType;
+  using IndexType ARCCORE_DEPRECATED_REASON("Y2025: Use 'MDIndexType' instead") = LoopIndexType;
 
  public:
 
@@ -390,7 +400,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
 
  public:
 
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE Int32 constExtent() const
+  template <Int32 I> constexpr ARCCORE_HOST_DEVICE ExtentIndexType constExtent() const
   {
     static_assert(I >= 0 && I < 4, "Invalid value for I (0<=I<4)");
     if (I == 0)
@@ -402,7 +412,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
     return m_extent3.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE std::array<Int32, 4> asStdArray() const
+  constexpr ARCCORE_HOST_DEVICE std::array<ExtentIndexType, 4> asStdArray() const
   {
     return { m_extent0.v, m_extent1.v, m_extent2.v, m_extent3.v };
   }
@@ -412,28 +422,28 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
     return m_extent0.size() * m_extent1.size() * m_extent2.size() * m_extent3.size();
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(Int32 i) const
+  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
   {
     // Compute base indices
-    Int32 i3 = impl::fastmod(i, m_extent3.v);
-    Int32 fac = m_extent3.v;
-    Int32 i2 = impl::fastmod(i / fac, m_extent2.v);
+    ExtentIndexType i3 = Impl::fastmod(i, m_extent3.v);
+    ExtentIndexType fac = m_extent3.v;
+    ExtentIndexType i2 = Impl::fastmod(i / fac, m_extent2.v);
     fac *= m_extent2.v;
-    Int32 i1 = impl::fastmod(i / fac, m_extent1.v);
+    ExtentIndexType i1 = Impl::fastmod(i / fac, m_extent1.v);
     fac *= m_extent1.v;
-    Int32 i0 = i / fac;
+    ExtentIndexType i0 = i / fac;
     return { i0, i1, i2, i3 };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int32 extent0() const { return m_extent0.v; };
-  constexpr ARCCORE_HOST_DEVICE Int32 extent1() const { return m_extent1.v; };
-  constexpr ARCCORE_HOST_DEVICE Int32 extent2() const { return m_extent2.v; };
-  constexpr ARCCORE_HOST_DEVICE Int32 extent3() const { return m_extent3.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent1() const { return m_extent1.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent2() const { return m_extent2.v; };
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent3() const { return m_extent3.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const
   {
-    std::array<Int32, ExtentsType::nb_dynamic> x = {};
+    std::array<ExtentIndexType, ExtentsType::nb_dynamic> x = {};
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
       x[i++] = m_extent0.v;
@@ -448,7 +458,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
 
  protected:
 
-  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const Int32> extents)
+  explicit ARCCORE_HOST_DEVICE ArrayExtentsValue(SmallSpan<const ExtentIndexType> extents)
   {
     if constexpr (X0 == DynExtent)
       m_extent0.v = extents[0];
@@ -474,7 +484,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
       m_extent3.v = dims[i++];
   }
 
-  constexpr std::array<Int32, 3> _removeFirstExtent() const
+  constexpr std::array<ExtentIndexType, 3> _removeFirstExtent() const
   {
     return { m_extent1.v, m_extent2.v, m_extent3.v };
   }
@@ -489,16 +499,16 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
 
  protected:
 
-  impl::ExtentValue<X0> m_extent0;
-  impl::ExtentValue<X1> m_extent1;
-  impl::ExtentValue<X2> m_extent2;
-  impl::ExtentValue<X3> m_extent3;
+  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
+  Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
+  Impl::ExtentValue<X2, ExtentIndexType> m_extent2;
+  Impl::ExtentValue<X3, ExtentIndexType> m_extent3;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace Arcane::impl
+} // namespace Arcane::Impl
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/BaseTypes.h
+++ b/arccore/src/base/arccore/base/BaseTypes.h
@@ -26,7 +26,6 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \file BaseTypes.h
  *
@@ -170,7 +169,7 @@ using Accelerator::RunQueue;
 class DefaultLayout;
 template <int RankValue> class RightLayoutN;
 template <int RankValue> class LeftLayoutN;
-template <int RankValue> class MDDimType;
+template <int RankValue, typename IndexType_ = Int32> class MDDimType;
 class ConstMemoryView;
 class MutableMemoryView;
 class IMemoryResourceMng;
@@ -200,7 +199,7 @@ template <typename Extents> class ArrayExtents;
 template <int RankValue> class ArrayStridesBase;
 template <int RankValue> class IMDRangeFunctor;
 template <int RankValue> class ArrayExtentsValueDynamic;
-namespace impl
+namespace Impl
 {
   template <typename IndexType_, Int32... RankSize> class ArrayExtentsValue;
 }

--- a/arccore/src/base/arccore/base/ExtentsV.h
+++ b/arccore/src/base/arccore/base/ExtentsV.h
@@ -27,13 +27,13 @@ namespace Impl::extent
   {
     return (x + ...);
   }
-  template<class Int32> constexpr int oneIfDynamic(Int32 x)
+  constexpr int oneIfDynamic(Int32 x)
   {
     return ((x == DynExtent) ? 1 : 0);
   }
   // Number of dynamic values in the list of arguments
   // An argument is dynamic if it equals Arcane::DynExtent
-  template <class... IndexType> constexpr int nbDynamic(IndexType... args)
+  template <class... Int32> constexpr int nbDynamic(Int32... args)
   {
     return doSum(oneIfDynamic(args)...);
   }

--- a/arccore/src/base/arccore/base/ExtentsV.h
+++ b/arccore/src/base/arccore/base/ExtentsV.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ExtentsV.h                                                  (C) 2000-2025 */
+/* ExtentsV.h                                                  (C) 2000-2026 */
 /*                                                                           */
 /* Tag for N-dimensional arrays.                                             */
 /*---------------------------------------------------------------------------*/
@@ -21,27 +21,26 @@
 
 namespace Arcane
 {
-namespace impl::extent
+namespace Impl::extent
 {
   template <class... Int32> constexpr int doSum(Int32... x)
   {
     return (x + ...);
   }
-  constexpr int oneIfDynamic(Int32 x)
+  template<class Int32> constexpr int oneIfDynamic(Int32 x)
   {
     return ((x == DynExtent) ? 1 : 0);
   }
   // Number of dynamic values in the list of arguments
   // An argument is dynamic if it equals Arcane::DynExtent
-  template <class... Int32> constexpr int nbDynamic(Int32... args)
+  template <class... IndexType> constexpr int nbDynamic(IndexType... args)
   {
     return doSum(oneIfDynamic(args)...);
   }
-} // namespace impl::extent
+} // namespace Impl::extent
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization for 0-dimensional array extents.
  */
@@ -50,7 +49,10 @@ class ExtentsV<IndexType_>
 {
  public:
 
-  using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_>;
+  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_>;
+  using ExtentIndexType = IndexType_;
+
+ public:
 
   static constexpr int rank() { return 0; }
   static constexpr int nb_dynamic = 0;
@@ -63,7 +65,6 @@ class ExtentsV<IndexType_>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization for 1-dimensional array extents.
  */
@@ -73,24 +74,24 @@ class ExtentsV<IndexType_, X0>
  public:
 
   static constexpr int rank() { return 1; }
-  static constexpr int nb_dynamic = impl::extent::nbDynamic(X0);
+  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 1); }
   static constexpr bool isDynamic1D() { return (nb_dynamic == 1); }
 
-  using MDIndexType = MDIndex<1>;
-  using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0>;
+  using ExtentIndexType = IndexType_;
+  using MDIndexType = MDIndex<1, IndexType_>;
+  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_>;
-  using DynamicDimsType = MDIndex<nb_dynamic>;
+  using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
   template <int X> using AddedFirstExtentsType = ExtentsV<IndexType_, X, X0>;
   template <int X, int Last> using AddedFirstLastExtentsType = ExtentsV<IndexType_, X, X0, Last>;
   template <int X, int Last1, int Last2> using AddedFirstLastLastExtentsType = ExtentsV<IndexType_, X, X0, Last1, Last2>;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = ArrayIndex<1>;
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization for 2-dimensional array extents.
  */
@@ -100,23 +101,23 @@ class ExtentsV<IndexType_, X0, X1>
  public:
 
   static constexpr int rank() { return 2; }
-  static constexpr int nb_dynamic = impl::extent::nbDynamic(X0, X1);
+  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0, X1);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 2); }
   static constexpr bool isDynamic1D() { return false; }
 
-  using MDIndexType = MDIndex<2>;
-  using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0, X1>;
+  using ExtentIndexType = IndexType_;
+  using MDIndexType = MDIndex<2, IndexType_>;
+  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0, X1>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_, X1>;
-  using DynamicDimsType = MDIndex<nb_dynamic>;
+  using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
   template <int X> using AddedFirstExtentsType = ExtentsV<IndexType_, X, X0, X1>;
   template <int X, int Last> using AddedFirstLastExtentsType = ExtentsV<IndexType_, X, X0, X1, Last>;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = ArrayIndex<2>;
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization for 3-dimensional array extents.
  */
@@ -126,22 +127,22 @@ class ExtentsV<IndexType_, X0, X1, X2>
  public:
 
   static constexpr int rank() { return 3; }
-  static constexpr int nb_dynamic = impl::extent::nbDynamic(X0, X1, X2);
+  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0, X1, X2);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 3); }
   static constexpr bool isDynamic1D() { return false; }
 
-  using MDIndexType = MDIndex<3>;
-  using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0, X1, X2>;
+  using ExtentIndexType = IndexType_;
+  using MDIndexType = MDIndex<3, IndexType_>;
+  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0, X1, X2>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_, X1, X2>;
-  using DynamicDimsType = MDIndex<nb_dynamic>;
+  using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
   template <int X> using AddedFirstExtentsType = ExtentsV<IndexType_, X, X0, X1, X2>;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndex<3>;
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Specialization for 4-dimensional array extents.
  */
@@ -151,16 +152,17 @@ class ExtentsV<IndexType_, X0, X1, X2, X3>
  public:
 
   static constexpr int rank() { return 4; }
-  static constexpr int nb_dynamic = impl::extent::nbDynamic(X0, X1, X2, X3);
+  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0, X1, X2, X3);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 4); }
   static constexpr bool isDynamic1D() { return false; }
 
-  using MDIndexType = MDIndex<4>;
-  using ArrayExtentsValueType = impl::ArrayExtentsValue<IndexType_, X0, X1, X2, X3>;
+  using ExtentIndexType = IndexType_;
+  using MDIndexType = MDIndex<4, IndexType_>;
+  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0, X1, X2, X3>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_, X1, X2, X3>;
-  using DynamicDimsType = MDIndex<nb_dynamic>;
+  using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
 
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndex<4>;
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/ForLoopRanges.h
+++ b/arccore/src/base/arccore/base/ForLoopRanges.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ForLoopRanges.h                                             (C) 2000-2025 */
+/* ForLoopRanges.h                                             (C) 2000-2026 */
 /*                                                                           */
 /* Iteration ranges for loops.                                               */
 /*---------------------------------------------------------------------------*/
@@ -24,13 +24,16 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Iteration range for a loop.
  */
 template <typename IndexType_>
 class ForLoopRange
 {
+ public:
+
+  using ExtentIndexType = IndexType_;
+
  public:
 
   //! Creates an interval between *[lower_bound,lower_bound+size[*
@@ -58,7 +61,6 @@ class ForLoopRange
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Simple iteration range.
  *
@@ -67,18 +69,21 @@ class ForLoopRange
 template <int N, typename IndexType_>
 class SimpleForLoopRanges
 {
-  friend class ComplexForLoopRanges<N>;
+  friend class ComplexForLoopRanges<N, IndexType_>;
 
  public:
 
-  using ArrayBoundsType = ArrayBounds<typename MDDimType<N>::DimType>;
-  using ArrayIndexType = ArrayBoundsType::MDIndexType;
+  using ArrayBoundsType = ArrayBounds<typename MDDimType<N, IndexType_>::DimType>;
+  using MDIndexType = ArrayBoundsType::MDIndexType;
+  using ArrayIndexType = MDIndexType;
   using LoopIndexType = ArrayIndexType;
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'LoopIndexType' instead") = LoopIndexType;
+  using ExtentIndexType = IndexType_;
+
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 
  public:
 
-  explicit SimpleForLoopRanges(std::array<Int32, N> b)
+  explicit SimpleForLoopRanges(std::array<ExtentIndexType, N> b)
   : m_bounds(b)
   {}
   explicit(false) SimpleForLoopRanges(ArrayBoundsType b)
@@ -87,11 +92,11 @@ class SimpleForLoopRanges
 
  public:
 
-  template <Int32 I> static constexpr Int32 lowerBound() { return 0; }
-  template <Int32 I> constexpr Int32 upperBound() const { return m_bounds.template constExtent<I>(); }
-  template <Int32 I> constexpr Int32 extent() const { return m_bounds.template constExtent<I>(); }
+  template <Int32 I> static constexpr ExtentIndexType lowerBound() { return 0; }
+  template <Int32 I> constexpr ExtentIndexType upperBound() const { return m_bounds.template constExtent<I>(); }
+  template <Int32 I> constexpr ExtentIndexType extent() const { return m_bounds.template constExtent<I>(); }
   constexpr Int64 nbElement() const { return m_bounds.nbElement(); }
-  constexpr ArrayIndexType getIndices(Int32 i) const { return m_bounds.getIndices(i); }
+  constexpr MDIndexType getIndices(Int32 i) const { return m_bounds.getIndices(i); }
 
  private:
 
@@ -100,9 +105,7 @@ class SimpleForLoopRanges
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
- * \internal
  * \brief Complex iteration range.
  *
  * The starting indices for each dimension are specified by \a lower and
@@ -113,10 +116,13 @@ class ComplexForLoopRanges
 {
  public:
 
-  using ArrayBoundsType = ArrayBounds<typename MDDimType<N>::DimType>;
-  using ArrayIndexType = ArrayBoundsType::MDIndexType;
+  using ArrayBoundsType = ArrayBounds<typename MDDimType<N, IndexType_>::DimType>;
+  using MDIndexType = ArrayBoundsType::MDIndexType;
+  using ArrayIndexType = MDIndexType;
   using LoopIndexType = ArrayIndexType;
-  using IndexType ARCCORE_DEPRECATED_REASON("Use 'LoopIndexType' instead") = LoopIndexType;
+  using ExtentIndexType = IndexType_;
+
+  using IndexType ARCCORE_DEPRECATED_REASON("Use 'MDIndexType' instead") = MDIndexType;
 
  public:
 
@@ -134,7 +140,7 @@ class ComplexForLoopRanges
   template <Int32 I> constexpr Int32 upperBound() const { return m_lower_bounds[I] + m_extents.template constExtent<I>(); }
   template <Int32 I> constexpr Int32 extent() const { return m_extents.template constExtent<I>(); }
   constexpr Int64 nbElement() const { return m_extents.nbElement(); }
-  constexpr ArrayIndexType getIndices(Int32 i) const
+  constexpr MDIndexType getIndices(Int32 i) const
   {
     auto x = m_extents.getIndices(i);
     x.add(m_lower_bounds);
@@ -242,7 +248,7 @@ makeLoopRanges(ForLoopRange<Int32> n1, ForLoopRange<Int32> n2, ForLoopRange<Int3
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-} // End namespace Arcane
+} // namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/MDDim.h
+++ b/arccore/src/base/arccore/base/MDDim.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MDDim.h                                                     (C) 2000-2025 */
+/* MDDim.h                                                     (C) 2000-2026 */
 /*                                                                           */
 /* Tag for N-dimensional arrays.                                             */
 /*---------------------------------------------------------------------------*/
@@ -43,40 +43,40 @@ using MDDim4 = ExtentsV<Int32, DynExtent, DynExtent, DynExtent, DynExtent>;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template <>
-class MDDimType<0>
+template <typename IndexType_>
+class MDDimType<0, IndexType_>
 {
  public:
 
-  using DimType = MDDim0;
+  using DimType = ExtentsV<IndexType_>;
 };
-template <>
-class MDDimType<1>
+template <typename IndexType_>
+class MDDimType<1, IndexType_>
 {
  public:
 
-  using DimType = MDDim1;
+  using DimType = ExtentsV<IndexType_, DynExtent>;
 };
-template <>
-class MDDimType<2>
+template <typename IndexType_>
+class MDDimType<2, IndexType_>
 {
  public:
 
-  using DimType = MDDim2;
+  using DimType = ExtentsV<IndexType_, DynExtent, DynExtent>;
 };
-template <>
-class MDDimType<3>
+template <typename IndexType_>
+class MDDimType<3, IndexType_>
 {
  public:
 
-  using DimType = MDDim3;
+  using DimType = ExtentsV<IndexType_, DynExtent, DynExtent, DynExtent>;
 };
-template <>
-class MDDimType<4>
+template <typename IndexType_>
+class MDDimType<4, IndexType_>
 {
  public:
 
-  using DimType = MDDim4;
+  using DimType = ExtentsV<IndexType_, DynExtent, DynExtent, DynExtent, DynExtent>;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/MDIndex.h
+++ b/arccore/src/base/arccore/base/MDIndex.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MDIndex.h                                                   (C) 2000-2025 */
+/* MDIndex.h                                                   (C) 2000-2026 */
 /*                                                                           */
 /* Management of multi-dimensional array indices.                            */
 /*---------------------------------------------------------------------------*/
@@ -33,22 +33,26 @@ namespace Arcane
 template <int RankValue, typename IndexType_>
 class MDIndexBase
 {
+ public:
+
+  using ExtentIndexType = IndexType_;
+
  protected:
 
   // Note: on pourrait utiliser '= default' mais cela ne passe pas
   // with VS2017 car pour lui le constructeur n'est pas 'constexpr'
   constexpr MDIndexBase() {}
-  constexpr MDIndexBase(std::array<Int32, RankValue> _id)
+  constexpr MDIndexBase(std::array<ExtentIndexType, RankValue> _id)
   : m_indexes(_id)
   {}
 
  public:
 
   //! List of indices
-  constexpr std::array<Int32, RankValue> operator()() const { return m_indexes; }
+  constexpr std::array<ExtentIndexType, RankValue> operator()() const { return m_indexes; }
 
   //! Returns the i-th index
-  constexpr ARCCORE_HOST_DEVICE Int32 operator[](int i) const
+  constexpr ARCCORE_HOST_DEVICE ExtentIndexType operator[](int i) const
   {
     ARCCORE_CHECK_AT(i, RankValue);
     return m_indexes[i];
@@ -61,7 +65,7 @@ class MDIndexBase
   }
 
   //! Adds \a rhs to the index values of the instance.
-  constexpr ARCCORE_HOST_DEVICE void add(const MDIndexBase<RankValue>& rhs)
+  constexpr ARCCORE_HOST_DEVICE void add(const MDIndexBase<RankValue, ExtentIndexType>& rhs)
   {
     for (int i = 0; i < RankValue; ++i)
       m_indexes[i] += rhs[i];
@@ -69,7 +73,7 @@ class MDIndexBase
 
  protected:
 
-  std::array<Int32, RankValue> m_indexes = {};
+  std::array<ExtentIndexType, RankValue> m_indexes = {};
 };
 
 /*---------------------------------------------------------------------------*/
@@ -79,10 +83,16 @@ template <typename IndexType_>
 class MDIndex<0, IndexType_>
 : public MDIndexBase<0, IndexType_>
 {
+  using BaseClass = MDIndexBase<0, IndexType_>;
+
+ public:
+
+  using ExtentIndexType = BaseClass::ExtentIndexType;
+
  public:
 
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<Int32, 0> _id)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 0> _id)
   : MDIndexBase<0, IndexType_>(_id)
   {}
 };
@@ -99,19 +109,23 @@ class MDIndex<1, IndexType_>
 
  public:
 
+  using ExtentIndexType = BaseClass::ExtentIndexType;
+
+ public:
+
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(Int32 _id0)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0)
   : BaseClass()
   {
     m_indexes[0] = _id0;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<Int32, 1> _id)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 1> _id)
   : BaseClass(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr Int32 id0() const { return m_indexes[0]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
 
   // Pour l'index de dimension 1, on autorise la conversion vers l'index
@@ -130,21 +144,25 @@ class MDIndex<2, IndexType_>
 
  public:
 
+  using ExtentIndexType = BaseClass::ExtentIndexType;
+
+ public:
+
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(Int32 _id0, Int32 _id1)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1)
   : BaseClass()
   {
     m_indexes[0] = _id0;
     m_indexes[1] = _id1;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<Int32, 2> _id)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 2> _id)
   : BaseClass(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr Int32 id0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr Int32 id1() const { return m_indexes[1]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id1() const { return m_indexes[1]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId1() const { return m_indexes[1]; }
 };
@@ -161,23 +179,27 @@ class MDIndex<3, IndexType_>
 
  public:
 
+  using ExtentIndexType = BaseClass::ExtentIndexType;
+
+ public:
+
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(Int32 _id0, Int32 _id1, Int32 _id2)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1, ExtentIndexType _id2)
   : BaseClass()
   {
     m_indexes[0] = _id0;
     m_indexes[1] = _id1;
     m_indexes[2] = _id2;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<Int32, 3> _id)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 3> _id)
   : BaseClass(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr Int32 id0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr Int32 id1() const { return m_indexes[1]; }
-  ARCCORE_HOST_DEVICE constexpr Int32 id2() const { return m_indexes[2]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id1() const { return m_indexes[1]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id2() const { return m_indexes[2]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId1() const { return m_indexes[1]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId2() const { return m_indexes[2]; }
@@ -195,8 +217,12 @@ class MDIndex<4, IndexType_>
 
  public:
 
+  using ExtentIndexType = BaseClass::ExtentIndexType;
+
+ public:
+
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(Int32 _id0, Int32 _id1, Int32 _id2, Int32 _id3)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1, ExtentIndexType _id2, ExtentIndexType _id3)
   : MDIndexBase<4, IndexType_>()
   {
     m_indexes[0] = _id0;
@@ -204,16 +230,16 @@ class MDIndex<4, IndexType_>
     m_indexes[2] = _id2;
     m_indexes[3] = _id3;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<Int32, 4> _id)
+  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 4> _id)
   : MDIndexBase<4, IndexType_>(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr Int32 id0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr Int32 id1() const { return m_indexes[1]; }
-  ARCCORE_HOST_DEVICE constexpr Int32 id2() const { return m_indexes[2]; }
-  ARCCORE_HOST_DEVICE constexpr Int32 id3() const { return m_indexes[3]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id1() const { return m_indexes[1]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id2() const { return m_indexes[2]; }
+  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id3() const { return m_indexes[3]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId1() const { return m_indexes[1]; }
   ARCCORE_HOST_DEVICE constexpr Int64 largeId2() const { return m_indexes[2]; }

--- a/arccore/src/base/tests/TestGetIndices.cc
+++ b/arccore/src/base/tests/TestGetIndices.cc
@@ -10,8 +10,6 @@
 #include "arccore/base/ArrayExtentsValue.h"
 #include "arccore/base/ArrayExtents.h"
 
-#include "arccore/base/ForLoopRanges.h"
-
 #include <iostream>
 
 using namespace Arcane;
@@ -32,9 +30,9 @@ struct XYZ
   }
   std::array<Int32, 3> getIndices1(Int32 index)
   {
-    Int32 i2 = impl::fastmod(index, z);
+    Int32 i2 = Impl::fastmod(index, z);
     Int32 fac = z;
-    Int32 i1 = impl::fastmod(index / fac, y);
+    Int32 i1 = Impl::fastmod(index / fac, y);
     fac *= y;
     Int32 i0 = index / fac;
     return { i0, i1, i2 };

--- a/arccore/src/common/arccore/common/SequentialFor.h
+++ b/arccore/src/common/arccore/common/SequentialFor.h
@@ -33,8 +33,8 @@ void arccoreSequentialFor(LoopBoundType<1, IndexType> bounds, Lambda func,
                           RemainingArgs... remaining_args)
 {
   Impl::HostKernelRemainingArgsHelper::applyAtBegin(remaining_args...);
-  for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
-    func(MDIndex<1>(i0), remaining_args...);
+  for (IndexType i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
+    func(MDIndex<1, IndexType>(i0), remaining_args...);
   Impl::HostKernelRemainingArgsHelper::applyAtEnd(remaining_args...);
 }
 
@@ -45,9 +45,9 @@ void arccoreSequentialFor(LoopBoundType<1, IndexType> bounds, Lambda func,
 template <typename IndexType, template <int T, typename> class LoopBoundType, typename Lambda> void
 arccoreSequentialFor(LoopBoundType<2, IndexType> bounds, Lambda func)
 {
-  for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
-    for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
-      func(MDIndex<2>(i0, i1));
+  for (IndexType i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
+    for (IndexType i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
+      func(MDIndex<2, IndexType>(i0, i1));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -57,10 +57,10 @@ arccoreSequentialFor(LoopBoundType<2, IndexType> bounds, Lambda func)
 template <typename IndexType, template <int T, typename> class LoopBoundType, typename Lambda> void
 arccoreSequentialFor(LoopBoundType<3, IndexType> bounds, Lambda func)
 {
-  for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
-    for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
-      for (Int32 i2 = bounds.template lowerBound<2>(); i2 < bounds.template upperBound<2>(); ++i2)
-        func(MDIndex<3>(i0, i1, i2));
+  for (IndexType i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
+    for (IndexType i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
+      for (IndexType i2 = bounds.template lowerBound<2>(); i2 < bounds.template upperBound<2>(); ++i2)
+        func(MDIndex<3, IndexType>(i0, i1, i2));
 }
 
 /*---------------------------------------------------------------------------*/
@@ -70,11 +70,11 @@ arccoreSequentialFor(LoopBoundType<3, IndexType> bounds, Lambda func)
 template <typename IndexType, template <int, typename> class LoopBoundType, typename Lambda> void
 arccoreSequentialFor(LoopBoundType<4, IndexType> bounds, Lambda func)
 {
-  for (Int32 i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
-    for (Int32 i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
-      for (Int32 i2 = bounds.template lowerBound<2>(); i2 < bounds.template upperBound<2>(); ++i2)
-        for (Int32 i3 = bounds.template lowerBound<3>(); i3 < bounds.template upperBound<3>(); ++i3)
-          func(MDIndex<4>(i0, i1, i2, i3));
+  for (IndexType i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
+    for (IndexType i1 = bounds.template lowerBound<1>(); i1 < bounds.template upperBound<1>(); ++i1)
+      for (IndexType i2 = bounds.template lowerBound<2>(); i2 < bounds.template upperBound<2>(); ++i2)
+        for (IndexType i3 = bounds.template lowerBound<3>(); i3 < bounds.template upperBound<3>(); ++i3)
+          func(MDIndex<4, IndexType>(i0, i1, i2, i3));
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/common/arccore/common/SpecificMemoryCopy.cc
+++ b/arccore/src/common/arccore/common/SpecificMemoryCopy.cc
@@ -43,7 +43,7 @@ class HostSpecificMemoryCopyList
 
   HostSpecificMemoryCopyList()
   {
-    using impl::ExtentValue;
+    using Impl::ExtentValue;
     //! Adds specific implementations for common sizes
     addCopier<SpecificType<std::byte, ExtentValue<1>>>(); // 1
     addCopier<SpecificType<Int16, ExtentValue<1>>>(); // 2

--- a/arccore/src/common/arccore/common/internal/SpecificMemoryCopyList.h
+++ b/arccore/src/common/arccore/common/internal/SpecificMemoryCopyList.h
@@ -358,7 +358,7 @@ class SpecificMemoryCopyRef
  private:
 
   ISpecificMemoryCopy* m_specialized_copier = nullptr;
-  SpecificType<std::byte, impl::ExtentValue<DynExtent>> m_generic_copier;
+  SpecificType<std::byte, Impl::ExtentValue<DynExtent>> m_generic_copier;
   ISpecificMemoryCopy* m_used_copier = nullptr;
 };
 

--- a/arccore/src/common/tests/CMakeLists.txt
+++ b/arccore/src/common/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 ﻿arccore_add_component_test_executable(common
   FILES
   TestProcess.cc
+  TestSequentialFor.cc
   TestStringVector.cc
 )
 

--- a/arccore/src/common/tests/TestSequentialFor.cc
+++ b/arccore/src/common/tests/TestSequentialFor.cc
@@ -1,0 +1,59 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "arccore/base/ForLoopRanges.h"
+
+#include "arccore/common/SequentialFor.h"
+#include "arccore/common/Array.h"
+
+using namespace Arcane;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template <typename IndexType_>
+class LoopTester
+{
+ public:
+
+  using IndexType = IndexType_;
+
+ public:
+
+  void doTest()
+  {
+    IndexType nb_dim1 = 20;
+    SimpleForLoopRanges<1, IndexType> loop1(nb_dim1);
+    UniqueArray<IndexType> sum_array;
+    IndexType ref_sum = {};
+    auto f = [&](MDIndex<1, IndexType> index) {
+      IndexType i = index;
+      sum_array.add(i);
+      ref_sum += i;
+    };
+    arccoreSequentialFor(loop1, f);
+    IndexType sum = {};
+    for (IndexType x : sum_array) {
+      sum += x;
+    }
+    ASSERT_EQ(ref_sum,sum);
+  }
+};
+
+TEST(SequentialFor, Misc)
+{
+  LoopTester<Int32> int32_tester;
+  int32_tester.doTest();
+
+  LoopTester<Int64> int64_tester;
+  int64_tester.doTest();
+
+  LoopTester<size_t> size_t_tester;
+  size_t_tester.doTest();
+}


### PR DESCRIPTION
Add missing template arguments for some classes handling array extents and add support for type other than `Int32` for `SimpleForLoopRanges`, `ComplexForLoopRanges` and `arccoreSequentialFor()` method.
