### PR TITLE
Add internal classes to Arccore to handle program options

### DIFF
--- a/arccore/src/common/arccore/common/ProgramOptions.cc
+++ b/arccore/src/common/arccore/common/ProgramOptions.cc
@@ -1,0 +1,475 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ProgramOptions.cc                                           (C) 2000-2026 */
+/*                                                                           */
+/* Program options parser implementation.                                    */
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/common/internal/ProgramOptions.h"
+
+#include <cctype>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::ProgramOptions
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace
+{
+
+  void
+  _parseNameString(const std::string& name_str, std::string& long_name,
+                   std::string& short_name, bool& has_short)
+  {
+    auto pos = name_str.find(',');
+    if (pos != std::string::npos) {
+      long_name = name_str.substr(0, pos);
+      short_name = name_str.substr(pos + 1);
+      has_short = true;
+    }
+    else {
+      long_name = name_str;
+      has_short = false;
+    }
+  }
+
+} // anonymous namespace
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+options_description::
+options_description(const std::string& title)
+: m_title(title)
+{}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+options_description::options_proxy options_description::
+add_options()
+{
+  return options_proxy(*this);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void options_description::
+add_option(const std::string& name,
+           std::shared_ptr<option_value> value_semantic,
+           const std::string& description)
+{
+  option_descriptor opt;
+  _parseNameString(name, opt.long_name, opt.short_name, opt.has_short);
+  opt.description = description;
+  opt.value_semantic = std::move(value_semantic);
+  m_options.push_back(std::move(opt));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+const option_descriptor* options_description::
+find(const std::string& name) const
+{
+  for (const auto& opt : m_options) {
+    if (opt.long_name == name)
+      return &opt;
+  }
+  return nullptr;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+const option_descriptor* options_description::
+find_by_short(char short_name) const
+{
+  for (const auto& opt : m_options) {
+    if (opt.has_short && !opt.short_name.empty() && opt.short_name[0] == short_name)
+      return &opt;
+  }
+  return nullptr;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+// options_proxy: no-value option (bare flag, e.g. ("help,h", "description"))
+options_description::options_proxy& options_description::options_proxy::
+operator()(const char* name, const char* description)
+{
+  m_desc.add_option(name, std::make_shared<untyped_value>(), description);
+  return *this;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+// options_proxy: bool option with description
+options_description::options_proxy& options_description::options_proxy::
+operator()(const char* name,
+           const typed_value<bool>* value,
+           const char* description)
+{
+  m_desc.add_option(name,
+                    std::shared_ptr<option_value>(const_cast<typed_value<bool>*>(value)),
+                    description);
+  return *this;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+// options_proxy: bool option without description
+options_description::options_proxy& options_description::options_proxy::
+operator()(const char* name,
+           const typed_value<bool>* value)
+{
+  m_desc.add_option(name,
+                    std::shared_ptr<option_value>(const_cast<typed_value<bool>*>(value)),
+                    std::string());
+  return *this;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+std::ostream&
+operator<<(std::ostream& os, const options_description& desc)
+{
+  if (!desc.m_title.empty())
+    os << desc.m_title << ":\n";
+
+  for (const auto& opt : desc.m_options) {
+    os << "  ";
+
+    if (opt.has_short && !opt.short_name.empty()) {
+      if (opt.short_name.size() == 1 && std::isalnum(static_cast<unsigned char>(opt.short_name[0])))
+        os << "-" << opt.short_name << " ";
+      else
+        os << "--" << opt.short_name << " ";
+    }
+
+    os << "[--" << opt.long_name;
+
+    if (opt.value_semantic && !opt.value_semantic->is_bool_switch())
+      os << " arg";
+
+    os << "]";
+
+    if (opt.value_semantic && opt.value_semantic->has_default()) {
+      auto ds = opt.value_semantic->default_string();
+      if (!ds.empty())
+        os << " (=" << ds << ")";
+    }
+
+    if (!opt.description.empty())
+      os << "\t" << opt.description;
+
+    os << "\n";
+  }
+
+  return os;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+positional_options_description& positional_options_description::
+add(const std::string& name, int count)
+{
+  m_options.emplace_back(name, count);
+  return *this;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void variables_map::
+add(const std::string& name, variable_value value)
+{
+  m_values[name] = std::move(value);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool variables_map::
+count(const std::string& name) const
+{
+  return m_values.find(name) != m_values.end();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+const variables_map::variable_value& variables_map::
+operator[](const std::string& name) const
+{
+  static variable_value empty_value;
+  auto it = m_values.find(name);
+  if (it != m_values.end())
+    return it->second;
+  return empty_value;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void variables_map::
+set_semantic(const std::string& name,
+             std::shared_ptr<option_value> semantic)
+{
+  auto it = m_values.find(name);
+  if (it != m_values.end())
+    it->second.set_semantic(std::move(semantic));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Core parsing algorithm.
+ *
+ * Iterates through argv[1..argc-1] and recognizes:
+ *   - Long options (--name or --name=value)
+ *   - Short options (-s or -svalue)
+ *   - Positional arguments (no leading dash)
+ *   -- as end-of-options marker
+ */
+parsed_options command_line_parser::
+run()
+{
+  parsed_options result(m_desc);
+
+  if (!m_desc)
+    return result;
+
+  std::vector<std::string> positional_args;
+  bool end_of_options = false;
+
+  for (int i = 1; i < m_argc; ++i) {
+    std::string token(m_argv[i]);
+
+    if (end_of_options || token.empty() || token[0] != '-') {
+      positional_args.push_back(token);
+      continue;
+    }
+
+    // End-of-options marker
+    if (token == "--") {
+      end_of_options = true;
+      continue;
+    }
+
+    if (token.size() >= 2 && token[1] == '-') {
+      // Long option: --name or --name=value
+      std::string name;
+      std::string value;
+      bool has_eq_value = false;
+
+      auto eq_pos = token.find('=', 2);
+      if (eq_pos != std::string::npos) {
+        name = token.substr(2, eq_pos - 2);
+        value = token.substr(eq_pos + 1);
+        has_eq_value = true;
+      }
+      else {
+        name = token.substr(2);
+      }
+
+      if (name.empty())
+        continue;
+
+      const auto* opt = m_desc->find(name);
+      if (!opt || !opt->value_semantic)
+        continue;
+
+      if (opt->value_semantic->is_bool_switch()) {
+        result.add_option(name, { has_eq_value ? value : "true" });
+      }
+      else if (opt->value_semantic->is_multitoken()) {
+        std::vector<std::string> values;
+        if (has_eq_value)
+          values.push_back(value);
+        while (i + 1 < m_argc) {
+          std::string next(m_argv[i + 1]);
+          if (!next.empty() && next[0] == '-' && next.size() > 1)
+            break;
+          ++i;
+          values.push_back(next);
+        }
+        result.add_option(name, std::move(values));
+      }
+      else {
+        if (has_eq_value) {
+          result.add_option(name, { value });
+        }
+        else if (i + 1 < m_argc) {
+          ++i;
+          result.add_option(name, { std::string(m_argv[i]) });
+        }
+      }
+    }
+    else {
+      // Short option: -s
+      if (token.size() < 2)
+        continue;
+
+      char short_char = token[1];
+      const auto* opt = m_desc->find_by_short(short_char);
+      if (!opt || !opt->value_semantic)
+        continue;
+
+      std::string name = opt->long_name;
+      std::string inline_value;
+      bool has_inline_value = (token.size() > 2);
+
+      if (has_inline_value)
+        inline_value = token.substr(2);
+
+      if (opt->value_semantic->is_bool_switch()) {
+        result.add_option(name, { "true" });
+      }
+      else if (opt->value_semantic->is_multitoken()) {
+        std::vector<std::string> values;
+        if (has_inline_value)
+          values.push_back(inline_value);
+        while (i + 1 < m_argc) {
+          std::string next(m_argv[i + 1]);
+          if (!next.empty() && next[0] == '-' && next.size() > 1)
+            break;
+          ++i;
+          values.push_back(next);
+        }
+        result.add_option(name, std::move(values));
+      }
+      else {
+        if (has_inline_value) {
+          result.add_option(name, { inline_value });
+        }
+        else if (i + 1 < m_argc) {
+          ++i;
+          result.add_option(name, { std::string(m_argv[i]) });
+        }
+      }
+    }
+  }
+
+  // Map positional arguments to named options
+  if (m_positional && !positional_args.empty()) {
+    size_t pos_idx = 0;
+    for (const auto& pos_opt : m_positional->options()) {
+      if (pos_idx >= positional_args.size())
+        break;
+
+      if (pos_opt.second == -1) {
+        // All remaining positional args
+        std::vector<std::string> remaining(positional_args.begin() + pos_idx,
+                                           positional_args.end());
+        result.add_option(pos_opt.first, std::move(remaining));
+        break;
+      }
+      else {
+        int count = pos_opt.second;
+        std::vector<std::string> values;
+        for (int c = 0; c < count && pos_idx < positional_args.size(); ++c, ++pos_idx)
+          values.push_back(positional_args[pos_idx]);
+        result.add_option(pos_opt.first, std::move(values));
+      }
+    }
+  }
+
+  return result;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+parsed_options
+parse_command_line(int argc, char** argv, const options_description& desc)
+{
+  command_line_parser parser(argc, argv);
+  parser.options(desc);
+  return parser.run();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Transfer parsed options to the variables_map.
+ *
+ * For each parsed option, converts string tokens to typed values and
+ * stores them. Also applies default values for defined options that
+ * were not provided on the command line.
+ */
+void store(const parsed_options& parsed, variables_map& vm)
+{
+  // Store all parsed values
+  for (const auto& po : parsed.options()) {
+    const auto* opt_desc = parsed.description().find(po.name);
+    if (!opt_desc || !opt_desc->value_semantic)
+      continue;
+
+    const auto& semantic = opt_desc->value_semantic;
+
+    if (po.values.empty())
+      continue;
+
+    if (semantic->is_multitoken()) {
+      std::any value = std::make_any<std::vector<std::string>>(po.values);
+      variables_map::variable_value vv(value, false);
+      vv.set_semantic(semantic);
+      vm.add(po.name, std::move(vv));
+    }
+    else {
+      std::any value = semantic->parse(po.values[0]);
+      variables_map::variable_value vv(value, false);
+      vv.set_semantic(semantic);
+      vm.add(po.name, std::move(vv));
+    }
+  }
+
+  // Apply defaults for defined options not present on command line
+  for (const auto& opt : parsed.description().options()) {
+    if (!vm.count(opt.long_name) && opt.value_semantic && opt.value_semantic->has_default()) {
+      std::any default_val = opt.value_semantic->default_value_any();
+      variables_map::variable_value vv(default_val, true);
+      vv.set_semantic(opt.value_semantic);
+      vm.add(opt.long_name, std::move(vv));
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Fill bound variables and validate required options.
+ *
+ * For each stored value, assigns to the bound variable (if any).
+ * Throws if a required option has no value.
+ */
+void notify(variables_map& vm)
+{
+  for (auto& [name, val] : vm) {
+    if (val.empty())
+      continue;
+    if (auto semantic = val.semantic())
+      semantic->assign_bound(val.value_ref());
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::ProgramOptions
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arccore/src/common/arccore/common/internal/ProgramOptions.h
+++ b/arccore/src/common/arccore/common/internal/ProgramOptions.h
@@ -1,0 +1,662 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* ProgramOptions.h                                            (C) 2000-2026 */
+/*                                                                           */
+/* Program options parser (replacement for boost::program_options).          */
+/*---------------------------------------------------------------------------*/
+#ifndef ARCCORE_ALINA_PROGRAMOPTIONS_H
+#define ARCCORE_ALINA_PROGRAMOPTIONS_H
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/common/CommonGlobal.h"
+
+#include <any>
+#include <string>
+#include <vector>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <iostream>
+#include <stdexcept>
+#include <algorithm>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::ProgramOptions
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+template <typename T>
+class typed_value;
+
+class options_description;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Type-erased base for option value semantics.
+ */
+class ARCCORE_COMMON_EXPORT option_value
+{
+ public:
+
+  virtual ~option_value() = default;
+  virtual std::any parse(const std::string& s) const = 0;
+  virtual std::string default_string() const = 0;
+  virtual bool has_default() const = 0;
+  virtual bool is_required() const = 0;
+  virtual bool is_bool_switch() const = 0;
+  virtual bool is_multitoken() const = 0;
+  virtual std::any default_value_any() const = 0;
+  virtual void assign_bound(const std::any& value) const = 0;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Typed option value with default, required, and multitoken support.
+ */
+template <typename T>
+class typed_value : public option_value
+{
+ public:
+
+  typed_value() = default;
+
+  explicit typed_value(T* bound_variable)
+  : m_bound_variable(bound_variable)
+  {}
+
+  typed_value* default_value(const T& value)
+  {
+    m_default_value = value;
+    m_has_default = true;
+    return this;
+  }
+
+  typed_value* required()
+  {
+    m_is_required = true;
+    return this;
+  }
+
+  typed_value* multitoken()
+  {
+    m_is_multitoken = true;
+    return this;
+  }
+
+  std::any parse(const std::string& s) const override
+  {
+    return std::any(parse_impl(s));
+  }
+
+  T parse_impl(const std::string& s) const
+  {
+    T value{};
+    if constexpr (std::is_same_v<T, std::string>) {
+      value = s;
+    }
+    else {
+      std::istringstream iss(s);
+      iss >> value;
+      if (iss.fail())
+        throw std::logic_error("Failed to parse option value \"" + s + "\"");
+    }
+    return value;
+  }
+
+  std::string default_string() const override
+  {
+    if (!m_has_default)
+      return {};
+    return default_string_impl(m_default_value);
+  }
+
+  static std::string default_string_impl(const T& value)
+  {
+    if constexpr (std::is_same_v<T, std::string>) {
+      return value;
+    }
+    else if constexpr (std::is_same_v<T, bool>) {
+      return value ? "true" : "false";
+    }
+    else {
+      std::ostringstream oss;
+      oss << value;
+      return oss.str();
+    }
+  }
+
+  bool has_default() const override { return m_has_default; }
+  bool is_required() const override { return m_is_required; }
+  bool is_bool_switch() const override { return false; }
+  bool is_multitoken() const override { return m_is_multitoken; }
+
+  std::any default_value_any() const override
+  {
+    return std::any(m_default_value);
+  }
+
+  void assign_bound(const std::any& value) const override
+  {
+    if (m_bound_variable)
+      *m_bound_variable = std::any_cast<T>(value);
+  }
+
+ private:
+
+  T* m_bound_variable = nullptr;
+  T m_default_value{};
+  bool m_has_default{ false };
+  bool m_is_required{ false };
+  bool m_is_multitoken{ false };
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Specialization for bool switch options.
+ */
+template <>
+class typed_value<bool> : public option_value
+{
+ public:
+
+  typed_value() = default;
+
+  explicit typed_value(bool* bound_variable)
+  : m_bound_variable(bound_variable)
+  , m_default_value(false)
+  , m_has_default(true)
+  , m_is_bool_switch(true)
+  {}
+
+  typed_value* default_value(const bool& value)
+  {
+    m_default_value = value;
+    m_has_default = true;
+    return this;
+  }
+
+  typed_value* required()
+  {
+    m_is_required = true;
+    return this;
+  }
+
+  typed_value* multitoken()
+  {
+    return this;
+  }
+
+  std::any parse(const std::string& s) const override
+  {
+    return std::any(parse_impl(s));
+  }
+
+  bool parse_impl(const std::string& s) const
+  {
+    if (s == "true" || s == "1" || s == "yes" || s == "on")
+      return true;
+    if (s == "false" || s == "0" || s == "no" || s == "off")
+      return false;
+    throw std::logic_error("Failed to parse bool option value \"" + s + "\"");
+  }
+
+  std::string default_string() const override
+  {
+    if (!m_has_default)
+      return {};
+    return m_default_value ? "true" : "false";
+  }
+
+  bool has_default() const override { return m_has_default; }
+  bool is_required() const override { return m_is_required; }
+  bool is_bool_switch() const override { return m_is_bool_switch; }
+  bool is_multitoken() const override { return false; }
+
+  std::any default_value_any() const override
+  {
+    return std::any(m_default_value);
+  }
+
+  void assign_bound(const std::any& value) const override
+  {
+    if (m_bound_variable)
+      *m_bound_variable = std::any_cast<bool>(value);
+  }
+
+ private:
+
+  bool* m_bound_variable = nullptr;
+  bool m_default_value = false;
+  bool m_has_default = true;
+  bool m_is_bool_switch = true;
+  bool m_is_required{ false };
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Specialization for std::vector<std::string> (multitoken).
+ */
+template <>
+class typed_value<std::vector<std::string>> : public option_value
+{
+ public:
+
+  typed_value() = default;
+
+  explicit typed_value(std::vector<std::string>* bound_variable)
+  : m_bound_variable(bound_variable)
+  {}
+
+  typed_value* default_value(const std::vector<std::string>& value)
+  {
+    m_default_value = value;
+    m_has_default = true;
+    return this;
+  }
+
+  typed_value* required()
+  {
+    m_is_required = true;
+    return this;
+  }
+
+  typed_value* multitoken()
+  {
+    m_is_multitoken = true;
+    return this;
+  }
+
+  std::any parse(const std::string& s) const override
+  {
+    std::vector<std::string> v;
+    v.push_back(s);
+    return std::any(std::move(v));
+  }
+
+  std::string default_string() const override
+  {
+    if (!m_has_default || m_default_value.empty())
+      return {};
+    std::string result;
+    for (size_t i = 0; i < m_default_value.size(); ++i) {
+      if (i > 0)
+        result += " ";
+      result += m_default_value[i];
+    }
+    return result;
+  }
+
+  bool has_default() const override { return m_has_default; }
+  bool is_required() const override { return m_is_required; }
+  bool is_bool_switch() const override { return false; }
+  bool is_multitoken() const override { return m_is_multitoken; }
+
+  std::any default_value_any() const override
+  {
+    return std::any(m_default_value);
+  }
+
+  void assign_bound(const std::any& value) const override
+  {
+    if (m_bound_variable)
+      *m_bound_variable = std::any_cast<std::vector<std::string>>(value);
+  }
+
+ private:
+
+  std::vector<std::string>* m_bound_variable = nullptr;
+  std::vector<std::string> m_default_value;
+  bool m_has_default{ false };
+  bool m_is_required{ false };
+  bool m_is_multitoken{ true };
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Presence-only option (no value, just a flag).
+ *
+ * Used for bare flags like ("help,h", "description") where
+ * the option has no value semantic.
+ */
+class ARCCORE_COMMON_EXPORT untyped_value : public option_value
+{
+ public:
+
+  std::any parse(const std::string&) const override
+  {
+    return std::any(true);
+  }
+
+  std::string default_string() const override { return {}; }
+
+  bool has_default() const override { return false; }
+  bool is_required() const override { return false; }
+  bool is_bool_switch() const override { return true; }
+  bool is_multitoken() const override { return false; }
+
+  std::any default_value_any() const override
+  {
+    return std::any(false);
+  }
+
+  void assign_bound(const std::any&) const override {}
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Create a typed option value.
+ */
+template <typename T>
+typed_value<T>*
+value()
+{
+  return new typed_value<T>();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Create a typed option value bound to a variable.
+ */
+template <typename T>
+typed_value<T>*
+value(T* v)
+{
+  return new typed_value<T>(v);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Create a boolean switch option.
+ */
+inline typed_value<bool>*
+bool_switch()
+{
+  return new typed_value<bool>();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Create a boolean switch option bound to a variable.
+ */
+inline typed_value<bool>*
+bool_switch(bool* v)
+{
+  return new typed_value<bool>(v);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Internal descriptor for a single option.
+ */
+struct option_descriptor
+{
+  std::string long_name;
+  std::string short_name;
+  std::string description;
+  std::shared_ptr<option_value> value_semantic;
+  bool has_short{ false };
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Describes a set of command-line options.
+ */
+class ARCCORE_COMMON_EXPORT options_description
+{
+ public:
+
+  explicit options_description(const std::string& title = "Options");
+
+  /*!
+   * \brief Proxy for chained add_options()() calls.
+   */
+  class ARCCORE_COMMON_EXPORT options_proxy
+  {
+   public:
+
+    explicit options_proxy(options_description& desc)
+    : m_desc(desc)
+    {}
+
+    options_proxy& operator()(const char* name, const char* description);
+    options_proxy& operator()(const char* name, const typed_value<bool>* value,
+                              const char* description);
+    options_proxy& operator()(const char* name, const typed_value<bool>* value);
+
+    template <typename T>
+    options_proxy& operator()(const char* name, const typed_value<T>* value,
+                              const char* description)
+    {
+      m_desc.add_option(name, std::shared_ptr<option_value>(const_cast<typed_value<T>*>(value)),
+                        description);
+      return *this;
+    }
+
+    template <typename T>
+    options_proxy& operator()(const char* name, const typed_value<T>* value)
+    {
+      m_desc.add_option(name, std::shared_ptr<option_value>(const_cast<typed_value<T>*>(value)),
+                        std::string());
+      return *this;
+    }
+
+   private:
+
+    options_description& m_desc;
+  };
+
+  options_proxy add_options();
+
+  void add_option(const std::string& name,
+                  std::shared_ptr<option_value> value_semantic,
+                  const std::string& description);
+
+  const std::vector<option_descriptor>& options() const { return m_options; }
+  const option_descriptor* find(const std::string& name) const;
+  const option_descriptor* find_by_short(char short_name) const;
+
+  ARCCORE_COMMON_EXPORT friend std::ostream& operator<<(std::ostream& os, const options_description& desc);
+
+ private:
+
+  std::vector<option_descriptor> m_options;
+  std::string m_title;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Stores parsed option values.
+ */
+class ARCCORE_COMMON_EXPORT variables_map
+{
+ public:
+
+  class variable_value
+  {
+   public:
+
+    variable_value() = default;
+
+    explicit variable_value(std::any value, bool is_default = false)
+    : m_value(std::move(value))
+    , m_is_default(is_default)
+    {}
+
+    bool empty() const { return !m_value.has_value(); }
+    bool is_default() const { return m_is_default; }
+
+    template <typename T>
+    T as() const
+    {
+      try {
+        return std::any_cast<T>(m_value);
+      }
+      catch (const std::bad_any_cast&) {
+        throw std::logic_error("Type mismatch in variable_value::as<T>()");
+      }
+    }
+
+    void set_semantic(std::shared_ptr<option_value> semantic)
+    {
+      m_semantic = std::move(semantic);
+    }
+
+    const std::shared_ptr<option_value>& semantic() const { return m_semantic; }
+    std::any& value_ref() { return m_value; }
+
+   private:
+
+    std::any m_value;
+    bool m_is_default{ false };
+    std::shared_ptr<option_value> m_semantic;
+  };
+
+  void add(const std::string& name, variable_value value);
+  bool count(const std::string& name) const;
+  const variable_value& operator[](const std::string& name) const;
+
+  void set_semantic(const std::string& name, std::shared_ptr<option_value> semantic);
+
+  using iterator = std::map<std::string, variable_value>::iterator;
+  using const_iterator = std::map<std::string, variable_value>::const_iterator;
+  iterator begin() { return m_values.begin(); }
+  iterator end() { return m_values.end(); }
+  const_iterator begin() const { return m_values.begin(); }
+  const_iterator end() const { return m_values.end(); }
+
+ private:
+
+  std::map<std::string, variable_value> m_values;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Describes positional (non-option) arguments.
+ */
+class ARCCORE_COMMON_EXPORT positional_options_description
+{
+ public:
+
+  positional_options_description& add(const std::string& name, int count);
+
+  const std::vector<std::pair<std::string, int>>& options() const { return m_options; }
+
+ private:
+
+  std::vector<std::pair<std::string, int>> m_options;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Result of parsing command-line arguments.
+ */
+class ARCCORE_COMMON_EXPORT parsed_options
+{
+ public:
+
+  struct parsed_option
+  {
+    std::string name;
+    std::vector<std::string> values;
+  };
+
+  explicit parsed_options(const options_description* desc)
+  : m_desc(desc)
+  {}
+
+  const options_description& description() const { return *m_desc; }
+
+  void add_option(const std::string& name, std::vector<std::string> values)
+  {
+    m_parsed.push_back({ name, std::move(values) });
+  }
+
+  const std::vector<parsed_option>& options() const { return m_parsed; }
+
+ private:
+
+  const options_description* m_desc = nullptr;
+  std::vector<parsed_option> m_parsed;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*!
+ * \brief Fluent command-line parser builder.
+ */
+class ARCCORE_COMMON_EXPORT command_line_parser
+{
+ public:
+
+  command_line_parser(int argc, char** argv)
+  : m_argc(argc)
+  , m_argv(argv)
+  {}
+
+  command_line_parser& options(const options_description& desc)
+  {
+    m_desc = &desc;
+    return *this;
+  }
+
+  command_line_parser& positional(const positional_options_description& pos)
+  {
+    m_positional = &pos;
+    return *this;
+  }
+
+  parsed_options run();
+
+ private:
+
+  int m_argc = 0;
+  char** m_argv = nullptr;
+  const options_description* m_desc = nullptr;
+  const positional_options_description* m_positional = nullptr;
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+extern "C++" ARCCORE_COMMON_EXPORT parsed_options
+parse_command_line(int argc, char** argv, const options_description& desc);
+
+extern "C++" ARCCORE_COMMON_EXPORT void
+store(const parsed_options& parsed, variables_map& vm);
+
+extern "C++" ARCCORE_COMMON_EXPORT void
+notify(variables_map& vm);
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::ProgramOptions
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#endif

--- a/arccore/src/common/arccore/common/srcs.cmake
+++ b/arccore/src/common/arccore/common/srcs.cmake
@@ -45,6 +45,7 @@
   ParameterList.h
   ParameterList.cc
   Process.cc
+  ProgramOptions.cc
   Property.cc
   SequentialFor.h
   SmallArray.h
@@ -66,6 +67,7 @@
   internal/MemoryUtilsInternal.h
   internal/ParameterListPropertyReader.h
   internal/Process.h
+  internal/ProgramOptions.h
   internal/Property.h
   internal/PropertyDeclarations.h
   internal/SpecificMemoryCopyList.h

--- a/arccore/src/common/tests/CMakeLists.txt
+++ b/arccore/src/common/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
   TestProcess.cc
   TestSequentialFor.cc
   TestStringVector.cc
+  TestProgramOptions.cc
 )
 
 target_link_libraries(arccore_common.tests PUBLIC arccore_common GTest::GTest GTest::Main)

--- a/arccore/src/common/tests/TestProgramOptions.cc
+++ b/arccore/src/common/tests/TestProgramOptions.cc
@@ -1,0 +1,733 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "arccore/common/internal/ProgramOptions.h"
+
+#include <sstream>
+
+using namespace Arcane;
+
+namespace po = Arcane::ProgramOptions;
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, options_description_add)
+{
+  po::options_description desc("Test");
+
+  ASSERT_EQ(desc.options().size(), 0);
+
+  desc.add_options()
+    ("help,h", "Show help.")
+    ("size,n", po::value<int>()->default_value(32), "Size")
+    ;
+
+  ASSERT_EQ(desc.options().size(), 2);
+
+  // find by long name
+  const auto* opt = desc.find("help");
+  ASSERT_NE(opt, nullptr);
+  ASSERT_EQ(opt->long_name, "help");
+  ASSERT_TRUE(opt->has_short);
+  ASSERT_EQ(opt->short_name, "h");
+  ASSERT_TRUE(opt->description.find("Show help") != std::string::npos);
+
+  // find by short name
+  const auto* short_opt = desc.find_by_short('n');
+  ASSERT_NE(short_opt, nullptr);
+  ASSERT_EQ(short_opt->long_name, "size");
+
+  // unknown option
+  ASSERT_EQ(desc.find("unknown"), nullptr);
+  ASSERT_EQ(desc.find_by_short('z'), nullptr);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, options_description_find_long)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("verbose", po::bool_switch(), "Verbose")
+    ;
+
+  ASSERT_NE(desc.find("verbose"), nullptr);
+  ASSERT_TRUE(desc.find("verbose")->value_semantic->is_bool_switch());
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, options_description_find_no_short)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("long-only", po::value<int>(), "Long only")
+    ;
+
+  const auto* opt = desc.find("long-only");
+  ASSERT_NE(opt, nullptr);
+  ASSERT_FALSE(opt->has_short);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, help_output)
+{
+  po::options_description desc("Test Options");
+  desc.add_options()
+    ("help,h", "Show help.")
+    ("size,n", po::value<int>()->default_value(32), "Domain size")
+    ("verbose", po::bool_switch()->default_value(false), "Verbose")
+    ;
+
+  std::ostringstream oss;
+  oss << desc;
+  std::string help = oss.str();
+
+  ASSERT_TRUE(help.find("Test Options") != std::string::npos);
+  ASSERT_TRUE(help.find("--help") != std::string::npos);
+  ASSERT_TRUE(help.find("-h") != std::string::npos);
+  ASSERT_TRUE(help.find("--size") != std::string::npos);
+  ASSERT_TRUE(help.find("-n") != std::string::npos);
+  ASSERT_TRUE(help.find("=32") != std::string::npos);
+  ASSERT_TRUE(help.find("Domain size") != std::string::npos);
+  ASSERT_TRUE(help.find("Show help") != std::string::npos);
+  ASSERT_TRUE(help.find("--verbose") != std::string::npos);
+  // bool_switch should not show "arg"
+  ASSERT_TRUE(help.find("--size arg") != std::string::npos);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, empty_title)
+{
+  po::options_description desc;
+  desc.add_options()
+    ("help,h", "Help.")
+    ;
+
+  std::ostringstream oss;
+  oss << desc;
+  std::string help = oss.str();
+  // When title is empty, no title line is printed
+  ASSERT_TRUE(help.find("Options") == std::string::npos || help.find("--help") != std::string::npos);
+  ASSERT_TRUE(help.find("--help") != std::string::npos);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, parse_long_option)
+{
+  po::options_description desc("Test");
+  int size = 0;
+  desc.add_options()
+    ("size,n", po::value<int>(&size)->default_value(32), "Size")
+    ;
+
+  const char* argv[] = {"program", "--size", "64"};
+  int argc = 3;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_TRUE(vm.count("size"));
+  ASSERT_EQ(vm["size"].as<int>(), 64);
+  ASSERT_EQ(size, 64);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, parse_short_option)
+{
+  po::options_description desc("Test");
+  int size = 0;
+  desc.add_options()
+    ("size,n", po::value<int>(&size)->default_value(32), "Size")
+    ;
+
+  const char* argv[] = {"program", "-n", "128"};
+  int argc = 3;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(vm["size"].as<int>(), 128);
+  ASSERT_EQ(size, 128);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, parse_short_option_inline_value)
+{
+  po::options_description desc("Test");
+  std::string name;
+  desc.add_options()
+    ("define,D", po::value<std::string>(&name), "Define")
+    ;
+
+  const char* argv[] = {"program", "-DNAME"};
+  int argc = 2;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(name, "NAME");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, parse_long_option_eq_syntax)
+{
+  po::options_description desc("Test");
+  std::string matrix;
+  desc.add_options()
+    ("matrix,A", po::value<std::string>(&matrix), "Matrix file")
+    ;
+
+  const char* argv[] = {"program", "--matrix=test.mtx"};
+  int argc = 2;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(matrix, "test.mtx");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, default_value_applied)
+{
+  po::options_description desc("Test");
+  int size = 0;
+  desc.add_options()
+    ("size,n", po::value<int>(&size)->default_value(32), "Size")
+    ;
+
+  // No command-line args at all
+  const char* argv[] = {"program"};
+  int argc = 1;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_TRUE(vm.count("size"));
+  ASSERT_EQ(vm["size"].as<int>(), 32);
+  ASSERT_EQ(size, 32);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, bool_switch_not_provided)
+{
+  po::options_description desc("Test");
+  bool verbose = true;
+  desc.add_options()
+    ("verbose,v", po::bool_switch(&verbose)->default_value(false), "Verbose")
+    ;
+
+  const char* argv[] = {"program"};
+  int argc = 1;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_TRUE(vm.count("verbose"));
+  ASSERT_FALSE(vm["verbose"].as<bool>());
+  ASSERT_FALSE(verbose);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, bool_switch_provided)
+{
+  po::options_description desc("Test");
+  bool verbose = false;
+  desc.add_options()
+    ("verbose,v", po::bool_switch(&verbose)->default_value(false), "Verbose")
+    ;
+
+  const char* argv[] = {"program", "--verbose"};
+  int argc = 2;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_TRUE(vm["verbose"].as<bool>());
+  ASSERT_TRUE(verbose);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, bool_switch_short)
+{
+  po::options_description desc("Test");
+  bool verbose = false;
+  desc.add_options()
+    ("verbose,v", po::bool_switch(&verbose)->default_value(false), "Verbose")
+    ;
+
+  const char* argv[] = {"program", "-v"};
+  int argc = 2;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_TRUE(verbose);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, bare_flag_presence)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("help,h", "Show help.")
+    ;
+
+  // Without flag
+  {
+    const char* argv[] = {"program"};
+    int argc = 1;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+    po::notify(vm);
+
+    // bare flags have no default, so count should be false
+    ASSERT_FALSE(vm.count("help"));
+  }
+
+  // With flag
+  {
+    const char* argv[] = {"program", "--help"};
+    int argc = 2;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+    po::notify(vm);
+
+    ASSERT_TRUE(vm.count("help"));
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, multitoken_vector)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("prm,p", po::value<std::vector<std::string>>()->multitoken(), "Params")
+    ;
+
+  const char* argv[] = {"program", "--prm", "tol=1e-6", "maxiter=100", "solver=CG"};
+  int argc = 5;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_TRUE(vm.count("prm"));
+  auto vals = vm["prm"].as<std::vector<std::string>>();
+  ASSERT_EQ(vals.size(), 3);
+  ASSERT_EQ(vals[0], "tol=1e-6");
+  ASSERT_EQ(vals[1], "maxiter=100");
+  ASSERT_EQ(vals[2], "solver=CG");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, multitoken_short)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("prm,p", po::value<std::vector<std::string>>()->multitoken(), "Params")
+    ;
+
+  const char* argv[] = {"program", "-p", "a=1", "b=2"};
+  int argc = 4;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+
+  auto vals = vm["prm"].as<std::vector<std::string>>();
+  ASSERT_EQ(vals.size(), 2);
+  ASSERT_EQ(vals[0], "a=1");
+  ASSERT_EQ(vals[1], "b=2");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, positional_arguments_remaining)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("prm,p", po::value<std::vector<std::string>>()->multitoken(), "Params")
+    ;
+
+  po::positional_options_description p;
+  p.add("prm", -1); // -1 means all remaining positional args
+
+  const char* argv[] = {"program", "x=1", "y=2", "z=3"};
+  int argc = 4;
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, const_cast<char**>(argv))
+              .options(desc).positional(p).run(), vm);
+
+  ASSERT_TRUE(vm.count("prm"));
+  auto vals = vm["prm"].as<std::vector<std::string>>();
+  ASSERT_EQ(vals.size(), 3);
+  ASSERT_EQ(vals[0], "x=1");
+  ASSERT_EQ(vals[1], "y=2");
+  ASSERT_EQ(vals[2], "z=3");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, positional_arguments_fixed_count)
+{
+  po::options_description desc("Test");
+  std::string input;
+  desc.add_options()
+    ("input,i", po::value<std::string>(&input)->required(), "Input file")
+    ;
+
+  po::positional_options_description pd;
+  pd.add("input", 1); // exactly 1 positional argument
+
+  const char* argv[] = {"program", "data.mtx"};
+  int argc = 2;
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, const_cast<char**>(argv))
+              .options(desc).positional(pd).run(), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(input, "data.mtx");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, mixed_options_and_positional)
+{
+  po::options_description desc("Test");
+  int size = 0;
+  std::vector<std::string> prm;
+  desc.add_options()
+    ("size,n", po::value<int>(&size)->default_value(32), "Size")
+    ("prm,p", po::value<std::vector<std::string>>()->multitoken(), "Params")
+    ;
+
+  po::positional_options_description p;
+  p.add("prm", -1);
+
+  const char* argv[] = {"program", "--size", "64", "a=1", "b=2"};
+  int argc = 5;
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, const_cast<char**>(argv))
+              .options(desc).positional(p).run(), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(vm["size"].as<int>(), 64);
+  ASSERT_EQ(size, 64);
+
+  auto vals = vm["prm"].as<std::vector<std::string>>();
+  ASSERT_EQ(vals.size(), 2);
+  ASSERT_EQ(vals[0], "a=1");
+  ASSERT_EQ(vals[1], "b=2");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, multiple_value_types)
+{
+  po::options_description desc("Test");
+  int i = 0;
+  double d = 0.0;
+  std::string s;
+  bool b = false;
+
+  desc.add_options()
+    ("int", po::value<int>(&i)->default_value(42), "Int")
+    ("double", po::value<double>(&d)->default_value(3.14), "Double")
+    ("string", po::value<std::string>(&s)->default_value("hello"), "String")
+    ("bool", po::bool_switch(&b)->default_value(false), "Bool")
+    ;
+
+  const char* argv[] = {"program", "--int", "99", "--double", "2.71",
+                        "--string", "world", "--bool"};
+  int argc = 8;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(vm["int"].as<int>(), 99);
+  ASSERT_EQ(i, 99);
+
+  ASSERT_DOUBLE_EQ(vm["double"].as<double>(), 2.71);
+  ASSERT_DOUBLE_EQ(d, 2.71);
+
+  ASSERT_EQ(vm["string"].as<std::string>(), "world");
+  ASSERT_EQ(s, "world");
+
+  ASSERT_TRUE(vm["bool"].as<bool>());
+  ASSERT_TRUE(b);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, all_defaults)
+{
+  po::options_description desc("Test");
+  int i = -1;
+  double d = -1.0;
+  std::string s = "none";
+
+  desc.add_options()
+    ("int", po::value<int>(&i)->default_value(42), "Int")
+    ("double", po::value<double>(&d)->default_value(3.14), "Double")
+    ("string", po::value<std::string>(&s)->default_value("hello"), "String")
+    ;
+
+  const char* argv[] = {"program"};
+  int argc = 1;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  // Default values should be applied
+  ASSERT_EQ(i, 42);
+  ASSERT_DOUBLE_EQ(d, 3.14);
+  ASSERT_EQ(s, "hello");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, end_of_options_marker)
+{
+  po::options_description desc("Test");
+  std::vector<std::string> files;
+  desc.add_options()
+    ("files", po::value<std::vector<std::string>>()->multitoken(), "Files")
+    ;
+
+  po::positional_options_description p;
+  p.add("files", -1);
+
+  const char* argv[] = {"program", "--", "-a", "-b", "-c"};
+  int argc = 5;
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, const_cast<char**>(argv))
+              .options(desc).positional(p).run(), vm);
+
+  // After --, all tokens should be treated as positional
+  auto vals = vm["files"].as<std::vector<std::string>>();
+  ASSERT_EQ(vals.size(), 3);
+  ASSERT_EQ(vals[0], "-a");
+  ASSERT_EQ(vals[1], "-b");
+  ASSERT_EQ(vals[2], "-c");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, count_checks)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("help,h", "Help")
+    ("opt", po::value<int>()->default_value(0), "Option")
+    ;
+
+  // Option not provided
+  {
+    const char* argv[] = {"program"};
+    int argc = 1;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+
+    // bare flag without default -> count false
+    ASSERT_FALSE(vm.count("help"));
+    // option with default -> count true even when not provided
+    ASSERT_TRUE(vm.count("opt"));
+  }
+
+  // Option provided
+  {
+    const char* argv[] = {"program", "--help"};
+    int argc = 2;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+
+    ASSERT_TRUE(vm.count("help"));
+    ASSERT_TRUE(vm.count("opt")); // has default
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, parse_command_line_convenience)
+{
+  po::options_description desc("Test");
+  std::string val;
+  desc.add_options()
+    ("opt,o", po::value<std::string>(&val), "Option")
+    ;
+
+  const char* argv[] = {"program", "-o", "test"};
+  int argc = 3;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(val, "test");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, type_mismatch_throws)
+{
+  po::options_description desc("Test");
+  desc.add_options()
+    ("opt", po::value<int>()->default_value(0), "Option")
+    ;
+
+  const char* argv[] = {"program", "--opt", "42"};
+  int argc = 3;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+
+  // Asking for wrong type should throw
+  ASSERT_THROW(vm["opt"].as<std::string>(), std::logic_error);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, bound_variable_all_types)
+{
+  po::options_description desc("Test");
+  int iv = 0;
+  double dv = 0.0;
+  std::string sv;
+  bool bv = false;
+
+  desc.add_options()
+    ("i", po::value<int>(&iv), "int")
+    ("d", po::value<double>(&dv), "double")
+    ("s", po::value<std::string>(&sv), "string")
+    ("b", po::bool_switch(&bv)->default_value(false), "bool")
+    ;
+
+  const char* argv[] = {"program", "--i", "7", "--d", "1.5", "--s", "foo", "--b"};
+  int argc = 8;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(iv, 7);
+  ASSERT_DOUBLE_EQ(dv, 1.5);
+  ASSERT_EQ(sv, "foo");
+  ASSERT_TRUE(bv);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, multiple_occurrences_overwrite)
+{
+  po::options_description desc("Test");
+  std::string val;
+  desc.add_options()
+    ("opt", po::value<std::string>(&val), "Option")
+    ;
+
+  // If same option appears multiple times, last value wins
+  const char* argv[] = {"program", "--opt", "first", "--opt", "second"};
+  int argc = 5;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  ASSERT_EQ(val, "second");
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+TEST(TestProgramOptions, multitoken_with_default)
+{
+  po::options_description desc("Test");
+  po::typed_value<std::vector<std::string>>* tv =
+    po::value<std::vector<std::string>>()->multitoken();
+
+  // Setting a default on multitoken is possible
+  // but not commonly used; just test it compiles and stores
+  desc.add_options()
+    ("prm,p", tv, "Params")
+    ;
+
+  const char* argv[] = {"program"};
+  int argc = 1;
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, const_cast<char**>(argv), desc), vm);
+  po::notify(vm);
+
+  // Without specified multi-default, count is false
+  ASSERT_FALSE(vm.count("prm"));
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
These classes have a API compatible with `boost::program_options`. They will be used to remove dependency on `boost` for some part of the framework (like Alina for example).
