### PR TITLE
Move `NumVector` and `NumMatrix` in public API

### DIFF
--- a/arcane/src/arcane/core/datatype/RealArray2Variant.cc
+++ b/arcane/src/arcane/core/datatype/RealArray2Variant.cc
@@ -78,7 +78,7 @@ _arcaneTestRealArray2Variant()
     for (Integer j = 0; j < 3; ++j)
       std::cout << "V1=" << i << " " << j << " v=" << m33(i, j) << "\n";
   for (Integer i = 0; i < 3; ++i) {
-    auto lc = m33(i);
+    auto lc = m33.row(i);
     for (Integer j = 0; j < 3; ++j)
       std::cout << "V2=" << i << " " << j << " v=" << lc(j) << "\n";
   }

--- a/arcane/src/arcane/utils/NumMatrix.h
+++ b/arcane/src/arcane/utils/NumMatrix.h
@@ -31,20 +31,17 @@ namespace Arcane
  *
  * \note Currently only implemented for the Real type.
  *
- * \warning API is under definition. Do not use outside of Arcane
- *
- * It is possible to access each vector component using 'operator[]'
- * or 'operator()' or via the methods vx(), vy(), vz() if the dimension is
+ * It is possible to access each row using method 'row()'
+ * or via the methods vx(), vy(), vz() if the dimension is
  * sufficient (for example, vz() is only accessible if Size>=3.
  */
 template <typename T, int RowSize, int ColumnSize>
 class NumMatrix
 {
-  static_assert(RowSize > 1, "RowSize has to be strictly greater than 1");
-  static_assert(ColumnSize > 1, "RowSize has to be strictly greater than 1");
-  //static_assert(RowSize == ColumnSize, "Only square matrix are allowed (ColumnSize==RowSize)");
-  static_assert(std::is_same_v<T, Real>, "Only type 'Real' is allowed");
-  static constexpr int Size = RowSize;
+  static_assert(RowSize >= 0, "RowSize has to be strictly greater than 0");
+  static_assert(ColumnSize >= 0, "RowSize has to be strictly greater than 0");
+
+  static constexpr bool isRealType() { return std::is_same_v<T, Real>; }
   static constexpr bool isSquare() { return RowSize == ColumnSize; }
   static constexpr bool isSquare2() { return RowSize == 2 && ColumnSize == 2; }
   static constexpr bool isSquare3() { return RowSize == 3 && ColumnSize == 3; }
@@ -101,46 +98,66 @@ class NumMatrix
     m_values[4] = a5;
   }
 
-  //! Constructs the instance with the triplet (v, v, v).
-  constexpr ARCCORE_HOST_DEVICE explicit NumMatrix(T v)
+  //! Constructs the matrix with rows (a1, a2, a3, a4, a5, a6)
+  constexpr ARCCORE_HOST_DEVICE NumMatrix(const VectorType& a1, const VectorType& a2,
+                                          const VectorType& a3, const VectorType& a4,
+                                          const VectorType& a5, const VectorType& a6)
+  requires(RowSize == 6)
   {
-    for (int i = 0; i < Size; ++i)
+    m_values[0] = a1;
+    m_values[1] = a2;
+    m_values[2] = a3;
+    m_values[3] = a4;
+    m_values[4] = a5;
+    m_values[5] = a6;
+  }
+
+  //! Constructs the instance with the triplet (v, v, v).
+  constexpr ARCCORE_HOST_DEVICE explicit NumMatrix(const T& v)
+  {
+    for (int i = 0; i < RowSize; ++i)
       m_values[i] = v;
   }
 
-  explicit constexpr ARCCORE_HOST_DEVICE NumMatrix(Real2x2 v) requires(isSquare2())
+  explicit constexpr ARCCORE_HOST_DEVICE NumMatrix(const Real2x2& v)
+  requires(isSquare2() && isRealType())
   : NumMatrix(VectorType(v.x), VectorType(v.y))
   {}
 
-  explicit constexpr ARCCORE_HOST_DEVICE NumMatrix(Real3x3 v) requires(isSquare3())
+  explicit constexpr ARCCORE_HOST_DEVICE NumMatrix(const Real3x3& v)
+  requires(isSquare3() && isRealType())
   : NumMatrix(VectorType(v.x), VectorType(v.y), VectorType(v.z))
   {}
 
   //! Assigns the triplet (v, v, v) to the instance.
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(T v)
+  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(const DataType& v)
   {
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       m_values[i] = v;
     return (*this);
   }
 
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(const Real2x2& v) requires(isSquare2())
+  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(const Real2x2& v)
+  requires(isSquare2() && isRealType())
   {
     *this = ThatClass(v);
     return (*this);
   }
 
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(const Real3x3& v) requires(isSquare3())
+  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(const Real3x3& v)
+  requires(isSquare3() && isRealType())
   {
     *this = ThatClass(v);
     return (*this);
   }
 
+  //! Conversion to Real2x2
   operator Real2x2() const requires(isSquare2())
   {
     return Real2x2(m_values[0], m_values[1]);
   }
 
+  //! Conversion to Real3x3
   constexpr operator Real3x3() const requires(isSquare3())
   {
     return Real3x3(m_values[0], m_values[1], m_values[2]);
@@ -170,58 +187,39 @@ class NumMatrix
 
  public:
 
-  /*!
-   * \brief Compares the matrix with the zero matrix.
-   *
-   * The matrix is zero if and only if each of its components
-   * is less than a given epsilon. The epsilon value used is that
-   * of float_info<value_type>::nearlyEpsilon():
-   * \f[A=0 \Leftrightarrow |A.x|<\epsilon,|A.y|<\epsilon,|A.z|<\epsilon \f]
-   *
-   * \retval true if the matrix is equal to the zero matrix,
-   * \retval false otherwise.
-   */
-  constexpr ARCCORE_HOST_DEVICE bool isNearlyZero() const
+  //! Adds b to a and returns a.
+  friend constexpr ARCCORE_HOST_DEVICE ThatClass& operator+=(ThatClass& a, const ThatClass& b)
   {
-    bool is_nearly_zero = true;
-    for (int i = 0; i < Size; ++i)
-      is_nearly_zero = is_nearly_zero && math::isNearlyZero(m_values[i]);
-    return is_nearly_zero;
+    for (int i = 0; i < RowSize; ++i)
+      a.m_values[i] += b.m_values[i];
+    return a;
   }
-
-  //! Adds b to the triplet.
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator+=(const ThatClass& b)
+  //! Subtracts b from a and returns a.
+  friend constexpr ARCCORE_HOST_DEVICE ThatClass& operator-=(ThatClass& a, const ThatClass& b)
   {
-    for (int i = 0; i < Size; ++i)
-      m_values[i] += b.m_values[i];
-    return (*this);
+    for (int i = 0; i < RowSize; ++i)
+      a.m_values[i] -= b.m_values[i];
+    return a;
   }
-  //! Subtracts b from the triplet
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator-=(const ThatClass& b)
+  //! Multiplies each component of the matrix a by the real number b and return a.
+  friend constexpr ARCCORE_HOST_DEVICE ThatClass& operator*=(ThatClass& a, T b)
   {
-    for (int i = 0; i < Size; ++i)
-      m_values[i] -= b.m_values[i];
-    return (*this);
-  }
-  //! Multiplies each component of the matrix by the real number b
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator*=(T b)
-  {
-    for (int i = 0; i < Size; ++i)
-      m_values[i] *= b;
-    return (*this);
+    for (int i = 0; i < RowSize; ++i)
+      a.m_values[i] *= b;
+    return a;
   }
   //! Divides each component of the matrix by the real number b
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator/=(T b)
+  friend constexpr ARCCORE_HOST_DEVICE ThatClass& operator/=(ThatClass& a, T b)
   {
-    for (int i = 0; i < Size; ++i)
-      m_values[i] *= b;
-    return (*this);
+    for (int i = 0; i < RowSize; ++i)
+      a.m_values[i] /= b;
+    return a;
   }
   //! Creates a triplet that equals this triplet added to b
   friend constexpr ARCCORE_HOST_DEVICE ThatClass operator+(const ThatClass& a, const ThatClass& b)
   {
     ThatClass v;
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       v.m_values[i] = a.m_values[i] + b.m_values[i];
     return v;
   }
@@ -229,7 +227,7 @@ class NumMatrix
   friend constexpr ARCCORE_HOST_DEVICE ThatClass operator-(const ThatClass& a, const ThatClass& b)
   {
     ThatClass v;
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       v.m_values[i] = a.m_values[i] - b.m_values[i];
     return v;
   }
@@ -237,7 +235,7 @@ class NumMatrix
   constexpr ARCCORE_HOST_DEVICE ThatClass operator-() const
   {
     ThatClass v;
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       v.m_values[i] = -m_values[i];
     return v;
   }
@@ -246,7 +244,7 @@ class NumMatrix
   friend constexpr ARCCORE_HOST_DEVICE ThatClass operator*(DataType a, const ThatClass& mat)
   {
     ThatClass v;
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       v.m_values[i] = a * mat.m_values[i];
     return v;
   }
@@ -254,7 +252,7 @@ class NumMatrix
   friend constexpr ARCCORE_HOST_DEVICE ThatClass operator*(const ThatClass& mat, DataType b)
   {
     ThatClass v;
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       v.m_values[i] = mat.m_values[i] * b;
     return v;
   }
@@ -262,7 +260,7 @@ class NumMatrix
   friend constexpr ARCCORE_HOST_DEVICE ThatClass operator/(const ThatClass& mat, DataType b)
   {
     ThatClass v;
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       v.m_values[i] = mat.m_values[i] / b;
     return v;
   }
@@ -275,7 +273,7 @@ class NumMatrix
    */
   friend constexpr ARCCORE_HOST_DEVICE bool operator==(const ThatClass& a, const ThatClass& b)
   {
-    for (int i = 0; i < Size; ++i)
+    for (int i = 0; i < RowSize; ++i)
       if (a.m_values[i] != b.m_values[i])
         return false;
     return true;
@@ -283,6 +281,7 @@ class NumMatrix
 
   /*!
    * \brief Compares two triplets.
+   *
    * For the notion of equality, see operator==()
    * \retval true if the two triplets are different,
    * \retval false otherwise.
@@ -294,22 +293,14 @@ class NumMatrix
 
  public:
 
-  // Retrieves the i-th row
-  constexpr ARCCORE_HOST_DEVICE VectorType operator()(Int32 i) const
-  {
-    ARCCORE_CHECK_AT(i, RowSize);
-    return m_values[i];
-  }
-
-  // Retrieves the i-th row
-  constexpr ARCCORE_HOST_DEVICE VectorType operator[](Int32 i) const
+  constexpr ARCCORE_HOST_DEVICE VectorType row(Int32 i) const
   {
     ARCCORE_CHECK_AT(i, RowSize);
     return m_values[i];
   }
 
   // Retrieves a reference to the value of the i-th row and j-th column
-  constexpr ARCCORE_HOST_DEVICE T& operator()(Int32 i, Int32 j)
+  constexpr ARCCORE_HOST_DEVICE DataType& operator()(Int32 i, Int32 j)
   {
     ARCCORE_CHECK_AT(i, RowSize);
     ARCCORE_CHECK_AT(j, ColumnSize);
@@ -317,7 +308,7 @@ class NumMatrix
   }
 
   // Retrieves the value of the i-th row and j-th column
-  constexpr ARCCORE_HOST_DEVICE T operator()(Int32 i, Int32 j) const
+  constexpr ARCCORE_HOST_DEVICE DataType operator()(Int32 i, Int32 j) const
   {
     ARCCORE_CHECK_AT(i, RowSize);
     ARCCORE_CHECK_AT(j, ColumnSize);
@@ -325,23 +316,23 @@ class NumMatrix
   }
 
   //! Sets the value of the i-th row to v
-  constexpr ARCCORE_HOST_DEVICE void setLine(Int32 i, const VectorType& v)
+  constexpr ARCCORE_HOST_DEVICE void setRow(Int32 i, const VectorType& v)
   {
     ARCCORE_CHECK_AT(i, RowSize);
     m_values[i] = v;
   }
 
   //! Fill the matrix with the value \a v
-  ARCCORE_HOST_DEVICE void fill(const T& v)
+  constexpr ARCCORE_HOST_DEVICE void fill(const DataType& v)
   {
-    for (int i = 0; i < Size; ++i) {
+    for (int i = 0; i < RowSize; ++i) {
       m_values[i].fill(v);
     }
   }
 
   friend std::ostream& operator<<(std::ostream& o, const NumMatrix& t)
   {
-    for (int i = 0; i < Size; ++i) {
+    for (int i = 0; i < RowSize; ++i) {
       if (i != 0)
         o << ' ';
       o << t.m_values[i];
@@ -351,32 +342,17 @@ class NumMatrix
 
  public:
 
-  VectorType& vx() requires(RowSize >= 1)
+  constexpr const VectorType vx() const requires(RowSize >= 1)
   {
     return m_values[0];
   }
 
-  VectorType vx() const requires(RowSize >= 1)
-  {
-    return m_values[0];
-  }
-
-  VectorType& vy() requires(RowSize >= 2)
+  constexpr const VectorType vy() const requires(RowSize >= 2)
   {
     return m_values[1];
   }
 
-  VectorType vy() const requires(RowSize >= 2)
-  {
-    return m_values[1];
-  }
-
-  VectorType& vz() requires(RowSize >= 3)
-  {
-    return m_values[2];
-  }
-
-  VectorType vz() const requires(RowSize >= 3)
+  constexpr const VectorType vz() const requires(RowSize >= 3)
   {
     return m_values[2];
   }
@@ -402,6 +378,39 @@ class NumMatrix
 /*---------------------------------------------------------------------------*/
 
 } // End namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::math
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Compares the matrix with the zero matrix.
+ *
+ * The matrix is zero if and only if each of its components
+ * is less than a given epsilon. The epsilon value used is that
+ * of float_info<value_type>::nearlyEpsilon():
+ * \f[A=0 \Leftrightarrow |A.x|<\epsilon,|A.y|<\epsilon,|A.z|<\epsilon \f]
+ *
+ * \retval true if the matrix is equal to the zero matrix,
+ * \retval false otherwise.
+ */
+template <typename DataType, int RowSize, int ColumnSize>
+constexpr ARCCORE_HOST_DEVICE bool isNearlyZero(const NumMatrix<DataType, RowSize, ColumnSize>& v)
+{
+  bool is_nearly_zero = true;
+  for (int i = 0; i < RowSize; ++i)
+    is_nearly_zero = is_nearly_zero && math::isNearlyZero(v.row(i));
+  return is_nearly_zero;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::math
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/NumVector.h
+++ b/arcane/src/arcane/utils/NumVector.h
@@ -28,11 +28,7 @@ namespace Arcane
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 /*!
- * \brief Small fixed-size vector of N numerical data points.
- *
- * \note Currently only implemented for the Real type.
- *
- * \warning API is currently under definition. Do not use outside of Arcane.
+ * \brief Small fixed-size vector of Size numerical data points.
  *
  * It is possible to access each component of the vector using 'operator[]'
  * or 'operator()' or via the methods vx(), vy(), vz() if the dimension is
@@ -41,13 +37,13 @@ namespace Arcane
 template <typename T, int Size>
 class NumVector
 {
-  static_assert(Size > 1, "Size has to be strictly greater than 1");
-  static_assert(std::is_same_v<T, Real>, "Only type 'Real' is allowed");
+  static_assert(Size > 0, "Size has to be strictly greater than 0");
 
  public:
 
   using ThatClass = NumVector<T, Size>;
   using DataType = T;
+  static constexpr bool isRealType() { return std::is_same_v<T, Real>; }
 
  public:
 
@@ -91,6 +87,17 @@ class NumVector
     m_values[4] = a5;
   }
 
+  //! Constructs with the sextuplet (a1,a2,a3,a4,a5,a6)
+  constexpr ARCCORE_HOST_DEVICE NumVector(T a1, T a2, T a3, T a4, T a5, T a6) requires(Size == 6)
+  {
+    m_values[0] = a1;
+    m_values[1] = a2;
+    m_values[2] = a3;
+    m_values[3] = a4;
+    m_values[4] = a5;
+    m_values[5] = a6;
+  }
+
   //! Constructs the instance with the value \a v for each component
   template <bool = true>
   explicit constexpr ARCCORE_HOST_DEVICE NumVector(const T (&v)[Size])
@@ -113,31 +120,33 @@ class NumVector
       m_values[i] = v;
   }
 
-  explicit constexpr ARCCORE_HOST_DEVICE NumVector(Real2 v) requires(Size == 2)
+  explicit constexpr ARCCORE_HOST_DEVICE NumVector(Real2 v) requires(Size == 2 && isRealType())
   : NumVector(v.x, v.y)
   {}
 
-  explicit constexpr ARCCORE_HOST_DEVICE NumVector(Real3 v) requires(Size == 3)
+  explicit constexpr ARCCORE_HOST_DEVICE NumVector(Real3 v) requires(Size == 3 && isRealType())
   : NumVector(v.x, v.y, v.z)
   {}
 
-  //! Assigns the triplet (v,v,v) to the instance.
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(Real v)
+  //! Assigns value to all components of the vector
+  constexpr ARCCORE_HOST_DEVICE NumVector& operator=(const DataType& value)
   {
     for (int i = 0; i < Size; ++i)
-      m_values[i] = v;
+      m_values[i] = value;
     return (*this);
   }
 
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(const Real2& v) requires(Size == 2)
+  constexpr ARCCORE_HOST_DEVICE NumVector& operator=(const Real2& v)
+  requires(Size == 2 && isRealType())
   {
-    *this = ThatClass(v);
+    *this = NumVector(v);
     return (*this);
   }
 
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator=(const Real3& v) requires(Size == 3)
+  constexpr ARCCORE_HOST_DEVICE NumVector& operator=(const Real3& v)
+  requires(Size == 3 && isRealType())
   {
-    *this = ThatClass(v);
+    *this = NumVector(v);
     return (*this);
   }
 
@@ -153,144 +162,124 @@ class NumVector
 
  public:
 
-  constexpr ARCCORE_HOST_DEVICE static ThatClass zero() { return ThatClass(); }
+  constexpr ARCCORE_HOST_DEVICE static NumVector zero() { return NumVector(); }
 
  public:
 
-  constexpr ARCCORE_HOST_DEVICE bool isNearlyZero() const
-  {
-    bool is_nearly_zero = true;
-    for (int i = 0; i < Size; ++i)
-      is_nearly_zero = is_nearly_zero && math::isNearlyZero(m_values[i]);
-    return is_nearly_zero;
-  }
-
-  //! Returns the square of the L2 norm of the triplet \f$x^2+y^2+z^2\f$
-  constexpr ARCCORE_HOST_DEVICE Real squareNormL2() const
-  {
-    T v = T();
-    for (int i = 0; i < Size; ++i)
-      v += m_values[i] * m_values[i];
-    return v;
-  }
-
-  //! Returns the L2 norm of the triplet \f$\sqrt{x^2+y^2+z^2}\f$
-  ARCCORE_HOST_DEVICE Real normL2() const { return _sqrt(squareNormL2()); }
-
   //! Absolute value component by component.
-  ARCCORE_HOST_DEVICE ThatClass absolute() const
+  ARCCORE_HOST_DEVICE NumVector absolute() const
   {
-    ThatClass v;
+    NumVector v;
     for (int i = 0; i < Size; ++i)
       v.m_values[i] = math::abs(m_values[i]);
     return v;
   }
 
   //! Fill the vector with the value \a v
-  ARCCORE_HOST_DEVICE void fill(const T& v)
+  constexpr ARCCORE_HOST_DEVICE void fill(const T& v)
   {
     for (int i = 0; i < Size; ++i) {
       m_values[i] = v;
     }
   }
 
-  //! Adds \a b to each component of the instance
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator+=(T b)
+  //! Adds \a b to each component of \a a
+  friend constexpr ARCCORE_HOST_DEVICE NumVector& operator+=(NumVector& a, T b)
   {
     for (int i = 0; i < Size; ++i)
-      m_values[i] += b;
-    return (*this);
+      a.m_values[i] += b;
+    return a;
   }
 
-  //! Adds \a b to the instance
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator+=(const ThatClass& b)
+  //! Adds \a b to \a a
+  friend constexpr ARCCORE_HOST_DEVICE NumVector& operator+=(NumVector& a, const NumVector& b)
   {
     for (int i = 0; i < Size; ++i)
-      m_values[i] += b.m_values[i];
-    return (*this);
+      a.m_values[i] += b.m_values[i];
+    return a;
   }
 
-  //! Subtracts \a b from each component of the instance
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator-=(T b)
+  //! Subtracts \a b from each component of \a a
+  friend constexpr ARCCORE_HOST_DEVICE NumVector& operator-=(NumVector& a, T b)
   {
     for (int i = 0; i < Size; ++i)
-      m_values[i] -= b;
-    return (*this);
+      a.m_values[i] -= b;
+    return a;
   }
 
-  //! Subtracts \a b from the instance
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator-=(const ThatClass& b)
+  //! Subtracts \a b from each component of \a a
+  friend constexpr ARCCORE_HOST_DEVICE NumVector& operator-=(NumVector& a, const NumVector& b)
   {
     for (int i = 0; i < Size; ++i)
-      m_values[i] -= b.m_values[i];
-    return (*this);
+      a.m_values[i] -= b.m_values[i];
+    return a;
   }
 
-  //! Multiplies each component by \a b
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator*=(T b)
+  //! Multiplies each component of \a a by \a b
+  friend constexpr ARCCORE_HOST_DEVICE NumVector& operator*=(NumVector& a, T b)
   {
     for (int i = 0; i < Size; ++i)
-      m_values[i] *= b;
-    return (*this);
+      a.m_values[i] *= b;
+    return a;
   }
 
-  //! Divides each component by \a b
-  constexpr ARCCORE_HOST_DEVICE ThatClass& operator/=(T b)
+  //! Divides each component of \a a by \a b
+  friend constexpr ARCCORE_HOST_DEVICE NumVector& operator/=(NumVector& a, T b)
   {
     for (int i = 0; i < Size; ++i)
-      m_values[i] /= b;
-    return (*this);
+      a.m_values[i] /= b;
+    return a;
   }
 
   //! Creates a triplet that equals this triplet added to \a b
-  friend constexpr ARCCORE_HOST_DEVICE ThatClass operator+(const ThatClass& a, const ThatClass& b)
+  friend constexpr ARCCORE_HOST_DEVICE NumVector operator+(const NumVector& a, const NumVector& b)
   {
-    ThatClass v;
+    NumVector v;
     for (int i = 0; i < Size; ++i)
       v.m_values[i] = a.m_values[i] + b.m_values[i];
     return v;
   }
 
   //! Creates a triplet that equals \a b subtracted from this triplet
-  friend constexpr ARCCORE_HOST_DEVICE ThatClass operator-(const ThatClass& a, const ThatClass& b)
+  friend constexpr ARCCORE_HOST_DEVICE NumVector operator-(const NumVector& a, const NumVector& b)
   {
-    ThatClass v;
+    NumVector v;
     for (int i = 0; i < Size; ++i)
       v.m_values[i] = a.m_values[i] - b.m_values[i];
     return v;
   }
 
   //! Creates a triplet opposite to the current triplet
-  constexpr ARCCORE_HOST_DEVICE ThatClass operator-() const
+  constexpr ARCCORE_HOST_DEVICE NumVector operator-() const
   {
-    ThatClass v;
+    NumVector v;
     for (int i = 0; i < Size; ++i)
       v.m_values[i] = -m_values[i];
     return v;
   }
 
   //! Multiplication by a scalar.
-  friend constexpr ARCCORE_HOST_DEVICE ThatClass operator*(T a, const ThatClass& vec)
+  friend constexpr ARCCORE_HOST_DEVICE NumVector operator*(T a, const NumVector& vec)
   {
-    ThatClass v;
+    NumVector v;
     for (int i = 0; i < Size; ++i)
       v.m_values[i] = a * vec.m_values[i];
     return v;
   }
 
   //! Multiplication by a scalar.
-  friend constexpr ARCCORE_HOST_DEVICE ThatClass operator*(const ThatClass& vec, T b)
+  friend constexpr ARCCORE_HOST_DEVICE NumVector operator*(const NumVector& vec, T b)
   {
-    ThatClass v;
+    NumVector v;
     for (int i = 0; i < Size; ++i)
       v.m_values[i] = vec.m_values[i] * b;
     return v;
   }
 
   //! Division by a scalar.
-  friend constexpr ARCCORE_HOST_DEVICE ThatClass operator/(const ThatClass& vec, T b)
+  friend constexpr ARCCORE_HOST_DEVICE NumVector operator/(const NumVector& vec, T b)
   {
-    ThatClass v;
+    NumVector v;
     for (int i = 0; i < Size; ++i)
       v.m_values[i] = vec.m_values[i] / b;
     return v;
@@ -302,7 +291,7 @@ class NumVector
    * \retval true if this.x==b.x and this.y==b.y and this.z==b.z.
    * \retval false otherwise.
    */
-  friend constexpr ARCCORE_HOST_DEVICE bool operator==(const ThatClass& a, const ThatClass& b)
+  friend constexpr ARCCORE_HOST_DEVICE bool operator==(const NumVector& a, const NumVector& b)
   {
     for (int i = 0; i < Size; ++i)
       if (!_eq(a.m_values[i], b.m_values[i]))
@@ -324,7 +313,7 @@ class NumVector
    * \brief Compares two vectors
    * For the notion of equality, see operator==()
    */
-  friend constexpr ARCCORE_HOST_DEVICE bool operator!=(const ThatClass& a, const ThatClass& b)
+  friend constexpr ARCCORE_HOST_DEVICE bool operator!=(const NumVector& a, const NumVector& b)
   {
     return !(a == b);
   }
@@ -344,41 +333,41 @@ class NumVector
     ARCCORE_CHECK_AT(i, Size);
     return m_values[i];
   }
-  constexpr ARCCORE_HOST_DEVICE T operator[](Int32 i) const
+  constexpr ARCCORE_HOST_DEVICE DataType operator[](Int32 i) const
   {
     ARCCORE_CHECK_AT(i, Size);
     return m_values[i];
   }
 
   //! Value of the first component
-  T& vx() requires(Size >= 1)
+  constexpr ARCCORE_HOST_DEVICE DataType& vx() requires(Size >= 1)
   {
     return m_values[0];
   }
   //! Value of the first component
-  T vx() const requires(Size >= 1)
+  constexpr ARCCORE_HOST_DEVICE DataType vx() const requires(Size >= 1)
   {
     return m_values[0];
   }
 
   //! Value of the second component
-  T& vy() requires(Size >= 2)
+  constexpr ARCCORE_HOST_DEVICE DataType& vy() requires(Size >= 2)
   {
     return m_values[1];
   }
   //! Value of the second component
-  T vy() const requires(Size >= 2)
+  constexpr ARCCORE_HOST_DEVICE DataType vy() const requires(Size >= 2)
   {
     return m_values[1];
   }
 
   //! Value of the third component
-  T& vz() requires(Size >= 3)
+  constexpr ARCCORE_HOST_DEVICE DataType& vz() requires(Size >= 3)
   {
     return m_values[2];
   }
   //! Value of the third component
-  T vz() const requires(Size >= 3)
+  constexpr ARCCORE_HOST_DEVICE DataType vz() const requires(Size >= 3)
   {
     return m_values[2];
   }
@@ -391,7 +380,8 @@ class NumVector
  private:
 
   /*!
-   * \brief Compares the values of \a a and \a b using the TypeEqualT comparator
+   * \brief Compares the values of \a a and \a b using the TypeEqualT comparator.
+   *
    * \retval true if \a a and \a b are equal,
    * \retval false otherwise.
    */
@@ -400,18 +390,59 @@ class NumVector
   {
     return math::isEqual(a, b);
   }
-
-  //! Returns the square root of \a a
-  ARCCORE_HOST_DEVICE static T _sqrt(T a)
-  {
-    return math::sqrt(a);
-  }
 };
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 } // End namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::math
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Compares the vector with the vector zero.
+ *
+ * The matrix is nearly zero if and only if each of its components
+ * is less than a given epsilon. The epsilon value used is that
+ * of FloatInfo<DataType>::nearlyEpsilon():
+ * \f[A=0 \Leftrightarrow |A.x|<\epsilon,|A.y|<\epsilon,|A.z|<\epsilon \f]
+ */
+template <typename DataType, int Size>
+constexpr ARCCORE_HOST_DEVICE bool isNearlyZero(const NumVector<DataType, Size>& v)
+{
+  bool is_nearly_zero = true;
+  for (int i = 0; i < Size; ++i)
+    is_nearly_zero = is_nearly_zero && math::isNearlyZero(v[i]);
+  return is_nearly_zero;
+}
+
+//! Returns the square of the L2 norm of the triplet \f$x^2+y^2+z^2\f$
+template <typename DataType, int Size>
+constexpr ARCCORE_HOST_DEVICE Real squareNormL2(const NumVector<DataType, Size>& v)
+{
+  DataType norm = {};
+  for (int i = 0; i < Size; ++i)
+    norm += v[i] * v[i];
+  return norm;
+}
+
+//! Returns the L2 norm of the triplet \f$\sqrt{x^2+y^2+z^2}\f$
+template <typename DataType, int Size>
+ARCCORE_HOST_DEVICE Real normL2(const NumVector<DataType, Size>& v)
+{
+  return Arcane::math::sqrt(squareNormL2(v));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::math
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/CMakeLists.txt
+++ b/arcane/src/arcane/utils/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
   TestDependencyInjection.cc
   TestEvent.cc
   TestRealN.cc
+  TestNumMatrix.cc
   TestNumVector.cc
   TestValueConvert.cc
   TestCollections.cc

--- a/arcane/src/arcane/utils/tests/TestNumMatrix.cc
+++ b/arcane/src/arcane/utils/tests/TestNumMatrix.cc
@@ -1,0 +1,501 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "arcane/utils/ValueConvert.h"
+#include "arcane/utils/NumMatrix.h"
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+using namespace Arcane;
+
+TEST(TestNumMatrix, Real2x2)
+{
+  RealN2 zero;
+  {
+    RealN2x2 v1;
+    ASSERT_EQ(v1.vx(), zero);
+    ASSERT_EQ(v1.vy(), zero);
+  }
+  {
+    double value = 0.2;
+    RealN2 r2_value(value);
+    RealN2x2 v1(value);
+    ASSERT_EQ(v1.vx(), r2_value);
+    ASSERT_EQ(v1.vy(), r2_value);
+    RealN2x2 v2(v1);
+    ASSERT_EQ(v2.vx(), v1.vx());
+    ASSERT_EQ(v2.vy(), v1.vy());
+    RealN2 rx(3.5, 1.2);
+    RealN2 ry(1.6, 2.1);
+    v2.setRow(0,rx);
+    v2.setRow(1,ry);
+    v1 = v2;
+    ASSERT_EQ(v2.vx(), rx);
+    ASSERT_EQ(v2.vy(), ry);
+    ASSERT_EQ(v1, v2);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2ElementAccess)
+{
+  RealN2x2 m;
+  m(0, 0) = 1.0;
+  m(0, 1) = 2.0;
+  m(1, 0) = 3.0;
+  m(1, 1) = 4.0;
+  ASSERT_EQ(m(0, 0), 1.0);
+  ASSERT_EQ(m(0, 1), 2.0);
+  ASSERT_EQ(m(1, 0), 3.0);
+  ASSERT_EQ(m(1, 1), 4.0);
+
+  // Row access
+  RealN2 r0 = m.row(0);
+  ASSERT_EQ(r0.vx(), 1.0);
+  ASSERT_EQ(r0.vy(), 2.0);
+  RealN2 r1 = m.row(1);
+  ASSERT_EQ(r1.vx(), 3.0);
+  ASSERT_EQ(r1.vy(), 4.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2SetRow)
+{
+  RealN2x2 m;
+  m.setRow(0, RealN2(5.0, 6.0));
+  m.setRow(1, RealN2(7.0, 8.0));
+  ASSERT_EQ(m(0, 0), 5.0);
+  ASSERT_EQ(m(0, 1), 6.0);
+  ASSERT_EQ(m(1, 0), 7.0);
+  ASSERT_EQ(m(1, 1), 8.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2Fill)
+{
+  RealN2x2 m;
+  m.fill(3.5);
+  ASSERT_EQ(m(0, 0), 3.5);
+  ASSERT_EQ(m(0, 1), 3.5);
+  ASSERT_EQ(m(1, 0), 3.5);
+  ASSERT_EQ(m(1, 1), 3.5);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2Zero)
+{
+  RealN2x2 m = RealN2x2::zero();
+  RealN2 zero;
+  ASSERT_EQ(m.vx(), zero);
+  ASSERT_EQ(m.vy(), zero);
+  ASSERT_TRUE(math::isNearlyZero(m));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2Arithmetic)
+{
+  RealN2x2 a(RealN2(1.0, 2.0), RealN2(3.0, 4.0));
+  RealN2x2 b(RealN2(5.0, 6.0), RealN2(7.0, 8.0));
+
+  // Addition
+  RealN2x2 c = a + b;
+  ASSERT_EQ(c(0, 0), 6.0);
+  ASSERT_EQ(c(0, 1), 8.0);
+  ASSERT_EQ(c(1, 0), 10.0);
+  ASSERT_EQ(c(1, 1), 12.0);
+
+  // Subtraction
+  RealN2x2 d = c - b;
+  ASSERT_EQ(d, a);
+
+  // Negation
+  RealN2x2 e = -a;
+  ASSERT_EQ(e(0, 0), -1.0);
+  ASSERT_EQ(e(0, 1), -2.0);
+
+  // Scalar multiplication
+  RealN2x2 f = a * 2.0;
+  ASSERT_EQ(f(0, 0), 2.0);
+  ASSERT_EQ(f(0, 1), 4.0);
+  ASSERT_EQ(f(1, 0), 6.0);
+  ASSERT_EQ(f(1, 1), 8.0);
+
+  RealN2x2 g = 3.0 * a;
+  ASSERT_EQ(g(0, 0), 3.0);
+  ASSERT_EQ(g(0, 1), 6.0);
+
+  // Scalar division
+  RealN2x2 h = f / 2.0;
+  ASSERT_EQ(h, a);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2CompoundAssignment)
+{
+  RealN2x2 a(RealN2(1.0, 2.0), RealN2(3.0, 4.0));
+  RealN2x2 b(RealN2(5.0, 6.0), RealN2(7.0, 8.0));
+
+  RealN2x2 c = a;
+  c += b;
+  ASSERT_EQ(c(0, 0), 6.0);
+  ASSERT_EQ(c(0, 1), 8.0);
+
+  c -= b;
+  ASSERT_EQ(c, a);
+
+  c *= 2.0;
+  ASSERT_EQ(c(0, 0), 2.0);
+  ASSERT_EQ(c(0, 1), 4.0);
+
+  RealN2x2 d = a;
+  d /= 2.0;
+  ASSERT_EQ(d(0, 0), 0.5);
+  ASSERT_EQ(d(0, 1), 1.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2ScalarAssignment)
+{
+  RealN2x2 m;
+  m = 5.0;
+  ASSERT_EQ(m(0, 0), 5.0);
+  ASSERT_EQ(m(0, 1), 5.0);
+  ASSERT_EQ(m(1, 0), 5.0);
+  ASSERT_EQ(m(1, 1), 5.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real2x2Conversion)
+{
+  RealN2x2 m(RealN2(1.0, 2.0), RealN2(3.0, 4.0));
+  Real2x2 r = static_cast<Real2x2>(m);
+  ASSERT_EQ(r.x.x, 1.0);
+  ASSERT_EQ(r.x.y, 2.0);
+  ASSERT_EQ(r.y.x, 3.0);
+  ASSERT_EQ(r.y.y, 4.0);
+
+  // Construction from Real2x2
+  RealN2x2 m2(Real2x2(Real2(1.0, 2.0), Real2(3.0, 4.0)));
+  ASSERT_EQ(m2(0, 0), 1.0);
+  ASSERT_EQ(m2(1, 1), 4.0);
+
+  // Assignment from Real2x2
+  RealN2x2 m3;
+  m3 = Real2x2(Real2(5.0, 6.0), Real2(7.0, 8.0));
+  ASSERT_EQ(m3(0, 0), 5.0);
+  ASSERT_EQ(m3(1, 1), 8.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3)
+{
+  RealN3 zero;
+  {
+    RealN3x3 v1;
+    ASSERT_EQ(v1.vx(), zero);
+    ASSERT_EQ(v1.vy(), zero);
+    ASSERT_EQ(v1.vz(), zero);
+  }
+  {
+    double value = 0.2;
+    RealN3 r3_value(value);
+    RealN3x3 v1(value);
+    ASSERT_EQ(v1.vx(), r3_value);
+    ASSERT_EQ(v1.vy(), r3_value);
+    ASSERT_EQ(v1.vz(), r3_value);
+    RealN3x3 v2(v1);
+    ASSERT_EQ(v2.vx(), v1.vx());
+    ASSERT_EQ(v2.vy(), v1.vy());
+    ASSERT_EQ(v2.vz(), v1.vz());
+    RealN3 rx(3.5, 1.2, -1.5);
+    RealN3 ry(1.6, 2.1, -2.3);
+    RealN3 rz(-2.3, 1.8, 9.4);
+    v2.setRow(0,rx);
+    v2.setRow(1,ry);
+    v2.setRow(2,rz);
+    v1 = v2;
+    ASSERT_EQ(v1.vx(), rx);
+    ASSERT_EQ(v1.vy(), ry);
+    ASSERT_EQ(v1.vz(), rz);
+    ASSERT_EQ(v1, v2);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3FromColumns)
+{
+  RealN3x3 m = RealN3x3::fromColumns(1.0, 2.0, 3.0,
+                                      4.0, 5.0, 6.0,
+                                      7.0, 8.0, 9.0);
+  // Columns: (ax,bx,cx) = (1,4,7), (ay,by,cy) = (2,5,8), (az,bz,cz) = (3,6,9)
+  // So row 0 = (ax, ay, az) = (1,2,3)
+  ASSERT_EQ(m(0, 0), 1.0);
+  ASSERT_EQ(m(0, 1), 4.0);
+  ASSERT_EQ(m(0, 2), 7.0);
+  ASSERT_EQ(m(1, 0), 2.0);
+  ASSERT_EQ(m(1, 1), 5.0);
+  ASSERT_EQ(m(1, 2), 8.0);
+  ASSERT_EQ(m(2, 0), 3.0);
+  ASSERT_EQ(m(2, 1), 6.0);
+  ASSERT_EQ(m(2, 2), 9.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3FromLines)
+{
+  RealN3x3 m = RealN3x3::fromLines(1.0, 2.0, 3.0,
+                                    4.0, 5.0, 6.0,
+                                    7.0, 8.0, 9.0);
+  ASSERT_EQ(m(0, 0), 1.0);
+  ASSERT_EQ(m(0, 1), 2.0);
+  ASSERT_EQ(m(0, 2), 3.0);
+  ASSERT_EQ(m(1, 0), 4.0);
+  ASSERT_EQ(m(1, 1), 5.0);
+  ASSERT_EQ(m(1, 2), 6.0);
+  ASSERT_EQ(m(2, 0), 7.0);
+  ASSERT_EQ(m(2, 1), 8.0);
+  ASSERT_EQ(m(2, 2), 9.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3Conversion)
+{
+  RealN3x3 m(RealN3(1.0, 2.0, 3.0),
+             RealN3(4.0, 5.0, 6.0),
+             RealN3(7.0, 8.0, 9.0));
+  Real3x3 r = static_cast<Real3x3>(m);
+  ASSERT_EQ(r.x.x, 1.0);
+  ASSERT_EQ(r.x.y, 2.0);
+  ASSERT_EQ(r.x.z, 3.0);
+  ASSERT_EQ(r.y.x, 4.0);
+  ASSERT_EQ(r.y.y, 5.0);
+  ASSERT_EQ(r.y.z, 6.0);
+  ASSERT_EQ(r.z.x, 7.0);
+  ASSERT_EQ(r.z.y, 8.0);
+  ASSERT_EQ(r.z.z, 9.0);
+
+  // Construction from Real3x3
+  Real3x3 r3(Real3(1.0, 2.0, 3.0), Real3(4.0, 5.0, 6.0), Real3(7.0, 8.0, 9.0));
+  RealN3x3 m2(r3);
+  ASSERT_EQ(m2(0, 0), 1.0);
+  ASSERT_EQ(m2(1, 1), 5.0);
+  ASSERT_EQ(m2(2, 2), 9.0);
+
+  // Assignment from Real3x3
+  RealN3x3 m3;
+  m3 = r3;
+  ASSERT_EQ(m3, m2);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3ElementAccess)
+{
+  RealN3x3 m;
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      m(i, j) = double(i * 3 + j + 1);
+
+  ASSERT_EQ(m(0, 0), 1.0);
+  ASSERT_EQ(m(0, 1), 2.0);
+  ASSERT_EQ(m(0, 2), 3.0);
+  ASSERT_EQ(m(1, 0), 4.0);
+  ASSERT_EQ(m(1, 1), 5.0);
+  ASSERT_EQ(m(1, 2), 6.0);
+  ASSERT_EQ(m(2, 0), 7.0);
+  ASSERT_EQ(m(2, 1), 8.0);
+  ASSERT_EQ(m(2, 2), 9.0);
+
+  ASSERT_EQ(m.row(0), RealN3(1.0, 2.0, 3.0));
+  ASSERT_EQ(m.row(1), RealN3(4.0, 5.0, 6.0));
+  ASSERT_EQ(m.row(2), RealN3(7.0, 8.0, 9.0));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3Arithmetic)
+{
+  RealN3x3 a(RealN3(1.0, 2.0, 3.0),
+             RealN3(4.0, 5.0, 6.0),
+             RealN3(7.0, 8.0, 9.0));
+  RealN3x3 b(RealN3(9.0, 8.0, 7.0),
+             RealN3(6.0, 5.0, 4.0),
+             RealN3(3.0, 2.0, 1.0));
+
+  RealN3x3 c = a + b;
+  ASSERT_EQ(c(0, 0), 10.0);
+  ASSERT_EQ(c(1, 1), 10.0);
+  ASSERT_EQ(c(2, 2), 10.0);
+
+  RealN3x3 d = c - b;
+  ASSERT_EQ(d, a);
+
+  RealN3x3 e = -a;
+  ASSERT_EQ(e(0, 0), -1.0);
+  ASSERT_EQ(e(1, 1), -5.0);
+  ASSERT_EQ(e(2, 2), -9.0);
+
+  RealN3x3 f = a * 2.0;
+  ASSERT_EQ(f(0, 0), 2.0);
+  ASSERT_EQ(f(1, 1), 10.0);
+
+  RealN3x3 g = 0.5 * f;
+  ASSERT_EQ(g, a);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3Fill)
+{
+  RealN3x3 m;
+  m.fill(-1.0);
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      ASSERT_EQ(m(i, j), -1.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Real3x3NearlyZero)
+{
+  RealN3x3 m;
+  ASSERT_TRUE(math::isNearlyZero(m));
+  m(0, 0) = 1e-20;
+  ASSERT_TRUE(math::isNearlyZero(m));
+  m(0, 0) = 1.0;
+  ASSERT_FALSE(math::isNearlyZero(m));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, NonSquare2x5)
+{
+  using M2x5 = NumMatrix<Real, 2, 5>;
+
+  M2x5 m;
+  for (int j = 0; j < 5; ++j) {
+    m(0, j) = double(j);
+    m(1, j) = double(j * 10);
+  }
+  for (int j = 0; j < 5; ++j) {
+    ASSERT_EQ(m(0, j), double(j));
+    ASSERT_EQ(m(1, j), double(j * 10));
+  }
+
+  ASSERT_EQ(m.row(0).vx(), 0.0);
+  ASSERT_EQ(m.row(0)(4), 4.0);
+  ASSERT_EQ(m.row(1)(3), 30.0);
+
+  M2x5 n;
+  n.fill(7.0);
+  for (int j = 0; j < 5; ++j) {
+    ASSERT_EQ(n(0, j), 7.0);
+    ASSERT_EQ(n(1, j), 7.0);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, NonSquare5x2)
+{
+  using M5x2 = NumMatrix<Real, 5, 2>;
+
+  M5x2 m;
+  for (int i = 0; i < 5; ++i)
+    for (int j = 0; j < 2; ++j)
+      m(i, j) = double(i + j);
+
+  for (int i = 0; i < 5; ++i)
+    for (int j = 0; j < 2; ++j)
+      ASSERT_EQ(m(i, j), double(i + j));
+
+  ASSERT_EQ(m.vx()(1), 1.0);
+  ASSERT_EQ(m.vy()(1), 1.0 + 1.0);
+  ASSERT_EQ(m.row(3)(1), 4.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumMatrix, Int32x2)
+{
+  using Int32x2 = NumMatrix<Int32, 2, 2>;
+
+  Int32x2 m;
+  ASSERT_EQ(m(0, 0), 0);
+  ASSERT_EQ(m(1, 1), 0);
+
+  m(0, 0) = 1;
+  m(0, 1) = 2;
+  m(1, 0) = 3;
+  m(1, 1) = 4;
+  ASSERT_EQ(m(0, 0), 1);
+  ASSERT_EQ(m(1, 1), 4);
+
+  Int32x2 n(Int32x2::VectorType(5, 6), Int32x2::VectorType(7, 8));
+  ASSERT_EQ(n(0, 0), 5);
+  ASSERT_EQ(n(1, 1), 8);
+
+  Int32x2 p = m + n;
+  ASSERT_EQ(p(0, 0), 6);
+  ASSERT_EQ(p(0, 1), 8);
+  ASSERT_EQ(p(1, 0), 10);
+  ASSERT_EQ(p(1, 1), 12);
+
+  p *= 2;
+  ASSERT_EQ(p(0, 0), 12);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane
+{
+template class NumMatrix<Real, 2, 2>;
+template class NumMatrix<Real, 3, 3>;
+template class NumMatrix<Real, 1, 1>;
+template class NumMatrix<Real, 2, 5>;
+template class NumMatrix<Real,5, 2>;
+template class NumMatrix<float, 2, 6>;
+template class NumMatrix<Int32, 2, 2>;
+} // namespace Arcane
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/utils/tests/TestNumVector.cc
+++ b/arcane/src/arcane/utils/tests/TestNumVector.cc
@@ -98,66 +98,404 @@ TEST(TestNumVector, Real3)
   }
 }
 
-TEST(TestNumMat, Real2x2)
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2ElementAccess)
 {
-  RealN2 zero;
-  {
-    RealN2x2 v1;
-    ASSERT_EQ(v1.vx(), zero);
-    ASSERT_EQ(v1.vy(), zero);
-  }
-  {
-    double value = 0.2;
-    RealN2 r2_value(value);
-    RealN2x2 v1(value);
-    ASSERT_EQ(v1.vx(), r2_value);
-    ASSERT_EQ(v1.vy(), r2_value);
-    RealN2x2 v2(v1);
-    ASSERT_EQ(v2.vx(), v1.vx());
-    ASSERT_EQ(v2.vy(), v1.vy());
-    RealN2 rx(3.5, 1.2);
-    RealN2 ry(1.6, 2.1);
-    v2.vx() = rx;
-    v2.vy() = ry;
-    v1 = v2;
-    ASSERT_EQ(v1.vx(), rx);
-    ASSERT_EQ(v1.vy(), ry);
-    ASSERT_EQ(v1, v2);
-  }
+  RealN2 v;
+  v(0) = 1.5;
+  v(1) = 2.5;
+  ASSERT_EQ(v(0), 1.5);
+  ASSERT_EQ(v(1), 2.5);
+  ASSERT_EQ(v[0], 1.5);
+  ASSERT_EQ(v[1], 2.5);
 }
 
-TEST(TestNumVector, Real3x3)
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2Fill)
 {
-  RealN3 zero;
-  {
-    RealN3x3 v1;
-    ASSERT_EQ(v1.vx(), zero);
-    ASSERT_EQ(v1.vy(), zero);
-    ASSERT_EQ(v1.vz(), zero);
-  }
-  {
-    double value = 0.2;
-    RealN3 r3_value(value);
-    RealN3x3 v1(value);
-    ASSERT_EQ(v1.vx(), r3_value);
-    ASSERT_EQ(v1.vy(), r3_value);
-    ASSERT_EQ(v1.vz(), r3_value);
-    RealN3x3 v2(v1);
-    ASSERT_EQ(v2.vx(), v1.vx());
-    ASSERT_EQ(v2.vy(), v1.vy());
-    ASSERT_EQ(v2.vz(), v1.vz());
-    RealN3 rx(3.5, 1.2, -1.5);
-    RealN3 ry(1.6, 2.1, -2.3);
-    RealN3 rz(-2.3, 1.8, 9.4);
-    v2.vx() = rx;
-    v2.vy() = ry;
-    v2.vz() = rz;
-    v1 = v2;
-    ASSERT_EQ(v1.vx(), rx);
-    ASSERT_EQ(v1.vy(), ry);
-    ASSERT_EQ(v1.vz(), rz);
-    ASSERT_EQ(v1, v2);
-  }
+  RealN2 v;
+  v.fill(4.2);
+  ASSERT_EQ(v.vx(), 4.2);
+  ASSERT_EQ(v.vy(), 4.2);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2Zero)
+{
+  RealN2 v = RealN2::zero();
+  ASSERT_EQ(v.vx(), 0.0);
+  ASSERT_EQ(v.vy(), 0.0);
+  ASSERT_TRUE(math::isNearlyZero(v));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2CompoundAssignment)
+{
+  RealN2 v1(1.0, 2.0);
+  RealN2 v2(3.0, 4.0);
+
+  v1 += v2;
+  ASSERT_EQ(v1.vx(), 4.0);
+  ASSERT_EQ(v1.vy(), 6.0);
+
+  v1 -= v2;
+  ASSERT_EQ(v1.vx(), 1.0);
+  ASSERT_EQ(v1.vy(), 2.0);
+
+  v1 *= 2.0;
+  ASSERT_EQ(v1.vx(), 2.0);
+  ASSERT_EQ(v1.vy(), 4.0);
+
+  v1 /= 2.0;
+  ASSERT_EQ(v1.vx(), 1.0);
+  ASSERT_EQ(v1.vy(), 2.0);
+
+  v1 += 10.0;
+  ASSERT_EQ(v1.vx(), 11.0);
+  ASSERT_EQ(v1.vy(), 12.0);
+
+  v1 -= 1.0;
+  ASSERT_EQ(v1.vx(), 10.0);
+  ASSERT_EQ(v1.vy(), 11.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2UnaryNegation)
+{
+  RealN2 v1(1.5, -2.5);
+  RealN2 v2 = -v1;
+  ASSERT_EQ(v2.vx(), -1.5);
+  ASSERT_EQ(v2.vy(), 2.5);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2Norm)
+{
+  RealN2 v(3.0, 4.0);
+  ASSERT_EQ(math::squareNormL2(v), 25.0);
+  ASSERT_EQ(math::normL2(v), 5.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2Absolute)
+{
+  RealN2 v1(-1.5, 2.5);
+  RealN2 v2 = v1.absolute();
+  ASSERT_EQ(v2.vx(), 1.5);
+  ASSERT_EQ(v2.vy(), 2.5);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2NearlyZero)
+{
+  RealN2 v;
+  ASSERT_TRUE(math::isNearlyZero(v));
+  v.vx() = 1e-20;
+  ASSERT_TRUE(math::isNearlyZero(v));
+  v.vx() = 1.0;
+  ASSERT_FALSE(math::isNearlyZero(v));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2Conversion)
+{
+  RealN2 v(1.5, 2.5);
+  Real2 r = static_cast<Real2>(v);
+  ASSERT_EQ(r.x, 1.5);
+  ASSERT_EQ(r.y, 2.5);
+
+  RealN2 v2(Real2(3.5, 4.5));
+  ASSERT_EQ(v2.vx(), 3.5);
+  ASSERT_EQ(v2.vy(), 4.5);
+
+  RealN2 v3;
+  v3 = Real2(5.5, 6.5);
+  ASSERT_EQ(v3.vx(), 5.5);
+  ASSERT_EQ(v3.vy(), 6.5);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN2NotEqual)
+{
+  RealN2 v1(1.0, 2.0);
+  RealN2 v2(1.0, 3.0);
+  ASSERT_NE(v1, v2);
+  ASSERT_TRUE(v1 != v2);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3ElementAccess)
+{
+  RealN3 v;
+  v(0) = 1.0;
+  v(1) = 2.0;
+  v(2) = 3.0;
+  ASSERT_EQ(v(0), 1.0);
+  ASSERT_EQ(v(1), 2.0);
+  ASSERT_EQ(v(2), 3.0);
+  ASSERT_EQ(v[0], 1.0);
+  ASSERT_EQ(v[1], 2.0);
+  ASSERT_EQ(v[2], 3.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3Fill)
+{
+  RealN3 v;
+  v.fill(-1.0);
+  ASSERT_EQ(v.vx(), -1.0);
+  ASSERT_EQ(v.vy(), -1.0);
+  ASSERT_EQ(v.vz(), -1.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3Zero)
+{
+  RealN3 v = RealN3::zero();
+  ASSERT_EQ(v.vx(), 0.0);
+  ASSERT_EQ(v.vy(), 0.0);
+  ASSERT_EQ(v.vz(), 0.0);
+  ASSERT_TRUE(math::isNearlyZero(v));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3CompoundAssignment)
+{
+  RealN3 v1(1.0, 2.0, 3.0);
+  RealN3 v2(4.0, 5.0, 6.0);
+
+  v1 += v2;
+  ASSERT_EQ(v1.vx(), 5.0);
+  ASSERT_EQ(v1.vy(), 7.0);
+  ASSERT_EQ(v1.vz(), 9.0);
+
+  v1 -= v2;
+  ASSERT_EQ(v1, RealN3(1.0, 2.0, 3.0));
+
+  v1 *= 2.0;
+  ASSERT_EQ(v1.vx(), 2.0);
+  ASSERT_EQ(v1.vy(), 4.0);
+  ASSERT_EQ(v1.vz(), 6.0);
+
+  v1 /= 2.0;
+  ASSERT_EQ(v1, RealN3(1.0, 2.0, 3.0));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3UnaryNegation)
+{
+  RealN3 v1(1.0, -2.0, 3.0);
+  RealN3 v2 = -v1;
+  ASSERT_EQ(v2.vx(), -1.0);
+  ASSERT_EQ(v2.vy(), 2.0);
+  ASSERT_EQ(v2.vz(), -3.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3Norm)
+{
+  RealN3 v(1.0, 2.0, 2.0);
+  ASSERT_EQ(math::squareNormL2(v), 9.0);
+  ASSERT_EQ(math::normL2(v), 3.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3Absolute)
+{
+  RealN3 v1(-1.0, 2.0, -3.0);
+  RealN3 v2 = v1.absolute();
+  ASSERT_EQ(v2.vx(), 1.0);
+  ASSERT_EQ(v2.vy(), 2.0);
+  ASSERT_EQ(v2.vz(), 3.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3NearlyZero)
+{
+  RealN3 v;
+  ASSERT_TRUE(math::isNearlyZero(v));
+  v.vz() = 1e-20;
+  ASSERT_TRUE(math::isNearlyZero(v));
+  v.vz() = 1.0;
+  ASSERT_FALSE(math::isNearlyZero(v));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3Conversion)
+{
+  RealN3 v(1.0, 2.0, 3.0);
+  Real3 r = static_cast<Real3>(v);
+  ASSERT_EQ(r.x, 1.0);
+  ASSERT_EQ(r.y, 2.0);
+  ASSERT_EQ(r.z, 3.0);
+
+  RealN3 v2(Real3(4.0, 5.0, 6.0));
+  ASSERT_EQ(v2.vx(), 4.0);
+  ASSERT_EQ(v2.vy(), 5.0);
+  ASSERT_EQ(v2.vz(), 6.0);
+
+  RealN3 v3;
+  v3 = Real3(7.0, 8.0, 9.0);
+  ASSERT_EQ(v3.vx(), 7.0);
+  ASSERT_EQ(v3.vy(), 8.0);
+  ASSERT_EQ(v3.vz(), 9.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3Arithmetic)
+{
+  RealN3 a(1.0, 2.0, 3.0);
+  RealN3 b(4.0, 5.0, 6.0);
+
+  RealN3 c = a + b;
+  ASSERT_EQ(c.vx(), 5.0);
+  ASSERT_EQ(c.vy(), 7.0);
+  ASSERT_EQ(c.vz(), 9.0);
+
+  RealN3 d = c - b;
+  ASSERT_EQ(d, a);
+
+  RealN3 e = 2.0 * a;
+  ASSERT_EQ(e.vx(), 2.0);
+  ASSERT_EQ(e.vy(), 4.0);
+  ASSERT_EQ(e.vz(), 6.0);
+
+  RealN3 f = a * 2.0;
+  ASSERT_EQ(f, e);
+
+  RealN3 g = e / 2.0;
+  ASSERT_EQ(g, a);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, RealN3NotEqual)
+{
+  RealN3 v1(1.0, 2.0, 3.0);
+  RealN3 v2(1.0, 2.0, 4.0);
+  ASSERT_NE(v1, v2);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, Size4)
+{
+  using V4 = NumVector<Real, 4>;
+  V4 v(1.0, 2.0, 3.0, 4.0);
+  ASSERT_EQ(v[0], 1.0);
+  ASSERT_EQ(v[1], 2.0);
+  ASSERT_EQ(v[2], 3.0);
+  ASSERT_EQ(v[3], 4.0);
+
+  V4 w = v * 2.0;
+  ASSERT_EQ(w[0], 2.0);
+  ASSERT_EQ(w[3], 8.0);
+
+  V4 z = V4::zero();
+  ASSERT_TRUE(math::isNearlyZero(z));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, Size5)
+{
+  using V5 = NumVector<Real, 5>;
+  V5 v(1.0, 2.0, 3.0, 4.0, 5.0);
+  ASSERT_EQ(v[0], 1.0);
+  ASSERT_EQ(v[4], 5.0);
+
+  v.fill(7.0);
+  ASSERT_EQ(v[0], 7.0);
+  ASSERT_EQ(v[4], 7.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, Size6)
+{
+  using V6 = NumVector<Real, 6>;
+  V6 v(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  ASSERT_EQ(v[0], 1.0);
+  ASSERT_EQ(v[3], 4.0);
+  ASSERT_EQ(v[5], 6.0);
+
+  V6 w;
+  w = 3.0;
+  ASSERT_EQ(w[0], 3.0);
+  ASSERT_EQ(w[5], 3.0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestNumVector, Int32x3)
+{
+  using V3i = NumVector<Int32, 3>;
+  V3i v;
+  ASSERT_EQ(v[0], 0);
+  ASSERT_EQ(v[1], 0);
+  ASSERT_EQ(v[2], 0);
+
+  v[0] = 1;
+  v[1] = 2;
+  v[2] = 3;
+  ASSERT_EQ(v[0], 1);
+  ASSERT_EQ(v[2], 3);
+
+  V3i w(4, 5, 6);
+  V3i s = v + w;
+  ASSERT_EQ(s[0], 5);
+  ASSERT_EQ(s[1], 7);
+  ASSERT_EQ(s[2], 9);
+
+  s *= 2;
+  ASSERT_EQ(s[0], 10);
+  ASSERT_EQ(s[1], 14);
+  ASSERT_EQ(s[2], 18);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -167,6 +505,11 @@ namespace Arcane
 {
 template class NumVector<Real, 2>;
 template class NumVector<Real, 3>;
+template class NumVector<Real, 4>;
+template class NumVector<Real, 5>;
+template class NumVector<Real, 6>;
+template class NumVector<Real, 1>;
+template class NumVector<Int32, 3>;
 } // namespace Arcane
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Refactor `NumVector` and `NumMatrix` to only add simple methods and to hide underlying container.
Other functions, like `isNearlyEqual()` or `normL2()` are in namespace `math`.
