### PR TITLE
Declare `NumVector` and `NumMatrix` as POD for Arccore array classes

### DIFF
--- a/arcane/src/arcane/utils/tests/TestNumMatrix.cc
+++ b/arcane/src/arcane/utils/tests/TestNumMatrix.cc
@@ -16,6 +16,9 @@
 
 using namespace Arcane;
 
+//! Make sure NumMatrix is a POD for arrays (no initialization)
+static_assert(std::is_same_v<TrueType,ArrayTraits<NumMatrix<double,4,2>>::IsPODType>);
+
 TEST(TestNumMatrix, Real2x2)
 {
   RealN2 zero;

--- a/arcane/src/arcane/utils/tests/TestNumVector.cc
+++ b/arcane/src/arcane/utils/tests/TestNumVector.cc
@@ -17,6 +17,9 @@
 
 using namespace Arcane;
 
+//! Make sure NumVector is a POD for arrays (no initialization)
+static_assert(std::is_same_v<TrueType,ArrayTraits<NumVector<double,4>>::IsPODType>);
+
 TEST(TestNumVector, RealN2)
 {
   std::cout << "   sizeof(NumVector<double,2>) = " << sizeof(NumVector<double, 2>) << "\n";

--- a/arccore/src/common/arccore/common/ArrayTraits.h
+++ b/arccore/src/common/arccore/common/ArrayTraits.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* ArrayTraits.h                                               (C) 2000-2025 */
+/* ArrayTraits.h                                               (C) 2000-2026 */
 /*                                                                           */
 /* Characteristics of a 1D array.                                            */
 /*---------------------------------------------------------------------------*/
@@ -113,6 +113,38 @@ ARCCORE_DEFINE_ARRAY_PODTYPE(long double);
 ARCCORE_DEFINE_ARRAY_PODTYPE(std::byte);
 ARCCORE_DEFINE_ARRAY_PODTYPE(Float16);
 ARCCORE_DEFINE_ARRAY_PODTYPE(BFloat16);
+
+// Not POD by default for legacy compatibility
+// but it may improve performance making them PODs.
+#if defined(ARCCORE_USE_POD_FOR_REALN_TYPE)
+ARCCORE_DEFINE_ARRAY_PODTYPE(Arcane::Real2);
+ARCCORE_DEFINE_ARRAY_PODTYPE(Arcane::Real3);
+ARCCORE_DEFINE_ARRAY_PODTYPE(Arcane::Real2x2);
+ARCCORE_DEFINE_ARRAY_PODTYPE(Arcane::Real3x3);
+#endif
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+//! Specialization for NumVector which are considered a POD Type
+template <typename DataType, int Size>
+class ArrayTraits<Arcane::NumVector<DataType, Size>>
+{
+ public:
+
+  using ConstReferenceType = const Arcane::NumVector<DataType, Size>&;
+  using IsPODType = TrueType;
+};
+
+//! Specialization for NumMatrix which are considered a POD Type
+template <typename DataType, int Row, int Column>
+class ArrayTraits<Arcane::NumMatrix<DataType, Row, Column>>
+{
+ public:
+
+  using ConstReferenceType = const Arcane::NumMatrix<DataType, Row, Column>&;
+  using IsPODType = TrueType;
+};
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Array of these classes (i.e. `UniqueArray`, `SharedArray`, ...) will not be initialized and we can use `realloc` for resize operations.