### PR TITLE
Add support to provide case file content when using `ArcaneLauncher`

### DIFF
--- a/arcane/src/arcane/impl/ArcaneSimpleExecutor.cc
+++ b/arcane/src/arcane/impl/ArcaneSimpleExecutor.cc
@@ -206,7 +206,7 @@ applicationBuildInfo() const
 /*---------------------------------------------------------------------------*/
 
 ISubDomain* ArcaneSimpleExecutor::
-createSubDomain(const String& case_file_name)
+createSubDomain(const String& case_file_name, Span<const std::byte> file_content)
 {
   _checkInit();
   IApplication* app = m_p->m_arcane_main->arcaneMainClass()->application();
@@ -226,16 +226,24 @@ createSubDomain(const String& case_file_name)
   UniqueArray<Byte> case_bytes;
   bool has_case_file = !case_file_name.empty();
   if (has_case_file) {
-    bool is_bad = app->ioMng()->collectiveRead(case_file_name, case_bytes);
-    if (is_bad)
-      ARCANE_FATAL("Can not read case file '{0}'", case_file_name);
     sdbi.setCaseFileName(case_file_name);
-    sdbi.setCaseBytes(case_bytes);
-    tr->info() << "Create sub domain with case file '" << case_file_name << "'";
+    if (file_content.empty()) {
+      bool is_bad = app->ioMng()->collectiveRead(case_file_name, case_bytes);
+      if (is_bad)
+        ARCANE_FATAL("Can not read case file '{0}'", case_file_name);
+      sdbi.setCaseBytes(case_bytes);
+      tr->info() << "Create sub domain with case file '" << case_file_name << "'";
+    }
+    else {
+      sdbi.setCaseContent(file_content);
+    }
   }
   else {
-    sdbi.setCaseFileName(String());
-    sdbi.setCaseBytes(ByteConstArrayView());
+    sdbi.setCaseFileName({});
+    if (file_content.empty())
+      sdbi.setCaseBytes({});
+    else
+      sdbi.setCaseContent(file_content);
   }
   // The statistics service must be explicitly destroyed
   ITimeStats* time_stat = main_factory->createTimeStats(world_pm->timerMng(), tr, "Stats");
@@ -248,6 +256,15 @@ createSubDomain(const String& case_file_name)
     code_service->initCase(sub_domain, false);
   }
   return sub_domain;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ISubDomain* ArcaneSimpleExecutor::
+createSubDomain(const String& case_file_name)
+{
+  return createSubDomain(case_file_name, {});
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/impl/ArcaneSimpleExecutor.h
+++ b/arcane/src/arcane/impl/ArcaneSimpleExecutor.h
@@ -32,12 +32,14 @@ class CommandLineArguments;
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
-
 /*!
  * \brief Class for directly executing code without
  * going through the time loop.
  *
  * Only one instance of this class must exist at any given time.
+ *
+ * This class is internal to %Arcane. If you want to have a standalone
+ * execution, use ArcaneLauncher instead.
  *
  * Instances of this class use the value of
  * ArcaneMain::defaultApplicationInfo() to initialize themselves and notably
@@ -66,6 +68,8 @@ class ARCANE_IMPL_EXPORT ArcaneSimpleExecutor
 
   int initialize();
   ISubDomain* createSubDomain(const String& case_file_name);
+  ISubDomain* createSubDomain(const String& case_file_name,
+                              Span<const std::byte> file_content);
   int runCode(IFunctor* f);
 
  private:

--- a/arcane/src/arcane/launcher/ArcaneLauncher.cc
+++ b/arcane/src/arcane/launcher/ArcaneLauncher.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneLauncher.cc                                           (C) 2000-2025 */
+/* ArcaneLauncher.cc                                           (C) 2000-2026 */
 /*                                                                           */
 /* Class managing the execution launch.                                      */
 /*---------------------------------------------------------------------------*/
@@ -423,11 +423,11 @@ createStandaloneAcceleratorMng()
 /*---------------------------------------------------------------------------*/
 
 StandaloneSubDomain ArcaneLauncher::
-createStandaloneSubDomain(const String& case_file_name)
+createStandaloneSubDomain(const String& case_file_name, Span<const std::byte> file_content)
 {
   _initStandalone();
   StandaloneSubDomain s;
-  s._initUniqueInstance(case_file_name);
+  s._initUniqueInstance(case_file_name, file_content);
   return s;
 }
 

--- a/arcane/src/arcane/launcher/ArcaneLauncher.h
+++ b/arcane/src/arcane/launcher/ArcaneLauncher.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneLauncher.h                                            (C) 2000-2025 */
+/* ArcaneLauncher.h                                            (C) 2000-2026 */
 /*                                                                           */
 /* Class managing execution.                                                 */
 /*---------------------------------------------------------------------------*/
@@ -205,10 +205,16 @@ class ARCANE_LAUNCHER_EXPORT ArcaneLauncher
    * If this method is called, you must not call other ArcaneLauncher execution
    * methods (for example ArcaneLauncher::run()).
    *
-   * \a case_file_name is the name of the file containing the dataset. If null,
-   * there is no dataset.
+   * \a case_file_name is the name of the file containing the dataset
+   * and \a file_content is the content of this file. If both are null,
+   * there is no dataset. If \a file_content is empty, then the content of
+   * \a case_file_name will be collectively read and used as case file.
+   *
+   * This method is collective and if \a file_content is not empty, it has to have
+   * the same value across all ranks.
    */
-  static StandaloneSubDomain createStandaloneSubDomain(const String& case_file_name);
+  static StandaloneSubDomain createStandaloneSubDomain(const String& case_file_name,
+                                                       Span<const std::byte> file_content = {});
 
   /*!
    * \brief Requests help with the "--help" or "-h" option.

--- a/arcane/src/arcane/launcher/StandaloneSubDomain.cc
+++ b/arcane/src/arcane/launcher/StandaloneSubDomain.cc
@@ -43,12 +43,12 @@ class StandaloneSubDomain::Impl
     StandaloneSubDomain::_notifyRemoveStandaloneSubDomain();
   }
 
-  void init(const String& case_file_name)
+  void init(const String& case_file_name, Span<const std::byte> file_content)
   {
     int r = m_simple_exec.initialize();
     if (r != 0)
       ARCANE_FATAL("Error during initialization r={0}", r);
-    m_sub_domain = m_simple_exec.createSubDomain(case_file_name);
+    m_sub_domain = m_simple_exec.createSubDomain(case_file_name, file_content);
     m_trace_mng = makeRef(m_sub_domain->traceMng());
   }
 
@@ -116,10 +116,10 @@ subDomain()
 /*---------------------------------------------------------------------------*/
 
 void StandaloneSubDomain::
-_initUniqueInstance(const String& case_file_name)
+_initUniqueInstance(const String& case_file_name, Span<const std::byte> file_content)
 {
   m_p = makeRef(new Impl());
-  m_p->init(case_file_name);
+  m_p->init(case_file_name, file_content);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/launcher/StandaloneSubDomain.h
+++ b/arcane/src/arcane/launcher/StandaloneSubDomain.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* StandaloneSubDomain.h                                       (C) 2000-2023 */
+/* StandaloneSubDomain.h                                       (C) 2000-2026 */
 /*                                                                           */
 /* Standalone implementation of a sub-domain.                                */
 /*---------------------------------------------------------------------------*/
@@ -67,7 +67,7 @@ class ARCANE_LAUNCHER_EXPORT StandaloneSubDomain
  private:
 
   // For ArcaneLauncher.
-  void _initUniqueInstance(const String& case_file_name);
+  void _initUniqueInstance(const String& case_file_name, Span<const std::byte> file_content);
   bool _isValid();
   static void _notifyRemoveStandaloneSubDomain();
 };

--- a/arcane/src/arcane/tests/ArcaneTestStandaloneSubDomain.cc
+++ b/arcane/src/arcane/tests/ArcaneTestStandaloneSubDomain.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArcaneTestStandaloneArcaneSubDomain.cc                      (C) 2000-2025 */
+/* ArcaneTestStandaloneArcaneSubDomain.cc                      (C) 2000-2026 */
 /*                                                                           */
 /* Test of ArcaneLauncher::createStandaloneSubDomain().                      */
 /*---------------------------------------------------------------------------*/
@@ -25,15 +25,9 @@
 #include "arcane/accelerator/core/Runner.h"
 #include "arcane/accelerator/core/DeviceMemoryInfo.h"
 
-#if defined(ARCANE_HAS_ACCELERATOR_API)
 #include "arcane/utils/NumArray.h"
 #include "arcane/accelerator/NumArrayViews.h"
 #include "arcane/accelerator/RunCommandLoop.h"
-#endif
-
-#include "arcane/utils/Exception.h"
-
-#include <fstream>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -45,7 +39,6 @@ using namespace Arcane;
 
 namespace
 {
-#if defined(ARCANE_HAS_ACCELERATOR_API)
 void _testSum(IAcceleratorMng* acc_mng)
 {
   // Test the sum of two arrays 'a' and 'b' into an array 'c'.
@@ -83,7 +76,6 @@ void _testSum(IAcceleratorMng* acc_mng)
   std::cout << "DeviceMemoryInfo: free_mem=" << dmi.freeMemory()
             << " total=" << dmi.totalMemory() << "\n";
 }
-#endif
 
 int _testStandaloneSubDomainLauncher1(const CommandLineArguments& cmd_line_args)
 {
@@ -127,13 +119,9 @@ int _testStandaloneSubDomainLauncher2(const CommandLineArguments& cmd_line_args)
                      " </meshes>"
                      "</case>";
   std::cout << "TEST2: StandaloneSubDomain\n";
-  String case_file_name = "subdomain_generated.arc";
-  {
-    std::ofstream ofile(case_file_name.localstr());
-    ofile << case_file;
-  }
+  String case_file_name = "unnamed.arc";
   ArcaneLauncher::init(cmd_line_args);
-  auto launcher{ ArcaneLauncher::createStandaloneSubDomain(case_file_name) };
+  auto launcher{ ArcaneLauncher::createStandaloneSubDomain(case_file_name,asBytes(case_file)) };
   ISubDomain* sd = launcher.subDomain();
   ITraceMng* tm = launcher.traceMng();
   IAcceleratorMng* acc_mng = sd->acceleratorMng();
@@ -147,9 +135,7 @@ int _testStandaloneSubDomainLauncher2(const CommandLineArguments& cmd_line_args)
     tm->error() << String::format("Bad number of cells n={0} expected={1}", nb_cell, expected_nb_cell);
     return 1;
   }
-#if defined(ARCANE_HAS_ACCELERATOR_API)
   _testSum(acc_mng);
-#endif
   return 0;
 }
 


### PR DESCRIPTION
This may be used when the content of the case file is already known, instead of reading it from a file.