### PR TITLE
[CI] Activate alina tests on windows

### DIFF
--- a/.github/workflows/compile-all-vcpkg.yml
+++ b/.github/workflows/compile-all-vcpkg.yml
@@ -284,12 +284,8 @@ jobs:
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest ${{ env.CTEST_ARGS }} -R compare
 
-      # At the moment there is a bug in the test on Win32 in debug.
-      # Some tests are failing with the following error message:
-      # include\vector(122) : Assertion failed: cannot seek vector iterator after end
       - name: Test alina
         shell: bash
-        if: matrix.full_name == 'windows-2022-cxx20-intelmpi'
         run: |
           cd "${{ env.CMAKE_BUILD_DIR }}" && ctest ${{ env.CTEST_ARGS }} -R alina
 


### PR DESCRIPTION
The tests were disabled because of errors messages on Win32 when compiling in debug when using `std::vector`.
Theses errors have been removed in the PR #2750.