### PR TITLE
Do not initialize by default `NumVector` and `NumMatrix`

### DIFF
--- a/arcane/src/arcane/utils/tests/TestNumMatrix.cc
+++ b/arcane/src/arcane/utils/tests/TestNumMatrix.cc
@@ -21,9 +21,9 @@ static_assert(std::is_same_v<TrueType,ArrayTraits<NumMatrix<double,4,2>>::IsPODT
 
 TEST(TestNumMatrix, Real2x2)
 {
-  RealN2 zero;
+  auto zero = RealN2::zero();
   {
-    RealN2x2 v1;
+    RealN2x2 v1{0.0};
     ASSERT_EQ(v1.vx(), zero);
     ASSERT_EQ(v1.vy(), zero);
   }
@@ -104,7 +104,7 @@ TEST(TestNumMatrix, Real2x2Fill)
 TEST(TestNumMatrix, Real2x2Zero)
 {
   RealN2x2 m = RealN2x2::zero();
-  RealN2 zero;
+  RealN2 zero{0.0};
   ASSERT_EQ(m.vx(), zero);
   ASSERT_EQ(m.vy(), zero);
   ASSERT_TRUE(math::isNearlyZero(m));
@@ -218,9 +218,9 @@ TEST(TestNumMatrix, Real2x2Conversion)
 
 TEST(TestNumMatrix, Real3x3)
 {
-  RealN3 zero;
+  RealN3 zero{0.0};
   {
-    RealN3x3 v1;
+    RealN3x3 v1{0.0};
     ASSERT_EQ(v1.vx(), zero);
     ASSERT_EQ(v1.vy(), zero);
     ASSERT_EQ(v1.vz(), zero);
@@ -397,7 +397,7 @@ TEST(TestNumMatrix, Real3x3Fill)
 
 TEST(TestNumMatrix, Real3x3NearlyZero)
 {
-  RealN3x3 m;
+  RealN3x3 m{0.0};
   ASSERT_TRUE(math::isNearlyZero(m));
   m(0, 0) = 1e-20;
   ASSERT_TRUE(math::isNearlyZero(m));
@@ -462,7 +462,7 @@ TEST(TestNumMatrix, Int32x2)
 {
   using Int32x2 = NumMatrix<Int32, 2, 2>;
 
-  Int32x2 m;
+  Int32x2 m{{}};
   ASSERT_EQ(m(0, 0), 0);
   ASSERT_EQ(m(1, 1), 0);
 

--- a/arcane/src/arcane/utils/tests/TestNumVector.cc
+++ b/arcane/src/arcane/utils/tests/TestNumVector.cc
@@ -25,7 +25,7 @@ TEST(TestNumVector, RealN2)
   std::cout << "   sizeof(NumVector<double,2>) = " << sizeof(NumVector<double, 2>) << "\n";
   std::cout << "   sizeof(NumVector<double,3>) = " << sizeof(NumVector<double, 3>) << "\n";
   {
-    RealN2 v1;
+    RealN2 v1{0.0};
     ASSERT_EQ(v1.vx(), 0.0);
     ASSERT_EQ(v1.vy(), 0.0);
   }
@@ -76,7 +76,7 @@ TEST(TestNumVector, RealN2)
 TEST(TestNumVector, Real3)
 {
   {
-    RealN3 v1;
+    RealN3 v1{0.0};
     ASSERT_EQ(v1.vx(), 0.0);
     ASSERT_EQ(v1.vy(), 0.0);
     ASSERT_EQ(v1.vz(), 0.0);
@@ -208,7 +208,7 @@ TEST(TestNumVector, RealN2Absolute)
 
 TEST(TestNumVector, RealN2NearlyZero)
 {
-  RealN2 v;
+  RealN2 v{0.0};
   ASSERT_TRUE(math::isNearlyZero(v));
   v.vx() = 1e-20;
   ASSERT_TRUE(math::isNearlyZero(v));
@@ -352,7 +352,7 @@ TEST(TestNumVector, RealN3Absolute)
 
 TEST(TestNumVector, RealN3NearlyZero)
 {
-  RealN3 v;
+  RealN3 v{0.0};
   ASSERT_TRUE(math::isNearlyZero(v));
   v.vz() = 1e-20;
   ASSERT_TRUE(math::isNearlyZero(v));
@@ -479,7 +479,7 @@ TEST(TestNumVector, Size6)
 TEST(TestNumVector, Int32x3)
 {
   using V3i = NumVector<Int32, 3>;
-  V3i v;
+  V3i v{0};
   ASSERT_EQ(v[0], 0);
   ASSERT_EQ(v[1], 0);
   ASSERT_EQ(v[2], 0);

--- a/arccore/src/base/arccore/base/NumMatrix.h
+++ b/arccore/src/base/arccore/base/NumMatrix.h
@@ -167,7 +167,7 @@ class NumMatrix
   //! Constructs the zero matrix
   constexpr ARCCORE_HOST_DEVICE static ThatClass zero()
   {
-    return ThatClass();
+    return ThatClass({});
   }
 
   //! Constructs the matrix ((ax,bx,cx), (ay,by,cy), (az,bz,cz)).
@@ -381,7 +381,7 @@ class NumMatrix
  private:
 
   //! Matrix values
-  DataType m_values[NbElement] = {};
+  DataType m_values[NbElement];
 
  private:
 

--- a/arccore/src/base/arccore/base/NumVector.h
+++ b/arccore/src/base/arccore/base/NumVector.h
@@ -169,7 +169,7 @@ class NumVector
 
  public:
 
-  constexpr ARCCORE_HOST_DEVICE static NumVector zero() { return NumVector(); }
+  constexpr ARCCORE_HOST_DEVICE static NumVector zero() { return NumVector({}); }
 
  public:
 
@@ -378,7 +378,7 @@ class NumVector
  private:
 
   //! Vector values
-  T m_values[Size] = {};
+  T m_values[Size];
 
  private:
 


### PR DESCRIPTION
When the size of these type is large, default initialization may be costly and the compiler does not always remove them.
The methods `NumVector::zero()` or `NumMatrix::zero()` may be used to initialize with default constructor of `DataType`.
