### PR TITLE
Add read-only accelerator views for mesh matrix mutli-dimensional variables

### DIFF
--- a/arcane/src/arcane/accelerator/MDVariableViews.h
+++ b/arcane/src/arcane/accelerator/MDVariableViews.h
@@ -1,0 +1,117 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* MDVariableViews.h                                           (C) 2000-2026 */
+/*                                                                           */
+/* multi-dimensional variable view management for accelerators.              */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCANE_ACCELERATOR_MDVARIABLEVIEWS_H
+#define ARCANE_ACCELERATOR_MDVARIABLEVIEWS_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arcane/accelerator/VariableViews.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Accelerator
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Read-only view of multi-dimensional matrix variable over a mesh item.
+ */
+template <typename ItemType_, typename DataType_, int Row, int Column, typename Extents>
+class MeshMatrixMDVariableInView
+: public VariableViewBase
+{
+ public:
+
+  using ItemType = ItemType_;
+  using DataType = DataType_;
+  using ItemLocalIdType = ItemType::LocalIdType;
+  using ConstReferenceType = NumMatrixDataViewGetter<DataType, Row, Column>;
+
+  using VariableRefType = MeshMatrixMDVariableRefT<ItemType, DataType, Row, Column, Extents>;
+
+ private:
+
+  using MDSpanType = VariableRefType::MDSpanType;
+
+ public:
+
+  MeshMatrixMDVariableInView(const ViewBuildInfo& view_bi, IVariable* var, const VariableRefType& var_values)
+  : VariableViewBase(view_bi, var)
+  , m_matrix_mdspan(var_values.m_matrix_mdspan)
+  {
+  }
+
+ public:
+
+  //! \name Operations for variable of dimension MDDim0
+  ///@{
+
+  //! Read-only view of the matrix for item \a id
+  constexpr ARCCORE_HOST_DEVICE ConstReferenceType operator()(ItemLocalIdType id) const
+  requires(Extents::rank() == 0)
+  {
+    return ConstReferenceType(m_matrix_mdspan.ptrAt(id.localId()));
+  }
+
+  //! Read-only view of the element (i,j) of the matrix for item \a id
+  constexpr ARCCORE_HOST_DEVICE DataType operator()(ItemLocalIdType id, Int32 i, Int32 j) const
+  requires(Extents::rank() == 0)
+  {
+    return m_matrix_mdspan(id.localId())(i, j);
+  }
+  ///@}
+
+  //! \name Operations for variable of dimension MDDim1
+
+  //! Read-only view of the matrix of index \a index for item \a id
+  constexpr ARCCORE_HOST_DEVICE ConstReferenceType operator()(ItemLocalIdType id, Int32 index) const
+  requires(Extents::rank() == 1)
+  {
+    return ConstReferenceType(m_matrix_mdspan.ptrAt(id.localId(), index));
+  }
+
+  //! Read-only view of the element (i,j) of the matrix for item \a id and index \a index
+  constexpr ARCCORE_HOST_DEVICE DataType operator()(ItemLocalIdType id, Int32 index, Int32 i, Int32 j) const
+  requires(Extents::rank() == 1)
+  {
+    return m_matrix_mdspan(id.localId(), index)(i, j);
+  }
+  ///@}
+
+ private:
+
+  MDSpanType m_matrix_mdspan;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Read-only view of matrix multi-dimensional mesh variable
+ */
+template <typename ItemType, typename DataType, int Row, int Column, typename Extents>
+auto viewIn(const ViewBuildInfo& command, const MeshMatrixMDVariableRefT<ItemType, DataType, Row, Column, Extents>& var)
+{
+  IVariable* v = var.underlyingVariable().variable();
+  return MeshMatrixMDVariableInView<ItemType, DataType, Row, Column, Extents>(command, v, var);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // End namespace Arcane::Accelerator
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arcane/src/arcane/accelerator/VariableViews.cc
+++ b/arcane/src/arcane/accelerator/VariableViews.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* VariableViews.cc                                            (C) 2000-2025 */
+/* VariableViews.cc                                            (C) 2000-2026 */
 /*                                                                           */
 /* Management of views on variables for accelerators.                        */
 /*---------------------------------------------------------------------------*/
@@ -19,17 +19,16 @@
 #include "arccore/common/accelerator/internal/IRunQueueStream.h"
 
 #include "arcane/core/VariableUtils.h"
+#include "arcane/accelerator/MDVariableViews.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \file VariableViews.h
  *
  * This file contains the type declarations for managing
  * views for mesh variable accelerators.
  */
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/arcane/src/arcane/accelerator/srcs.cmake
+++ b/arcane/src/arcane/accelerator/srcs.cmake
@@ -16,6 +16,7 @@
   KernelLauncher.h
   MaterialVariableViews.h
   MaterialVariableViews.cc
+  MDVariableViews.h
   NumArray.h
   NumArrayViews.h
   Reduce.h

--- a/arcane/src/arcane/accelerator/tests/CMakeLists.txt
+++ b/arcane/src/arcane/accelerator/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ set(ACCELERATOR_FILES
 # Check whether tests on virtual methods are performed
 set(DO_TEST_VIRTUAL FALSE)
 # These tests are only valid for CUDA and HIP
-if ((ARCANE_ACCELERATOR_MODE STREQUAL "CUDA") OR (ARCANE_ACCELERATOR_MODE STREQUAL "ROCM"))
+if (ARCCORE_HAS_CUDA OR ARCCORE_HAS_HIP)
   set(DO_TEST_VIRTUAL TRUE)
 endif ()
 # We do not test virtual methods with CUDA/Clang because

--- a/arcane/src/arcane/core/ArcaneTypes.h
+++ b/arcane/src/arcane/core/ArcaneTypes.h
@@ -501,6 +501,10 @@ template <typename ItemType, typename DataType, typename Extents>
 class MeshMDVariableRefBaseT;
 template <typename ItemType, typename DataType, typename Extents>
 class MeshMDVariableRefT;
+template <typename ItemType, typename DataType_, int Row, int Column, typename Extents>
+class MeshMatrixMDVariableRefT;
+template <typename ItemType, typename DataType_, int Size, typename Extents>
+class MeshVectorMDVariableRefT;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -652,6 +656,8 @@ namespace Accelerator
 {
   class IAcceleratorMng;
   class AcceleratorRuntimeInitialisationInfo;
+  template <typename ItemType_, typename DataType_, int Row, int Column, typename Extents>
+  class MeshMatrixMDVariableInView;
 } // namespace Accelerator
 using Accelerator::AcceleratorRuntimeInitialisationInfo;
 using Accelerator::IAcceleratorMng;

--- a/arcane/src/arcane/core/MeshMDVariableRef.h
+++ b/arcane/src/arcane/core/MeshMDVariableRef.h
@@ -100,6 +100,8 @@ class MeshMDVariableRefBaseT
   }
 
   //! Associated underlying variable.
+  const UnderlyingVariableType& underlyingVariable() const { return m_underlying_var; }
+  //! Associated underlying variable.
   UnderlyingVariableType& underlyingVariable() { return m_underlying_var; }
 
   //! Full shape (static + dynamic) of the variable.

--- a/arcane/src/arcane/core/MeshMatrixMDVariableRef.h
+++ b/arcane/src/arcane/core/MeshMatrixMDVariableRef.h
@@ -42,6 +42,9 @@ template <typename ItemType, typename DataType_, int Row, int Column, typename E
 class MeshMatrixMDVariableRefT
 : public MeshMDVariableRefBaseT<ItemType, DataType_, typename Extents::template AddedFirstLastLastExtentsType<DynExtent, Row, Column>>
 {
+  // To access m_matrix_mdspan
+  friend class Arcane::Accelerator::MeshMatrixMDVariableInView<ItemType, DataType_, Row, Column, Extents>;
+
  public:
 
   using DataType = DataType_;
@@ -83,7 +86,7 @@ class MeshMatrixMDVariableRefT
   //! Read-only view of the matrix for item \a id
   ConstReferenceType operator()(ItemLocalIdType id) const requires(Extents::rank() == 0)
   {
-    return ReferenceType(m_matrix_mdspan.ptrAt(id.localId()));
+    return ConstReferenceType(m_matrix_mdspan.ptrAt(id.localId()));
   }
 
   //! Mutable view of the element (i,j) of the matrix for item \a id
@@ -112,7 +115,7 @@ class MeshMatrixMDVariableRefT
   ConstReferenceType operator()(ItemLocalIdType id, Int32 index) const
   requires(Extents::rank() == 1)
   {
-    return ReferenceType(m_matrix_mdspan.ptrAt(id.localId(), index));
+    return ConstReferenceType(m_matrix_mdspan.ptrAt(id.localId(), index));
   }
 
   //! Mutable view of the element (i,j) of the matrix for item \a id and index \a index

--- a/arcane/src/arcane/tests/MDVariableUnitTest.cc
+++ b/arcane/src/arcane/tests/MDVariableUnitTest.cc
@@ -24,6 +24,11 @@
 #include "arcane/core/VariableTypes.h"
 #include "arcane/core/ServiceFactory.h"
 
+// These two files are added to make sure this file compiles
+// event if 'axlstar' is old and does not include them.
+#include "arcane/core/MeshMatrixMDVariableRef.h"
+#include "arcane/core/MeshVectorMDVariableRef.h"
+
 #include "arcane/tests/ArcaneTestGlobal.h"
 #include "arcane/tests/MDVariableUnitTest_axl.h"
 

--- a/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
+++ b/arcane/src/arcane/tests/accelerator/AcceleratorViewsUnitTest.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* AcceleratorViewsUnitTest.cc                                 (C) 2000-2025 */
+/* AcceleratorViewsUnitTest.cc                                 (C) 2000-2026 */
 /*                                                                           */
 /* Test service for accelerator views.                                       */
 /*---------------------------------------------------------------------------*/
@@ -19,6 +19,8 @@
 #include "arcane/core/ServiceFactory.h"
 #include "arcane/core/IItemFamily.h"
 #include "arcane/core/IMesh.h"
+#include "arcane/core/ItemPrinter.h"
+#include "arcane/core/MeshMatrixMDVariableRef.h"
 
 #include "arcane/accelerator/core/Runner.h"
 #include "arcane/accelerator/core/Memory.h"
@@ -26,9 +28,9 @@
 
 #include "arcane/accelerator/RunCommandLoop.h"
 #include "arcane/accelerator/VariableViews.h"
+#include "arcane/accelerator/MDVariableViews.h"
 #include "arcane/accelerator/NumArrayViews.h"
 #include "arcane/accelerator/RunCommandEnumerate.h"
-#include "arcane/materials/ComponentSimd.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -40,7 +42,6 @@ namespace ax = Arcane::Accelerator;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Test service for the 'AcceleratorViews' class.
  */
@@ -59,8 +60,8 @@ class AcceleratorViewsUnitTest
 
  private:
 
-  ax::Runner m_runner;
-  ax::RunQueue m_queue;
+  Runner m_runner;
+  RunQueue m_queue;
   VariableCellArrayReal m_cell_array1;
   VariableCellArrayReal m_cell_array2;
   VariableCellReal2 m_cell1_real2;
@@ -96,6 +97,7 @@ class AcceleratorViewsUnitTest
   void _checkResultReal3x3(Real to_add);
   void _executeTestGroupIndexTable();
   void _executeTestMultiArray();
+  void _executeTestMDMatrixVariable();
 };
 
 /*---------------------------------------------------------------------------*/
@@ -215,6 +217,7 @@ executeTest()
   _executeTestVariableCopy();
   _executeTestVariableFill();
   _executeTestMultiArray();
+  _executeTestMDMatrixVariable();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -997,6 +1000,58 @@ _executeTestMultiArray()
     };
   }
   vc.areEqualArray(result_values.to1DSpan(), expected_result_values.to1DSpan(), "Result");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void AcceleratorViewsUnitTest::
+_executeTestMDMatrixVariable()
+{
+  info() << "Test MDMatrix variable";
+  MeshMatrixMDVariableRefT<Cell, Real, 3, 3, MDDim0> cell_matrix(VariableBuildInfo(mesh(), "CellMatrix"));
+  cell_matrix.reshape({});
+
+  VariableCellReal cell_matrix_determinant_ref(VariableBuildInfo(mesh(), "CellMatrixDeterminant"));
+  VariableCellReal cell_matrix_determinant(VariableBuildInfo(mesh(), "CellMatrixDeterminantRef"));
+
+  // Compute the determinant of the matrix on host
+  ENUMERATE_ (Cell, icell, allCells()) {
+    Real r0 = static_cast<Real>(icell.itemLocalId() + 1);
+    NumMatrix<Real, 3, 3> x({ r0, r0 + 1.5, r0 - 1.2 },
+                            { r0 + 2.3, r0 - 4.3, r0 + 4.2 },
+                            { r0, r0 + 1.0, r0 + 2.0 });
+    cell_matrix(icell) = x;
+    Real3x3 r = x;
+    cell_matrix_determinant_ref[icell] = 2.0 * r.determinant();
+  }
+
+  // Compute the determinant of the matrix on RunQueue device
+  // The determinant is computed in two ways
+  // - using direct access to NumMatrix.
+  // - using each component of the NumMatrix
+  {
+    auto command = makeCommand(m_queue);
+    auto in_cell_matrix = viewIn(command, cell_matrix);
+    auto out_cell_matrix_determinant = viewOut(command, cell_matrix_determinant);
+    command << RUNCOMMAND_ENUMERATE (CellLocalId, cell_id, allCells())
+    {
+      NumMatrix<Real, 3, 3> x = in_cell_matrix(cell_id);
+      Real3x3 r1 = x;
+      Real3 v1(in_cell_matrix(cell_id, 0, 0), in_cell_matrix(cell_id, 0, 1), in_cell_matrix(cell_id, 0, 2));
+      Real3 v2(in_cell_matrix(cell_id, 1, 0), in_cell_matrix(cell_id, 1, 1), in_cell_matrix(cell_id, 1, 2));
+      Real3 v3(in_cell_matrix(cell_id, 2, 0), in_cell_matrix(cell_id, 2, 1), in_cell_matrix(cell_id, 2, 2));
+      Real3x3 r2(v1, v2, v3);
+      out_cell_matrix_determinant(cell_id) = r1.determinant() + r2.determinant();
+    };
+  }
+  // Check the result
+  ENUMERATE_ (Cell, icell, allCells()) {
+    Real determinant_ref = cell_matrix_determinant_ref[icell];
+    Real determinant = cell_matrix_determinant[icell];
+    if (!math::isNearlyEqualWithEpsilon(determinant, determinant_ref, 1.0e-10))
+      ARCANE_FATAL("Bad determinant cell={0} v={1} ref={2}", ItemPrinter(*icell), determinant, determinant_ref);
+  }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/NumMatrix.h
+++ b/arcane/src/arcane/utils/NumMatrix.h
@@ -141,7 +141,7 @@ class NumMatrix
     return Real2x2(m_values[0], m_values[1]);
   }
 
-  operator Real3x3() const requires(isSquare3())
+  constexpr operator Real3x3() const requires(isSquare3())
   {
     return Real3x3(m_values[0], m_values[1], m_values[2]);
   }

--- a/arcane/src/arcane/utils/NumMatrixDataView.h
+++ b/arcane/src/arcane/utils/NumMatrixDataView.h
@@ -31,6 +31,23 @@ template <typename DataType_, int Row, int Column>
 class NumMatrixDataViewGetter
 : public DataViewGetter<NumMatrix<DataType_, Row, Column>>
 {
+ public:
+
+  using NumMatrixType = NumMatrix<DataType_, Row, Column>;
+
+ public:
+
+  explicit ARCCORE_HOST_DEVICE NumMatrixDataViewGetter(const NumMatrixType* ptr)
+  : m_ptr(ptr)
+  {}
+
+ public:
+
+  constexpr operator const NumMatrixType&() const { return *m_ptr; }
+
+ private:
+
+  const NumMatrixType* m_ptr = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/NumVector.h
+++ b/arcane/src/arcane/utils/NumVector.h
@@ -141,9 +141,15 @@ class NumVector
     return (*this);
   }
 
-  operator Real2() const requires(Size == 2) { return Real2(m_values[0], m_values[1]); }
+  constexpr operator Real2() const requires(Size == 2)
+  {
+    return Real2(m_values[0], m_values[1]);
+  }
 
-  operator Real3() const requires(Size == 3) { return Real3(m_values[0], m_values[1], m_values[2]); }
+  constexpr operator Real3() const requires(Size == 3)
+  {
+    return Real3(m_values[0], m_values[1], m_values[2]);
+  }
 
  public:
 

--- a/arcane/src/arcane/utils/UtilsTypes.h
+++ b/arcane/src/arcane/utils/UtilsTypes.h
@@ -61,6 +61,10 @@ using Int64x2 = Vector2<Int64>;
 using Int32x2 = Vector2<Int32>;
 template <typename T, int Size> class NumVector;
 template <typename T, int RowSize, int ColumnSize = RowSize> class NumMatrix;
+template <typename DataType_, int RowSize, int ColumnSize>
+class NumMatrixDataViewGetter;
+template <typename DataType_, int RowSize, int ColumnSize>
+class NumMatrixDataViewGetterSetter;
 using RealN2 = NumVector<Real, 2>;
 using RealN3 = NumVector<Real, 3>;
 using RealN2x2 = NumMatrix<Real, 2>;


### PR DESCRIPTION
Add read-only view for variables of type `MeshMatrixMDVariableRef`.
