### PR TITLE
Add mixed precision option for CprAMG, ILUk and ColorILU0

### DIFF
--- a/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/mcg/linear_solver/MCGInternalLinearSolver.cc
+++ b/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/mcg/linear_solver/MCGInternalLinearSolver.cc
@@ -289,11 +289,17 @@ MCGInternalLinearSolver::init()
   if (!m_options->ILUk().empty()) {
     m_solver->setOpt(MCGSolver::eOptType::ILUkLevel, m_options->ILUk()[0]->levelOfFill());
     m_solver->setOpt(MCGSolver::eOptType::ILUkSp, m_options->ILUk()[0]->sp());
+    m_solver->setOpt(MCGSolver::eOptType::UseMXP, m_options->ILUk()[0]->mxp());
+  }
+
+  if (!m_options->ColorILU0().empty()) {
+    m_solver->setOpt(MCGSolver::eOptType::UseMXP, m_options->ColorILU0()[0]->mxp());
   }
 
   if (!m_options->CprAmg().empty()) {
     m_solver->setOpt(MCGSolver::eOptType::CxrSolver, m_options->CprAmg()[0]->cxrSolver());
     m_solver->setOpt(MCGSolver::eOptType::RelaxSolver, m_options->CprAmg()[0]->relaxSolver());
+    m_solver->setOpt(MCGSolver::eOptType::UseMXP, m_options->CprAmg()[0]->mxp());
   }
 
   if (!m_options->amgx().empty()) {

--- a/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/mcg/linear_solver/arcane/MCGSolver.axl
+++ b/alien/ArcaneInterface/modules/ifpen_solvers/src/alien/kernels/mcg/linear_solver/arcane/MCGSolver.axl
@@ -152,6 +152,12 @@
                     <description>Block Jacobi preconditioner for MPI</description>
                 </enumvalue>
             </enumeration>
+            <simple name="mxp" type="bool" default="false">
+                <description>
+                    Mixed precision preconditioner: vector operands are fp64
+                    but preconditioner application is done with fp32.
+                </description>
+            </simple>
         </complex>
 
         <complex name="ILUk" type="ILUkOptType" minOccurs="0" maxOccurs="1">
@@ -160,17 +166,26 @@
                 <description>fill level</description>
             </simple>
             <simple name="sp" type="bool" default="true">
-                <description>Use single precision ILU matrix</description>
+                <description>
+                    Use fp32 ILU matrix but triangular solves are done with fp64.
+                    Corresponds to the legacy IFPSolver behavior.
+                </description>
+            </simple>
+            <simple name="mxp" type="bool" default="false">
+                <description>
+                    Mixed precision preconditioner: vector operands are fp64
+                    but preconditioner application is done with fp32.
+                </description>
             </simple>
             <enumeration name="ordering" type="MCGSolver::Graph::Ordering::eType" default="None">
                 <enumvalue name="None" genvalue="MCGSolver::Graph::Ordering::None">
                     <description>No ordering</description>
                 </enumvalue>
                 <enumvalue name="RCM" genvalue="MCGSolver::Graph::Ordering::RCM">
-                    <description>Reverse Cuthill–McKee ordering</description>
+                    <description>Reverse Cuthill-McKee ordering</description>
                 </enumvalue>
                 <enumvalue name="CM" genvalue="MCGSolver::Graph::Ordering::CM">
-                    <description>Cuthill–McKee ordering</description>
+                    <description>Cuthill-McKee ordering</description>
                 </enumvalue>
             </enumeration>
         </complex>
@@ -233,6 +248,12 @@
             </simple>
             <simple name="dir" type="string" default="+Z">
                 <description>Coloring preferential direction</description>
+            </simple>
+            <simple name="mxp" type="bool" default="false">
+                <description>
+                    Mixed precision preconditioner: vector operands are fp64
+                    but preconditioner application is done with fp32.
+                </description>
             </simple>
         </complex>
 


### PR DESCRIPTION
This option allow CprAMG, ColorILU0 and ILUk to be applied with fp32 but using f64 operands (from an fp64 Krylov).
This option is effective from MCGSolver 3.0.5 but may requires some specific versions of Hypre
There is no restriction with AMGX.
You can still use MCGSolver 3.0.4 if you do not use this option.