### PR TITLE
Add support for 1D `NumArray` and accelerator loops using index type other than `Int32`

### DIFF
--- a/arccore/src/accelerator/arccore/accelerator/RunCommandLoop.h
+++ b/arccore/src/accelerator/arccore/accelerator/RunCommandLoop.h
@@ -165,18 +165,6 @@ class DoDirectSYCLLambdaArrayBounds
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
-} // namespace Arcane::Accelerator::Impl
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
-namespace Arcane::Accelerator::Impl
-{
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Applies the lambda \a func on a loop \a bounds.
  *
@@ -376,8 +364,8 @@ run(RunCommand& command, ComplexForLoopRanges<N, Int32> bounds, const Lambda& fu
 /*---------------------------------------------------------------------------*/
 
 //! Applies the lambda \a func on the iteration range given by \a bounds
-template <int N, typename Lambda> void
-launchRunCommand(RunCommand& command, SimpleForLoopRanges<N, Int32> bounds, Lambda func)
+template <int N, typename IndexType_, typename Lambda> void
+launchRunCommand(RunCommand& command, SimpleForLoopRanges<N, IndexType_> bounds, Lambda func)
 {
   Impl::_applyGenericLoop(command, bounds, func);
 }
@@ -386,8 +374,8 @@ launchRunCommand(RunCommand& command, SimpleForLoopRanges<N, Int32> bounds, Lamb
 /*---------------------------------------------------------------------------*/
 
 //! Applies the lambda \a func on the iteration range given by \a bounds
-template <int N, typename Lambda> void
-launchRunCommand(RunCommand& command, ComplexForLoopRanges<N, Int32> bounds, const Lambda& func)
+template <int N, typename IndexType_, typename Lambda> void
+launchRunCommand(RunCommand& command, ComplexForLoopRanges<N, IndexType_> bounds, const Lambda& func)
 {
   Impl::_applyGenericLoop(command, bounds, func);
 }

--- a/arccore/src/accelerator/tests/TestLambda.cc
+++ b/arccore/src/accelerator/tests/TestLambda.cc
@@ -7,15 +7,8 @@
 
 #include <gtest/gtest.h>
 
-#include "arccore/base/PlatformUtils.h"
-
 #include "arccore/common/accelerator/Runner.h"
-#include "arccore/common/accelerator/RunQueue.h"
-#include "arccore/common/NumArray.h"
 
-#include "arccore/accelerator/NumArrayViews.h"
-#include "arccore/accelerator/RunCommandLoop.h"
-#include "arccore/accelerator/Reduce.h"
 #include "arccore/accelerator/internal/Initializer.h"
 
 #include "./TestCommon.h"

--- a/arccore/src/accelerator/tests/TestLambda_Accelerator.cc
+++ b/arccore/src/accelerator/tests/TestLambda_Accelerator.cc
@@ -23,17 +23,18 @@ using namespace Arcane::Accelerator;
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void
-_fillArray(NumArray<Int64, MDDim1>& num_array, Int64 base_value)
+template<typename Extents> void
+_fillArray(NumArray<Int64, Extents>& num_array, Int64 base_value)
 {
-  Int32 nb_value = num_array.extent0();
-  for (Int32 i = 0; i < nb_value; ++i) {
+  using ExtentIndexType = Extents::ExtentIndexType;
+  ExtentIndexType nb_value = num_array.extent0();
+  for (ExtentIndexType i = 0; i < nb_value; ++i) {
     num_array(i) = (i + base_value);
   }
 }
 
-extern "C++" void
-_doTestLambda(RunQueue queue)
+void
+_doTestLambda1(RunQueue queue)
 {
   Int32 nb_value = 50000;
 
@@ -65,6 +66,7 @@ _doTestLambda(RunQueue queue)
     }
   }
 
+  // Test direct mutable lambda launch
   {
     _fillArray(a, 5);
 
@@ -85,6 +87,52 @@ _doTestLambda(RunQueue queue)
       ASSERT_EQ(a_view[k], b_view[k]) << " Index2=" << k;
     }
   }
+}
+
+// Check using a loop with a NumArray using 'Int64' as index type
+void
+_doTestLambda2(RunQueue queue)
+{
+  Int32 nb_value = 50000;
+
+  std::cout << "Using accelerator policy name=" << queue.executionPolicy() << "\n";
+  std::cout << " nb_value=" << nb_value << "\n";
+
+  NumArray<Int64, MDDim1Ext<Int64>> a(nb_value);
+  _fillArray(a, 3);
+
+  NumArray<Int64, MDDim1Ext<Int64>> b(nb_value);
+
+  // Test direct lambda launch
+  {
+    Span<const Int64> a_view(a.to1DSpan());
+    Span<Int64> b_view(a.to1DSpan());
+    auto lambda1 = [=] ARCCORE_HOST_DEVICE(Int64 index) {
+      b_view[index] = a_view[index];
+    };
+
+    {
+      std::cout << "Test lambda direct\n";
+      RunCommand command = makeCommand(queue);
+      SimpleForLoopRanges<1,Int64> loop_range(nb_value);
+      launchRunCommand(command, loop_range, lambda1);
+    }
+
+    for (Int32 k = 0; k < nb_value; ++k) {
+      ASSERT_EQ(a_view[k], b_view[k]) << " Index1=" << k;
+    }
+  }
+
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+extern "C++" void
+_doTestLambda(RunQueue queue)
+{
+  _doTestLambda1(queue);
+  _doTestLambda2(queue);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/ArrayBounds.h
+++ b/arccore/src/base/arccore/base/ArrayBounds.h
@@ -37,6 +37,7 @@ class ArrayBoundsBase
   using BaseClass::asStdArray;
   using BaseClass::constExtent;
   using BaseClass::getIndices;
+  using BaseClass::dynamicExtents;
   using MDIndexType = BaseClass::MDIndexType;
   using LoopIndexType = BaseClass::LoopIndexType;
   using ExtentIndexType = Extents::ExtentIndexType;
@@ -59,7 +60,11 @@ class ArrayBoundsBase
 
  public:
 
-  constexpr ARCCORE_HOST_DEVICE Int64 nbElement() const { return this->totalNbElement(); }
+  constexpr Int64 nbElement() const { return this->totalNbElement(); }
+
+ protected:
+
+  using BaseClass::asOtherStdArray;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -71,6 +76,8 @@ template <typename Extents>
 class ArrayBounds
 : public ArrayBoundsBase<Extents>
 {
+  template <typename OtherExtents> friend class ArrayBounds;
+
  public:
 
   using ExtentsType = Extents;
@@ -111,6 +118,14 @@ class ArrayBounds
   constexpr explicit ArrayBounds(std::array<ExtentIndexType, Extents::nb_dynamic>& v)
   : BaseClass(v)
   {
+  }
+
+  //! Convert to a ArrayBound with same Extent buf with a different index type
+  template <typename OtherArrayBounds> static constexpr ArrayBounds
+  fromOther(const OtherArrayBounds& rhs)
+  {
+    std::array<ExtentIndexType, Extents::nb_dynamic> x = rhs.template asOtherStdArray<ExtentIndexType>();
+    return ArrayBounds(x);
   }
 };
 

--- a/arccore/src/base/arccore/base/ArrayExtents.h
+++ b/arccore/src/base/arccore/base/ArrayExtents.h
@@ -145,6 +145,7 @@ class ArrayExtentsBase
 
  public:
 
+  using BaseClass::asOtherStdArray;
   using BaseClass::asStdArray;
   using BaseClass::constExtent;
   using BaseClass::dynamicExtents;
@@ -182,7 +183,7 @@ class ArrayExtentsBase
   }
 
   // Number of elements of the I-th dimension converted to an 'Int64'.
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE Int64 constLargeExtent() const
+  template <Int32 I> constexpr Int64 constLargeExtent() const
   {
     return BaseClass::template constExtent<I>();
   }
@@ -201,13 +202,13 @@ class ArrayExtentsBase
 /*!
  * \brief Extent for 1-dimensional arrays.
  */
-template <typename SizeType_, Int32 X0>
-class ArrayExtents<ExtentsV<SizeType_, X0>>
-: public ArrayExtentsBase<ExtentsV<SizeType_, X0>>
+template <typename IndexType_, Int32 X0>
+class ArrayExtents<ExtentsV<IndexType_, X0>>
+: public ArrayExtentsBase<ExtentsV<IndexType_, X0>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0>;
+  using ExtentsType = ExtentsV<IndexType_, X0>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
   using BaseClass::extent0;
   using BaseClass::totalNbElement;
@@ -218,15 +219,15 @@ class ArrayExtents<ExtentsV<SizeType_, X0>>
  public:
 
   ArrayExtents() = default;
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(const BaseClass& rhs)
+  constexpr ArrayExtents(const BaseClass& rhs)
   : BaseClass(rhs)
   {}
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(const DynamicDimsType& extents)
+  constexpr ArrayExtents(const DynamicDimsType& extents)
   : BaseClass(extents)
   {
   }
   // TODO: To be removed
-  constexpr ARCCORE_HOST_DEVICE explicit ArrayExtents(ExtentIndexType dim1_size)
+  constexpr explicit ArrayExtents(ExtentIndexType dim1_size)
   {
     static_assert(ExtentsType::nb_dynamic == 1, "This method is only allowed for full dynamic extents");
     this->m_extent0.v = dim1_size;
@@ -238,13 +239,13 @@ class ArrayExtents<ExtentsV<SizeType_, X0>>
 /*!
  * \brief Extent for 2-dimensional arrays.
  */
-template <typename SizeType_, Int32 X0, Int32 X1>
-class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
-: public ArrayExtentsBase<ExtentsV<SizeType_, X0, X1>>
+template <typename IndexType_, Int32 X0, Int32 X1>
+class ArrayExtents<ExtentsV<IndexType_, X0, X1>>
+: public ArrayExtentsBase<ExtentsV<IndexType_, X0, X1>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0, X1>;
+  using ExtentsType = ExtentsV<IndexType_, X0, X1>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
   using BaseClass::extent0;
   using BaseClass::extent1;
@@ -256,15 +257,15 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
  public:
 
   ArrayExtents() = default;
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(const BaseClass& rhs)
+  constexpr ArrayExtents(const BaseClass& rhs)
   : BaseClass(rhs)
   {}
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(const DynamicDimsType& extents)
+  constexpr ArrayExtents(const DynamicDimsType& extents)
   : BaseClass(extents)
   {
   }
   // TODO: To be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(ExtentIndexType dim1_size, ExtentIndexType dim2_size)
+  constexpr ArrayExtents(ExtentIndexType dim1_size, ExtentIndexType dim2_size)
   {
     static_assert(ExtentsType::nb_dynamic == 2, "This method is only allowed for full dynamic extents");
     this->m_extent0.v = dim1_size;
@@ -277,13 +278,13 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1>>
 /*!
  * \brief Extent for 3-dimensional arrays.
  */
-template <typename SizeType_, Int32 X0, Int32 X1, Int32 X2>
-class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
-: public ArrayExtentsBase<ExtentsV<SizeType_, X0, X1, X2>>
+template <typename IndexType_, Int32 X0, Int32 X1, Int32 X2>
+class ArrayExtents<ExtentsV<IndexType_, X0, X1, X2>>
+: public ArrayExtentsBase<ExtentsV<IndexType_, X0, X1, X2>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0, X1, X2>;
+  using ExtentsType = ExtentsV<IndexType_, X0, X1, X2>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
   using BaseClass::extent0;
   using BaseClass::extent1;
@@ -296,15 +297,15 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
  public:
 
   ArrayExtents() = default;
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(const BaseClass& rhs)
+  constexpr ArrayExtents(const BaseClass& rhs)
   : BaseClass(rhs)
   {}
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(const DynamicDimsType& extents)
+  constexpr ArrayExtents(const DynamicDimsType& extents)
   : BaseClass(extents)
   {
   }
   // TODO: To be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtents(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size)
+  constexpr ArrayExtents(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size)
   {
     static_assert(ExtentsType::nb_dynamic == 3, "This method is only allowed for full dynamic extents");
     this->m_extent0.v = dim1_size;
@@ -318,13 +319,13 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
 /*!
  * \brief Extent for 4-dimensional arrays.
  */
-template <typename SizeType_, Int32 X0, Int32 X1, Int32 X2, Int32 X3>
-class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
-: public ArrayExtentsBase<ExtentsV<SizeType_, X0, X1, X2, X3>>
+template <typename IndexType_, Int32 X0, Int32 X1, Int32 X2, Int32 X3>
+class ArrayExtents<ExtentsV<IndexType_, X0, X1, X2, X3>>
+: public ArrayExtentsBase<ExtentsV<IndexType_, X0, X1, X2, X3>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0, X1, X2, X3>;
+  using ExtentsType = ExtentsV<IndexType_, X0, X1, X2, X3>;
   using BaseClass = ArrayExtentsBase<ExtentsType>;
   using BaseClass::extent0;
   using BaseClass::extent1;
@@ -364,13 +365,13 @@ class ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
 /*!
  * \brief Extent and Offset for 1-dimensional arrays.
  */
-template <typename SizeType_, SizeType_ X0, typename LayoutType>
-class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
-: private ArrayExtents<ExtentsV<SizeType_, X0>>
+template <typename IndexType_, Int32 X0, typename LayoutType>
+class ArrayExtentsWithOffset<ExtentsV<IndexType_, X0>, LayoutType>
+: private ArrayExtents<ExtentsV<IndexType_, X0>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0>;
+  using ExtentsType = ExtentsV<IndexType_, X0>;
   using BaseClass = ArrayExtents<ExtentsType>;
   using BaseClass::asStdArray;
   using BaseClass::extent0;
@@ -417,13 +418,13 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0>, LayoutType>
 /*!
  * \brief Extent and Offset for 2-dimensional arrays.
  */
-template <typename SizeType_, SizeType_ X0, SizeType_ X1, typename LayoutType>
-class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
-: private ArrayExtents<ExtentsV<SizeType_, X0, X1>>
+template <typename IndexType_, Int32 X0, Int32 X1, typename LayoutType>
+class ArrayExtentsWithOffset<ExtentsV<IndexType_, X0, X1>, LayoutType>
+: private ArrayExtents<ExtentsV<IndexType_, X0, X1>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0, X1>;
+  using ExtentsType = ExtentsV<IndexType_, X0, X1>;
   using BaseClass = ArrayExtents<ExtentsType>;
   using BaseClass::asStdArray;
   using BaseClass::extent0;
@@ -441,19 +442,19 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
 
   ArrayExtentsWithOffset() = default;
   // TODO: to be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsWithOffset(ArrayExtents<ExtentsType> rhs)
+  constexpr ArrayExtentsWithOffset(ArrayExtents<ExtentsType> rhs)
   : BaseClass(rhs)
   {
   }
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsWithOffset(const DynamicDimsType& rhs)
+  constexpr ArrayExtentsWithOffset(const DynamicDimsType& rhs)
   : BaseClass(rhs)
   {
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(ExtentIndexType i, ExtentIndexType j) const
+  constexpr Int64 offset(ExtentIndexType i, ExtentIndexType j) const
   {
     return offset({ i, j });
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
+  constexpr Int64 offset(MDIndexType idx) const
   {
     BaseClass::_checkIndex(idx);
     return Layout::offset(idx, this->template constExtent<Layout::LastExtent>());
@@ -467,17 +468,16 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1>, LayoutType>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Extent and Offset for 3-dimensional arrays.
  */
-template <typename SizeType_, SizeType_ X0, SizeType_ X1, SizeType_ X2, typename LayoutType>
-class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
-: private ArrayExtents<ExtentsV<SizeType_, X0, X1, X2>>
+template <typename IndexType_, Int32 X0, Int32 X1, Int32 X2, typename LayoutType>
+class ArrayExtentsWithOffset<ExtentsV<IndexType_, X0, X1, X2>, LayoutType>
+: private ArrayExtents<ExtentsV<IndexType_, X0, X1, X2>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0, X1, X2>;
+  using ExtentsType = ExtentsV<IndexType_, X0, X1, X2>;
   using BaseClass = ArrayExtents<ExtentsType>;
   using BaseClass::asStdArray;
   using BaseClass::extent0;
@@ -496,21 +496,21 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
 
   ArrayExtentsWithOffset() = default;
   // TODO: to be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsWithOffset(ArrayExtents<ExtentsType> rhs)
+  constexpr ArrayExtentsWithOffset(ArrayExtents<ExtentsType> rhs)
   : BaseClass(rhs)
   {
     _computeOffsets();
   }
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsWithOffset(const DynamicDimsType& rhs)
+  constexpr ArrayExtentsWithOffset(const DynamicDimsType& rhs)
   : BaseClass(rhs)
   {
     _computeOffsets();
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k) const
+  constexpr Int64 offset(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k) const
   {
     return offset({ i, j, k });
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
+  constexpr Int64 offset(MDIndexType idx) const
   {
     this->_checkIndex(idx);
     return Layout::offset(idx, this->template constExtent<Layout::LastExtent>(), m_dim23_size);
@@ -539,13 +539,13 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2>, LayoutType>
 /*!
  * \brief Extent and Offset for 4-dimensional arrays.
  */
-template <typename SizeType_, SizeType_ X0, SizeType_ X1, SizeType_ X2, SizeType_ X3, typename LayoutType>
-class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
-: private ArrayExtents<ExtentsV<SizeType_, X0, X1, X2, X3>>
+template <typename IndexType_, Int32 X0, Int32 X1, Int32 X2, Int32 X3, typename LayoutType>
+class ArrayExtentsWithOffset<ExtentsV<IndexType_, X0, X1, X2, X3>, LayoutType>
+: private ArrayExtents<ExtentsV<IndexType_, X0, X1, X2, X3>>
 {
  public:
 
-  using ExtentsType = ExtentsV<SizeType_, X0, X1, X2, X3>;
+  using ExtentsType = ExtentsV<IndexType_, X0, X1, X2, X3>;
   using BaseClass = ArrayExtents<ExtentsType>;
   using BaseClass::asStdArray;
   using BaseClass::extent0;
@@ -554,7 +554,7 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
   using BaseClass::extent3;
   using BaseClass::getIndices;
   using BaseClass::totalNbElement;
-  using Layout = typename LayoutType::Layout4Type;
+  using Layout = LayoutType::Layout4Type;
   using DynamicDimsType = BaseClass::DynamicDimsType;
   using MDIndexType = BaseClass::MDIndexType;
   using ExtentIndexType = BaseClass::ExtentIndexType;
@@ -565,21 +565,21 @@ class ArrayExtentsWithOffset<ExtentsV<SizeType_, X0, X1, X2, X3>, LayoutType>
 
   ArrayExtentsWithOffset() = default;
   // TODO: to be removed
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsWithOffset(ArrayExtents<ExtentsType> rhs)
+  constexpr ArrayExtentsWithOffset(ArrayExtents<ExtentsType> rhs)
   : BaseClass(rhs)
   {
     _computeOffsets();
   }
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsWithOffset(const DynamicDimsType& rhs)
+  constexpr ArrayExtentsWithOffset(const DynamicDimsType& rhs)
   : BaseClass(rhs)
   {
     _computeOffsets();
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k, ExtentIndexType l) const
+  constexpr Int64 offset(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k, ExtentIndexType l) const
   {
     return offset({ i, j, k, l });
   }
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
+  constexpr Int64 offset(MDIndexType idx) const
   {
     this->_checkIndex(idx);
     return (m_dim234_size * idx.largeId0()) + m_dim34_size * idx.largeId1() + this->m_extent3.v * idx.largeId2() + idx.largeId3();

--- a/arccore/src/base/arccore/base/ArrayExtentsValue.h
+++ b/arccore/src/base/arccore/base/ArrayExtentsValue.h
@@ -96,28 +96,36 @@ class ArrayExtentsValue<IndexType_, X0>
 
   ArrayExtentsValue() = default;
 
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE ExtentIndexType constExtent() const
+  template <Int32 I> constexpr ExtentIndexType constExtent() const
   {
     static_assert(I == 0, "Invalid value for i (i==0)");
     return m_extent0.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE std::array<ExtentIndexType, 1> asStdArray() const
+  constexpr std::array<ExtentIndexType, 1> asStdArray() const
   {
     return std::array<ExtentIndexType, 1>{ m_extent0.v };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int64 totalNbElement() const
+  template <typename OtherExtentIndexType>
+  constexpr std::array<OtherExtentIndexType, 1> asOtherStdArray() const
+  {
+    return std::array<OtherExtentIndexType, 1>{
+      static_cast<OtherExtentIndexType>(m_extent0.v)
+    };
+  }
+
+  constexpr Int64 totalNbElement() const
   {
     return m_extent0.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
+  constexpr MDIndexType getIndices(ExtentIndexType i) const
   {
     return { i };
   }
 
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
+  constexpr ExtentIndexType extent0() const { return m_extent0.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const
@@ -138,7 +146,7 @@ class ArrayExtentsValue<IndexType_, X0>
   }
 
   //! Constructs an instance with the N dynamic values.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DynamicDimsType dims)
+  constexpr ArrayExtentsValue([[maybe_unused]] DynamicDimsType dims)
   {
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
@@ -184,7 +192,7 @@ class ArrayExtentsValue<IndexType_, X0, X1>
 
  public:
 
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE ExtentIndexType constExtent() const
+  template <Int32 I> constexpr ExtentIndexType constExtent() const
   {
     static_assert(I >= 0 && I < 2, "Invalid value for I (0<=I<2)");
     if (I == 0)
@@ -192,25 +200,31 @@ class ArrayExtentsValue<IndexType_, X0, X1>
     return m_extent1.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE std::array<ExtentIndexType, 2> asStdArray() const
+  constexpr std::array<ExtentIndexType, 2> asStdArray() const
   {
     return { m_extent0.v, m_extent1.v };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int64 totalNbElement() const
+  template <typename OtherExtentIndexType>
+  constexpr std::array<OtherExtentIndexType, 2> asOtherStdArray() const
+  {
+    return std::array<OtherExtentIndexType, 2>{ m_extent0.v, m_extent1.v };
+  }
+
+  constexpr Int64 totalNbElement() const
   {
     return m_extent0.size() * m_extent1.size();
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
+  constexpr MDIndexType getIndices(ExtentIndexType i) const
   {
     ExtentIndexType i0 = i / m_extent1.v;
     ExtentIndexType i1 = i % m_extent1.v;
     return { i0, i1 };
   }
 
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent1() const { return m_extent1.v; };
+  constexpr ExtentIndexType extent0() const { return m_extent0.v; };
+  constexpr ExtentIndexType extent1() const { return m_extent1.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const
@@ -235,7 +249,7 @@ class ArrayExtentsValue<IndexType_, X0, X1>
   }
 
   //! Constructs an instance with the N dynamic values.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DynamicDimsType dims)
+  constexpr ArrayExtentsValue([[maybe_unused]] DynamicDimsType dims)
   {
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
@@ -285,7 +299,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
 
  public:
 
-  template <Int32 I> constexpr ARCCORE_HOST_DEVICE ExtentIndexType constExtent() const
+  template <Int32 I> constexpr ExtentIndexType constExtent() const
   {
     static_assert(I >= 0 && I < 3, "Invalid value for I (0<=I<3)");
     if (I == 0)
@@ -295,17 +309,23 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
     return m_extent2.v;
   }
 
-  constexpr ARCCORE_HOST_DEVICE std::array<ExtentIndexType, 3> asStdArray() const
+  constexpr std::array<ExtentIndexType, 3> asStdArray() const
   {
     return { m_extent0.v, m_extent1.v, m_extent2.v };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int64 totalNbElement() const
+  template <typename OtherExtentIndexType>
+  constexpr std::array<OtherExtentIndexType, 3> asOtherStdArray() const
+  {
+    return std::array<OtherExtentIndexType, 3>{ m_extent0.v, m_extent1.v, m_extent2.v };
+  }
+
+  constexpr Int64 totalNbElement() const
   {
     return m_extent0.size() * m_extent1.size() * m_extent2.size();
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
+  constexpr MDIndexType getIndices(ExtentIndexType i) const
   {
     ExtentIndexType i0 = i / (m_extent1.v * m_extent2.v);
     i %= (m_extent1.v * m_extent2.v);
@@ -314,9 +334,9 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
     return { i0, i1, i2 };
   }
 
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent1() const { return m_extent1.v; };
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent2() const { return m_extent2.v; };
+  constexpr ExtentIndexType extent0() const { return m_extent0.v; };
+  constexpr ExtentIndexType extent1() const { return m_extent1.v; };
+  constexpr ExtentIndexType extent2() const { return m_extent2.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const
@@ -345,7 +365,7 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
   }
 
   //! Constructs an instance with N dynamic values.
-  constexpr ARCCORE_HOST_DEVICE ArrayExtentsValue([[maybe_unused]] DynamicDimsType dims)
+  constexpr ArrayExtentsValue([[maybe_unused]] DynamicDimsType dims)
   {
     Int32 i = 0;
     if constexpr (X0 == DynExtent)
@@ -417,12 +437,18 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
     return { m_extent0.v, m_extent1.v, m_extent2.v, m_extent3.v };
   }
 
-  constexpr ARCCORE_HOST_DEVICE Int64 totalNbElement() const
+  template <typename OtherExtentIndexType>
+  constexpr std::array<OtherExtentIndexType, 4> asOtherStdArray() const
+  {
+    return std::array<OtherExtentIndexType, 4>{ m_extent0.v, m_extent1.v, m_extent2.v, m_extent3.v };
+  }
+
+  constexpr Int64 totalNbElement() const
   {
     return m_extent0.size() * m_extent1.size() * m_extent2.size() * m_extent3.size();
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDIndexType getIndices(ExtentIndexType i) const
+  constexpr MDIndexType getIndices(ExtentIndexType i) const
   {
     // Compute base indices
     ExtentIndexType i3 = Impl::fastmod(i, m_extent3.v);
@@ -435,10 +461,10 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
     return { i0, i1, i2, i3 };
   }
 
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent0() const { return m_extent0.v; };
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent1() const { return m_extent1.v; };
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent2() const { return m_extent2.v; };
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType extent3() const { return m_extent3.v; };
+  constexpr ExtentIndexType extent0() const { return m_extent0.v; };
+  constexpr ExtentIndexType extent1() const { return m_extent1.v; };
+  constexpr ExtentIndexType extent2() const { return m_extent2.v; };
+  constexpr ExtentIndexType extent3() const { return m_extent3.v; };
 
   //! List of dynamic dimensions
   constexpr DynamicDimsType dynamicExtents() const

--- a/arccore/src/base/arccore/base/ForLoopRanges.h
+++ b/arccore/src/base/arccore/base/ForLoopRanges.h
@@ -114,6 +114,8 @@ class SimpleForLoopRanges
 template <int N, typename IndexType_>
 class ComplexForLoopRanges
 {
+  template <int OtherN, typename OtherIndexType> friend class ComplexForLoopRanges;
+
  public:
 
   using ArrayBoundsType = ArrayBounds<typename MDDimType<N, IndexType_>::DimType>;
@@ -130,8 +132,26 @@ class ComplexForLoopRanges
   : m_lower_bounds(lower.asStdArray())
   , m_extents(extents)
   {}
-  explicit(false) ComplexForLoopRanges(const SimpleForLoopRanges<N>& bounds)
+  explicit(false) ComplexForLoopRanges(const SimpleForLoopRanges<N, IndexType_>& bounds)
   : m_extents(bounds.m_bounds)
+  {}
+
+ public:
+
+  //! Convert from loop with different index type
+  template <typename OtherIndexType> static ComplexForLoopRanges
+  fromOther(const ComplexForLoopRanges<N, OtherIndexType>& other_loop)
+  {
+    auto a = MDIndexType::fromOther(other_loop.m_lower_bounds);
+    auto b = ArrayBoundsType::fromOther(other_loop.m_extents);
+    return ComplexForLoopRanges(a, b);
+  }
+
+ private:
+
+  ComplexForLoopRanges(MDIndexType lower, ArrayBoundsType extents)
+  : m_lower_bounds(lower)
+  , m_extents(extents)
   {}
 
  public:
@@ -150,7 +170,7 @@ class ComplexForLoopRanges
 
  private:
 
-  ArrayIndexType m_lower_bounds;
+  MDIndexType m_lower_bounds;
   ArrayBoundsType m_extents;
 };
 

--- a/arccore/src/base/arccore/base/IRangeFunctor.h
+++ b/arccore/src/base/arccore/base/IRangeFunctor.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* IRangeFunctor.h                                             (C) 2000-2025 */
+/* IRangeFunctor.h                                             (C) 2000-2026 */
 /*                                                                           */
 /* Interface of a functor on an iteration interval.                          */
 /*---------------------------------------------------------------------------*/
@@ -48,7 +48,6 @@ class ARCCORE_BASE_EXPORT IRangeFunctor
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Interface of a functor on a multi-dimensional iteration interval
  * of dimension \a RankValue

--- a/arccore/src/base/arccore/base/MDDim.h
+++ b/arccore/src/base/arccore/base/MDDim.h
@@ -40,6 +40,9 @@ using MDDim3 = ExtentsV<Int32, DynExtent, DynExtent, DynExtent>;
 //! Constant for a rank 4 dynamic array
 using MDDim4 = ExtentsV<Int32, DynExtent, DynExtent, DynExtent, DynExtent>;
 
+//! 1D Dynamic Extent with a specific index type
+template<typename IndexType_> using MDDim1Ext = ExtentsV<IndexType_, DynExtent>;
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/arccore/src/base/arccore/base/MDIndex.h
+++ b/arccore/src/base/arccore/base/MDIndex.h
@@ -26,7 +26,6 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Base class for managing indices of an N-dimensional array.
  */
@@ -52,20 +51,20 @@ class MDIndexBase
   constexpr std::array<ExtentIndexType, RankValue> operator()() const { return m_indexes; }
 
   //! Returns the i-th index
-  constexpr ARCCORE_HOST_DEVICE ExtentIndexType operator[](int i) const
+  constexpr ExtentIndexType operator[](int i) const
   {
     ARCCORE_CHECK_AT(i, RankValue);
     return m_indexes[i];
   }
   //! Returns the i-th index as an Int64
-  constexpr ARCCORE_HOST_DEVICE Int64 asInt64(int i) const
+  constexpr Int64 asInt64(int i) const
   {
     ARCCORE_CHECK_AT(i, RankValue);
     return m_indexes[i];
   }
 
   //! Adds \a rhs to the index values of the instance.
-  constexpr ARCCORE_HOST_DEVICE void add(const MDIndexBase<RankValue, ExtentIndexType>& rhs)
+  constexpr void add(const MDIndexBase<RankValue, ExtentIndexType>& rhs)
   {
     for (int i = 0; i < RankValue; ++i)
       m_indexes[i] += rhs[i];
@@ -92,7 +91,7 @@ class MDIndex<0, IndexType_>
  public:
 
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 0> _id)
+  constexpr MDIndex(std::array<ExtentIndexType, 0> _id)
   : MDIndexBase<0, IndexType_>(_id)
   {}
 };
@@ -114,22 +113,31 @@ class MDIndex<1, IndexType_>
  public:
 
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0)
+  constexpr MDIndex(ExtentIndexType _id0)
   : BaseClass()
   {
     m_indexes[0] = _id0;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 1> _id)
+  constexpr MDIndex(std::array<ExtentIndexType, 1> _id)
   : BaseClass(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
+  constexpr ExtentIndexType id0() const { return m_indexes[0]; }
+  constexpr Int64 largeId0() const { return m_indexes[0]; }
 
   // Pour l'index de dimension 1, on autorise la conversion vers l'index
-  ARCCORE_HOST_DEVICE constexpr operator IndexType_() const { return m_indexes[0]; }
+  constexpr operator IndexType_() const { return m_indexes[0]; }
+
+ public:
+
+  //! Convert to a MDIndex with different index type
+  template <typename OtherIndexType> static constexpr MDIndex
+  fromOther(const MDIndex<1, OtherIndexType>& rhs)
+  {
+    return MDIndex(static_cast<ExtentIndexType>(rhs.id0()));
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -149,22 +157,32 @@ class MDIndex<2, IndexType_>
  public:
 
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1)
+  constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1)
   : BaseClass()
   {
     m_indexes[0] = _id0;
     m_indexes[1] = _id1;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 2> _id)
+  constexpr MDIndex(std::array<ExtentIndexType, 2> _id)
   : BaseClass(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id1() const { return m_indexes[1]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId1() const { return m_indexes[1]; }
+  constexpr ExtentIndexType id0() const { return m_indexes[0]; }
+  constexpr ExtentIndexType id1() const { return m_indexes[1]; }
+  constexpr Int64 largeId0() const { return m_indexes[0]; }
+  constexpr Int64 largeId1() const { return m_indexes[1]; }
+
+ public:
+
+  //! Convert to a MDIndex with different index type
+  template <typename OtherIndexType> static constexpr MDIndex
+  fromOther(const MDIndex<2, OtherIndexType>& rhs)
+  {
+    return MDIndex(static_cast<ExtentIndexType>(rhs.id0()),
+                   static_cast<ExtentIndexType>(rhs.id1()));
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -184,25 +202,36 @@ class MDIndex<3, IndexType_>
  public:
 
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1, ExtentIndexType _id2)
+  constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1, ExtentIndexType _id2)
   : BaseClass()
   {
     m_indexes[0] = _id0;
     m_indexes[1] = _id1;
     m_indexes[2] = _id2;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 3> _id)
+  constexpr MDIndex(std::array<ExtentIndexType, 3> _id)
   : BaseClass(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id1() const { return m_indexes[1]; }
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id2() const { return m_indexes[2]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId1() const { return m_indexes[1]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId2() const { return m_indexes[2]; }
+  constexpr ExtentIndexType id0() const { return m_indexes[0]; }
+  constexpr ExtentIndexType id1() const { return m_indexes[1]; }
+  constexpr ExtentIndexType id2() const { return m_indexes[2]; }
+  constexpr Int64 largeId0() const { return m_indexes[0]; }
+  constexpr Int64 largeId1() const { return m_indexes[1]; }
+  constexpr Int64 largeId2() const { return m_indexes[2]; }
+
+ public:
+
+  //! Convert to a MDIndex with different index type
+  template <typename OtherIndexType> static constexpr MDIndex
+  fromOther(const MDIndex<3, OtherIndexType>& rhs)
+  {
+    return MDIndex(static_cast<ExtentIndexType>(rhs.id0()),
+                   static_cast<ExtentIndexType>(rhs.id1()),
+                   static_cast<ExtentIndexType>(rhs.id2()));
+  }
 };
 
 /*---------------------------------------------------------------------------*/
@@ -222,7 +251,8 @@ class MDIndex<4, IndexType_>
  public:
 
   MDIndex() = default;
-  ARCCORE_HOST_DEVICE constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1, ExtentIndexType _id2, ExtentIndexType _id3)
+  constexpr MDIndex(ExtentIndexType _id0, ExtentIndexType _id1,
+                    ExtentIndexType _id2, ExtentIndexType _id3)
   : MDIndexBase<4, IndexType_>()
   {
     m_indexes[0] = _id0;
@@ -230,20 +260,32 @@ class MDIndex<4, IndexType_>
     m_indexes[2] = _id2;
     m_indexes[3] = _id3;
   }
-  ARCCORE_HOST_DEVICE constexpr MDIndex(std::array<ExtentIndexType, 4> _id)
+  constexpr MDIndex(std::array<ExtentIndexType, 4> _id)
   : MDIndexBase<4, IndexType_>(_id)
   {}
 
  public:
 
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id1() const { return m_indexes[1]; }
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id2() const { return m_indexes[2]; }
-  ARCCORE_HOST_DEVICE constexpr ExtentIndexType id3() const { return m_indexes[3]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId0() const { return m_indexes[0]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId1() const { return m_indexes[1]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId2() const { return m_indexes[2]; }
-  ARCCORE_HOST_DEVICE constexpr Int64 largeId3() const { return m_indexes[3]; }
+  constexpr ExtentIndexType id0() const { return m_indexes[0]; }
+  constexpr ExtentIndexType id1() const { return m_indexes[1]; }
+  constexpr ExtentIndexType id2() const { return m_indexes[2]; }
+  constexpr ExtentIndexType id3() const { return m_indexes[3]; }
+  constexpr Int64 largeId0() const { return m_indexes[0]; }
+  constexpr Int64 largeId1() const { return m_indexes[1]; }
+  constexpr Int64 largeId2() const { return m_indexes[2]; }
+  constexpr Int64 largeId3() const { return m_indexes[3]; }
+
+ public:
+
+  //! Convert to a MDIndex with different index type
+  template <typename OtherIndexType> static constexpr MDIndex
+  fromOther(const MDIndex<4, OtherIndexType>& rhs)
+  {
+    return MDIndex(static_cast<ExtentIndexType>(rhs.id0()),
+                   static_cast<ExtentIndexType>(rhs.id1()),
+                   static_cast<ExtentIndexType>(rhs.id2()),
+                   static_cast<ExtentIndexType>(rhs.id3()));
+  }
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/MDSpan.h
+++ b/arccore/src/base/arccore/base/MDSpan.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* MDSpan.h                                                    (C) 2000-2025 */
+/* MDSpan.h                                                    (C) 2000-2026 */
 /*                                                                           */
 /* View on a multi-dimensional array for numeric types.                      */
 /*---------------------------------------------------------------------------*/
@@ -27,9 +27,8 @@ namespace Arcane
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
- * \brief Base class for multi-dimensional views.
+ * \brief Base class for multidimensional views.
  *
  * This class is inspired by the std::mdspan class currently being defined
  * (see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0009r12.html)
@@ -53,6 +52,7 @@ class MDSpan
 
   using value_type = DataType;
   using ExtentsType = Extents;
+  using ExtentIndexType = Extents::ExtentIndexType;
   using LayoutPolicyType = LayoutPolicy;
   using MDIndexType = typename Extents::MDIndexType;
   using LoopIndexType = MDIndexType;
@@ -67,36 +67,40 @@ class MDSpan
  public:
 
   MDSpan() = default;
-  constexpr ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents)
+  constexpr MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents)
   : m_ptr(ptr)
   , m_extents(extents)
   {
   }
-  constexpr ARCCORE_HOST_DEVICE MDSpan(DataType* ptr, const DynamicDimsType& dims)
+  constexpr MDSpan(DataType* ptr, const DynamicDimsType& dims)
   : m_ptr(ptr)
   , m_extents(dims)
   {}
   // Constructor MDSpan<const T> from an MDSpan<T>
   template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
-  constexpr ARCCORE_HOST_DEVICE MDSpan(const MDSpan<X, Extents>& rhs)
+  constexpr MDSpan(const MDSpan<X, Extents>& rhs)
   : m_ptr(rhs.m_ptr)
   , m_extents(rhs.m_extents)
   {}
-  constexpr ARCCORE_HOST_DEVICE MDSpan(SmallSpan<DataType> v) requires(Extents::isDynamic1D() && !IsConst)
+  constexpr MDSpan(SmallSpan<DataType> v)
+  requires(Extents::isDynamic1D() && !IsConst)
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
-  constexpr ARCCORE_HOST_DEVICE MDSpan(SmallSpan<const DataType> v) requires(Extents::isDynamic1D() && IsConst)
+  constexpr MDSpan(SmallSpan<const DataType> v)
+  requires(Extents::isDynamic1D() && IsConst)
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(SmallSpan<DataType> v) requires(Extents::isDynamic1D() && !IsConst)
+  constexpr ThatClass& operator=(SmallSpan<DataType> v)
+  requires(Extents::isDynamic1D() && !IsConst)
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
     return (*this);
   }
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(SmallSpan<const DataType> v) requires(Extents::isDynamic1D() && IsConst)
+  constexpr ThatClass& operator=(SmallSpan<const DataType> v)
+  requires(Extents::isDynamic1D() && IsConst)
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
@@ -105,8 +109,15 @@ class MDSpan
 
  public:
 
-  constexpr ARCCORE_HOST_DEVICE DataType* _internalData() { return m_ptr; }
-  constexpr ARCCORE_HOST_DEVICE const DataType* _internalData() const { return m_ptr; }
+  //! Base pointer for allocated memory
+  constexpr DataType* data() { return m_ptr; }
+  //! Base pointer for allocated memory
+  constexpr const DataType* data() const { return m_ptr; }
+
+ public:
+
+  constexpr DataType* _internalData() { return m_ptr; }
+  constexpr const DataType* _internalData() const { return m_ptr; }
 
  public:
 
@@ -122,36 +133,42 @@ class MDSpan
  public:
 
   //! Value of the first dimension
-  constexpr ARCCORE_HOST_DEVICE Int32 extent0() const requires(Extents::rank() >= 1) { return m_extents.extent0(); }
+  constexpr ExtentIndexType extent0() const requires(Extents::rank() >= 1) { return m_extents.extent0(); }
   //! Value of the second dimension
-  constexpr ARCCORE_HOST_DEVICE Int32 extent1() const requires(Extents::rank() >= 2) { return m_extents.extent1(); }
+  constexpr ExtentIndexType extent1() const requires(Extents::rank() >= 2) { return m_extents.extent1(); }
   //! Value of the third dimension
-  constexpr ARCCORE_HOST_DEVICE Int32 extent2() const requires(Extents::rank() >= 3) { return m_extents.extent2(); }
+  constexpr ExtentIndexType extent2() const requires(Extents::rank() >= 3) { return m_extents.extent2(); }
   //! Value of the fourth dimension
-  constexpr ARCCORE_HOST_DEVICE Int32 extent3() const requires(Extents::rank() >= 4) { return m_extents.extent3(); }
+  constexpr ExtentIndexType extent3() const requires(Extents::rank() >= 4) { return m_extents.extent3(); }
 
  public:
 
   //! Value for element \a i,j,k,l
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j, Int32 k, Int32 l) const requires(Extents::rank() == 4)
+  constexpr Int64 offset(ExtentIndexType i, ExtentIndexType j,
+                         ExtentIndexType k, ExtentIndexType l) const
+  requires(Extents::rank() == 4)
   {
     return m_extents.offset(i, j, k, l);
   }
   //! Value for element \a i,j,k
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j, Int32 k) const requires(Extents::rank() == 3)
+  constexpr Int64 offset(ExtentIndexType i, ExtentIndexType j,
+                         ExtentIndexType k) const
+  requires(Extents::rank() == 3)
   {
     return m_extents.offset(i, j, k);
   }
   //! Value for element \a i,j
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i, Int32 j) const requires(Extents::rank() == 2)
+  constexpr Int64 offset(ExtentIndexType i, ExtentIndexType j) const
+  requires(Extents::rank() == 2)
   {
     return m_extents.offset(i, j);
   }
   //! Value for element \a i
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(Int32 i) const requires(Extents::rank() == 1) { return m_extents.offset(i); }
+  constexpr Int64 offset(ExtentIndexType i) const
+  requires(Extents::rank() == 1) { return m_extents.offset(i); }
 
   //! Value for element \a idx
-  constexpr ARCCORE_HOST_DEVICE Int64 offset(MDIndexType idx) const
+  constexpr Int64 offset(MDIndexType idx) const
   {
     return m_extents.offset(idx);
   }
@@ -159,27 +176,39 @@ class MDSpan
  public:
 
   //! Value for element \a i,j,k,l
-  constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j, Int32 k, Int32 l) const requires(Extents::rank() == 4)
+  constexpr DataType& operator()(ExtentIndexType i, ExtentIndexType j,
+                                 ExtentIndexType k, ExtentIndexType l) const
+  requires(Extents::rank() == 4)
   {
     return m_ptr[offset(i, j, k, l)];
   }
   //! Value for element \a i,j,k
-  ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j, Int32 k) const requires(Extents::rank() == 3)
+  constexpr DataType& operator()(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k) const
+  requires(Extents::rank() == 3)
   {
     return m_ptr[offset(i, j, k)];
   }
   //! Value for element \a i,j
-  constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j) const requires(Extents::rank() == 2)
+  constexpr DataType& operator()(ExtentIndexType i, ExtentIndexType j) const
+  requires(Extents::rank() == 2)
   {
     return m_ptr[offset(i, j)];
   }
   //! Value for element \a i
-  constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i) const requires(Extents::rank() == 1) { return m_ptr[offset(i)]; }
+  constexpr DataType& operator()(ExtentIndexType i) const
+  requires(Extents::rank() == 1)
+  {
+    return m_ptr[offset(i)];
+  }
   //! Value for element \a i
-  constexpr ARCCORE_HOST_DEVICE DataType operator[](Int32 i) const requires(Extents::rank() == 1) { return m_ptr[offset(i)]; }
+  constexpr DataType operator[](ExtentIndexType i) const
+  requires(Extents::rank() == 1)
+  {
+    return m_ptr[offset(i)];
+  }
 
   //! Value for element \a idx
-  constexpr ARCCORE_HOST_DEVICE DataType& operator()(MDIndexType idx) const
+  constexpr DataType& operator()(MDIndexType idx) const
   {
     return m_ptr[offset(idx)];
   }
@@ -187,25 +216,34 @@ class MDSpan
  public:
 
   //! Pointer to the value for element \a i,j,k,l
-  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j, Int32 k, Int32 l) const requires(Extents::rank() == 4)
+  constexpr DataType* ptrAt(ExtentIndexType i, ExtentIndexType j,
+                            ExtentIndexType k, ExtentIndexType l) const
+  requires(Extents::rank() == 4)
   {
     return m_ptr + offset(i, j, k, l);
   }
   //! Pointer to the value for element \a i,j,k
-  ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j, Int32 k) const requires(Extents::rank() == 3)
+  constexpr DataType* ptrAt(ExtentIndexType i, ExtentIndexType j,
+                            ExtentIndexType k) const
+  requires(Extents::rank() == 3)
   {
     return m_ptr + offset(i, j, k);
   }
   //! Pointer to the value for element \a i,j
-  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i, Int32 j) const requires(Extents::rank() == 2)
+  constexpr DataType* ptrAt(ExtentIndexType i, ExtentIndexType j) const
+  requires(Extents::rank() == 2)
   {
     return m_ptr + offset(i, j);
   }
   //! Pointer to the value for element \a i
-  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(Int32 i) const requires(Extents::rank() == 1) { return m_ptr + offset(i); }
+  constexpr DataType* ptrAt(ExtentIndexType i) const
+  requires(Extents::rank() == 1)
+  {
+    return m_ptr + offset(i);
+  }
 
   //! Pointer to the value for element \a i
-  constexpr ARCCORE_HOST_DEVICE DataType* ptrAt(MDIndexType idx) const
+  constexpr DataType* ptrAt(MDIndexType idx) const
   {
     return m_ptr + offset(idx);
   }
@@ -225,10 +263,10 @@ class MDSpan
    * \warning This is only valid if \a LayoutPolicy is \a RightLayout.
    */
   ARCCORE_HOST_DEVICE MDSpan<DataType, RemovedFirstExtentsType, LayoutPolicy>
-  slice(Int32 i) const requires(Extents::rank() >= 2 && std::is_base_of_v<RightLayout, LayoutPolicy>)
+  slice(ExtentIndexType i) const requires(Extents::rank() >= 2 && std::is_base_of_v<RightLayout, LayoutPolicy>)
   {
     auto new_extents = m_extents.extents().removeFirstExtent().dynamicExtents();
-    std::array<Int32, ExtentsType::rank()> indexes = {};
+    std::array<ExtentIndexType, ExtentsType::rank()> indexes = {};
     indexes[0] = i;
     DataType* base_ptr = this->ptrAt(MDIndexType(indexes));
     return MDSpan<DataType, RemovedFirstExtentsType, LayoutPolicy>(base_ptr, new_extents);
@@ -236,24 +274,25 @@ class MDSpan
 
  public:
 
-  constexpr ARCCORE_HOST_DEVICE MDSpan<const DataType, Extents, LayoutPolicy> constSpan() const
+  constexpr MDSpan<const DataType, Extents, LayoutPolicy> constSpan() const
   {
     return MDSpan<const DataType, Extents, LayoutPolicy>(m_ptr, m_extents);
   }
 
-  constexpr ARCCORE_HOST_DEVICE MDSpan<const DataType, Extents, LayoutPolicy> constMDSpan() const
+  constexpr MDSpan<const DataType, Extents, LayoutPolicy> constMDSpan() const
   {
     return MDSpan<const DataType, Extents, LayoutPolicy>(m_ptr, m_extents);
   }
 
-  constexpr ARCCORE_HOST_DEVICE Span<DataType> to1DSpan() const
+  constexpr Span<DataType> to1DSpan() const
   {
     return { m_ptr, m_extents.totalNbElement() };
   }
 
   constexpr SmallSpan<DataType> to1DSmallSpan() requires(Extents::rank() == 1)
   {
-    return { _internalData(), extent0() };
+    // TODO: maybe add a test in Check mode to make sure extent0() fit in a 'Int32'
+    return { _internalData(), static_cast<Int32>(extent0()) };
   }
   constexpr SmallSpan<const DataType> to1DSmallSpan() const requires(Extents::rank() == 1)
   {
@@ -261,7 +300,8 @@ class MDSpan
   }
   constexpr SmallSpan<const DataType> to1DConstSmallSpan() const requires(Extents::rank() == 1)
   {
-    return { _internalData(), extent0() };
+    // TODO: maybe add a test in Check mode to make sure extent0() fit in a 'Int32'
+    return { _internalData(), static_cast<Int32>(extent0()) };
   }
 
  private:

--- a/arccore/src/common/arccore/common/NumArray.h
+++ b/arccore/src/common/arccore/common/NumArray.h
@@ -33,7 +33,6 @@ concept NumArrayDataTypeConcept = std::is_trivially_copyable_v<T>;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Multi-dimensional arrays for numerical types accessible
  * on accelerators.
@@ -65,12 +64,13 @@ class NumArray
  public:
 
   using ExtentsType = Extents;
+  using ExtentIndexType = Extents::ExtentIndexType;
   using ThatClass = NumArray<DataType, Extents, LayoutPolicy>;
-  using DynamicDimsType = typename ExtentsType::DynamicDimsType;
+  using DynamicDimsType = ExtentsType::DynamicDimsType;
   using ConstMDSpanType = MDSpan<const DataType, ExtentsType, LayoutPolicy>;
   using MDSpanType = MDSpan<DataType, ExtentsType, LayoutPolicy>;
   using ArrayWrapper = Impl::NumArrayContainer<DataType>;
-  using ArrayBoundsIndexType = typename MDSpanType::ArrayBoundsIndexType;
+  using ArrayBoundsIndexType = MDSpanType::ArrayBoundsIndexType;
   using value_type = DataType;
   using LayoutPolicyType = LayoutPolicy;
 
@@ -146,12 +146,12 @@ class NumArray
   }
 
   //! Constructs an array with 1 dynamic value
-  explicit NumArray(Int32 dim1_size) requires(Extents::nb_dynamic == 1)
+  explicit NumArray(ExtentIndexType dim1_size) requires(Extents::nb_dynamic == 1)
   : ThatClass(DynamicDimsType(dim1_size))
   {
   }
   //! Constructs an array with 1 dynamic value
-  NumArray(Int32 dim1_size, eMemoryResource r) requires(Extents::nb_dynamic == 1)
+  NumArray(ExtentIndexType dim1_size, eMemoryResource r) requires(Extents::nb_dynamic == 1)
   : ThatClass(DynamicDimsType(dim1_size), r)
   {
   }
@@ -279,27 +279,27 @@ class NumArray
  public:
 
   //! Value of the first dimension
-  constexpr Int32 dim1Size() const requires(Extents::rank() >= 1) { return m_span.extent0(); }
+  constexpr ExtentIndexType dim1Size() const requires(Extents::rank() >= 1) { return m_span.extent0(); }
   //! Value of the second dimension
-  constexpr Int32 dim2Size() const requires(Extents::rank() >= 2) { return m_span.extent1(); }
+  constexpr ExtentIndexType dim2Size() const requires(Extents::rank() >= 2) { return m_span.extent1(); }
   //! Value of the third dimension
-  constexpr Int32 dim3Size() const requires(Extents::rank() >= 3) { return m_span.extent2(); }
+  constexpr ExtentIndexType dim3Size() const requires(Extents::rank() >= 3) { return m_span.extent2(); }
   //! Value of the fourth dimension
-  constexpr Int32 dim4Size() const requires(Extents::rank() >= 4) { return m_span.extent3(); }
+  constexpr ExtentIndexType dim4Size() const requires(Extents::rank() >= 4) { return m_span.extent3(); }
 
   //! Value of the first dimension
-  constexpr Int32 extent0() const requires(Extents::rank() >= 1) { return m_span.extent0(); }
+  constexpr ExtentIndexType extent0() const requires(Extents::rank() >= 1) { return m_span.extent0(); }
   //! Value of the second dimension
-  constexpr Int32 extent1() const requires(Extents::rank() >= 2) { return m_span.extent1(); }
+  constexpr ExtentIndexType extent1() const requires(Extents::rank() >= 2) { return m_span.extent1(); }
   //! Value of the third dimension
-  constexpr Int32 extent2() const requires(Extents::rank() >= 3) { return m_span.extent2(); }
+  constexpr ExtentIndexType extent2() const requires(Extents::rank() >= 3) { return m_span.extent2(); }
   //! Value of the fourth dimension
-  constexpr Int32 extent3() const requires(Extents::rank() >= 4) { return m_span.extent3(); }
+  constexpr ExtentIndexType extent3() const requires(Extents::rank() >= 4) { return m_span.extent3(); }
 
  public:
 
   //! Resizes the array without keeping current values
-  void resize(Int32 dim1_size) requires(Extents::nb_dynamic == 1)
+  void resize(ExtentIndexType dim1_size) requires(Extents::nb_dynamic == 1)
   {
     m_span.m_extents = DynamicDimsType(dim1_size);
     _resize();
@@ -307,21 +307,21 @@ class NumArray
 
   // TODO: Deprecate (June 2025)
   //! Resizes the array without keeping current values
-  void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, Int32 dim4_size) requires(Extents::nb_dynamic == 4)
+  void resize(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size, ExtentIndexType dim4_size) requires(Extents::nb_dynamic == 4)
   {
     this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size, dim4_size));
   }
 
   // TODO: Deprecate (June 2025)
   //! Resizes the array without keeping current values
-  void resize(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size) requires(Extents::nb_dynamic == 3)
+  void resize(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size) requires(Extents::nb_dynamic == 3)
   {
     this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size));
   }
 
   // TODO: Deprecate (June 2025)
   //! Resizes the array without keeping current values
-  void resize(Int32 dim1_size, Int32 dim2_size) requires(Extents::nb_dynamic == 2)
+  void resize(ExtentIndexType dim1_size, ExtentIndexType dim2_size) requires(Extents::nb_dynamic == 2)
   {
     this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size));
   }
@@ -333,25 +333,25 @@ class NumArray
    */
   //@{
   //! Resizes the array without keeping current values
-  void resizeDestructive(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size, Int32 dim4_size) requires(Extents::nb_dynamic == 4)
+  void resizeDestructive(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size, ExtentIndexType dim4_size) requires(Extents::nb_dynamic == 4)
   {
     this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size, dim4_size));
   }
 
   //! Resizes the array without keeping current values
-  void resizeDestructive(Int32 dim1_size, Int32 dim2_size, Int32 dim3_size) requires(Extents::nb_dynamic == 3)
+  void resizeDestructive(ExtentIndexType dim1_size, ExtentIndexType dim2_size, ExtentIndexType dim3_size) requires(Extents::nb_dynamic == 3)
   {
     this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size, dim3_size));
   }
 
   //! Resizes the array without keeping current values
-  void resizeDestructive(Int32 dim1_size, Int32 dim2_size) requires(Extents::nb_dynamic == 2)
+  void resizeDestructive(ExtentIndexType dim1_size, ExtentIndexType dim2_size) requires(Extents::nb_dynamic == 2)
   {
     this->resizeDestructive(DynamicDimsType(dim1_size, dim2_size));
   }
 
   //! Resizes the array without keeping current values
-  void resizeDestructive(Int32 dim1_size) requires(Extents::nb_dynamic == 1)
+  void resizeDestructive(ExtentIndexType dim1_size) requires(Extents::nb_dynamic == 1)
   {
     this->resizeDestructive(DynamicDimsType(dim1_size));
   }
@@ -564,48 +564,48 @@ class NumArray
  public:
 
   //! Retrieves a reference for element \a i
-  DataType& operator[](Int32 i) requires(Extents::rank() == 1) { return m_span(i); }
+  DataType& operator[](ExtentIndexType i) requires(Extents::rank() == 1) { return m_span(i); }
   //! Value for element \a i
-  DataType operator[](Int32 i) const requires(Extents::rank() == 1) { return m_span(i); }
+  DataType operator[](ExtentIndexType i) const requires(Extents::rank() == 1) { return m_span(i); }
 
  public:
 
   //! Value for element \a i,j,k,l
-  DataType operator()(Int32 i, Int32 j, Int32 k, Int32 l) const requires(Extents::rank() == 4)
+  DataType operator()(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k, ExtentIndexType l) const requires(Extents::rank() == 4)
   {
     return m_span(i, j, k, l);
   }
   //! Positions the value for element \a i,j,k,l
-  DataType& operator()(Int32 i, Int32 j, Int32 k, Int32 l) requires(Extents::rank() == 4)
+  DataType& operator()(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k, ExtentIndexType l) requires(Extents::rank() == 4)
   {
     return m_span(i, j, k, l);
   }
 
   //! Value for element \a i,j,k
-  DataType operator()(Int32 i, Int32 j, Int32 k) const requires(Extents::rank() == 3)
+  DataType operator()(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k) const requires(Extents::rank() == 3)
   {
     return m_span(i, j, k);
   }
   //! Positions the value for element \a i,j,k
-  DataType& operator()(Int32 i, Int32 j, Int32 k) requires(Extents::rank() == 3)
+  DataType& operator()(ExtentIndexType i, ExtentIndexType j, ExtentIndexType k) requires(Extents::rank() == 3)
   {
     return m_span(i, j, k);
   }
 
   //! Value for element \a i,j
-  DataType operator()(Int32 i, Int32 j) const requires(Extents::rank() == 2)
+  DataType operator()(ExtentIndexType i, ExtentIndexType j) const requires(Extents::rank() == 2)
   {
     return m_span(i, j);
   }
   //! Positions the value for element \a i,j
-  DataType& operator()(Int32 i, Int32 j) requires(Extents::rank() == 2)
+  DataType& operator()(ExtentIndexType i, ExtentIndexType j) requires(Extents::rank() == 2)
   {
     return m_span(i, j);
   }
   //! Value for element \a i
-  DataType operator()(Int32 i) const requires(Extents::rank() == 1) { return m_span(i); }
+  DataType operator()(ExtentIndexType i) const requires(Extents::rank() == 1) { return m_span(i); }
   //! Positions the value for element \a i
-  DataType& operator()(Int32 i) requires(Extents::rank() == 1) { return m_span(i); }
+  DataType& operator()(ExtentIndexType i) requires(Extents::rank() == 1) { return m_span(i); }
 
  public:
 

--- a/arccore/src/common/tests/TestSequentialFor.cc
+++ b/arccore/src/common/tests/TestSequentialFor.cc
@@ -8,9 +8,11 @@
 #include <gtest/gtest.h>
 
 #include "arccore/base/ForLoopRanges.h"
+#include "arccore/base/MDSpan.h"
 
 #include "arccore/common/SequentialFor.h"
 #include "arccore/common/Array.h"
+#include "arccore/common/NumArray.h"
 
 using namespace Arcane;
 
@@ -31,18 +33,27 @@ class LoopTester
     IndexType nb_dim1 = 20;
     SimpleForLoopRanges<1, IndexType> loop1(nb_dim1);
     UniqueArray<IndexType> sum_array;
+    NumArray<IndexType, MDDim1Ext<IndexType>> sum_array2;
+    sum_array2.resize(nb_dim1);
     IndexType ref_sum = {};
+    IndexType numarray_index = {};
     auto f = [&](MDIndex<1, IndexType> index) {
       IndexType i = index;
       sum_array.add(i);
+      sum_array2[numarray_index] = i;
+      ++numarray_index;
       ref_sum += i;
     };
     arccoreSequentialFor(loop1, f);
-    IndexType sum = {};
+    IndexType sum1 = {};
     for (IndexType x : sum_array) {
-      sum += x;
+      sum1 += x;
     }
-    ASSERT_EQ(ref_sum,sum);
+    IndexType sum2 = {};
+    for (IndexType x : sum_array2) {
+      sum2 += x;
+    }
+    ASSERT_EQ(ref_sum,sum2);
   }
 };
 

--- a/arccore/src/concurrency/arccore/concurrency/CMakeLists.txt
+++ b/arccore/src/concurrency/arccore/concurrency/CMakeLists.txt
@@ -12,7 +12,7 @@ if (ARCCORE_ENABLE_TBB)
       message(STATUS "[arcane_thread] Using OneTBB 2021+ implementation")
       set(ARCANE_HAS_ONETBB TRUE)
     else ()
-      message(FATAL_ERROR "[arcane_thread] Your version '${TBB_VERSION} of TBB is too old. Version 2020+ is required."
+      message(FATAL_ERROR "[arcane_thread] Your version '${TBB_VERSION} of TBB is too old. Version 2021+ is required."
         " Install a recent version of TBB or disable TBB support using -DARCCORE_ENABLE_TBB=FALSE when running cmake command")
     endif ()
   elseif (TBB_FOUND)
@@ -24,7 +24,7 @@ if (ARCCORE_ENABLE_TBB)
   else ()
     message(FATAL_ERROR
       "[arccore_concurrency] Can not find OneTBB."
-      "Install a recent version of TBB or disable TBB support using -DARCCORE_ENABLE_TBB=FALSE when running cmake command"
+      "Install a recent version (2021+) of TBB or disable TBB support using -DARCCORE_ENABLE_TBB=FALSE when running cmake command"
     )
   endif ()
 endif ()

--- a/arccore/src/concurrency/arccore/concurrency/ParallelFor.h
+++ b/arccore/src/concurrency/arccore/concurrency/ParallelFor.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ParallelFor.h                                               (C) 2000-2025 */
+/* ParallelFor.h                                               (C) 2000-2026 */
 /*                                                                           */
 /* Parallel loop management.                                                 */
 /*---------------------------------------------------------------------------*/
@@ -78,13 +78,12 @@ class ARCCORE_CONCURRENCY_EXPORT ParallelFor1DLoopInfo
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Applies the lambda function \a lambda_function concurrently
  * over the iteration interval given by \a loop_ranges.
  */
-template <int RankValue, typename LambdaType, typename... ReducerArgs> inline void
-arccoreParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
+template <int RankValue, typename IndexType_, typename LambdaType, typename... ReducerArgs> inline void
+arccoreParallelFor(const ComplexForLoopRanges<RankValue, IndexType_>& loop_ranges,
                    const ForLoopRunInfo& run_info,
                    const LambdaType& lambda_function,
                    const ReducerArgs&... reducer_args)
@@ -99,13 +98,20 @@ arccoreParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
   // of reducers (Reduce2), this privatization is no longer useful. Once
   // we have removed the old classes managing reductions (Reduce),
   // we can remove this privatization
+
+  // The final loop is always with index of type 'Int32'
+  // (because ITaskImplementation only support that) so we convert the loop
+  // if needed.
+  // TODO: Only do the conversion if needed
+  // TODO: Add support for Int64 loop in TaskFactory
+  auto final_loop_ranges = ComplexForLoopRanges<RankValue, Int32>::fromOther(loop_ranges);
   auto xfunc = [&lambda_function, reducer_args...](const ComplexForLoopRanges<RankValue>& sub_bounds) {
     using Type = typename std::remove_reference<LambdaType>::type;
     Type private_lambda(lambda_function);
     arccoreSequentialFor(sub_bounds, private_lambda, reducer_args...);
   };
   LambdaMDRangeFunctor<RankValue, decltype(xfunc)> ipf(xfunc);
-  TaskFactory::executeParallelFor(loop_ranges, run_info, &ipf);
+  TaskFactory::executeParallelFor(final_loop_ranges, run_info, &ipf);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -115,8 +121,8 @@ arccoreParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
  * \brief Applies the lambda function \a lambda_function concurrently
  * over the iteration interval given by \a loop_ranges.
  */
-template <int RankValue, typename LambdaType, typename... ReducerArgs> inline void
-arccoreParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
+template <int RankValue, typename IndexType_, typename LambdaType, typename... ReducerArgs> inline void
+arccoreParallelFor(const ComplexForLoopRanges<RankValue, IndexType_>& loop_ranges,
                    const ParallelLoopOptions& options,
                    const LambdaType& lambda_function,
                    const ReducerArgs&... reducer_args)
@@ -126,47 +132,44 @@ arccoreParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Applies the lambda function \a lambda_function concurrently
  * over the iteration interval given by \a loop_ranges.
  */
-template <int RankValue, typename LambdaType, typename... ReducerArgs> inline void
-arccoreParallelFor(const SimpleForLoopRanges<RankValue>& loop_ranges,
+template <int RankValue, typename IndexType_, typename LambdaType, typename... ReducerArgs> inline void
+arccoreParallelFor(const SimpleForLoopRanges<RankValue, IndexType_>& loop_ranges,
                    const ForLoopRunInfo& run_info,
                    const LambdaType& lambda_function,
                    const ReducerArgs&... reducer_args)
 {
-  ComplexForLoopRanges<RankValue> complex_loop_ranges{ loop_ranges };
+  ComplexForLoopRanges<RankValue, IndexType_> complex_loop_ranges{ loop_ranges };
   arccoreParallelFor(complex_loop_ranges, run_info, lambda_function, reducer_args...);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Applies the lambda function \a lambda_function concurrently
  * over the iteration interval given by \a loop_ranges.
  */
-template <int RankValue, typename LambdaType, typename... ReducerArgs> inline void
-arccoreParallelFor(const SimpleForLoopRanges<RankValue>& loop_ranges,
+template <int RankValue, typename IndexType_, typename LambdaType, typename... ReducerArgs> inline void
+arccoreParallelFor(const SimpleForLoopRanges<RankValue, IndexType_>& loop_ranges,
                    const ParallelLoopOptions& options,
                    const LambdaType& lambda_function,
                    const ReducerArgs&... reducer_args)
 {
-  ComplexForLoopRanges<RankValue> complex_loop_ranges{ loop_ranges };
+  ComplexForLoopRanges<RankValue, IndexType_> complex_loop_ranges{ loop_ranges };
   arccoreParallelFor(complex_loop_ranges, ForLoopRunInfo(options), lambda_function, reducer_args...);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Applies the lambda function \a lambda_function concurrently
  * over the iteration interval given by \a loop_ranges.
  */
-template <int RankValue, typename LambdaType> inline void
-arccoreParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
+template <int RankValue, typename IndexType_, typename LambdaType> inline void
+arccoreParallelFor(const ComplexForLoopRanges<RankValue, IndexType_>& loop_ranges,
                    const LambdaType& lambda_function)
 {
   ParallelLoopOptions options;
@@ -175,17 +178,16 @@ arccoreParallelFor(const ComplexForLoopRanges<RankValue>& loop_ranges,
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Applies the lambda function \a lambda_function concurrently
  * over the iteration interval given by \a loop_ranges.
  */
-template <int RankValue, typename LambdaType> inline void
-arccoreParallelFor(const SimpleForLoopRanges<RankValue>& loop_ranges,
+template <int RankValue, typename IndexType_, typename LambdaType> inline void
+arccoreParallelFor(const SimpleForLoopRanges<RankValue, IndexType_>& loop_ranges,
                    const LambdaType& lambda_function)
 {
   ParallelLoopOptions options;
-  ComplexForLoopRanges<RankValue> complex_loop_ranges{ loop_ranges };
+  ComplexForLoopRanges<RankValue, IndexType_> complex_loop_ranges{ loop_ranges };
   arccoreParallelFor(complex_loop_ranges, options, lambda_function);
 }
 


### PR DESCRIPTION
This is experimental and should only be used with `Arcane::Accelerator::launchRunCommand()` function.