### PR TITLE
[CI] Add alina in vcpkg workflow

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Configure build script
         shell: bash
         run: |
-          cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_VERBOSE_MAKEFILE=TRUE -DVCPKG_INSTALLED_DIR="${{ env.VCPKG_BUILD_DIR }}/installed" -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.cmake_specific_args }} -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" -GNinja -DARCANE_FORCE_NOASNEEDED=TRUE -DCMAKE_INSTALL_PREFIX="${{ env.CMAKE_BUILD_DIR }}/install"
+          cmake -S "${{ github.workspace }}" -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_VERBOSE_MAKEFILE=TRUE -DVCPKG_INSTALLED_DIR="${{ env.VCPKG_BUILD_DIR }}/installed" -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.cmake_specific_args }} -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" -GNinja -DARCANE_FORCE_NOASNEEDED=TRUE -DARCCORE_ENABLE_ALINA=ON -DCMAKE_INSTALL_PREFIX="${{ env.CMAKE_BUILD_DIR }}/install"
 
       - name: Dump Some Generated files
         shell: bash
@@ -250,7 +250,7 @@ jobs:
       - name: Test arcane
         shell: bash
         run: |
-          cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }} -E python_test
+          cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure ${{ matrix.ctest_specific_args }} -E 'python_test|alina'
 
       - name: Test Aleph kappa
         if: matrix.base_os != 'windows'
@@ -282,6 +282,15 @@ jobs:
         shell: bash
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R compare
+
+      # At the moment there is a bug in the test on Win32 in debug.
+      # Some tests are failing with the following error message:
+      # include\vector(122) : Assertion failed: cannot seek vector iterator after end
+      - name: Test alina
+        shell: bash
+        if: matrix.full_name == 'windows-2022-cxx20-intelmpi'
+        run: |
+          cd "${{ env.CMAKE_BUILD_DIR }}" && ctest --output-on-failure -R alina
 
       # Comme ces tests sont un peu long on ne les exécute que sous Windows.
       # Pour Linux, ils sont déjà lancés dans des CI dédiés.

--- a/arccore/src/alina/arccore/alina/AlinaGlobal.cc
+++ b/arccore/src/alina/arccore/alina/AlinaGlobal.cc
@@ -13,6 +13,7 @@
 
 // These files are not used but we need to include them to export symbols
 #include "arccore/alina/SolverBase.h"
+#include "arccore/alina/RelaxationBase.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/alina/arccore/alina/AlinaGlobal.h
+++ b/arccore/src/alina/arccore/alina/AlinaGlobal.h
@@ -19,7 +19,7 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#ifdef ARCANE_COMPONENT_arcane_alina
+#ifdef ARCCORE_COMPONENT_arccore_alina
 #define ARCCORE_ALINA_EXPORT ARCCORE_EXPORT
 #else
 #define ARCCORE_ALINA_EXPORT ARCCORE_IMPORT

--- a/arccore/src/alina/arccore/alina/CMakeLists.txt
+++ b/arccore/src/alina/arccore/alina/CMakeLists.txt
@@ -4,10 +4,7 @@ arccore_add_component_library(alina
   FILES ${SOURCES}
 )
 
-target_compile_definitions(arccore_alina PRIVATE ARCANE_COMPONENT_arccore_alina)
-
 target_link_libraries(arccore_alina PUBLIC arccore_accelerator)
-#arcane_register_library(arccore_alina OPTIONAL)
 
 if (ARCCORE_CXX_COMPILER_IS_GNU_OR_CLANG_BASED)
   target_compile_options(arccore_alina PUBLIC -Wno-conversion -Wno-float-conversion)


### PR DESCRIPTION
At the moment tests are only enabled in release versions of windows because there is assertion error in the Win32 STL when using `std::vector`.
