### PR TITLE
Remove some direct usage of MPI in Alina

### DIFF
--- a/arccore/src/alina/arccore/alina/DistributedSubDomainDeflation.h
+++ b/arccore/src/alina/arccore/alina/DistributedSubDomainDeflation.h
@@ -221,7 +221,13 @@ class DistributedSubDomainDeflation
 
     // Lets see how many deflation vectors are there.
     std::vector<ptrdiff_t> dv_size(comm.size);
-    MPI_Allgather(&ndv, 1, mpi_datatype<ptrdiff_t>(), &dv_size[0], 1, mpi_datatype<ptrdiff_t>(), comm);
+
+    {
+      ConstArrayView<ptrdiff_t> send_buf(1, &ndv);
+      ArrayView<ptrdiff_t> receive_buf(comm.size, &dv_size[0]);
+
+      mpAllGather(comm.m_message_passing_mng.get(), send_buf, receive_buf);
+    }
 
     std::partial_sum(dv_size.begin(), dv_size.end(), dv_start.begin() + 1);
     nz = dv_start.back();

--- a/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
+++ b/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
@@ -255,9 +255,9 @@ mpi_graph_perm_index(mpi_communicator comm, int npart, const std::vector<Idx>& p
 
   for (Idx p : part)
     ++loc_part_cnt[p];
-
-  MPI_Exscan(&loc_part_cnt[0], &loc_part_beg[0], npart, mpi_datatype<ptrdiff_t>(), MPI_SUM, comm);
-  MPI_Allreduce(&loc_part_cnt[0], &glo_part_cnt[0], npart, mpi_datatype<ptrdiff_t>(), MPI_SUM, comm);
+  MPI_Datatype ptr_datatype = MPI_LONG_LONG; //mpi_datatype<ptrdiff_t>();
+  MPI_Exscan(&loc_part_cnt[0], &loc_part_beg[0], npart, ptr_datatype, MPI_SUM, comm);
+  MPI_Allreduce(&loc_part_cnt[0], &glo_part_cnt[0], npart, ptr_datatype, MPI_SUM, comm);
 
   glo_part_beg[0] = 0;
   std::partial_sum(glo_part_cnt.begin(), glo_part_cnt.end(), glo_part_beg.begin() + 1);

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.h
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.h
@@ -44,119 +44,6 @@
 namespace Arcane::Alina
 {
 
-/// Converts C type to MPI datatype.
-template <class T, class Enable = void>
-struct mpi_datatype_impl
-{
-  static MPI_Datatype get()
-  {
-    static const MPI_Datatype t = create();
-    return t;
-  }
-
-  static MPI_Datatype create()
-  {
-    static_assert(false,"BAD");
-    typedef typename math::scalar_of<T>::type S;
-    MPI_Datatype t;
-    int n = sizeof(T) / sizeof(S);
-    MPI_Type_contiguous(n, mpi_datatype_impl<S>::get(), &t);
-    MPI_Type_commit(&t);
-    return t;
-  }
-};
-
-template <>
-struct mpi_datatype_impl<float>
-{
-  static MPI_Datatype get() { return MPI_FLOAT; }
-};
-
-template <>
-struct mpi_datatype_impl<double>
-{
-  static MPI_Datatype get() { return MPI_DOUBLE; }
-};
-
-template <>
-struct mpi_datatype_impl<long double>
-{
-  static MPI_Datatype get() { return MPI_LONG_DOUBLE; }
-};
-
-template <>
-struct mpi_datatype_impl<int>
-{
-  static MPI_Datatype get() { return MPI_INT; }
-};
-
-template <>
-struct mpi_datatype_impl<unsigned>
-{
-  static MPI_Datatype get() { return MPI_UNSIGNED; }
-};
-
-template <>
-struct mpi_datatype_impl<long long>
-{
-  static MPI_Datatype get() { return MPI_LONG_LONG_INT; }
-};
-
-template <>
-struct mpi_datatype_impl<unsigned long long>
-{
-  static MPI_Datatype get() { return MPI_UNSIGNED_LONG_LONG; }
-};
-
-#if (MPI_VERSION > 2) || (MPI_VERSION == 2 && MPI_SUBVERSION >= 2)
-template <>
-struct mpi_datatype_impl<std::complex<double>>
-{
-  static MPI_Datatype get() { return MPI_CXX_DOUBLE_COMPLEX; }
-};
-
-template <>
-struct mpi_datatype_impl<std::complex<float>>
-{
-  static MPI_Datatype get() { return MPI_CXX_FLOAT_COMPLEX; }
-};
-#endif
-
-template <typename T>
-struct mpi_datatype_impl<T,
-                         typename std::enable_if<
-                         std::is_same<T, ptrdiff_t>::value &&
-                         !std::is_same<ptrdiff_t, long long>::value &&
-                         !std::is_same<ptrdiff_t, int>::value>::type> : std::conditional<sizeof(ptrdiff_t) == sizeof(int), mpi_datatype_impl<int>, mpi_datatype_impl<long long>>::type
-{};
-
-template <typename T>
-struct mpi_datatype_impl<T,
-                         typename std::enable_if<
-                         std::is_same<T, size_t>::value &&
-                         !std::is_same<size_t, unsigned long long>::value &&
-                         !std::is_same<ptrdiff_t, unsigned int>::value>::type>
-: std::conditional<
-  sizeof(size_t) == sizeof(unsigned), mpi_datatype_impl<unsigned>, mpi_datatype_impl<unsigned long long>>::type
-{};
-
-template <>
-struct mpi_datatype_impl<char>
-{
-  static MPI_Datatype get() { return MPI_CHAR; }
-};
-
-/*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
-/*!
- * \brief Wrapper to obtain the equivalent MPI datatype for a datatype.
- */
-template <typename T>
-MPI_Datatype mpi_datatype()
-{
-  return mpi_datatype_impl<T>::get();
-}
-
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -277,7 +164,7 @@ struct mpi_communicator
     int lc = static_cast<int>(cond);
     int gc = _reduce(MPI_PROD, lc);
 
-    if (!gc) {
+    if (gc==0) {
       IMessagePassingMng* pm = m_message_passing_mng.get();
       UniqueArray<int> c(size);
       if (rank == 0)
@@ -339,12 +226,11 @@ struct mpi_communicator
 
  private:
 
-  template <typename T> T _reduce(MPI_Op op, const T& lval) const
+  int _reduce(MPI_Op op, int lval) const
   {
-    const int elems = math::static_rows<T>::value * math::static_cols<T>::value;
-    T gval;
+    int gval = 0;
 
-    MPI_Allreduce((void*)&lval, &gval, elems, mpi_datatype<T>(), op, comm);
+    MPI_Allreduce((void*)&lval, &gval, 1, MPI_INT, op, comm);
     return gval;
   }
 

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.h
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.h
@@ -56,6 +56,7 @@ struct mpi_datatype_impl
 
   static MPI_Datatype create()
   {
+    static_assert(false,"BAD");
     typedef typename math::scalar_of<T>::type S;
     MPI_Datatype t;
     int n = sizeof(T) / sizeof(S);
@@ -225,7 +226,10 @@ struct mpi_communicator
     // TODO: Use scan.
     std::vector<T> v(size + 1);
     v[0] = 0;
-    MPI_Allgather(&n, 1, mpi_datatype<T>(), &v[1], 1, mpi_datatype<T>(), comm);
+    T v0 = n;
+    ConstArrayView<T> v0_view(1, &v0);
+    ArrayView<T> out_view(static_cast<Int32>(v.size()), &v[1]);
+    mpAllGather(m_message_passing_mng.get(), v0_view, out_view);
     std::partial_sum(v.begin(), v.end(), v.begin());
     return v;
   }
@@ -274,8 +278,12 @@ struct mpi_communicator
     int gc = _reduce(MPI_PROD, lc);
 
     if (!gc) {
-      std::vector<int> c(size);
-      MPI_Gather(&lc, 1, MPI_INT, &c[0], size, MPI_INT, 0, comm);
+      IMessagePassingMng* pm = m_message_passing_mng.get();
+      UniqueArray<int> c(size);
+      if (rank == 0)
+        c.resize(size);
+      ConstArrayView<int> in_view(1, &lc);
+      mpGather(pm, in_view, c, 0);
       if (rank == 0) {
         std::cerr << "Failed assumption: " << message << std::endl;
         std::cerr << "Offending processes:";
@@ -284,7 +292,7 @@ struct mpi_communicator
             std::cerr << " " << i;
         std::cerr << std::endl;
       }
-      MPI_Barrier(comm);
+      mpBarrier(pm);
       ARCCORE_FATAL("CheckError in MessagePassingUtils: {0}", message);
     }
   }

--- a/arccore/src/alina/arccore/alina/samples/DistributedAlinaLibraryUsage.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedAlinaLibraryUsage.cc
@@ -42,9 +42,12 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
 {
   ITraceMng* tm = ctx.traceMng();
 
-  int rank, size;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  Alina::mpi_communicator world(MPI_COMM_WORLD);
+
+  int rank = world.rank;
+  int size = world.size;
+  //MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  //MPI_Comm_size(MPI_COMM_WORLD, &size);
 
   if (rank == 0)
     tm->info() << "World size: " << size;
@@ -60,7 +63,9 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
   ptrdiff_t chunk = part.size(rank);
 
   std::vector<ptrdiff_t> domain(size + 1);
-  MPI_Allgather(&chunk, 1, Alina::mpi_datatype<ptrdiff_t>(), &domain[1], 1, Alina::mpi_datatype<ptrdiff_t>(), MPI_COMM_WORLD);
+  ConstArrayView<ptrdiff_t> send_buf(1, &chunk);
+  ArrayView<ptrdiff_t> receive_buf(size, &domain[1]);
+  mpAllGather(world.m_message_passing_mng.get(), send_buf, receive_buf);
   std::partial_sum(domain.begin(), domain.end(), domain.begin());
 
   ptrdiff_t chunk_start = domain[rank];

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeBP.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeBP.cc
@@ -174,8 +174,9 @@ int main(int argc, char* argv[])
   ptrdiff_t chunk = part.size(world.rank);
 
   std::vector<ptrdiff_t> domain(world.size + 1);
-  MPI_Allgather(&chunk, 1, Alina::mpi_datatype<ptrdiff_t>(),
-                &domain[1], 1, Alina::mpi_datatype<ptrdiff_t>(), world);
+  ConstArrayView<ptrdiff_t> send_buf(1,&chunk);
+  ArrayView<ptrdiff_t> receive_buf(world.size, &domain[1]);
+  mpAllGather(world.m_message_passing_mng.get(),send_buf,receive_buf);
   std::partial_sum(domain.begin(), domain.end(), domain.begin());
 
   lo = part.domain(world.rank).min_corner();

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD.cc
@@ -566,8 +566,9 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
   ptrdiff_t chunk = part.size(world.rank);
 
   std::vector<ptrdiff_t> domain(world.size + 1);
-  MPI_Allgather(&chunk, 1, Alina::mpi_datatype<ptrdiff_t>(),
-                &domain[1], 1, Alina::mpi_datatype<ptrdiff_t>(), world);
+  ConstArrayView<ptrdiff_t> send_buf(1, &chunk);
+  ArrayView<ptrdiff_t> receive_buf(world.size, &domain[1]);
+  mpAllGather(world.m_message_passing_mng.get(), send_buf, receive_buf);
   std::partial_sum(domain.begin(), domain.end(), domain.begin());
 
   lo = part.domain(world.rank).min_corner();

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD3D.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD3D.cc
@@ -214,8 +214,9 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
   ptrdiff_t chunk = part.size(world.rank);
 
   std::vector<ptrdiff_t> domain(world.size + 1);
-  MPI_Allgather(&chunk, 1, Alina::mpi_datatype<ptrdiff_t>(),
-                &domain[1], 1, Alina::mpi_datatype<ptrdiff_t>(), world);
+  ConstArrayView<ptrdiff_t> send_buf(1, &chunk);
+  ArrayView<ptrdiff_t> receive_buf(world.size, &domain[1]);
+  mpAllGather(world.m_message_passing_mng.get(), send_buf, receive_buf);
   std::partial_sum(domain.begin(), domain.end(), domain.begin());
 
   lo = part.domain(world.rank).min_corner();

--- a/arccore/src/alina/arccore/alina/samples/DistributedSPMM.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedSPMM.cc
@@ -16,11 +16,6 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include <iostream>
-#include <vector>
-
-#include <boost/scope_exit.hpp>
-
 #include "arccore/alina/BuiltinBackend.h"
 #include "arccore/alina/StaticMatrix.h"
 #include "arccore/alina/Adapters.h"
@@ -28,6 +23,9 @@
 #include "arccore/alina/IO.h"
 
 #include "arccore/alina/Profiler.h"
+
+#include <iostream>
+#include <vector>
 
 using namespace Arcane;
 
@@ -75,9 +73,13 @@ void assemble(int n, int beg, int end,
 template <class Val>
 void test()
 {
-  typedef typename math::rhs_of<Val>::type Rhs;
+  // In case of block, Rhs may be a StaticMatrix.
+  using Rhs = math::rhs_of<Val>::type;
+  using ScalarRhs = math::scalar_of<Rhs>::type;
+  int nb_scalar_for_rhs = sizeof(Rhs) / sizeof(ScalarRhs);
 
   Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  IMessagePassingMng* pm = comm.m_message_passing_mng.get();
 
   int n = 16;
   int chunk_len = (n + comm.size - 1) / comm.size;
@@ -85,11 +87,9 @@ void test()
   int chunk_end = std::min(n, chunk_len * (comm.rank + 1));
   int chunk = chunk_end - chunk_beg;
 
-  std::vector<int> chunks(comm.size);
-  MPI_Allgather(&chunk, 1, MPI_INT, &chunks[0], 1, MPI_INT, comm);
-  std::vector<int> displ(comm.size, 0);
-  for (int i = 1; i < comm.size; ++i)
-    displ[i] = displ[i - 1] + chunks[i - 1];
+  UniqueArray<int> chunks(comm.size);
+  ConstArrayView<int> sent_chunk(1,&chunk);
+  mpAllGather(pm,sent_chunk,chunks);
 
   std::vector<int> ptr;
   std::vector<int> col;
@@ -112,11 +112,23 @@ void test()
 
   Alina::backend::spmv(1, *B, x, 0, y);
 
-  std::vector<Rhs> X(n), R(n);
-  MPI_Gatherv(&x[0], chunk, Alina::mpi_datatype<Rhs>(), &X[0], &chunks[0], &displ[0], Alina::mpi_datatype<Rhs>(), 0, comm);
-  MPI_Gatherv(&y[0], chunk, Alina::mpi_datatype<Rhs>(), &R[0], &chunks[0], &displ[0], Alina::mpi_datatype<Rhs>(), 0, comm);
+  // Because Rhs may be a StaticMatrix and it is not a basic type
+  // we convert it to an array of basic type (which is math::scalar_of<Rhs>::type).
+  UniqueArray<ScalarRhs> scalarX;
+  UniqueArray<ScalarRhs> scalarR;
+  Span<const ScalarRhs> scalar_x_view(reinterpret_cast<ScalarRhs*>(x.data()), x.size() * nb_scalar_for_rhs);
+  Span<const ScalarRhs> scalar_r_view(reinterpret_cast<ScalarRhs*>(y.data()), y.size() * nb_scalar_for_rhs);
+  mpGatherVariable(pm, scalar_x_view, scalarX, 0);
+  mpGatherVariable(pm, scalar_r_view, scalarR, 0);
 
   if (comm.rank == 0) {
+    std::cout << "Doing verification size=" << scalarX.size() << "\n";
+    Rhs* scalar_x_begin = reinterpret_cast<Rhs*>(scalarX.data());
+    std::vector<Rhs> X(scalar_x_begin, scalar_x_begin + n);
+
+    Rhs* scalar_r_begin = reinterpret_cast<Rhs*>(scalarR.data());
+    std::vector<Rhs> R(scalar_r_begin, scalar_r_begin + n);
+
     std::vector<Rhs> Y(n);
     assemble(n, 0, n, ptr, col, val);
 
@@ -135,12 +147,8 @@ void test()
 int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
-  BOOST_SCOPE_EXIT(void)
-  {
-    MPI_Finalize();
-  }
-  BOOST_SCOPE_EXIT_END
 
   test<double>();
   test<Alina::StaticMatrix<double, 2, 2>>();
+  MPI_Finalize();
 }


### PR DESCRIPTION
This is replaced by use of `IMessagePassingMng`.
