### PR TITLE
Decouple ghost layer builders from dynamic mesh

### DIFF
--- a/arcane/src/arcane/core/internal/IMeshInternal.h
+++ b/arcane/src/arcane/core/internal/IMeshInternal.h
@@ -25,6 +25,11 @@ namespace Arcane
 class IItemConnectivityMng;
 class IPolyhedralMeshModifier;
 class IItemFamilySerializerMngInternal;
+namespace mesh
+{
+  class ItemInternalMap;
+  class FaceFamily;
+}
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -75,6 +80,19 @@ class ARCANE_CORE_EXPORT IMeshInternal
    * @return This method returns nullptr if the manager does not exist.
    */
   virtual IItemFamilySerializerMngInternal* familySerializerMng() const noexcept { return nullptr; }
+
+  /*! Temporary add of DynamicMesh and DynamicMeshIncrementalBuilder methods
+   * to make GhostLayerBuilder independent of DynamicMesh.
+   * These methods may be moved to more specific interfaces.
+ */
+  virtual mesh::ItemInternalMap& nodesMap() = 0;
+  virtual mesh::ItemInternalMap& edgesMap() = 0;
+  virtual mesh::ItemInternalMap& facesMap() = 0;
+  virtual mesh::ItemInternalMap& cellsMap() = 0;
+
+  virtual mesh::FaceFamily& trueFaceFamily() = 0;
+
+  virtual void printStats(Int32 level) = 0;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/DynamicMeshIncrementalBuilder.cc
+++ b/arcane/src/arcane/mesh/DynamicMeshIncrementalBuilder.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DynamicMeshIncrementalBuilder.cc                            (C) 2000-2025 */
+/* DynamicMeshIncrementalBuilder.cc                            (C) 2000-2026 */
 /*                                                                           */
 /* Incremental mesh construction.                                            */
 /*---------------------------------------------------------------------------*/
@@ -1616,7 +1616,7 @@ addGhostLayers(bool is_allocate)
 {
   debug() << "Add one ghost layer";
   if (!m_ghost_layer_builder)
-    m_ghost_layer_builder = new GhostLayerBuilder(this);
+    m_ghost_layer_builder = new GhostLayerBuilder(m_mesh);
   m_ghost_layer_builder->addGhostLayers(is_allocate);
 }
 
@@ -1629,7 +1629,7 @@ addGhostChildFromParent(Array<Int64>& ghost_cell_to_refine)
 {
   debug() << "Add one ghost layer";
   if (!m_ghost_layer_builder)
-    m_ghost_layer_builder = new GhostLayerBuilder(this);
+    m_ghost_layer_builder = new GhostLayerBuilder(m_mesh);
   m_ghost_layer_builder->addGhostChildFromParent2(ghost_cell_to_refine);
 }
 

--- a/arcane/src/arcane/mesh/DynamicMeshInternal.cc
+++ b/arcane/src/arcane/mesh/DynamicMeshInternal.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DynamicMeshInternal.cc                                      (C) 2000-2025 */
+/* DynamicMeshInternal.cc                                      (C) 2000-2026 */
 /*                                                                           */
 /* Internal part of DynamicMesh for Arcane.                                  */
 /*---------------------------------------------------------------------------*/
@@ -16,6 +16,8 @@
 #include "arcane/mesh/DynamicMesh.h"
 #include "arcane/mesh/DynamicMeshIncrementalBuilder.h"
 #include "arcane/mesh/ItemConnectivityMng.h"
+#include "arcane/mesh/FaceFamily.h"
+
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -117,6 +119,38 @@ addCell(ItemUniqueId unique_id, ItemTypeId type_id, ConstArrayView<Int64> nodes_
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
+
+ItemInternalMap& DynamicMeshInternal::nodesMap()
+{
+  return m_mesh->nodesMap();
+}
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+ItemInternalMap& DynamicMeshInternal::edgesMap()
+{
+  return m_mesh->edgesMap();
+}
+
+ItemInternalMap& DynamicMeshInternal::facesMap()
+{
+  return m_mesh->facesMap();
+}
+
+ItemInternalMap& DynamicMeshInternal::cellsMap()
+{
+  return m_mesh->cellsMap();
+}
+
+FaceFamily& DynamicMeshInternal::trueFaceFamily()
+{
+  return m_mesh->trueFaceFamily();
+}
+
+void DynamicMeshInternal::printStats(Int32 level)
+{
+  m_mesh->incrementalBuilder()->printStats(level);
+}
 
 } // namespace Arcane::mesh
 

--- a/arcane/src/arcane/mesh/GhostLayerBuilder.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder.cc
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* GhostLayerBuilder.cc                                        (C) 2000-2025 */
+/* GhostLayerBuilder.cc                                        (C) 2000-2026 */
 /*                                                                           */
 /* Construction of ghost layers.                                             */
 /*---------------------------------------------------------------------------*/
@@ -33,6 +33,7 @@
 #include "arcane/core/IItemFamilySerializer.h"
 #include "arcane/core/ParallelMngUtils.h"
 #include "arcane/core/IGhostLayerMng.h"
+#include "arcane/core/internal/IMeshInternal.h"
 
 #include "arcane/mesh/DynamicMesh.h"
 #include "arcane/mesh/GhostLayerBuilder.h"
@@ -48,7 +49,7 @@ namespace Arcane::mesh
 /*---------------------------------------------------------------------------*/
 
 extern "C++" void
-_buildGhostLayerNewVersion(DynamicMesh* mesh, bool is_allocate, Int32 version);
+_buildGhostLayerNewVersion(IMesh* mesh, bool is_allocate, Int32 version);
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -63,10 +64,10 @@ _buildGhostLayerNewVersion(DynamicMesh* mesh, bool is_allocate, Int32 version);
 /*---------------------------------------------------------------------------*/
 
 GhostLayerBuilder::
-GhostLayerBuilder(DynamicMeshIncrementalBuilder* mesh_builder)
-: TraceAccessor(mesh_builder->mesh()->traceMng())
-, m_mesh(mesh_builder->mesh())
-, m_mesh_builder(mesh_builder)
+GhostLayerBuilder(IMesh* mesh)
+: TraceAccessor(mesh->traceMng())
+, m_mesh(mesh)
+, m_mesh_internal(mesh->_internalApi())
 {
 }
 
@@ -201,10 +202,10 @@ _addOneGhostLayerV2()
 
   Integer nb_sub_domain_boundary_face = 0;
   // Marks nodes on the boundary
-  ItemInternalMap& cells_map = m_mesh->cellsMap(); // Supports mesh transfers
-  ItemInternalMap& faces_map = m_mesh->facesMap(); // Determines boundaries before transfer
-  // ItemInternalMap& edges_map = m_mesh->edgesMap(); // Not directly used by the algorithm
-  ItemInternalMap& nodes_map = m_mesh->nodesMap(); // Locates modifications
+  ItemInternalMap& cells_map = m_mesh_internal->cellsMap(); // Supports mesh transfers
+  ItemInternalMap& faces_map = m_mesh_internal->facesMap(); // Determines boundaries before transfer
+  // ItemInternalMap& edges_map = m_mesh_internal->edgesMap(); // Not directly used by the algorithm
+  ItemInternalMap& nodes_map = m_mesh_internal->nodesMap(); // Locates modifications
 
   const int shared_and_boundary_flags = ItemFlags::II_Shared | ItemFlags::II_SubDomainBoundary;
   // Iterates over faces and marks boundary nodes, edges, and faces
@@ -443,7 +444,7 @@ _addOneGhostLayerV2()
 
   // Sends and receives ghost cells
   _exchangeCells(cells_to_send, false);
-  m_mesh_builder->printStats();
+  m_mesh_internal->printStats(TraceMessage::DEFAULT_LEVEL);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -507,9 +508,9 @@ addGhostChildFromParent()
   Integer sid = pm->commRank();
 
   // Mark the nodes on the boundary
-  ItemInternalMap& cells_map = m_mesh->cellsMap();
+  ItemInternalMap& cells_map = m_mesh_internal->cellsMap();
 
-  FaceFamily& true_face_family = m_mesh->trueFaceFamily();
+  FaceFamily& true_face_family = m_mesh_internal->trueFaceFamily();
 
   //TODO: choose correct value to initialize the table
   BoundaryInfosMap boundary_infos_to_send(200, true);
@@ -580,7 +581,7 @@ addGhostChildFromParent()
   }
   // Sends and receives ghost cells
   _exchangeCells(cells_to_send, true);
-  m_mesh_builder->printStats();
+  m_mesh_internal->printStats(TraceMessage::DEFAULT_LEVEL);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -602,7 +603,7 @@ addGhostChildFromParent2(Array<Int64>& ghost_cell_to_refine)
   Integer sid = pm->commRank();
 
   // Mark the nodes on the boundary
-  ItemInternalMap& cells_map = m_mesh->cellsMap();
+  ItemInternalMap& cells_map = m_mesh_internal->cellsMap();
 
   //TODO: choose correct value to initialize the table
   BoundaryInfosMap boundary_infos_to_send(200, true);
@@ -675,7 +676,7 @@ addGhostChildFromParent2(Array<Int64>& ghost_cell_to_refine)
 
   // Sends and receives ghost cells
   _exchangeCells(cells_to_send, true);
-  m_mesh_builder->printStats();
+  m_mesh_internal->printStats(TraceMessage::DEFAULT_LEVEL);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/GhostLayerBuilder.h
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* GhostLayerBuilder.h                                         (C) 2000-2024 */
+/* GhostLayerBuilder.h                                         (C) 2000-2026 */
 /*                                                                           */
 /* Construction of ghost layers.                                             */
 /*---------------------------------------------------------------------------*/
@@ -14,9 +14,8 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arcane/mesh/DynamicMeshKindInfos.h"
 #include "arcane/utils/TraceAccessor.h"
-
-#include "arcane/mesh/DynamicMeshIncrementalBuilder.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -48,7 +47,7 @@ class GhostLayerBuilder
  public:
 
   //! Constructs an instance for the \a mesh.
-  explicit GhostLayerBuilder(DynamicMeshIncrementalBuilder* mesh_builder);
+  explicit GhostLayerBuilder(IMesh* mesh);
   virtual ~GhostLayerBuilder();
 
  public:
@@ -61,8 +60,8 @@ class GhostLayerBuilder
 
  private:
 
-  DynamicMesh* m_mesh;
-  DynamicMeshIncrementalBuilder* m_mesh_builder;
+  IMesh* m_mesh = nullptr;
+  IMeshInternal* m_mesh_internal = nullptr;
 
  private:
 

--- a/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
+++ b/arcane/src/arcane/mesh/GhostLayerBuilder2.cc
@@ -28,9 +28,11 @@
 #include "arcane/core/IItemFamilyPolicyMng.h"
 #include "arcane/core/IItemFamilySerializer.h"
 #include "arcane/core/ParallelMngUtils.h"
+#include "arcane/core/internal/IMeshInternal.h"
 
 #include "arcane/mesh/DynamicMesh.h"
 #include "arcane/mesh/DynamicMeshIncrementalBuilder.h"
+#include "arcane/utils/ScopedPtr.h"
 
 #include <algorithm>
 #include <set>
@@ -61,7 +63,7 @@ class GhostLayerBuilder2
  public:
 
   //! Constructs an instance for the mesh \a mesh
-  GhostLayerBuilder2(DynamicMeshIncrementalBuilder* mesh_builder, bool is_allocate, Int32 version);
+  GhostLayerBuilder2(IMesh* mesh, bool is_allocate, Int32 version);
 
  public:
 
@@ -69,8 +71,8 @@ class GhostLayerBuilder2
 
  private:
 
-  DynamicMesh* m_mesh = nullptr;
-  DynamicMeshIncrementalBuilder* m_mesh_builder = nullptr;
+  IMesh* m_mesh = nullptr;
+  IMeshInternal* m_mesh_internal = nullptr;
   IParallelMng* m_parallel_mng = nullptr;
   bool m_is_verbose = false;
   bool m_is_allocate = false;
@@ -93,10 +95,10 @@ class GhostLayerBuilder2
 /*---------------------------------------------------------------------------*/
 
 GhostLayerBuilder2::
-GhostLayerBuilder2(DynamicMeshIncrementalBuilder* mesh_builder, bool is_allocate, Int32 version)
-: TraceAccessor(mesh_builder->mesh()->traceMng())
-, m_mesh(mesh_builder->mesh())
-, m_mesh_builder(mesh_builder)
+GhostLayerBuilder2(IMesh* mesh, bool is_allocate, Int32 version)
+: TraceAccessor(mesh->traceMng())
+, m_mesh(mesh)
+, m_mesh_internal(mesh->_internalApi())
 , m_parallel_mng(m_mesh->parallelMng())
 , m_is_allocate(is_allocate)
 , m_version(version)
@@ -318,8 +320,8 @@ addGhostLayers()
   if (is_non_manifold && (m_version != 3))
     ARCANE_FATAL("Only version 3 of ghostlayer builder is supported for non manifold meshes");
 
-  ItemInternalMap& cells_map = m_mesh->cellsMap();
-  ItemInternalMap& nodes_map = m_mesh->nodesMap();
+  ItemInternalMap& cells_map = m_mesh_internal->cellsMap();
+  ItemInternalMap& nodes_map = m_mesh_internal->nodesMap();
 
   Integer boundary_nodes_uid_count = 0;
 
@@ -437,7 +439,7 @@ _markBoundaryNodes(ArrayView<Int32> node_layer)
 {
   IParallelMng* pm = m_mesh->parallelMng();
   const Int32 my_rank = pm->commRank();
-  ItemInternalMap& faces_map = m_mesh->facesMap();
+  ItemInternalMap& faces_map = m_mesh_internal->facesMap();
   // TODO: check if it is correct to modify ItemFlags::II_SubDomainBoundary
   const int shared_and_boundary_flags = ItemFlags::II_Shared | ItemFlags::II_SubDomainBoundary;
   // Iterates over faces and marks boundary nodes, edges and faces
@@ -478,8 +480,8 @@ _addGhostLayer(Integer current_layer, Int32ConstArrayView node_layer)
 
   bool is_verbose = m_is_verbose;
 
-  ItemInternalMap& cells_map = m_mesh->cellsMap();
-  ItemInternalMap& nodes_map = m_mesh->nodesMap();
+  ItemInternalMap& cells_map = m_mesh_internal->cellsMap();
+  ItemInternalMap& nodes_map = m_mesh_internal->nodesMap();
 
   Int64 nb_added_for_different_rank = 0;
   Int64 nb_added_for_in_layer = 0;
@@ -949,9 +951,13 @@ _sendAndReceiveCells(SubDomainItemMap& cells_to_send)
   for (Integer i = 0, ns = exchanger->nbReceiver(); i < ns; ++i) {
     ISerializeMessage* sm = exchanger->messageToReceive(i);
     ISerializer* s = sm->serializer();
-    m_mesh->addCells(s);
+    // Do not use DynamicMesh but use cell serializer as in GhostLayerBuilder v1
+    // m_mesh->addCells(s);
+    s->setMode(ISerializer::ModeGet);
+    ScopedPtrT<IItemFamilySerializer> cell_serializer(m_mesh->cellFamily()->policyMng()->createSerializer());
+    cell_serializer->deserializeItems(s, nullptr);
   }
-  m_mesh_builder->printStats();
+  m_mesh_internal->printStats(TraceMessage::DEFAULT_LEVEL);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -968,7 +974,7 @@ _markBoundaryItems(ArrayView<Int32> node_layer)
 {
   IParallelMng* pm = m_mesh->parallelMng();
   Int32 my_rank = pm->commRank();
-  ItemInternalMap& faces_map = m_mesh->facesMap();
+  ItemInternalMap& faces_map = m_mesh_internal->facesMap();
 
   const int shared_and_boundary_flags = ItemFlags::II_Shared | ItemFlags::II_SubDomainBoundary;
 
@@ -1012,7 +1018,7 @@ _markBoundaryNodesFromEdges(ArrayView<Int32> node_layer)
   // and we mark the corresponding nodes.
   IParallelMng* pm = m_mesh->parallelMng();
   Int32 my_rank = pm->commRank();
-  ItemInternalMap& edges_map = m_mesh->edgesMap();
+  ItemInternalMap& edges_map = m_mesh_internal->edgesMap();
   edges_map.eachItem([&](Edge edge) {
     Int32 nb_cell = edge.nbCell();
     Int32 nb_dim2_cell = 0;
@@ -1039,9 +1045,9 @@ _markBoundaryNodesFromEdges(ArrayView<Int32> node_layer)
 /*---------------------------------------------------------------------------*/
 // This function handles versions 3 and 4 of ghost entity calculation.
 extern "C++" void
-_buildGhostLayerNewVersion(DynamicMesh* mesh, bool is_allocate, Int32 version)
+_buildGhostLayerNewVersion(IMesh* mesh, bool is_allocate, Int32 version)
 {
-  GhostLayerBuilder2 glb(mesh->m_mesh_builder, is_allocate, version);
+  GhostLayerBuilder2 glb(mesh, is_allocate, version);
   glb.addGhostLayers();
 }
 

--- a/arcane/src/arcane/mesh/PolyhedralMesh.cc
+++ b/arcane/src/arcane/mesh/PolyhedralMesh.cc
@@ -1214,8 +1214,7 @@ class mesh::PolyhedralMesh::InternalApi
 
   FaceFamily& trueFaceFamily() override
   {
-    m_mesh->traceMng()->fatal() << "PolyhedralMesh::trueFaceFamily() is not implemented. PolyhedralMesh has no concrete FaceFamily.";
-    return *m_empty_face_family;
+    ARCANE_FATAL("PolyhedralMesh::trueFaceFamily() is not implemented. PolyhedralMesh has no concrete FaceFamily.");
   }
 
   void printStats(Int32 level)
@@ -1237,7 +1236,6 @@ class mesh::PolyhedralMesh::InternalApi
   PolyhedralMesh* m_mesh = nullptr;
   std::unique_ptr<IItemConnectivityMng> m_connectivity_mng = nullptr;
   std::unique_ptr<IPolyhedralMeshModifier> m_polyhedral_mesh_modifier = nullptr;
-  FaceFamily* m_empty_face_family = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/PolyhedralMesh.cc
+++ b/arcane/src/arcane/mesh/PolyhedralMesh.cc
@@ -68,6 +68,7 @@
 
 #include "arcane/mesh/ItemConnectivityMng.h"
 #include "arcane/core/ItemPrinter.h"
+#include "arcane/mesh/FaceFamily.h"
 
 #endif
 
@@ -1214,6 +1215,7 @@ class mesh::PolyhedralMesh::InternalApi
   FaceFamily& trueFaceFamily() override
   {
     m_mesh->traceMng()->fatal() << "PolyhedralMesh::trueFaceFamily() is not implemented. PolyhedralMesh has no concrete FaceFamily.";
+    return *m_empty_face_family;
   }
 
   void printStats(Int32 level)
@@ -1235,6 +1237,7 @@ class mesh::PolyhedralMesh::InternalApi
   PolyhedralMesh* m_mesh = nullptr;
   std::unique_ptr<IItemConnectivityMng> m_connectivity_mng = nullptr;
   std::unique_ptr<IPolyhedralMeshModifier> m_polyhedral_mesh_modifier = nullptr;
+  FaceFamily* m_empty_face_family = nullptr;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/arcane/src/arcane/mesh/PolyhedralMesh.cc
+++ b/arcane/src/arcane/mesh/PolyhedralMesh.cc
@@ -65,8 +65,8 @@
 
 #include "neo/Mesh.h"
 #include "neo/Utils.h"
-#include "ItemConnectivityMng.h"
 
+#include "arcane/mesh/ItemConnectivityMng.h"
 #include "arcane/core/ItemPrinter.h"
 
 #endif
@@ -1189,6 +1189,45 @@ class mesh::PolyhedralMesh::InternalApi
   IItemFamilySerializerMngInternal* familySerializerMng() const noexcept override
   {
     return m_mesh->polyhedralFamilySerializerMng();
+  }
+
+  ItemInternalMap& nodesMap() override
+  {
+    return m_mesh->_itemFamily(IK_Node)->itemsMap();
+  }
+
+  ItemInternalMap& edgesMap() override
+  {
+    return m_mesh->_itemFamily(IK_Edge)->itemsMap();
+  }
+
+  ItemInternalMap& facesMap() override
+  {
+    return m_mesh->_itemFamily(IK_Face)->itemsMap();
+  }
+
+  ItemInternalMap& cellsMap() override
+  {
+    return m_mesh->_itemFamily(IK_Cell)->itemsMap();
+  }
+
+  FaceFamily& trueFaceFamily() override
+  {
+    m_mesh->traceMng()->fatal() << "PolyhedralMesh::trueFaceFamily() is not implemented. PolyhedralMesh has no concrete FaceFamily.";
+  }
+
+  void printStats(Int32 level)
+  {
+    m_mesh->traceMng()->info(level) << "-- -- Statistics";
+    m_mesh->traceMng()->info(level) << "Number of nodes after addition     &: "
+                << " hashmap=" << m_mesh->_internalApi()->nodesMap().count();
+    m_mesh->traceMng()->info(level) << "Number of edges after addition     : "
+                << " hashmap=" << m_mesh->_internalApi()->edgesMap().count();
+    m_mesh->traceMng()->info(level) << "Number of faces after addition     : "
+                << " hashmap=" << m_mesh->_internalApi()->facesMap().count();
+    m_mesh->traceMng()->info(level) << "Number of cells after addition     : "
+                << " hashmap=" << m_mesh->_internalApi()->cellsMap().count();
+    m_mesh->traceMng()->info(level) << "--";
   }
 
  private:

--- a/arcane/src/arcane/mesh/internal/DynamicMeshInternal.h
+++ b/arcane/src/arcane/mesh/internal/DynamicMeshInternal.h
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //-----------------------------------------------------------------------------
 /*---------------------------------------------------------------------------*/
-/* DynamicMeshInternal.h                                       (C) 2000-2025 */
+/* DynamicMeshInternal.h                                       (C) 2000-2026 */
 /*                                                                           */
 /* Internal Arcane part of DynamicMesh.                                      */
 /*---------------------------------------------------------------------------*/
@@ -20,6 +20,8 @@
 #include "arcane/core/internal/IMeshModifierInternal.h"
 
 #include "arcane/mesh/ItemConnectivityMng.h"
+
+#include "arcane/mesh/DynamicMeshKindInfos.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -52,7 +54,15 @@ class DynamicMeshInternal
   FaceLocalId addFace(ItemUniqueId unique_id, ItemTypeId type_id, ConstArrayView<Int64> nodes_uid) override;
   CellLocalId addCell(ItemUniqueId unique_id, ItemTypeId type_id, ConstArrayView<Int64> nodes_uid) override;
 
- private:
+  // Methods added to make GhostLayerMng independent of DynamicMesh
+  mesh::ItemInternalMap& nodesMap() override;
+  mesh::ItemInternalMap& edgesMap() override;
+  mesh::ItemInternalMap& facesMap() override;
+  mesh::ItemInternalMap& cellsMap() override;
+  FaceFamily& trueFaceFamily() override;
+  void printStats(Int32 level) override;
+
+private:
 
   DynamicMesh* m_mesh = nullptr;
   std::unique_ptr<IItemConnectivityMng> m_connectivity_mng = nullptr;


### PR DESCRIPTION
Only a few methods were needed: access to itemsMap and to printStats. 
- These methods have been added to IMeshInternal API for a first implem. They can be moved elsewhere in a more specialized interface if needed.
- In GhostLayerBuilder2 a DynamicMesh::addCells(Serializer) was used while a CellSerializer was used in GhostLayerBuilder v1. The CellSerializer was thus used in GhostLayerBuilder2 too. 