### PR TITLE
Use `IMessagePassingMng` instead of direct MPI call in Alina

### DIFF
--- a/arccore/src/alina/arccore/alina/AlinaLib.cc
+++ b/arccore/src/alina/arccore/alina/AlinaLib.cc
@@ -357,7 +357,7 @@ AlinaDistributedSolver(Arcane::MessagePassing::IMessagePassingMng* comm,
   auto A = std::make_tuple(matrix_view.nbRow(), matrix_view.rowIndexes(),
                            matrix_view.columns(), matrix_view.values());
 
-  Alina::mpi_communicator mpi_comm(comm);
+  Alina::AlinaCommunicator mpi_comm(comm);
   auto* p = new DistributedSolverType(mpi_comm, A, prm);
 
   m_p = std::make_shared<AlinaDistributedSolverImpl>(p);

--- a/arccore/src/alina/arccore/alina/AlinaLib.cc
+++ b/arccore/src/alina/arccore/alina/AlinaLib.cc
@@ -331,12 +331,8 @@ class AlinaDistributedSolverImpl
 /*---------------------------------------------------------------------------*/
 
 AlinaDistributedSolver::
-AlinaDistributedSolver(MPI_Comm comm,
+AlinaDistributedSolver(Arcane::MessagePassing::IMessagePassingMng* comm,
                        const AlinaCSRMatrixView& matrix_view,
-                       //ptrdiff_t n,
-                       //const int* ptr,
-                       //const int* col,
-                       //const double* val,
                        int n_def_vec,
                        AlinaDefVecFunction def_vec_func,
                        void* def_vec_data,

--- a/arccore/src/alina/arccore/alina/AlinaLib.cc
+++ b/arccore/src/alina/arccore/alina/AlinaLib.cc
@@ -330,15 +330,25 @@ class AlinaDistributedSolverImpl
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+namespace
+{
+double constant_deflation(int, ptrdiff_t, void*)
+{
+  return 1;
+}
+
+}
 AlinaDistributedSolver::
 AlinaDistributedSolver(Arcane::MessagePassing::IMessagePassingMng* comm,
                        const AlinaCSRMatrixView& matrix_view,
-                       int n_def_vec,
-                       AlinaDefVecFunction def_vec_func,
-                       void* def_vec_data,
                        const AlinaParameters& params)
 {
+  int n_def_vec = 1;
+  AlinaDefVecFunction def_vec_func = constant_deflation;
+  void* def_vec_data = nullptr;
+
   std::function<double(ptrdiff_t, unsigned)> dv = deflation_vectors(n_def_vec, def_vec_func, def_vec_data);
+
   Alina::PropertyTree prm = params.m_p->m_properties;
   prm.put("num_def_vec", n_def_vec);
   prm.put("def_vec", &dv);

--- a/arccore/src/alina/arccore/alina/AlinaLib.h
+++ b/arccore/src/alina/arccore/alina/AlinaLib.h
@@ -26,12 +26,14 @@
 #include "arccore/alina/AlinaGlobal.h"
 
 #include "arccore/base/Span.h"
+#include "arccore/message_passing/MessagePassingGlobal.h"
 
 #include <memory>
 
-#include <mpi.h>
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
 
-// Convergence info
+//! Convergence info
 struct ARCCORE_ALINA_EXPORT AlinaConvergenceInfo
 {
   int iterations = 0;
@@ -226,7 +228,7 @@ class ARCCORE_ALINA_EXPORT AlinaDistributedSolver
    * The matrix view \a matrix_view passed as arguments must remain valid
    * for as long as this instance is alive.
    */
-  AlinaDistributedSolver(MPI_Comm comm,
+  AlinaDistributedSolver(Arcane::MessagePassing::IMessagePassingMng* comm,
                          const AlinaCSRMatrixView& matrix_view,
                          int n_def_vec,
                          AlinaDefVecFunction def_vec_func,

--- a/arccore/src/alina/arccore/alina/AlinaLib.h
+++ b/arccore/src/alina/arccore/alina/AlinaLib.h
@@ -230,9 +230,6 @@ class ARCCORE_ALINA_EXPORT AlinaDistributedSolver
    */
   AlinaDistributedSolver(Arcane::MessagePassing::IMessagePassingMng* comm,
                          const AlinaCSRMatrixView& matrix_view,
-                         int n_def_vec,
-                         AlinaDefVecFunction def_vec_func,
-                         void* def_vec_data,
                          const AlinaParameters& params);
 
   //! Find solution for the given RHS.

--- a/arccore/src/alina/arccore/alina/DistributedAMG.h
+++ b/arccore/src/alina/arccore/alina/DistributedAMG.h
@@ -153,7 +153,7 @@ class DistributedAMG
   } prm;
 
   template <class Matrix>
-  DistributedAMG(mpi_communicator comm,
+  DistributedAMG(AlinaCommunicator comm,
                  const Matrix& A,
                  const params& prm = params(),
                  const backend_params& bprm = backend_params())
@@ -164,7 +164,7 @@ class DistributedAMG
     init(std::make_shared<matrix>(comm, A, backend::nbRow(A)), bprm);
   }
 
-  DistributedAMG(mpi_communicator comm,
+  DistributedAMG(AlinaCommunicator comm,
                  std::shared_ptr<matrix> A,
                  const params& prm = params(),
                  const backend_params& bprm = backend_params())
@@ -376,7 +376,7 @@ class DistributedAMG
 
   typedef typename std::list<DistributedAMGLevel>::const_iterator level_iterator;
 
-  mpi_communicator comm;
+  AlinaCommunicator comm;
   std::shared_ptr<matrix> A;
   Repartition repart;
   std::list<DistributedAMGLevel> levels;

--- a/arccore/src/alina/arccore/alina/DistributedCPRPreconditioner.h
+++ b/arccore/src/alina/arccore/alina/DistributedCPRPreconditioner.h
@@ -90,7 +90,7 @@ class DistributedCPRPreconditioner
   };
 
   template <class Matrix>
-  DistributedCPRPreconditioner(mpi_communicator comm,
+  DistributedCPRPreconditioner(AlinaCommunicator comm,
                                const Matrix& K,
                                const params& prm = params(),
                                const backend_params& bprm = backend_params())
@@ -101,7 +101,7 @@ class DistributedCPRPreconditioner
     init(std::make_shared<matrix>(comm, K, backend::nbRow(K)), bprm);
   }
 
-  DistributedCPRPreconditioner(mpi_communicator comm,
+  DistributedCPRPreconditioner(AlinaCommunicator comm,
                                std::shared_ptr<matrix> K,
                                const params& prm = params(),
                                const backend_params& bprm = backend_params())
@@ -143,7 +143,7 @@ class DistributedCPRPreconditioner
 
  private:
 
-  mpi_communicator comm;
+  AlinaCommunicator comm;
   size_t n, np;
 
   std::shared_ptr<PPrecond> P;

--- a/arccore/src/alina/arccore/alina/DistributedCoarsening.h
+++ b/arccore/src/alina/arccore/alina/DistributedCoarsening.h
@@ -23,17 +23,17 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-#include <cstddef>
-#include <tuple>
-#include <memory>
-#include <numeric>
-#include <cassert>
-
 #include "arccore/alina/BuiltinBackend.h"
 #include "arccore/alina/AlinaUtils.h"
 #include "arccore/alina/Coarsening.h"
 #include "arccore/alina/MessagePassingUtils.h"
 #include "arccore/alina/DistributedMatrix.h"
+
+#include <cstddef>
+#include <tuple>
+#include <memory>
+#include <numeric>
+#include <cassert>
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -776,15 +776,12 @@ struct DistributedPMISAggregation
       }
 
       // Setup the exchange
-      MPI_Request req;
-      MPI_Ialltoall(scounts.data(), 1, MPI_INT,
-                    rcounts.data(), 1, MPI_INT,
-                    comm, &req);
+      SmallSpan<const int> send_counts_view(scounts);
+      SmallSpan<int> receive_counts_view(rcounts);
+      MessagePassing::mpAllToAll(comm.messagePassingMng(), send_counts_view, receive_counts_view, 1);
 
       P_loc.set_nonzeros(P_loc.scan_row_sizes());
       P_rem.set_nonzeros(P_rem.scan_row_sizes());
-
-      MPI_Wait(&req, MPI_STATUS_IGNORE);
 
       int snbr = 0;
       int rnbr = 0;

--- a/arccore/src/alina/arccore/alina/DistributedCoarsening.h
+++ b/arccore/src/alina/arccore/alina/DistributedCoarsening.h
@@ -435,7 +435,7 @@ struct DistributedPMISAggregation
 
     ptrdiff_t n = A_loc.nbRow();
 
-    mpi_communicator comm = A.comm();
+    AlinaCommunicator comm = A.comm();
 
     // 1. Get symbolic square of the connectivity matrix.
     ARCCORE_ALINA_TIC("symbolic square");
@@ -733,7 +733,7 @@ struct DistributedPMISAggregation
   }
 
   std::shared_ptr<matrix>
-  tentative_prolongation(mpi_communicator comm, ptrdiff_t n, ptrdiff_t naggr,
+  tentative_prolongation(AlinaCommunicator comm, ptrdiff_t n, ptrdiff_t naggr,
                          UniqueArray<ptrdiff_t>& state, UniqueArray<int>& owner)
   {
     auto p_loc = std::make_shared<build_matrix>();
@@ -1309,7 +1309,7 @@ struct DistributedSmoothedAggregationCoarsening
     DistributedPMISAggregation<Backend> aggr(A, prm.aggr);
     prm.aggr.eps_strong *= 0.5;
 
-    mpi_communicator comm = A.comm();
+    AlinaCommunicator comm = A.comm();
     const build_matrix& A_loc = *A.local();
     const build_matrix& A_rem = *A.remote();
 

--- a/arccore/src/alina/arccore/alina/DistributedDirectSolverBase.h
+++ b/arccore/src/alina/arccore/alina/DistributedDirectSolverBase.h
@@ -79,7 +79,7 @@ class DistributedDirectSolverBase
     group_master = active[group_beg];
 
     // Communicator for masters (used to solve the coarse problem):
-    MPI_Comm_split(comm,
+    MPI_Comm_split(comm.mpiCommunicator(),
                    comm.rank == group_master ? 0 : MPI_UNDEFINED,
                    comm.rank, &masters_comm);
 

--- a/arccore/src/alina/arccore/alina/DistributedDirectSolverBase.h
+++ b/arccore/src/alina/arccore/alina/DistributedDirectSolverBase.h
@@ -52,7 +52,7 @@ class DistributedDirectSolverBase
 
   DistributedDirectSolverBase() {}
 
-  void init(mpi_communicator comm, const build_matrix& Astrip)
+  void init(AlinaCommunicator comm, const build_matrix& Astrip)
   {
     this->comm = comm;
     n = Astrip.nbRow();
@@ -157,7 +157,7 @@ class DistributedDirectSolverBase
       comm.waitAll(col_req);
       comm.waitAll(val_req);
 
-      solver().init(mpi_communicator(masters_comm), A);
+      solver().init(AlinaCommunicator(masters_comm), A);
     }
     else {
       comm.doSend(widths.data(), n, group_master, cnt_tag);
@@ -169,7 +169,7 @@ class DistributedDirectSolverBase
   }
 
   template <class B>
-  void init(mpi_communicator comm, const DistributedMatrix<B>& A)
+  void init(AlinaCommunicator comm, const DistributedMatrix<B>& A)
   {
     const build_matrix& A_loc = *A.local();
     const build_matrix& A_rem = *A.remote();
@@ -265,7 +265,7 @@ class DistributedDirectSolverBase
   static const int rhs_tag = 5004;
   static const int sol_tag = 5005;
 
-  mpi_communicator comm;
+  AlinaCommunicator comm;
   int n;
   int group_master;
   MPI_Comm masters_comm;

--- a/arccore/src/alina/arccore/alina/DistributedDirectSolverRuntime.h
+++ b/arccore/src/alina/arccore/alina/DistributedDirectSolverRuntime.h
@@ -83,7 +83,7 @@ class DistributedDirectSolverRuntime
   using SkylineSolverType = DistributedSkylineLUDirectSolver<Backend>;
 
   template <class Matrix>
-  DistributedDirectSolverRuntime(Alina::mpi_communicator comm, const Matrix& A, params prm = params())
+  DistributedDirectSolverRuntime(Alina::AlinaCommunicator comm, const Matrix& A, params prm = params())
   : s(prm.get("type", eDistributedDirectSolverType::skyline_lu))
   {
     if (!prm.erase("type"))
@@ -137,14 +137,14 @@ class DistributedDirectSolverRuntime
 
   template <class S, class V, class Matrix>
   typename std::enable_if<std::is_same<V, float>::value || std::is_same<V, double>::value, void>::type
-  do_construct(Alina::mpi_communicator comm, const Matrix& A, const params& prm)
+  do_construct(Alina::AlinaCommunicator comm, const Matrix& A, const params& prm)
   {
     handle = static_cast<void*>(new S(comm, A, prm));
   }
 
   template <class S, class V, class Matrix>
   typename std::enable_if<!std::is_same<V, float>::value && !std::is_same<V, double>::value, void>::type
-  do_construct(Alina::mpi_communicator, const Matrix&, const params&)
+  do_construct(Alina::AlinaCommunicator, const Matrix&, const params&)
   {
     throw std::logic_error("The direct solver does not support the value type");
   }

--- a/arccore/src/alina/arccore/alina/DistributedEigenSparseLUDirectSolver.h
+++ b/arccore/src/alina/arccore/alina/DistributedEigenSparseLUDirectSolver.h
@@ -60,7 +60,7 @@ class DistributedEigenSparseLUDirectSolver
 
   /// Constructor.
   template <class Matrix>
-  DistributedEigenSparseLUDirectSolver(mpi_communicator comm, const Matrix& A,
+  DistributedEigenSparseLUDirectSolver(AlinaCommunicator comm, const Matrix& A,
                                        const params& prm = params())
   : prm(prm)
   {
@@ -77,7 +77,7 @@ class DistributedEigenSparseLUDirectSolver
     return 1;
   }
 
-  void init(mpi_communicator, const build_matrix& A)
+  void init(AlinaCommunicator, const build_matrix& A)
   {
     S = std::make_shared<Solver>(A, prm);
   }

--- a/arccore/src/alina/arccore/alina/DistributedInnerProduct.h
+++ b/arccore/src/alina/arccore/alina/DistributedInnerProduct.h
@@ -40,9 +40,9 @@ namespace Arcane::Alina
  */
 struct DistributedInnerProduct
 {
-  mpi_communicator comm;
+  AlinaCommunicator comm;
 
-  explicit DistributedInnerProduct(mpi_communicator comm)
+  explicit DistributedInnerProduct(AlinaCommunicator comm)
   : comm(comm)
   {}
 

--- a/arccore/src/alina/arccore/alina/DistributedMatrix.h
+++ b/arccore/src/alina/arccore/alina/DistributedMatrix.h
@@ -93,7 +93,7 @@ class CommunicationPattern
 
   std::shared_ptr<vector> x_rem;
 
-  CommunicationPattern(mpi_communicator comm,
+  CommunicationPattern(AlinaCommunicator comm,
                        ptrdiff_t n_loc_cols,
                        size_t n_rem_cols, const col_type* p_rem_cols)
   : comm(comm)
@@ -311,7 +311,7 @@ class CommunicationPattern
     ARCCORE_ALINA_TOC("MPI Wait");
   }
 
-  mpi_communicator mpi_comm() const
+  AlinaCommunicator mpi_comm() const
   {
     return comm;
   }
@@ -329,7 +329,7 @@ class CommunicationPattern
   static const int tag_exc_cols = 1002;
   static const int tag_exc_vals = 1003;
 
-  mpi_communicator comm;
+  AlinaCommunicator comm;
 
   std::unordered_map<ptrdiff_t, std::tuple<int, int>> idx;
   std::shared_ptr<Gather> gather;
@@ -358,7 +358,7 @@ class DistributedMatrix
   typedef CommunicationPattern<Backend> CommPattern;
   typedef typename Backend::matrix build_matrix;
 
-  DistributedMatrix(mpi_communicator comm,
+  DistributedMatrix(AlinaCommunicator comm,
                     std::shared_ptr<build_matrix> a_loc,
                     std::shared_ptr<build_matrix> a_rem,
                     std::shared_ptr<CommPattern> c = std::shared_ptr<CommPattern>())
@@ -402,7 +402,7 @@ class DistributedMatrix
   }
 
   template <class Matrix>
-  DistributedMatrix(mpi_communicator comm,
+  DistributedMatrix(AlinaCommunicator comm,
                     const Matrix& A,
                     ptrdiff_t _n_loc_cols = -1)
   : n_loc_rows(backend::nbRow(A))
@@ -471,7 +471,7 @@ class DistributedMatrix
     a_rem->ncols = C->recv.count();
   }
 
-  mpi_communicator comm() const
+  AlinaCommunicator comm() const
   {
     return C->mpi_comm();
   }
@@ -628,7 +628,7 @@ transpose(const DistributedMatrix<Backend>& A)
   static const int tag_col = 2002;
   static const int tag_val = 2003;
 
-  mpi_communicator comm = A.comm();
+  AlinaCommunicator comm = A.comm();
   const CommPattern& C = A.cpat();
 
   build_matrix& A_loc = *A.local();
@@ -787,7 +787,7 @@ remote_rows(const CommunicationPattern<Backend>& C,
   static const int tag_val = 3003;
 
   ARCCORE_ALINA_TIC("remote_rows");
-  mpi_communicator comm = C.mpi_comm();
+  AlinaCommunicator comm = C.mpi_comm();
 
   build_matrix& B_loc = *B.local();
   build_matrix& B_rem = *B.remote();
@@ -1241,7 +1241,7 @@ spectral_radius(const DistributedMatrix<Backend>& A, int power_iters = 0)
   typedef typename math::scalar_of<value_type>::type scalar_type;
   typedef CSRMatrix<value_type> build_matrix;
 
-  mpi_communicator comm = A.comm();
+  AlinaCommunicator comm = A.comm();
 
   const build_matrix& A_loc = *A.local();
   const build_matrix& A_rem = *A.remote();

--- a/arccore/src/alina/arccore/alina/DistributedMatrix.h
+++ b/arccore/src/alina/arccore/alina/DistributedMatrix.h
@@ -115,8 +115,8 @@ class CommunicationPattern
     ptrdiff_t rnbr = 0, snbr = 0, send_size = 0;
 
     {
-      std::vector<int> rcounts(comm.size, 0);
-      std::vector<int> scounts(comm.size);
+      UniqueArray<int> rcounts(comm.size, 0);
+      UniqueArray<int> scounts(comm.size);
 
       // Build index for column renumbering;
       // count how many domains send us data and how much.
@@ -148,8 +148,7 @@ class CommunicationPattern
           recv.ptr.push_back(recv.ptr.back() + rcounts[d]);
         }
       }
-
-      MPI_Alltoall(rcounts.data(), 1, MPI_INT, scounts.data(), 1, MPI_INT, comm.mpiCommunicator());
+      MessagePassing::mpAllToAll(comm.messagePassingMng(), rcounts, scounts, 1);
 
       for (ptrdiff_t d = 0; d < comm.size; ++d) {
         if (scounts[d]) {
@@ -182,7 +181,7 @@ class CommunicationPattern
     // Here is what I need from you:
     for (size_t i = 0; i < recv.nbr.size(); ++i)
       recv.req[i] = comm.doISend(&rem_cols[recv.ptr[i]], recv.ptr[i + 1] - recv.ptr[i],
-                              recv.nbr[i], tag_exc_cols);
+                                 recv.nbr[i], tag_exc_cols);
 
     ARCCORE_ALINA_TIC("MPI Wait");
     comm.waitAll(recv.req);
@@ -299,11 +298,11 @@ class CommunicationPattern
   {
     for (size_t i = 0; i < recv.nbr.size(); ++i)
       recv.req[i] = comm.doIReceive(&recv_val[recv.ptr[i]], recv.ptr[i + 1] - recv.ptr[i],
-                                 recv.nbr[i], tag_exc_vals);
+                                    recv.nbr[i], tag_exc_vals);
 
     for (size_t i = 0; i < send.nbr.size(); ++i)
       send.req[i] = comm.doISend(const_cast<T*>(&send_val[send.ptr[i]]), send.ptr[i + 1] - send.ptr[i],
-                              send.nbr[i], tag_exc_vals);
+                                 send.nbr[i], tag_exc_vals);
 
     ARCCORE_ALINA_TIC("MPI Wait");
     comm.waitAll(recv.req);

--- a/arccore/src/alina/arccore/alina/DistributedMatrix.h
+++ b/arccore/src/alina/arccore/alina/DistributedMatrix.h
@@ -149,7 +149,7 @@ class CommunicationPattern
         }
       }
 
-      MPI_Alltoall(rcounts.data(), 1, MPI_INT, scounts.data(), 1, MPI_INT, comm);
+      MPI_Alltoall(rcounts.data(), 1, MPI_INT, scounts.data(), 1, MPI_INT, comm.mpiCommunicator());
 
       for (ptrdiff_t d = 0; d < comm.size; ++d) {
         if (scounts[d]) {

--- a/arccore/src/alina/arccore/alina/DistributedPreconditionedSolver.h
+++ b/arccore/src/alina/arccore/alina/DistributedPreconditionedSolver.h
@@ -81,7 +81,7 @@ class DistributedPreconditionedSolver
   } prm;
 
   template <class Matrix>
-  DistributedPreconditionedSolver(mpi_communicator comm, const Matrix& A,
+  DistributedPreconditionedSolver(AlinaCommunicator comm, const Matrix& A,
                                   const params& prm = params(),
                                   const backend_params& bprm = backend_params())
   : prm(prm)
@@ -90,7 +90,7 @@ class DistributedPreconditionedSolver
   , S(backend::nbRow(A), prm.solver, bprm, DistributedInnerProduct(comm))
   {}
 
-  DistributedPreconditionedSolver(mpi_communicator comm,
+  DistributedPreconditionedSolver(AlinaCommunicator comm,
                                   std::shared_ptr<matrix> A,
                                   const params& prm = params(),
                                   const backend_params& bprm = backend_params())
@@ -102,7 +102,7 @@ class DistributedPreconditionedSolver
   }
 
   template <class Backend>
-  DistributedPreconditionedSolver(mpi_communicator comm,
+  DistributedPreconditionedSolver(AlinaCommunicator comm,
                                   std::shared_ptr<DistributedMatrix<Backend>> A,
                                   const params& prm = params(),
                                   const backend_params& bprm = backend_params())
@@ -114,7 +114,7 @@ class DistributedPreconditionedSolver
     A->move_to_backend(bprm);
   }
 
-  DistributedPreconditionedSolver(mpi_communicator comm, std::shared_ptr<build_matrix> A,
+  DistributedPreconditionedSolver(AlinaCommunicator comm, std::shared_ptr<build_matrix> A,
                                   const params& prm = params(),
                                   const backend_params& bprm = backend_params())
   : prm(prm)

--- a/arccore/src/alina/arccore/alina/DistributedPreconditioner.h
+++ b/arccore/src/alina/arccore/alina/DistributedPreconditioner.h
@@ -103,7 +103,7 @@ class DistributedPreconditioner
                                         MatrixPartitionerRuntime<Backend>>;
 
   template <class Matrix>
-  DistributedPreconditioner(mpi_communicator comm,
+  DistributedPreconditioner(AlinaCommunicator comm,
                             const Matrix& Astrip,
                             params prm = params(),
                             const backend_params& bprm = backend_params())
@@ -113,7 +113,7 @@ class DistributedPreconditioner
     init(std::make_shared<matrix>(comm, Astrip, backend::nbRow(Astrip)), prm, bprm);
   }
 
-  DistributedPreconditioner(mpi_communicator,
+  DistributedPreconditioner(AlinaCommunicator,
                             std::shared_ptr<matrix> A,
                             params prm = params(),
                             const backend_params& bprm = backend_params())
@@ -254,7 +254,7 @@ class DistributedBlockPreconditioner
   typedef DistributedMatrix<backend_type> matrix;
 
   template <class Matrix>
-  DistributedBlockPreconditioner(mpi_communicator comm,
+  DistributedBlockPreconditioner(AlinaCommunicator comm,
                                  const Matrix& Astrip,
                                  const params& prm = params(),
                                  const backend_params& bprm = backend_params())
@@ -265,7 +265,7 @@ class DistributedBlockPreconditioner
     A->move_to_backend(bprm);
   }
 
-  DistributedBlockPreconditioner(mpi_communicator,
+  DistributedBlockPreconditioner(AlinaCommunicator,
                                  std::shared_ptr<matrix> A,
                                  const params& prm = params(),
                                  const backend_params& bprm = backend_params())

--- a/arccore/src/alina/arccore/alina/DistributedRelaxation.h
+++ b/arccore/src/alina/arccore/alina/DistributedRelaxation.h
@@ -300,7 +300,7 @@ struct AsDistributedPreconditioner
   typedef typename backend_type::vector vector;
 
   template <class Matrix>
-  AsDistributedPreconditioner(mpi_communicator comm,
+  AsDistributedPreconditioner(AlinaCommunicator comm,
                               const Matrix& A,
                               const params& prm = params(),
                               const backend_params& bprm = backend_params())
@@ -310,7 +310,7 @@ struct AsDistributedPreconditioner
     this->A->move_to_backend(bprm);
   }
 
-  AsDistributedPreconditioner(mpi_communicator,
+  AsDistributedPreconditioner(AlinaCommunicator,
                               std::shared_ptr<matrix> A,
                               const params& prm = params(),
                               const backend_params& bprm = backend_params())

--- a/arccore/src/alina/arccore/alina/DistributedSchurPressureCorrection.h
+++ b/arccore/src/alina/arccore/alina/DistributedSchurPressureCorrection.h
@@ -159,7 +159,7 @@ class DistributedSchurPressureCorrection
   };
 
   template <class Matrix>
-  DistributedSchurPressureCorrection(mpi_communicator comm,
+  DistributedSchurPressureCorrection(AlinaCommunicator comm,
                                      const Matrix& K,
                                      const params& prm = params(),
                                      const backend_params& bprm = backend_params())
@@ -170,7 +170,7 @@ class DistributedSchurPressureCorrection
     init(bprm);
   }
 
-  DistributedSchurPressureCorrection(mpi_communicator comm,
+  DistributedSchurPressureCorrection(AlinaCommunicator comm,
                                      std::shared_ptr<matrix> K,
                                      const params& prm = params(),
                                      const backend_params& bprm = backend_params())
@@ -631,7 +631,7 @@ class DistributedSchurPressureCorrection
  private:
 
   typedef CommunicationPattern<backend_type> CommPattern;
-  mpi_communicator comm;
+  AlinaCommunicator comm;
 
   std::shared_ptr<bmatrix> x2p, x2u, p2x, u2x;
   std::shared_ptr<matrix> K, Kpu, Kup;

--- a/arccore/src/alina/arccore/alina/DistributedSkylineLUDirectSolver.h
+++ b/arccore/src/alina/arccore/alina/DistributedSkylineLUDirectSolver.h
@@ -57,7 +57,7 @@ class DistributedSkylineLUDirectSolver
 
   /// Constructor.
   template <class Matrix>
-  DistributedSkylineLUDirectSolver(mpi_communicator comm, const Matrix& A,
+  DistributedSkylineLUDirectSolver(AlinaCommunicator comm, const Matrix& A,
                                    const params& prm = params{})
   : prm(prm)
   {
@@ -74,7 +74,7 @@ class DistributedSkylineLUDirectSolver
     return 1;
   }
 
-  void init(mpi_communicator, const build_matrix& A)
+  void init(AlinaCommunicator, const build_matrix& A)
   {
     S = std::make_shared<Solver>(A, prm);
   }

--- a/arccore/src/alina/arccore/alina/DistributedSubDomainDeflation.h
+++ b/arccore/src/alina/arccore/alina/DistributedSubDomainDeflation.h
@@ -181,7 +181,7 @@ class DistributedSubDomainDeflation
   typedef DistributedMatrix<backend_type> matrix;
 
   template <class Matrix>
-  DistributedSubDomainDeflation(mpi_communicator comm,
+  DistributedSubDomainDeflation(AlinaCommunicator comm,
                                 const Matrix& Astrip,
                                 const params& prm = params(),
                                 const backend_params& bprm = backend_params())
@@ -197,7 +197,7 @@ class DistributedSubDomainDeflation
     init(prm, bprm);
   }
 
-  DistributedSubDomainDeflation(mpi_communicator comm,
+  DistributedSubDomainDeflation(AlinaCommunicator comm,
                                 std::shared_ptr<matrix> A,
                                 const params& prm = params(),
                                 const backend_params& bprm = backend_params())
@@ -537,7 +537,7 @@ class DistributedSubDomainDeflation
   static const int tag_exc_dvec = 4011;
   static const int tag_exc_lnnz = 5011;
 
-  mpi_communicator comm;
+  AlinaCommunicator comm;
   ptrdiff_t nrows, ndv, nz;
 
   std::shared_ptr<matrix> A, AZ;

--- a/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
+++ b/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
@@ -23,14 +23,16 @@
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+#include "arccore/alina/BackendInterface.h"
+#include "arccore/alina/DistributedMatrix.h"
+
+#include "arccore/message_passing/Messages.h"
+
 #include <vector>
 #include <algorithm>
 #include <numeric>
 
 #include <tuple>
-
-#include "arccore/alina/BackendInterface.h"
-#include "arccore/alina/DistributedMatrix.h"
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -255,10 +257,13 @@ mpi_graph_perm_index(AlinaCommunicator comm, int npart, const std::vector<Idx>& 
 
   for (Idx p : part)
     ++loc_part_cnt[p];
-  MPI_Datatype ptr_datatype = MPI_LONG_LONG; //mpi_datatype<ptrdiff_t>();
-  MPI_Exscan(&loc_part_cnt[0], &loc_part_beg[0], npart, ptr_datatype, MPI_SUM, comm);
-  MPI_Allreduce(&loc_part_cnt[0], &glo_part_cnt[0], npart, ptr_datatype, MPI_SUM, comm);
+  MPI_Datatype ptr_datatype = MPI_LONG_LONG;
+  MPI_Exscan(loc_part_cnt.data(), loc_part_beg.data(), npart, ptr_datatype, MPI_SUM, comm);
 
+  Span<const ptrdiff_t> loc_part_cnt_view(loc_part_cnt.data(), npart);
+  Span<ptrdiff_t> glo_part_cnt_view(glo_part_cnt.data(), npart);
+  glo_part_cnt_view.copy(loc_part_cnt_view);
+  mpAllReduce(comm.messagePassingMng(), Arcane::MessagePassing::eReduceType::ReduceSum, glo_part_cnt_view);
   glo_part_beg[0] = 0;
   std::partial_sum(glo_part_cnt.begin(), glo_part_cnt.end(), glo_part_beg.begin() + 1);
 

--- a/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
+++ b/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
@@ -241,7 +241,7 @@ mpi_symm_graph(const DistributedMatrix<Backend>& A,
 /*---------------------------------------------------------------------------*/
 
 template <class Idx> std::tuple<ptrdiff_t, ptrdiff_t>
-mpi_graph_perm_index(mpi_communicator comm, int npart, const std::vector<Idx>& part,
+mpi_graph_perm_index(AlinaCommunicator comm, int npart, const std::vector<Idx>& part,
                      std::vector<ptrdiff_t>& perm)
 {
   ARCCORE_ALINA_TIC("perm index");
@@ -279,7 +279,7 @@ mpi_graph_perm_index(mpi_communicator comm, int npart, const std::vector<Idx>& p
 
 template <class Backend, class Idx>
 std::shared_ptr<DistributedMatrix<Backend>>
-mpi_graph_perm_matrix(mpi_communicator comm, ptrdiff_t col_beg, ptrdiff_t col_end,
+mpi_graph_perm_matrix(AlinaCommunicator comm, ptrdiff_t col_beg, ptrdiff_t col_end,
                       const std::vector<Idx>& perm)
 {
   typedef typename Backend::value_type value_type;

--- a/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
+++ b/arccore/src/alina/arccore/alina/MatrixPartitionUtils.h
@@ -258,7 +258,7 @@ mpi_graph_perm_index(AlinaCommunicator comm, int npart, const std::vector<Idx>& 
   for (Idx p : part)
     ++loc_part_cnt[p];
   MPI_Datatype ptr_datatype = MPI_LONG_LONG;
-  MPI_Exscan(loc_part_cnt.data(), loc_part_beg.data(), npart, ptr_datatype, MPI_SUM, comm);
+  MPI_Exscan(loc_part_cnt.data(), loc_part_beg.data(), npart, ptr_datatype, MPI_SUM, comm.mpiCommunicator());
 
   Span<const ptrdiff_t> loc_part_cnt_view(loc_part_cnt.data(), npart);
   Span<ptrdiff_t> glo_part_cnt_view(glo_part_cnt.data(), npart);

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
@@ -51,6 +51,35 @@ mpi_communicator(IMessagePassingMng* mpm_comm)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
+void mpi_communicator::
+check(bool cond, const String& message)
+{
+  int lc = (cond) ? 1 : 0;
+  int gc = mpAllReduce(m_message_passing_mng.get(), MessagePassing::eReduceType::ReduceMin, cond);
+
+  if (gc != 0)
+    return;
+  IMessagePassingMng* pm = m_message_passing_mng.get();
+  UniqueArray<int> c(size);
+  if (rank == 0)
+    c.resize(size);
+  ConstArrayView<int> in_view(1, &lc);
+  mpGather(pm, in_view, c, 0);
+  if (rank == 0) {
+    std::cerr << "Failed assumption: " << message << std::endl;
+    std::cerr << "Offending processes:";
+    for (int i = 0; i < size; ++i)
+      if (!c[i])
+        std::cerr << " " << i;
+    std::cerr << std::endl;
+  }
+  mpBarrier(pm);
+  ARCCORE_FATAL("CheckError in MessagePassingUtils: {0}", message);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
 } // namespace Arcane::Alina
 
 /*---------------------------------------------------------------------------*/

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
@@ -26,7 +26,7 @@ namespace Arcane::Alina
 
 AlinaCommunicator::
 AlinaCommunicator(MPI_Comm comm)
-: comm(comm)
+: m_mpi_communicator(comm)
 {
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
@@ -42,9 +42,9 @@ AlinaCommunicator(IMessagePassingMng* mpm_comm)
   MessagePassing::Communicator c = mpm_comm->communicator();
   if (!c.isValid())
     ARCCORE_FATAL("Invalid 'IMessagePassingMng' communicator. Only MPI implementation is currently supported");
-  comm = static_cast<MPI_Comm>(c);
-  MPI_Comm_rank(comm, &rank);
-  MPI_Comm_size(comm, &size);
+  m_mpi_communicator = static_cast<MPI_Comm>(c);
+  MPI_Comm_rank(m_mpi_communicator, &rank);
+  MPI_Comm_size(m_mpi_communicator, &size);
   m_message_passing_mng = makeRef(mpm_comm);
 };
 

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
@@ -1,0 +1,57 @@
+﻿// -*- tab-width: 2; indent-tabs-mode: nil; coding: utf-8-with-signature -*-
+//-----------------------------------------------------------------------------
+// Copyright 2000-2026 CEA (www.cea.fr) IFPEN (www.ifpenergiesnouvelles.com)
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: Apache-2.0
+//-----------------------------------------------------------------------------
+/*---------------------------------------------------------------------------*/
+/* MessagePassingUtils.cc                                      (C) 2000-2026 */
+/*                                                                           */
+/* Various utilities to handle message passing.                              */
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+#include "arccore/alina/MessagePassingUtils.h"
+
+#include <mpi.h>
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+namespace Arcane::Alina
+{
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+mpi_communicator::
+mpi_communicator(MPI_Comm comm)
+: comm(comm)
+{
+  MPI_Comm_rank(comm, &rank);
+  MPI_Comm_size(comm, &size);
+  m_message_passing_mng = MessagePassing::Mpi::StandaloneMpiMessagePassingMng::createRef(comm);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+mpi_communicator::
+mpi_communicator(IMessagePassingMng* mpm_comm)
+{
+  MessagePassing::Communicator c = mpm_comm->communicator();
+  if (!c.isValid())
+    ARCCORE_FATAL("Invalid 'IMessagePassingMng' communicator. Only MPI implementation is currently supported");
+  comm = static_cast<MPI_Comm>(c);
+  MPI_Comm_rank(comm, &rank);
+  MPI_Comm_size(comm, &size);
+  m_message_passing_mng = makeRef(mpm_comm);
+};
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+} // namespace Arcane::Alina
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.cc
@@ -24,8 +24,8 @@ namespace Arcane::Alina
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-mpi_communicator::
-mpi_communicator(MPI_Comm comm)
+AlinaCommunicator::
+AlinaCommunicator(MPI_Comm comm)
 : comm(comm)
 {
   MPI_Comm_rank(comm, &rank);
@@ -36,8 +36,8 @@ mpi_communicator(MPI_Comm comm)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-mpi_communicator::
-mpi_communicator(IMessagePassingMng* mpm_comm)
+AlinaCommunicator::
+AlinaCommunicator(IMessagePassingMng* mpm_comm)
 {
   MessagePassing::Communicator c = mpm_comm->communicator();
   if (!c.isValid())
@@ -51,7 +51,7 @@ mpi_communicator(IMessagePassingMng* mpm_comm)
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-void mpi_communicator::
+void AlinaCommunicator::
 check(bool cond, const String& message)
 {
   int lc = (cond) ? 1 : 0;

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.h
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.h
@@ -84,7 +84,7 @@ struct mpi_init_thread
 /*!
  * \brief Convenience wrapper around MPI_Comm.
  */
-struct mpi_communicator
+struct ARCCORE_ALINA_EXPORT mpi_communicator
 {
   MPI_Comm comm = MPI_COMM_NULL;
   int rank = 0;
@@ -93,13 +93,9 @@ struct mpi_communicator
 
   mpi_communicator() = default;
 
-  explicit mpi_communicator(MPI_Comm comm)
-  : comm(comm)
-  {
-    MPI_Comm_rank(comm, &rank);
-    MPI_Comm_size(comm, &size);
-    m_message_passing_mng = MessagePassing::Mpi::StandaloneMpiMessagePassingMng::createRef(comm);
-  };
+  explicit mpi_communicator(MPI_Comm comm);
+
+  explicit mpi_communicator(IMessagePassingMng* mpm_comm);
 
   operator MPI_Comm() const
   {
@@ -237,7 +233,7 @@ struct mpi_communicator
   template <typename T> std::complex<T>
   _reduceSumForComplex(const std::complex<T>& lval) const
   {
-    // Specialisation for 'std::complex<float>' as 2 float.
+    // Specialisation for 'std::complex<T>' as 2 T.
     FixedArray<T, 2> values = { { lval.real(), lval.imag() } };
     mpAllReduce(m_message_passing_mng.get(), MessagePassing::eReduceType::ReduceSum, values.view());
     return std::complex<T>(values[0], values[1]);

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.h
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.h
@@ -84,18 +84,18 @@ struct mpi_init_thread
 /*!
  * \brief Convenience wrapper around MPI_Comm.
  */
-struct ARCCORE_ALINA_EXPORT mpi_communicator
+struct ARCCORE_ALINA_EXPORT AlinaCommunicator
 {
   MPI_Comm comm = MPI_COMM_NULL;
   int rank = 0;
   int size = 0;
   Ref<IMessagePassingMng> m_message_passing_mng;
 
-  mpi_communicator() = default;
+  AlinaCommunicator() = default;
 
-  explicit mpi_communicator(MPI_Comm comm);
+  explicit AlinaCommunicator(MPI_Comm comm);
 
-  explicit mpi_communicator(IMessagePassingMng* mpm_comm);
+  explicit AlinaCommunicator(IMessagePassingMng* mpm_comm);
 
   operator MPI_Comm() const
   {

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.h
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.h
@@ -154,31 +154,7 @@ struct ARCCORE_ALINA_EXPORT mpi_communicator
    * provided message together with the ranks of the offending process.
    * After that each process in the communicator throws.
    */
-  template <class Condition, class Message>
-  void check(const Condition& cond, const Message& message)
-  {
-    int lc = static_cast<int>(cond);
-    int gc = _reduce(MPI_PROD, lc);
-
-    if (gc==0) {
-      IMessagePassingMng* pm = m_message_passing_mng.get();
-      UniqueArray<int> c(size);
-      if (rank == 0)
-        c.resize(size);
-      ConstArrayView<int> in_view(1, &lc);
-      mpGather(pm, in_view, c, 0);
-      if (rank == 0) {
-        std::cerr << "Failed assumption: " << message << std::endl;
-        std::cerr << "Offending processes:";
-        for (int i = 0; i < size; ++i)
-          if (!c[i])
-            std::cerr << " " << i;
-        std::cerr << std::endl;
-      }
-      mpBarrier(pm);
-      ARCCORE_FATAL("CheckError in MessagePassingUtils: {0}", message);
-    }
-  }
+  void check(bool cond, const String& message);
 
   template <typename T> MessagePassing::Request
   doIReceive(T* buf, int count, int source, int tag) const
@@ -221,14 +197,6 @@ struct ARCCORE_ALINA_EXPORT mpi_communicator
   }
 
  private:
-
-  int _reduce(MPI_Op op, int lval) const
-  {
-    int gval = 0;
-
-    MPI_Allreduce((void*)&lval, &gval, 1, MPI_INT, op, comm);
-    return gval;
-  }
 
   template <typename T> std::complex<T>
   _reduceSumForComplex(const std::complex<T>& lval) const

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.h
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.h
@@ -102,6 +102,8 @@ struct ARCCORE_ALINA_EXPORT AlinaCommunicator
     return comm;
   }
 
+  IMessagePassingMng* messagePassingMng() const { return  m_message_passing_mng.get(); }
+
   /// Exclusive sum over mpi communicator
   template <typename T>
   UniqueArray<T> exclusive_sum(T n) const

--- a/arccore/src/alina/arccore/alina/MessagePassingUtils.h
+++ b/arccore/src/alina/arccore/alina/MessagePassingUtils.h
@@ -86,7 +86,12 @@ struct mpi_init_thread
  */
 struct ARCCORE_ALINA_EXPORT AlinaCommunicator
 {
-  MPI_Comm comm = MPI_COMM_NULL;
+ private:
+
+  MPI_Comm m_mpi_communicator = MPI_COMM_NULL;
+
+ public:
+
   int rank = 0;
   int size = 0;
   Ref<IMessagePassingMng> m_message_passing_mng;
@@ -97,12 +102,8 @@ struct ARCCORE_ALINA_EXPORT AlinaCommunicator
 
   explicit AlinaCommunicator(IMessagePassingMng* mpm_comm);
 
-  operator MPI_Comm() const
-  {
-    return comm;
-  }
-
-  IMessagePassingMng* messagePassingMng() const { return  m_message_passing_mng.get(); }
+  MPI_Comm mpiCommunicator() const { return m_mpi_communicator; }
+  IMessagePassingMng* messagePassingMng() const { return m_message_passing_mng.get(); }
 
   /// Exclusive sum over mpi communicator
   template <typename T>
@@ -157,6 +158,8 @@ struct ARCCORE_ALINA_EXPORT AlinaCommunicator
    * After that each process in the communicator throws.
    */
   void check(bool cond, const String& message);
+
+  void barrier() { mpBarrier(m_message_passing_mng.get()); }
 
   template <typename T> MessagePassing::Request
   doIReceive(T* buf, int count, int source, int tag) const

--- a/arccore/src/alina/arccore/alina/ParmetisMatrixPartitioner.h
+++ b/arccore/src/alina/arccore/alina/ParmetisMatrixPartitioner.h
@@ -88,7 +88,7 @@ struct ParmetisMatrixPartitioner
     if (!prm.shrink)
       return false;
 
-    mpi_communicator comm = A.comm();
+    AlinaCommunicator comm = A.comm();
     ptrdiff_t n = A.loc_rows();
     UniqueArray<ptrdiff_t> row_dom = comm.exclusive_sum(n);
 
@@ -107,7 +107,7 @@ struct ParmetisMatrixPartitioner
 
   std::shared_ptr<matrix> operator()(const matrix& A, unsigned block_size = 1) const
   {
-    mpi_communicator comm = A.comm();
+    AlinaCommunicator comm = A.comm();
     idx_t n = A.loc_rows();
     ptrdiff_t row_beg = A.loc_col_shift();
 
@@ -169,7 +169,7 @@ struct ParmetisMatrixPartitioner
   std::tuple<ptrdiff_t, ptrdiff_t>
   partition(const DistributedMatrix<B>& A, idx_t npart, std::vector<ptrdiff_t>& perm) const
   {
-    mpi_communicator comm = A.comm();
+    AlinaCommunicator comm = A.comm();
     idx_t n = A.loc_rows();
     int active = (n > 0);
 
@@ -194,7 +194,7 @@ struct ParmetisMatrixPartitioner
     MPI_Comm_split(comm, active ? 0 : MPI_UNDEFINED, comm.rank, &scomm);
 
     if (active) {
-      mpi_communicator sc(scomm);
+      AlinaCommunicator sc(scomm);
       UniqueArray<idx_t> vtxdist = sc.exclusive_sum(n);
 
       sc.check(

--- a/arccore/src/alina/arccore/alina/ParmetisMatrixPartitioner.h
+++ b/arccore/src/alina/arccore/alina/ParmetisMatrixPartitioner.h
@@ -191,7 +191,7 @@ struct ParmetisMatrixPartitioner
       part.reserve(1); // So that part.data() is not NULL
 
     MPI_Comm scomm;
-    MPI_Comm_split(comm, active ? 0 : MPI_UNDEFINED, comm.rank, &scomm);
+    MPI_Comm_split(comm.mpiCommunicator(), active ? 0 : MPI_UNDEFINED, comm.rank, &scomm);
 
     if (active) {
       AlinaCommunicator sc(scomm);

--- a/arccore/src/alina/arccore/alina/SimpleMatrixPartitioner.h
+++ b/arccore/src/alina/arccore/alina/SimpleMatrixPartitioner.h
@@ -81,7 +81,7 @@ struct SimpleMatrixPartitioner
     if (!prm.enable)
       return false;
 
-    mpi_communicator comm = A.comm();
+    AlinaCommunicator comm = A.comm();
     ptrdiff_t n = A.loc_rows();
     UniqueArray<ptrdiff_t> row_dom = comm.exclusive_sum(n);
 
@@ -100,7 +100,7 @@ struct SimpleMatrixPartitioner
 
   std::shared_ptr<matrix> operator()(const matrix& A, unsigned /*block_size*/ = 1) const
   {
-    mpi_communicator comm = A.comm();
+    AlinaCommunicator comm = A.comm();
     ptrdiff_t nrows = A.loc_rows();
 
     UniqueArray<ptrdiff_t> row_dom = comm.exclusive_sum(nrows);

--- a/arccore/src/alina/arccore/alina/samples/DistributedBasicSolver.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedBasicSolver.cc
@@ -40,7 +40,7 @@ using namespace Arcane;
 //---------------------------------------------------------------------------
 template <class Backend, class Matrix>
 std::shared_ptr<Alina::DistributedMatrix<Backend>>
-partition(Alina::mpi_communicator comm, const Matrix& Astrip,
+partition(Alina::AlinaCommunicator comm, const Matrix& Astrip,
           typename Backend::vector& rhs, const typename Backend::params& bprm,
           Alina::eMatrixPartitionerType ptype, int block_size = 1)
 {
@@ -75,7 +75,7 @@ partition(Alina::mpi_communicator comm, const Matrix& Astrip,
 }
 
 //---------------------------------------------------------------------------
-void solve_scalar(Alina::mpi_communicator comm,
+void solve_scalar(Alina::AlinaCommunicator comm,
                   ptrdiff_t chunk,
                   const std::vector<ptrdiff_t>& ptr,
                   const std::vector<ptrdiff_t>& col,
@@ -185,7 +185,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
   auto& prof = Alina::Profiler::globalProfiler();
 
   //Alina::mpi_init_thread mpi(&argc, &argv);
-  Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator comm(MPI_COMM_WORLD);
 
   tm->info() << "World size: " << comm.size;
 

--- a/arccore/src/alina/arccore/alina/samples/DistributedCPR.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedCPR.cc
@@ -46,7 +46,7 @@ using Alina::precondition;
 
 //---------------------------------------------------------------------------
 ptrdiff_t
-read_matrix_market(Alina::mpi_communicator comm,
+read_matrix_market(Alina::AlinaCommunicator comm,
                    const std::string& A_file, const std::string& rhs_file, int block_size,
                    std::vector<ptrdiff_t>& ptr,
                    std::vector<ptrdiff_t>& col,
@@ -82,7 +82,7 @@ read_matrix_market(Alina::mpi_communicator comm,
 
 //---------------------------------------------------------------------------
 ptrdiff_t
-read_binary(Alina::mpi_communicator comm,
+read_binary(Alina::AlinaCommunicator comm,
             const std::string& A_file, const std::string& rhs_file, int block_size,
             std::vector<ptrdiff_t>& ptr,
             std::vector<ptrdiff_t>& col,
@@ -118,7 +118,7 @@ read_binary(Alina::mpi_communicator comm,
 //---------------------------------------------------------------------------
 template <class Backend, class Matrix>
 std::shared_ptr<Alina::DistributedMatrix<Backend>>
-partition(Alina::mpi_communicator comm, const Matrix& Astrip,
+partition(Alina::AlinaCommunicator comm, const Matrix& Astrip,
           std::vector<double>& rhs, const typename Backend::params& bprm,
           Alina::eMatrixPartitionerType ptype, int block_size = 1)
 {
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
   }
   BOOST_SCOPE_EXIT_END
 
-  Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator comm(MPI_COMM_WORLD);
 
   if (comm.rank == 0)
     std::cout << "World size: " << comm.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
@@ -92,7 +92,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
   chunk = chunk_end - chunk_start;
 
   std::vector<int> domain(comm.size + 1);
-  MPI_Allgather(&chunk, 1, MPI_INT, &domain[1], 1, MPI_INT, comm);
+  MPI_Allgather(&chunk, 1, MPI_INT, &domain[1], 1, MPI_INT, comm.mpiCommunicator());
   std::partial_sum(domain.begin(), domain.end(), domain.begin());
 
   prof.tic("assemble");

--- a/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedCheckDirect.cc
@@ -41,7 +41,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
 
   auto& prof = Alina::Profiler::globalProfiler();
 
-  Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator comm(MPI_COMM_WORLD);
 
   tm->info() << "World size: " << comm.size;
 

--- a/arccore/src/alina/arccore/alina/samples/DistributedComplex.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedComplex.cc
@@ -40,7 +40,7 @@ using namespace Arcane;
 using namespace Arcane::Alina;
 
 //---------------------------------------------------------------------------
-void solve_scalar(Alina::mpi_communicator comm,
+void solve_scalar(Alina::AlinaCommunicator comm,
                   ptrdiff_t chunk,
                   const std::vector<ptrdiff_t>& ptr,
                   const std::vector<ptrdiff_t>& col,
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
 {
   auto& prof = Alina::Profiler::globalProfiler();
   Alina::mpi_init_thread mpi(&argc, &argv);
-  Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator comm(MPI_COMM_WORLD);
 
   if (comm.rank == 0)
     std::cout << "World size: " << comm.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedMatrixMarketSolver.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedMatrixMarketSolver.cc
@@ -49,7 +49,7 @@ using Alina::precondition;
 
 //---------------------------------------------------------------------------
 std::vector<ptrdiff_t>
-read_problem(const Alina::mpi_communicator& world,
+read_problem(const Alina::AlinaCommunicator& world,
              const std::string& A_file,
              const std::string& rhs_file,
              const std::string& part_file,
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
   }
   BOOST_SCOPE_EXIT_END
 
-  Alina::mpi_communicator world(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator world(MPI_COMM_WORLD);
 
   if (world.rank == 0)
     std::cout << "World size: " << world.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedMatrixMarketSolver.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedMatrixMarketSolver.cc
@@ -353,7 +353,7 @@ int main(int argc, char* argv[])
         std::ostream_iterator<double> oi(f, "\n");
         std::copy(x.begin(), x.end(), oi);
       }
-      MPI_Barrier(world);
+      world.barrier();
     }
     prof.toc("save");
   }

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeBP.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeBP.cc
@@ -72,9 +72,9 @@ struct renumbering
 //---------------------------------------------------------------------------
 
 template <template <class> class Precond, class Matrix>
-Alina::SolverResult
-solve(const Alina::mpi_communicator& comm,
-      const Alina::PropertyTree& prm,
+SolverResult
+solve(const AlinaCommunicator& comm,
+      const PropertyTree& prm,
       const Matrix& A)
 {
   auto& prof = Alina::Profiler::globalProfiler();
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
   }
   BOOST_SCOPE_EXIT_END
 
-  Alina::mpi_communicator world(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator world(MPI_COMM_WORLD);
 
   if (world.rank == 0)
     std::cout << "World size: " << world.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD.cc
@@ -460,7 +460,7 @@ int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
 {
   auto& prof = Alina::Profiler::globalProfiler();
 
-  Alina::mpi_communicator world(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator world(MPI_COMM_WORLD);
 
   if (world.rank == 0)
     std::cout << "World size: " << world.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD3D.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedRuntimeSDD3D.cc
@@ -121,11 +121,11 @@ struct renumbering
   }
 };
 
-int main2(const Alina::SampleMainContext& ctx, int argc, char* argv[])
+int main2(const SampleMainContext& ctx, int argc, char* argv[])
 {
   auto& prof = Alina::Profiler::globalProfiler();
   ITraceMng* tm = ctx.traceMng();
-  Alina::mpi_communicator world(MPI_COMM_WORLD);
+  AlinaCommunicator world(MPI_COMM_WORLD);
 
   tm->info() << "World size: " << world.size;
 

--- a/arccore/src/alina/arccore/alina/samples/DistributedSCHUR.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedSCHUR.cc
@@ -293,7 +293,7 @@ int main(int argc, char* argv[])
 
   Alina::backend::clear(*x);
 
-  MPI_Barrier(world);
+  world.barrier();
 
   prof.tic("setup");
   typedef DistributedPreconditionedSolver<

--- a/arccore/src/alina/arccore/alina/samples/DistributedSCHUR.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedSCHUR.cc
@@ -65,7 +65,7 @@ using Alina::precondition;
 
 //---------------------------------------------------------------------------
 std::vector<ptrdiff_t>
-read_problem(const Alina::mpi_communicator& world,
+read_problem(const Alina::AlinaCommunicator& world,
              const std::string& A_file,
              const std::string& rhs_file,
              const std::string& part_file,
@@ -189,7 +189,7 @@ int main(int argc, char* argv[])
   }
   BOOST_SCOPE_EXIT_END
 
-  Alina::mpi_communicator world(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator world(MPI_COMM_WORLD);
 
   if (world.rank == 0)
     std::cout << "World size: " << world.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedSPMM.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedSPMM.cc
@@ -78,7 +78,7 @@ void test()
   using ScalarRhs = math::scalar_of<Rhs>::type;
   int nb_scalar_for_rhs = sizeof(Rhs) / sizeof(ScalarRhs);
 
-  Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator comm(MPI_COMM_WORLD);
   IMessagePassingMng* pm = comm.m_message_passing_mng.get();
 
   int n = 16;

--- a/arccore/src/alina/arccore/alina/samples/DistributedSPMMScaling.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedSPMMScaling.cc
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
   }
   BOOST_SCOPE_EXIT_END
 
-  Alina::mpi_communicator world(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator world(MPI_COMM_WORLD);
 
   if (world.rank == 0)
     std::cout << "World size: " << world.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedSolver.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedSolver.cc
@@ -58,7 +58,7 @@ using namespace Arcane;
 
 //---------------------------------------------------------------------------
 ptrdiff_t
-read_matrix_market(Alina::mpi_communicator comm,
+read_matrix_market(Alina::AlinaCommunicator comm,
                    const std::string& A_file, const std::string& rhs_file, int block_size,
                    std::vector<ptrdiff_t>& ptr,
                    std::vector<ptrdiff_t>& col,
@@ -94,7 +94,7 @@ read_matrix_market(Alina::mpi_communicator comm,
 
 //---------------------------------------------------------------------------
 ptrdiff_t
-read_binary(Alina::mpi_communicator comm,
+read_binary(Alina::AlinaCommunicator comm,
             const std::string& A_file, const std::string& rhs_file, int block_size,
             std::vector<ptrdiff_t>& ptr,
             std::vector<ptrdiff_t>& col,
@@ -130,7 +130,7 @@ read_binary(Alina::mpi_communicator comm,
 //---------------------------------------------------------------------------
 template <class Backend, class Matrix>
 std::shared_ptr<Alina::DistributedMatrix<Backend>>
-partition(Alina::mpi_communicator comm, const Matrix& Astrip,
+partition(Alina::AlinaCommunicator comm, const Matrix& Astrip,
           typename Backend::vector& rhs, const typename Backend::params& bprm,
           Alina::eMatrixPartitionerType ptype, int block_size = 1)
 {
@@ -171,7 +171,7 @@ partition(Alina::mpi_communicator comm, const Matrix& Astrip,
 //---------------------------------------------------------------------------
 #if defined(SOLVER_BACKEND_BUILTIN)
 template <int B>
-void solve_block(Alina::mpi_communicator comm,
+void solve_block(Alina::AlinaCommunicator comm,
                  ptrdiff_t chunk,
                  const std::vector<ptrdiff_t>& ptr,
                  const std::vector<ptrdiff_t>& col,
@@ -262,7 +262,7 @@ void solve_block(Alina::mpi_communicator comm,
 #endif
 
 //---------------------------------------------------------------------------
-void solve_scalar(Alina::mpi_communicator comm,
+void solve_scalar(Alina::AlinaCommunicator comm,
                   ptrdiff_t chunk,
                   const std::vector<ptrdiff_t>& ptr,
                   const std::vector<ptrdiff_t>& col,
@@ -368,7 +368,7 @@ int main(int argc, char* argv[])
   auto& prof = Alina::Profiler::globalProfiler();
 
   Alina::mpi_init_thread mpi(&argc, &argv);
-  Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator comm(MPI_COMM_WORLD);
 
   if (comm.rank == 0)
     std::cout << "World size: " << comm.size << std::endl;

--- a/arccore/src/alina/arccore/alina/samples/DistributedTranspose.cc
+++ b/arccore/src/alina/arccore/alina/samples/DistributedTranspose.cc
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
   }
   BOOST_SCOPE_EXIT_END
 
-  Alina::mpi_communicator comm(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator comm(MPI_COMM_WORLD);
 
   int n = 16;
   int chunk_len = (n + comm.size - 1) / comm.size;

--- a/arccore/src/alina/arccore/alina/srcs.cmake
+++ b/arccore/src/alina/arccore/alina/srcs.cmake
@@ -86,5 +86,6 @@
   ParmetisMatrixPartitioner.h
   MatrixPartitionerRuntime.h
   MatrixPartitionUtils.h
+  MessagePassingUtils.cc
   MessagePassingUtils.h
 )

--- a/arccore/src/alina/arccore/alina/tests/TestDistributedAlinaLib.cc
+++ b/arccore/src/alina/arccore/alina/tests/TestDistributedAlinaLib.cc
@@ -63,8 +63,9 @@ TEST(alina_test_mpi, DistributedAlinaLib)
 
   // Solve
   {
+    Ref<IMessagePassingMng> mpm = MessagePassing::Mpi::StandaloneMpiMessagePassingMng::createRef(MPI_COMM_WORLD);
     AlinaCSRMatrixView matrix_view(chunk, ptr.data(), col.data(), val.data());
-    AlinaDistributedSolver solver(MPI_COMM_WORLD, matrix_view,
+    AlinaDistributedSolver solver(mpm.get(), matrix_view,
                                   1, constant_deflation, nullptr, prm);
     SmallSpan<const double> rhs_view(rhs.data(), rhs.size());
     AlinaConvergenceInfo cnv = solver.solve(rhs_view, x.smallSpan());

--- a/arccore/src/alina/arccore/alina/tests/TestDistributedAlinaLib.cc
+++ b/arccore/src/alina/arccore/alina/tests/TestDistributedAlinaLib.cc
@@ -27,7 +27,7 @@ using namespace Arcane;
 
 TEST(alina_test_mpi, DistributedAlinaLib)
 {
-  Alina::mpi_communicator world(MPI_COMM_WORLD);
+  Alina::AlinaCommunicator world(MPI_COMM_WORLD);
 
   int comm_rank = world.rank;
   int comm_size = world.size;

--- a/arccore/src/alina/arccore/alina/tests/TestDistributedAlinaLib.cc
+++ b/arccore/src/alina/arccore/alina/tests/TestDistributedAlinaLib.cc
@@ -23,11 +23,6 @@
 
 #include <gtest/gtest.h>
 
-double constant_deflation(int, ptrdiff_t, void*)
-{
-  return 1;
-}
-
 using namespace Arcane;
 
 TEST(alina_test_mpi, DistributedAlinaLib)
@@ -65,8 +60,7 @@ TEST(alina_test_mpi, DistributedAlinaLib)
   {
     Ref<IMessagePassingMng> mpm = MessagePassing::Mpi::StandaloneMpiMessagePassingMng::createRef(MPI_COMM_WORLD);
     AlinaCSRMatrixView matrix_view(chunk, ptr.data(), col.data(), val.data());
-    AlinaDistributedSolver solver(mpm.get(), matrix_view,
-                                  1, constant_deflation, nullptr, prm);
+    AlinaDistributedSolver solver(mpm.get(), matrix_view, prm);
     SmallSpan<const double> rhs_view(rhs.data(), rhs.size());
     AlinaConvergenceInfo cnv = solver.solve(rhs_view, x.smallSpan());
 

--- a/arccore/src/alina/arccore/alina/tests/TestDistributedSolver.cc
+++ b/arccore/src/alina/arccore/alina/tests/TestDistributedSolver.cc
@@ -23,7 +23,7 @@ using namespace Arcane;
 
 //---------------------------------------------------------------------------
 
-void solve_scalar(Alina::mpi_communicator comm,
+void solve_scalar(Alina::AlinaCommunicator comm,
                   ptrdiff_t chunk,
                   const std::vector<ptrdiff_t>& ptr,
                   const std::vector<ptrdiff_t>& col,
@@ -96,7 +96,7 @@ void solve_scalar(Alina::mpi_communicator comm,
 
 TEST(alina_test_mpi, BasicSolver)
 {
-  Alina::mpi_communicator comm(AlinaTest::global_mpi_comm_world);
+  Alina::AlinaCommunicator comm(AlinaTest::global_mpi_comm_world);
 
   std::cout << "World size: " << comm.size << "\n";
 


### PR DESCRIPTION
There is two remaining functions in Alina where MPI is directly used: `MPI_Exscan` and `MPI_Comm_split`.
The class `mpi_communicator` is also renamed `AlinaCommunicator`.

