### PR TITLE
Rename namespace `Arcane::Materials::Impl` to `Arcane::Materials::MatImpl`

### DIFF
--- a/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
+++ b/arcane/src/arcane/core/materials/ConstituentItemIndexedSelectionView.h
@@ -20,7 +20,7 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-namespace Arcane::Materials::Impl
+namespace Arcane::Materials::MatImpl
 {
 
 /*---------------------------------------------------------------------------*/
@@ -179,7 +179,7 @@ class ConstituentItemIndexedSelectionView
 
   using ItemVecView = ContainerView_;
   using ThatClass = ConstituentItemIndexedSelectionView;
-  using TraitsType = Impl::ConstituentItemIndexedSelectionViewTraits<ContainerView_>;
+  using TraitsType = Arcane::Materials::MatImpl::ConstituentItemIndexedSelectionViewTraits<ContainerView_>;
   using ValueType = TraitsType::ValueType;
   static constexpr bool IsSpanContainer() { return TraitsType::IsSpan(); }
 

--- a/arcane/src/arcane/core/materials/MatItemEnumerator.h
+++ b/arcane/src/arcane/core/materials/MatItemEnumerator.h
@@ -675,7 +675,7 @@ arcaneImplCreateConstituentEnumerator(EnvPartCell, IMeshEnvironment* c, eMatPart
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-namespace Impl
+namespace MatImpl
 {
 
   /*!
@@ -720,7 +720,7 @@ namespace Impl
   ::Arcane::Materials::EnumeratorBuilder<::Arcane::Materials::ClassName_>::create(__VA_ARGS__)
 
 #define A_ENUMERATEBUILDER_HELPER2(ConstituentItemNameType, env_or_mat_container, ...) \
-  ::Arcane::Materials::Impl::makeConstituentItemEnumeratorLoop(ConstituentItemNameType(), env_or_mat_container __VA_OPT__(, __VA_ARGS__))
+  ::Arcane::Materials::MatImpl::makeConstituentItemEnumeratorLoop(ConstituentItemNameType(), env_or_mat_container __VA_OPT__(, __VA_ARGS__))
 
 #define A_ENUMERATE_COMPONENTCELL(ClassName_, iname, env_or_mat_container, ...) \
   for (A_TRACE_COMPONENT_DIRECT_CLASS(decltype(A_ENUMERATEBUILDER_HELPER2(ClassName_, env_or_mat_container __VA_OPT__(, __VA_ARGS__)))) \

--- a/arccore/src/base/arccore/base/ArrayExtentsValue.h
+++ b/arccore/src/base/arccore/base/ArrayExtentsValue.h
@@ -165,7 +165,7 @@ class ArrayExtentsValue<IndexType_, X0>
 
  protected:
 
-  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
+  Arcane::Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -271,8 +271,8 @@ class ArrayExtentsValue<IndexType_, X0, X1>
 
  protected:
 
-  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
-  Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
+  Arcane::Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
+  Arcane::Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -390,9 +390,9 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2>
 
  protected:
 
-  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
-  Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
-  Impl::ExtentValue<X2, ExtentIndexType> m_extent2;
+  Arcane::Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
+  Arcane::Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
+  Arcane::Impl::ExtentValue<X2, ExtentIndexType> m_extent2;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -451,11 +451,11 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
   constexpr MDIndexType getIndices(ExtentIndexType i) const
   {
     // Compute base indices
-    ExtentIndexType i3 = Impl::fastmod(i, m_extent3.v);
+    ExtentIndexType i3 = Arcane::Impl::fastmod(i, m_extent3.v);
     ExtentIndexType fac = m_extent3.v;
-    ExtentIndexType i2 = Impl::fastmod(i / fac, m_extent2.v);
+    ExtentIndexType i2 = Arcane::Impl::fastmod(i / fac, m_extent2.v);
     fac *= m_extent2.v;
-    ExtentIndexType i1 = Impl::fastmod(i / fac, m_extent1.v);
+    ExtentIndexType i1 = Arcane::Impl::fastmod(i / fac, m_extent1.v);
     fac *= m_extent1.v;
     ExtentIndexType i0 = i / fac;
     return { i0, i1, i2, i3 };
@@ -525,10 +525,10 @@ class ArrayExtentsValue<IndexType_, X0, X1, X2, X3>
 
  protected:
 
-  Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
-  Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
-  Impl::ExtentValue<X2, ExtentIndexType> m_extent2;
-  Impl::ExtentValue<X3, ExtentIndexType> m_extent3;
+  Arcane::Impl::ExtentValue<X0, ExtentIndexType> m_extent0;
+  Arcane::Impl::ExtentValue<X1, ExtentIndexType> m_extent1;
+  Arcane::Impl::ExtentValue<X2, ExtentIndexType> m_extent2;
+  Arcane::Impl::ExtentValue<X3, ExtentIndexType> m_extent3;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/base/arccore/base/ExtentsV.h
+++ b/arccore/src/base/arccore/base/ExtentsV.h
@@ -49,7 +49,7 @@ class ExtentsV<IndexType_>
 {
  public:
 
-  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_>;
+  using ArrayExtentsValueType = Arcane::Impl::ArrayExtentsValue<IndexType_>;
   using ExtentIndexType = IndexType_;
 
  public:
@@ -74,13 +74,13 @@ class ExtentsV<IndexType_, X0>
  public:
 
   static constexpr int rank() { return 1; }
-  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0);
+  static constexpr int nb_dynamic = Arcane::Impl::extent::nbDynamic(X0);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 1); }
   static constexpr bool isDynamic1D() { return (nb_dynamic == 1); }
 
   using ExtentIndexType = IndexType_;
   using MDIndexType = MDIndex<1, IndexType_>;
-  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0>;
+  using ArrayExtentsValueType = Arcane::Impl::ArrayExtentsValue<IndexType_, X0>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_>;
   using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
   template <int X> using AddedFirstExtentsType = ExtentsV<IndexType_, X, X0>;
@@ -101,13 +101,13 @@ class ExtentsV<IndexType_, X0, X1>
  public:
 
   static constexpr int rank() { return 2; }
-  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0, X1);
+  static constexpr int nb_dynamic = Arcane::Impl::extent::nbDynamic(X0, X1);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 2); }
   static constexpr bool isDynamic1D() { return false; }
 
   using ExtentIndexType = IndexType_;
   using MDIndexType = MDIndex<2, IndexType_>;
-  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0, X1>;
+  using ArrayExtentsValueType = Arcane::Impl::ArrayExtentsValue<IndexType_, X0, X1>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_, X1>;
   using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
   template <int X> using AddedFirstExtentsType = ExtentsV<IndexType_, X, X0, X1>;
@@ -127,13 +127,13 @@ class ExtentsV<IndexType_, X0, X1, X2>
  public:
 
   static constexpr int rank() { return 3; }
-  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0, X1, X2);
+  static constexpr int nb_dynamic = Arcane::Impl::extent::nbDynamic(X0, X1, X2);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 3); }
   static constexpr bool isDynamic1D() { return false; }
 
   using ExtentIndexType = IndexType_;
   using MDIndexType = MDIndex<3, IndexType_>;
-  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0, X1, X2>;
+  using ArrayExtentsValueType = Arcane::Impl::ArrayExtentsValue<IndexType_, X0, X1, X2>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_, X1, X2>;
   using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
   template <int X> using AddedFirstExtentsType = ExtentsV<IndexType_, X, X0, X1, X2>;
@@ -152,13 +152,13 @@ class ExtentsV<IndexType_, X0, X1, X2, X3>
  public:
 
   static constexpr int rank() { return 4; }
-  static constexpr int nb_dynamic = Impl::extent::nbDynamic(X0, X1, X2, X3);
+  static constexpr int nb_dynamic = Arcane::Impl::extent::nbDynamic(X0, X1, X2, X3);
   static constexpr bool is_full_dynamic() { return (nb_dynamic == 4); }
   static constexpr bool isDynamic1D() { return false; }
 
   using ExtentIndexType = IndexType_;
   using MDIndexType = MDIndex<4, IndexType_>;
-  using ArrayExtentsValueType = Impl::ArrayExtentsValue<IndexType_, X0, X1, X2, X3>;
+  using ArrayExtentsValueType = Arcane::Impl::ArrayExtentsValue<IndexType_, X0, X1, X2, X3>;
   using RemovedFirstExtentsType = ExtentsV<IndexType_, X1, X2, X3>;
   using DynamicDimsType = MDIndex<nb_dynamic, IndexType_>;
 

--- a/arccore/src/base/arccore/base/Profiling.h
+++ b/arccore/src/base/arccore/base/Profiling.h
@@ -194,7 +194,7 @@ class ARCCORE_BASE_EXPORT ProfilingRegistry
    */
   static void visitAcceleratorStat(const std::function<void(const Arcane::Impl::AcceleratorStatInfoList&)>& f);
 
-  static const Impl::ForLoopCumulativeStat& globalLoopStat();
+  static const Arcane::Impl::ForLoopCumulativeStat& globalLoopStat();
 
  public:
 


### PR DESCRIPTION
This is to prevent ambiguities when some code add `using namespace Arcane` and `using namespace Arcane::Materials` in some headers.
Also use explicit `Arcane::Impl` in some parts.