### PR TITLE
Remove some ambigous usage of namespace `Impl`

### DIFF
--- a/arccore/src/base/arccore/base/Profiling.h
+++ b/arccore/src/base/arccore/base/Profiling.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* Profiling.h                                                 (C) 2000-2025 */
+/* Profiling.h                                                 (C) 2000-2026 */
 /*                                                                           */
 /* Classes to manage profiling.                                              */
 /*---------------------------------------------------------------------------*/
@@ -159,7 +159,7 @@ class ARCCORE_BASE_EXPORT ProfilingRegistry
    * instead.
    */
   ARCCORE_DEPRECATED_REASON("Y2023: Use _threadLocalForLoopInstance() instead")
-  static Impl::ForLoopStatInfoList* threadLocalInstance();
+  static Arcane::Impl::ForLoopStatInfoList* threadLocalInstance();
 
   /*!
    * \brief Sets the profiling level.
@@ -182,7 +182,7 @@ class ARCCORE_BASE_EXPORT ProfilingRegistry
    *
    * This method must not be called if loops are currently executing.
    */
-  static void visitLoopStat(const std::function<void(const Impl::ForLoopStatInfoList&)>& f);
+  static void visitLoopStat(const std::function<void(const Arcane::Impl::ForLoopStatInfoList&)>& f);
 
   /*!
    * \brief Visits the accelerator statistics list
@@ -192,7 +192,7 @@ class ARCCORE_BASE_EXPORT ProfilingRegistry
    *
    * This method must not be called when profiling is active.
    */
-  static void visitAcceleratorStat(const std::function<void(const Impl::AcceleratorStatInfoList&)>& f);
+  static void visitAcceleratorStat(const std::function<void(const Arcane::Impl::AcceleratorStatInfoList&)>& f);
 
   static const Impl::ForLoopCumulativeStat& globalLoopStat();
 
@@ -204,13 +204,13 @@ class ARCCORE_BASE_EXPORT ProfilingRegistry
    * \internal.
    * Thread-local instance of the loop statistics manager
    */
-  static Impl::ForLoopStatInfoList* _threadLocalForLoopInstance();
+  static Arcane::Impl::ForLoopStatInfoList* _threadLocalForLoopInstance();
 
   /*!
    * \internal.
    * Thread-local instance of the accelerator statistics manager
    */
-  static Impl::AcceleratorStatInfoList* _threadLocalAcceleratorInstance();
+  static Arcane::Impl::AcceleratorStatInfoList* _threadLocalAcceleratorInstance();
 
  private:
 

--- a/arccore/src/common/arccore/common/NumArray.h
+++ b/arccore/src/common/arccore/common/NumArray.h
@@ -53,7 +53,7 @@ concept NumArrayDataTypeConcept = std::is_trivially_copyable_v<T>;
  */
 template <typename DataType, typename Extents, typename LayoutPolicy>
 class NumArray
-: private Impl::NumArrayBaseCommon
+: private Arcane::Impl::NumArrayBaseCommon
 {
  public:
 
@@ -69,7 +69,7 @@ class NumArray
   using DynamicDimsType = ExtentsType::DynamicDimsType;
   using ConstMDSpanType = MDSpan<const DataType, ExtentsType, LayoutPolicy>;
   using MDSpanType = MDSpan<DataType, ExtentsType, LayoutPolicy>;
-  using ArrayWrapper = Impl::NumArrayContainer<DataType>;
+  using ArrayWrapper = Arcane::Impl::NumArrayContainer<DataType>;
   using ArrayBoundsIndexType = MDSpanType::ArrayBoundsIndexType;
   using value_type = DataType;
   using LayoutPolicyType = LayoutPolicy;

--- a/arccore/src/common/arccore/common/SequentialFor.h
+++ b/arccore/src/common/arccore/common/SequentialFor.h
@@ -32,10 +32,10 @@ template <typename IndexType, template <int T, typename> class LoopBoundType,
 void arccoreSequentialFor(LoopBoundType<1, IndexType> bounds, Lambda func,
                           RemainingArgs... remaining_args)
 {
-  Impl::HostKernelRemainingArgsHelper::applyAtBegin(remaining_args...);
+  Arcane::Impl::HostKernelRemainingArgsHelper::applyAtBegin(remaining_args...);
   for (IndexType i0 = bounds.template lowerBound<0>(); i0 < bounds.template upperBound<0>(); ++i0)
     func(MDIndex<1, IndexType>(i0), remaining_args...);
-  Impl::HostKernelRemainingArgsHelper::applyAtEnd(remaining_args...);
+  Arcane::Impl::HostKernelRemainingArgsHelper::applyAtEnd(remaining_args...);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Depending of the list of header files includes, there is ambiguity between `Arcane::Impl` and `Arcane::Materials::Impl` namespace.
To remove the ambiguity, we use full qualified names in these parts.
