### PR TITLE
Improve usage of `MDSpan`

### DIFF
--- a/arccore/src/base/arccore/base/MDSpan.h
+++ b/arccore/src/base/arccore/base/MDSpan.h
@@ -70,80 +70,78 @@ class MDSpan
  public:
 
   MDSpan() = default;
-  constexpr MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents)
+  ~MDSpan() = default;
+  constexpr MDSpan(DataType* ptr, ArrayExtentsWithOffsetType extents) noexcept
   : m_ptr(ptr)
   , m_extents(extents)
   {
   }
-  constexpr MDSpan(DataType* ptr, const DynamicDimsType& dims)
+  constexpr MDSpan(DataType* ptr, const DynamicDimsType& dims) noexcept
   : m_ptr(ptr)
   , m_extents(dims)
   {}
-  constexpr MDSpan(const MDSpan<UnqualifiedValueType, Extents, LayoutPolicy>& rhs) requires(IsConst)
+  constexpr MDSpan(const MDSpan<UnqualifiedValueType, Extents, LayoutPolicy>& rhs) noexcept requires(IsConst)
   : m_ptr(rhs.m_ptr)
   , m_extents(rhs.m_extents)
   {}
-  constexpr MDSpan(const MDSpan<DataType, Extents, LayoutPolicy>& rhs)
-  : m_ptr(rhs.m_ptr)
-  , m_extents(rhs.m_extents)
-  {}
-  constexpr MDSpan(SmallSpan<DataType> v)
+  MDSpan(const MDSpan<DataType, Extents, LayoutPolicy>& rhs) = default;
+  constexpr MDSpan(SmallSpan<DataType> v) noexcept
   requires(Extents::isDynamic1D())
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
-  constexpr MDSpan(ArrayView<UnqualifiedValueType> v)
+  constexpr MDSpan(ArrayView<UnqualifiedValueType> v) noexcept
   requires(Extents::isDynamic1D())
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
-  constexpr MDSpan(SmallSpan<UnqualifiedValueType> v)
+  constexpr MDSpan(SmallSpan<UnqualifiedValueType> v) noexcept
   requires(Extents::isDynamic1D() && IsConst)
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
-  constexpr MDSpan(ConstArrayView<UnqualifiedValueType> v)
+  constexpr MDSpan(ConstArrayView<UnqualifiedValueType> v) noexcept
   requires(Extents::isDynamic1D() && IsConst)
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
-  constexpr ThatClass& operator=(SmallSpan<DataType> v)
+  constexpr ThatClass& operator=(SmallSpan<DataType> v) noexcept
   requires(Extents::isDynamic1D())
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
     return (*this);
   }
-  constexpr ThatClass& operator=(SmallSpan<UnqualifiedValueType> v)
+  constexpr ThatClass& operator=(SmallSpan<UnqualifiedValueType> v) noexcept
   requires(Extents::isDynamic1D() && IsConst)
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
     return (*this);
   }
-  constexpr ThatClass& operator=(ArrayView<UnqualifiedValueType> v)
+  constexpr ThatClass& operator=(ArrayView<UnqualifiedValueType> v) noexcept
   requires(Extents::isDynamic1D())
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
     return (*this);
   }
-  constexpr ThatClass& operator=(ConstArrayView<UnqualifiedValueType> v)
+  constexpr ThatClass& operator=(ConstArrayView<UnqualifiedValueType> v) noexcept
   requires(Extents::isDynamic1D() && IsConst)
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
     return (*this);
   }
-  constexpr MDSpan& operator=(const MDSpan& v) = default;
-  constexpr MDSpan& operator=(MDSpan&& v) = default;
+  MDSpan& operator=(const MDSpan& v) = default;
+  MDSpan& operator=(MDSpan&& v) noexcept = default;
 
  public:
 
   //! Base pointer for allocated memory
-  constexpr DataType* data() { return m_ptr; }
+  constexpr DataType* data() noexcept { return m_ptr; }
   //! Base pointer for allocated memory
-  constexpr const DataType* data() const { return m_ptr; }
+  constexpr const DataType* data() const noexcept { return m_ptr; }
 
  public:
 

--- a/arccore/src/base/arccore/base/MDSpan.h
+++ b/arccore/src/base/arccore/base/MDSpan.h
@@ -38,18 +38,21 @@ namespace Arcane
  *
  * For more information, refer to the page \ref arcanedoc_core_types_numarray.
  */
-template <typename DataType, typename Extents, typename LayoutPolicy>
+template <typename DataType_, typename Extents_, typename LayoutPolicy_>
 class MDSpan
 {
-  using UnqualifiedValueType = std::remove_cv_t<DataType>;
-  friend class NumArray<UnqualifiedValueType, Extents, LayoutPolicy>;
+  using UnqualifiedValueType = std::remove_cv_t<DataType_>;
+  friend class NumArray<UnqualifiedValueType, Extents_, LayoutPolicy_>;
   // For MDSpan<const T> to access MDSpan<T>
-  friend class MDSpan<const UnqualifiedValueType, Extents, LayoutPolicy>;
-  using ThatClass = MDSpan<DataType, Extents, LayoutPolicy>;
-  static constexpr bool IsConst = std::is_const_v<DataType>;
+  friend class MDSpan<const UnqualifiedValueType, Extents_, LayoutPolicy_>;
+  using ThatClass = MDSpan<DataType_, Extents_, LayoutPolicy_>;
+  static constexpr bool IsConst = std::is_const_v<DataType_>;
 
  public:
 
+  using DataType = DataType_;
+  using Extents = Extents_;
+  using LayoutPolicy = LayoutPolicy_;
   using value_type = DataType;
   using ExtentsType = Extents;
   using ExtentIndexType = Extents::ExtentIndexType;
@@ -59,7 +62,7 @@ class MDSpan
   using ArrayExtentsWithOffsetType = ArrayExtentsWithOffset<Extents, LayoutPolicy>;
   using DynamicDimsType = typename Extents::DynamicDimsType;
   using RemovedFirstExtentsType = typename Extents::RemovedFirstExtentsType;
-
+  using ConstMDSpanType = MDSpan<const DataType, Extents, LayoutPolicy>;
   // For compatibility. To be removed for consistency with other 'using'
   using ArrayBoundsIndexType = typename Extents::MDIndexType;
   using IndexType = typename Extents::MDIndexType;
@@ -76,36 +79,64 @@ class MDSpan
   : m_ptr(ptr)
   , m_extents(dims)
   {}
-  // Constructor MDSpan<const T> from an MDSpan<T>
-  template <typename X, typename = std::enable_if_t<std::is_same_v<X, UnqualifiedValueType>>>
-  constexpr MDSpan(const MDSpan<X, Extents>& rhs)
+  constexpr MDSpan(const MDSpan<UnqualifiedValueType, Extents, LayoutPolicy>& rhs) requires(IsConst)
+  : m_ptr(rhs.m_ptr)
+  , m_extents(rhs.m_extents)
+  {}
+  constexpr MDSpan(const MDSpan<DataType, Extents, LayoutPolicy>& rhs)
   : m_ptr(rhs.m_ptr)
   , m_extents(rhs.m_extents)
   {}
   constexpr MDSpan(SmallSpan<DataType> v)
-  requires(Extents::isDynamic1D() && !IsConst)
+  requires(Extents::isDynamic1D())
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
-  constexpr MDSpan(SmallSpan<const DataType> v)
+  constexpr MDSpan(ArrayView<UnqualifiedValueType> v)
+  requires(Extents::isDynamic1D())
+  : m_ptr(v.data())
+  , m_extents(DynamicDimsType(v.size()))
+  {}
+  constexpr MDSpan(SmallSpan<UnqualifiedValueType> v)
+  requires(Extents::isDynamic1D() && IsConst)
+  : m_ptr(v.data())
+  , m_extents(DynamicDimsType(v.size()))
+  {}
+  constexpr MDSpan(ConstArrayView<UnqualifiedValueType> v)
   requires(Extents::isDynamic1D() && IsConst)
   : m_ptr(v.data())
   , m_extents(DynamicDimsType(v.size()))
   {}
   constexpr ThatClass& operator=(SmallSpan<DataType> v)
-  requires(Extents::isDynamic1D() && !IsConst)
+  requires(Extents::isDynamic1D())
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
     return (*this);
   }
-  constexpr ThatClass& operator=(SmallSpan<const DataType> v)
+  constexpr ThatClass& operator=(SmallSpan<UnqualifiedValueType> v)
   requires(Extents::isDynamic1D() && IsConst)
   {
     m_ptr = v.data();
     m_extents = DynamicDimsType(v.size());
     return (*this);
   }
+  constexpr ThatClass& operator=(ArrayView<UnqualifiedValueType> v)
+  requires(Extents::isDynamic1D())
+  {
+    m_ptr = v.data();
+    m_extents = DynamicDimsType(v.size());
+    return (*this);
+  }
+  constexpr ThatClass& operator=(ConstArrayView<UnqualifiedValueType> v)
+  requires(Extents::isDynamic1D() && IsConst)
+  {
+    m_ptr = v.data();
+    m_extents = DynamicDimsType(v.size());
+    return (*this);
+  }
+  constexpr MDSpan& operator=(const MDSpan& v) = default;
+  constexpr MDSpan& operator=(MDSpan&& v) = default;
 
  public:
 

--- a/arccore/src/base/tests/TestArrayView.cc
+++ b/arccore/src/base/tests/TestArrayView.cc
@@ -11,6 +11,7 @@
 #include "arccore/base/ArrayView.h"
 #include "arccore/base/Array3View.h"
 #include "arccore/base/Array4View.h"
+#include "arccore/base/MDSpan.h"
 
 #include <vector>
 #include <type_traits>
@@ -765,6 +766,61 @@ TEST(Span, FixedValue)
   ASSERT_EQ(fixed_span_only_const_ptr.data(), vlist.data());
 }
 
+TEST(MDSpan, Misc)
+{
+  using namespace Arcane;
+  Int32 v1[4] = { 1, 3, -5, 2 };
+
+  MDSpan<Int32, MDDim1> mdspan1;
+  ASSERT_EQ(mdspan1.extent0(),0);
+
+  mdspan1 = MDSpan<Int32,MDDim1>(v1,4);
+  ASSERT_EQ(mdspan1.extent0(),4);
+  ASSERT_EQ(mdspan1.data(),v1);
+  ASSERT_EQ(mdspan1[0],1);
+  ASSERT_EQ(mdspan1[1],3);
+  ASSERT_EQ(mdspan1[2],-5);
+  ASSERT_EQ(mdspan1[3],2);
+
+  MDSpan<const Int32, MDDim1> const_mdspan1(mdspan1);
+  ASSERT_EQ(const_mdspan1.data(), mdspan1.data());
+  ASSERT_EQ(const_mdspan1.extent0(), mdspan1.extent0());
+
+  // Convert from ArrayView
+  {
+    ArrayView arrayview1(4,v1);
+
+    MDSpan<Int32, MDDim1> mdspan2(arrayview1);
+    ASSERT_EQ(mdspan2.data(), mdspan1.data());
+    ASSERT_EQ(mdspan2.extent0(), mdspan1.extent0());
+
+    MDSpan<const Int32, MDDim1> const_mdspan2(arrayview1);
+    ASSERT_EQ(const_mdspan2.data(), mdspan1.data());
+    ASSERT_EQ(const_mdspan2.extent0(), mdspan1.extent0());
+
+    mdspan2 = arrayview1;
+    ASSERT_EQ(mdspan2.data(), mdspan1.data());
+    ASSERT_EQ(mdspan2.extent0(), mdspan1.extent0());
+
+    const_mdspan2 = arrayview1;
+    ASSERT_EQ(const_mdspan2.data(), mdspan1.data());
+    ASSERT_EQ(const_mdspan2.extent0(), mdspan1.extent0());
+  }
+
+  // Convert from ConstArrayView
+  {
+    ConstArrayView const_arrayview1(4,v1);
+
+    MDSpan<const Int32, MDDim1> const_mdspan2(const_arrayview1);
+    ASSERT_EQ(const_mdspan2.data(), mdspan1.data());
+    ASSERT_EQ(const_mdspan2.extent0(), mdspan1.extent0());
+
+    const_mdspan2 = const_arrayview1;
+    ASSERT_EQ(const_mdspan2.data(), mdspan1.data());
+    ASSERT_EQ(const_mdspan2.extent0(), mdspan1.extent0());
+  }
+}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -804,6 +860,11 @@ template class SmallSpan2<Int32>;
 template class SmallSpan2<const Int32>;
 template class SmallSpan2<double>;
 template class SmallSpan2<const double>;
+
+template class MDSpan<Int32,MDDim1>;
+template class MDSpan<Int32,MDDim2>;
+template class MDSpan<Int32,MDDim3>;
+template class MDSpan<Int32,MDDim4>;
 } // namespace Arcane
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/common/arccore/common/NumArray.cc
+++ b/arccore/src/common/arccore/common/NumArray.cc
@@ -97,10 +97,10 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-template class NumArray<Real, MDDim4>;
-template class NumArray<Real, MDDim3>;
-template class NumArray<Real, MDDim2>;
 template class NumArray<Real, MDDim1>;
+template class NumArray<Real, MDDim2>;
+template class NumArray<Real, MDDim3>;
+template class NumArray<Real, MDDim4>;
 
 template class ArrayStridesBase<1>;
 template class ArrayStridesBase<2>;

--- a/arccore/src/common/arccore/common/NumArray.h
+++ b/arccore/src/common/arccore/common/NumArray.h
@@ -178,7 +178,7 @@ class NumArray
   }
 
   //! Constructs an instance from a view (only dynamic 1D arrays)
-  NumArray(SmallSpan<const DataType> v)
+  explicit NumArray(SmallSpan<const DataType> v)
   requires(Extents::isDynamic1D())
   : NumArray(v.size())
   {
@@ -186,7 +186,7 @@ class NumArray
   }
 
   //! Constructs an instance from a view (only dynamic 1D arrays)
-  NumArray(Span<const DataType> v)
+  explicit NumArray(Span<const DataType> v)
   requires(Extents::isDynamic1D())
   {
     copy(v.smallView());
@@ -453,17 +453,6 @@ class NumArray
    * This operation is valid regardless of the memory associated
    * with the instance.
    */
-  void copy(SmallSpan<const DataType> rhs) requires(Extents::isDynamic1D())
-  {
-    copy(rhs, nullptr);
-  }
-
-  /*!
-   * \brief Copies the values from \a rhs into the instance.
-   *
-   * This operation is valid regardless of the memory associated
-   * with the instance.
-   */
   void copy(ConstMDSpanType rhs) { copy(rhs, nullptr); }
 
   /*!
@@ -483,38 +472,9 @@ class NumArray
    * \a queue can be null. If the queue is asynchronous, it must be
    * synchronized before the instance can be used.
    */
-  void copy(SmallSpan<const DataType> rhs, const RunQueue* queue) requires(Extents::isDynamic1D())
-  {
-    _resizeAndCopy(ConstMDSpanType(rhs), eMemoryResource::Unknown, queue);
-  }
-
-  /*!
-   * \brief Copies the values from \a rhs into the instance via the
-   * queue \a queue.
-   *
-   * This operation is valid regardless of the memory associated
-   * with the instance.
-   * \a queue can be null. If the queue is asynchronous, it must be
-   * synchronized before the instance can be used.
-   */
   void copy(ConstMDSpanType rhs, const RunQueue* queue)
   {
     _resizeAndCopy(rhs, eMemoryResource::Unknown, queue);
-  }
-
-  /*!
-   * \brief Copies the values from \a rhs into the instance via the
-   * queue \a queue.
-   *
-   * This operation is valid regardless of the memory associated
-   * with the instance.
-   * \a queue can be null, in which case the copy is performed on the host.
-   * If the queue is asynchronous, it must be synchronized before the instance
-   * can be used.
-   */
-  void copy(SmallSpan<const DataType> rhs, const RunQueue& queue) requires(Extents::isDynamic1D())
-  {
-    _resizeAndCopy(ConstMDSpanType(rhs), eMemoryResource::Unknown, &queue);
   }
 
   /*!


### PR DESCRIPTION
- Add constructor and copy operator from `ArrayView` and `ConstArrayView`.
- Use C++ concepts instead of SFINAE.
- Add `typedef` for template parameter types.